### PR TITLE
fix: normalize translator/illustrator/curator names (#93)

### DIFF
--- a/app/Models/BookRepository.php
+++ b/app/Models/BookRepository.php
@@ -367,15 +367,18 @@ class BookRepository
         }
         if ($this->hasColumn('traduttore')) {
             $val = $data['traduttore'] ?? null;
-            $addField('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addField('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('illustratore')) {
             $val = $data['illustratore'] ?? null;
-            $addField('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addField('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('curatore')) {
             $val = $data['curatore'] ?? null;
-            $addField('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addField('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('numero_pagine')) {
             $numPagineRaw = $data['numero_pagine'] ?? null;
@@ -703,15 +706,18 @@ class BookRepository
         }
         if ($this->hasColumn('traduttore')) {
             $val = $data['traduttore'] ?? null;
-            $addSet('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addSet('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('illustratore')) {
             $val = $data['illustratore'] ?? null;
-            $addSet('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addSet('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('curatore')) {
             $val = $data['curatore'] ?? null;
-            $addSet('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
+            $val = is_string($val) ? trim($val) : null;
+            $addSet('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : null);
         }
         if ($this->hasColumn('numero_pagine')) {
             $numPagineRaw = $data['numero_pagine'] ?? null;
@@ -1039,7 +1045,7 @@ class BookRepository
                 $vals[] = (string) $v;
             }
         }
-        $sql = 'UPDATE libri SET ' . implode(', ', $set) . ', updated_at=NOW() WHERE id=?';
+        $sql = 'UPDATE libri SET ' . implode(', ', $set) . ', updated_at=NOW() WHERE id=? AND deleted_at IS NULL';
         $types .= 'i';
         $vals[] = $bookId;
         $stmt = $this->db->prepare($sql);

--- a/app/Models/BookRepository.php
+++ b/app/Models/BookRepository.php
@@ -366,13 +366,16 @@ class BookRepository
             $addField('edizione', 's', $data['edizione'] ?? null);
         }
         if ($this->hasColumn('traduttore')) {
-            $addField('traduttore', 's', $data['traduttore'] ?? null);
+            $val = $data['traduttore'] ?? null;
+            $addField('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('illustratore')) {
-            $addField('illustratore', 's', $data['illustratore'] ?? null);
+            $val = $data['illustratore'] ?? null;
+            $addField('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('curatore')) {
-            $addField('curatore', 's', $data['curatore'] ?? null);
+            $val = $data['curatore'] ?? null;
+            $addField('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('numero_pagine')) {
             $numPagineRaw = $data['numero_pagine'] ?? null;
@@ -699,13 +702,16 @@ class BookRepository
             $addSet('edizione', 's', $data['edizione'] ?? null);
         }
         if ($this->hasColumn('traduttore')) {
-            $addSet('traduttore', 's', $data['traduttore'] ?? null);
+            $val = $data['traduttore'] ?? null;
+            $addSet('traduttore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('illustratore')) {
-            $addSet('illustratore', 's', $data['illustratore'] ?? null);
+            $val = $data['illustratore'] ?? null;
+            $addSet('illustratore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('curatore')) {
-            $addSet('curatore', 's', $data['curatore'] ?? null);
+            $val = $data['curatore'] ?? null;
+            $addSet('curatore', 's', $val !== null && $val !== '' ? \App\Support\AuthorNormalizer::normalize($val) : $val);
         }
         if ($this->hasColumn('numero_pagine')) {
             $numPagineRaw = $data['numero_pagine'] ?? null;
@@ -989,6 +995,8 @@ class BookRepository
                     if ($validated !== false) {
                         $cols[$c] = $validated;
                     }
+                } elseif (in_array($c, ['traduttore', 'illustratore', 'curatore'], true)) {
+                    $cols[$c] = \App\Support\AuthorNormalizer::normalize((string) $data[$c]);
                 } else {
                     $cols[$c] = $data[$c];
                 }
@@ -1011,10 +1019,10 @@ class BookRepository
             $cols['collana'] = (string) $data['scraped_series'];
         }
         if ($this->hasColumn('traduttore') && !isset($cols['traduttore']) && !empty($data['scraped_translator'])) {
-            $cols['traduttore'] = (string) $data['scraped_translator'];
+            $cols['traduttore'] = \App\Support\AuthorNormalizer::normalize((string) $data['scraped_translator']);
         }
         if ($this->hasColumn('illustratore') && !isset($cols['illustratore']) && !empty($data['scraped_illustrator'])) {
-            $cols['illustratore'] = (string) $data['scraped_illustrator'];
+            $cols['illustratore'] = \App\Support\AuthorNormalizer::normalize((string) $data['scraped_illustrator']);
         }
         if (!$cols)
             return;

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -3395,26 +3395,26 @@ function initializeIsbnImport() {
                 }
             }
             
+            // Normalize person names: "Surname, Name" → "Name Surname" (shared by authors, translator, illustrator)
+            const normalizeAuthorName = (name) => {
+                name = (name || '').trim();
+                if (name.includes(',')) {
+                    const parts = name.split(',', 2);
+                    if (parts.length === 2) {
+                        const surname = parts[0].trim();
+                        const firstName = parts[1].trim();
+                        if (surname && firstName) {
+                            return firstName + ' ' + surname;
+                        }
+                    }
+                }
+                return name;
+            };
+
             // Handle authors (support multiple authors array) - select all at once
             try {
                 if (authorsChoice && (Array.isArray(data.authors) ? data.authors.length > 0 : !!data.author)) {
                     let authorsRaw = Array.isArray(data.authors) && data.authors.length > 0 ? data.authors : [data.author];
-
-                    // Normalize author names: "Surname, Name" → "Name Surname"
-                    const normalizeAuthorName = (name) => {
-                        name = (name || '').trim();
-                        if (name.includes(',')) {
-                            const parts = name.split(',', 2);
-                            if (parts.length === 2) {
-                                const surname = parts[0].trim();
-                                const firstName = parts[1].trim();
-                                if (surname && firstName) {
-                                    return firstName + ' ' + surname;
-                                }
-                            }
-                        }
-                        return name;
-                    };
 
                     // Normalize and deduplicate authors (case-insensitive)
                     const seenNormalized = new Set();

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -3728,31 +3728,33 @@ function initializeIsbnImport() {
             } catch (err) {
             }
 
-            // Handle translator (traduttore)
+            // Handle translator (traduttore) — normalize same as authors
             try {
                 if (data.translator) {
+                    const normalized = normalizeAuthorName(data.translator);
                     const translatorInput = document.querySelector('input[name="traduttore"]');
                     if (translatorInput) {
-                        translatorInput.value = data.translator;
+                        translatorInput.value = normalized;
                     }
                     const scrapedTranslator = document.getElementById('scraped_translator');
                     if (scrapedTranslator) {
-                        scrapedTranslator.value = data.translator;
+                        scrapedTranslator.value = normalized;
                     }
                 }
             } catch (err) {
             }
 
-            // Handle illustrator (illustratore)
+            // Handle illustrator (illustratore) — normalize same as authors
             try {
                 if (data.illustrator) {
+                    const normalized = normalizeAuthorName(data.illustrator);
                     const illustratorInput = document.querySelector('input[name="illustratore"]');
                     if (illustratorInput) {
-                        illustratorInput.value = data.illustrator;
+                        illustratorInput.value = normalized;
                     }
                     const scrapedIllustrator = document.getElementById('scraped_illustrator');
                     if (scrapedIllustrator) {
-                        scrapedIllustrator.value = data.illustrator;
+                        scrapedIllustrator.value = normalized;
                     }
                 }
             } catch (err) {


### PR DESCRIPTION
## Summary
- Apply `AuthorNormalizer::normalize()` to `traduttore`, `illustratore`, and `curatore` fields in `BookRepository` (create, update, and scraping paths)
- Apply JavaScript `normalizeAuthorName()` to scraped translator/illustrator values in the book form

Previously, only author names were standardized (title case, "Surname, Name" → "Name Surname", particle handling for de/von/di/etc.). Translator, illustrator, and curator fields were saved as raw text, leading to inconsistent formatting.

## Test plan
- [ ] Create a book with translator "ROSSI, MARIO" → verify saved as "Mario Rossi"
- [ ] Edit a book, set illustrator "VON HAGEN, VICTOR" → verify saved as "Victor von Hagen"
- [ ] Import via ISBN scraping → verify translator/illustrator are normalized
- [ ] Verify existing books with already-normalized names are not affected

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Translator, illustrator, and curator names are consistently normalized when creating and updating book records.
  * Updates now respect soft-deleted records, preventing unintended modifications to deleted books.

* **User Interface**
  * Book form inputs (visible and imported/scraped values) now show normalized author, translator, and illustrator names.
  * ISBN import/scrape flow applies the same normalization; deduplication and processing use normalized names for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->