### PR TITLE
feat(archives): ISAD(G)/ISAAR(CPF) plugin — skeleton + phase 1a (#103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,13 @@ storage/plugins/musicbrainz/*
 !storage/plugins/musicbrainz/*.md
 !storage/plugins/musicbrainz/views/
 !storage/plugins/musicbrainz/views/*.php
+!storage/plugins/archives/
+storage/plugins/archives/*
+!storage/plugins/archives/*.php
+!storage/plugins/archives/*.json
+!storage/plugins/archives/*.md
+!storage/plugins/archives/views/
+!storage/plugins/archives/views/*.php
 
 # Premium plugin - never track (private/commercial)
 storage/plugins/scraping-pro/

--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,7 @@ phpunit.xml
 tests/*
 !tests/*.spec.js
 !tests/*.config.js
+!tests/*.unit.php
 !tests/helpers/
 tests/helpers/*
 !tests/helpers/*.php

--- a/app/Support/BundledPlugins.php
+++ b/app/Support/BundledPlugins.php
@@ -7,6 +7,7 @@ final class BundledPlugins
 {
     public const LIST = [
         'api-book-scraper',
+        'archives',
         'deezer',
         'dewey-editor',
         'digital-library',

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -63,10 +63,21 @@ class ArchivesPlugin
      * Called by PluginManager when the plugin is activated via the admin UI.
      * Creates the archival schema if missing. Idempotent: the DDLs use
      * CREATE TABLE IF NOT EXISTS so re-activation is safe.
+     *
+     * Throws on partial-schema failure so PluginManager does not mark the
+     * plugin active with missing tables. The exception bubbles up to the
+     * admin UI where it surfaces as a red flash; SecureLogger has already
+     * captured the per-table reason inside ensureSchema().
      */
     public function onActivate(): void
     {
-        $this->ensureSchema();
+        $result = $this->ensureSchema();
+        if (!empty($result['failed'])) {
+            throw new \RuntimeException(
+                '[Archives] Schema activation failed for: ' . implode(', ', $result['failed'])
+                . '. See app.log for the mysqli error emitted during each CREATE TABLE.'
+            );
+        }
         // Hook registration will iterate plannedHooks() once wiring lands.
     }
 

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -4,21 +4,30 @@ declare(strict_types=1);
 
 namespace App\Plugins\Archives;
 
+use App\Support\HookManager;
+use App\Support\SecureLogger;
+use mysqli;
+
 /**
  * Archives plugin — ISAD(G) / ISAAR(CPF) support for Pinakes.
  *
- * SKELETON for issue #103. Introduces two new tables:
- *   - archival_units   : hierarchical archival records (fonds/series/file/item)
- *   - authority_records: persons, corporate bodies, families (ISAAR(CPF))
+ * Phase 1a (issue #103). Introduces three tables:
+ *   - archival_units             : hierarchical archival records (fonds/series/file/item)
+ *   - authority_records          : persons, corporate bodies, families (ISAAR(CPF))
+ *   - archival_unit_authority    : M:N link between the two with a role enum
  *
  * The design mirrors the ABA (Copenhagen) mapping of ISAD(G) onto an extended
  * danMARC2 — see README.md for the ISAD(G) → column crosswalk.
  *
- * Nothing UI- or API-facing is wired yet. Activating the plugin creates the
- * tables; deactivating keeps them (data preservation).
+ * Activation creates the schema via ensureSchema() executed against the host's
+ * mysqli connection. Deactivation is a no-op: the tables stay in place because
+ * archival records are typically more valuable than a clean uninstall.
  */
 class ArchivesPlugin
 {
+    private mysqli $db;
+    private HookManager $hookManager;
+
     /**
      * Logical archival-unit levels, per ISAD(G) 3.1.4.
      * Ordered from most-inclusive (1) to least (4).
@@ -39,13 +48,21 @@ class ArchivesPlugin
         'family'    => 'Family (genealogical authority)',
     ];
 
-    public function __construct()
+    /**
+     * PluginManager::runPluginMethod() instantiates every plugin with
+     * ($this->db, $this->hookManager) — see PluginManager.php:878. The plugin
+     * must match this signature even if the hooks aren't wired yet.
+     */
+    public function __construct(mysqli $db, HookManager $hookManager)
     {
+        $this->db = $db;
+        $this->hookManager = $hookManager;
     }
 
     /**
      * Called by PluginManager when the plugin is activated via the admin UI.
-     * Creates the archival schema if missing. Idempotent.
+     * Creates the archival schema if missing. Idempotent: the DDLs use
+     * CREATE TABLE IF NOT EXISTS so re-activation is safe.
      */
     public function onActivate(): void
     {
@@ -60,6 +77,60 @@ class ArchivesPlugin
      */
     public function onDeactivate(): void
     {
+        // Deliberate no-op: preserve archival data on deactivation.
+        // Manual DROP is only available via a future admin "Uninstall archives"
+        // action with an explicit confirmation.
+    }
+
+    /**
+     * Execute the DDL for archival_units, authority_records, and the
+     * M:N link table. Errors are logged but don't abort activation —
+     * the admin can inspect the log and retry. Partial success is
+     * acceptable because each CREATE is IF NOT EXISTS + independent.
+     *
+     * @return array{created: list<string>, failed: list<string>}
+     */
+    public function ensureSchema(): array
+    {
+        $steps = [
+            'archival_units'          => self::ddlArchivalUnits(),
+            'authority_records'       => self::ddlAuthorityRecords(),
+            'archival_unit_authority' => self::ddlArchivalAuthorityLinks(),
+        ];
+
+        $created = [];
+        $failed = [];
+
+        foreach ($steps as $table => $ddl) {
+            try {
+                $result = $this->db->query($ddl);
+                if ($result === false) {
+                    $failed[] = $table;
+                    SecureLogger::warning(
+                        '[Archives] CREATE TABLE failed for ' . $table . ': ' . $this->db->error
+                    );
+                } else {
+                    $created[] = $table;
+                }
+            } catch (\Throwable $e) {
+                $failed[] = $table;
+                SecureLogger::error(
+                    '[Archives] Exception during CREATE TABLE ' . $table . ': ' . $e->getMessage()
+                );
+            }
+        }
+
+        return ['created' => $created, 'failed' => $failed];
+    }
+
+    /**
+     * Expose the injected HookManager. Kept as a public accessor rather than
+     * a private unused property so static analysis is happy and tests can
+     * verify the DI wiring without reflection.
+     */
+    public function getHookManager(): HookManager
+    {
+        return $this->hookManager;
     }
 
     /**
@@ -94,23 +165,6 @@ class ArchivesPlugin
                 'description' => 'Share authority_records with the legacy `libri.autori` table',
             ],
         ];
-    }
-
-    /**
-     * Create archival tables if they do not exist. Uses the global mysqli
-     * connection conventionally exposed as `Database::getInstance()->getMysqli()`
-     * in Pinakes — keep in sync with the host's DI container when wiring.
-     *
-     * Schema is intentionally minimal: core ISAD(G) 3.1-3.5 fields only.
-     * Extensions (3.6 note area, 3.7 control area, finding aids) will land
-     * in follow-up migrations once CRUD is in place.
-     */
-    private function ensureSchema(): void
-    {
-        // TODO: wire to the host's Database service (see app/Support/Database.php).
-        // Deliberately not executing raw queries here yet — the skeleton ships
-        // the DDL as string constants so reviewers can audit schema intent
-        // before we touch production DBs.
     }
 
     /**

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins\Archives;
+
+/**
+ * Archives plugin — ISAD(G) / ISAAR(CPF) support for Pinakes.
+ *
+ * SKELETON for issue #103. Introduces two new tables:
+ *   - archival_units   : hierarchical archival records (fonds/series/file/item)
+ *   - authority_records: persons, corporate bodies, families (ISAAR(CPF))
+ *
+ * The design mirrors the ABA (Copenhagen) mapping of ISAD(G) onto an extended
+ * danMARC2 — see README.md for the ISAD(G) → column crosswalk.
+ *
+ * Nothing UI- or API-facing is wired yet. Activating the plugin creates the
+ * tables; deactivating keeps them (data preservation).
+ */
+class ArchivesPlugin
+{
+    /**
+     * Logical archival-unit levels, per ISAD(G) 3.1.4.
+     * Ordered from most-inclusive (1) to least (4).
+     */
+    public const LEVELS = [
+        'fonds'  => 1, // archive collection — whole of a creator's output
+        'series' => 2, // grouping by provenance/function/form
+        'file'   => 3, // organic unit (case file, volume)
+        'item'   => 4, // smallest indivisible unit (single letter, memo)
+    ];
+
+    /**
+     * Authority-record types, per ISAAR(CPF).
+     */
+    public const AUTHORITY_TYPES = [
+        'person'    => 'Single person (biographical authority)',
+        'corporate' => 'Corporate body (organisation, union, party)',
+        'family'    => 'Family (genealogical authority)',
+    ];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Called by PluginManager when the plugin is activated via the admin UI.
+     * Creates the archival schema if missing. Idempotent.
+     */
+    public function onActivate(): void
+    {
+        $this->ensureSchema();
+        // Hook registration will iterate plannedHooks() once wiring lands.
+    }
+
+    /**
+     * Called when deactivated. Keeps the tables in place — dropping them
+     * would delete archival records, which are probably more valuable than
+     * a clean uninstall.
+     */
+    public function onDeactivate(): void
+    {
+    }
+
+    /**
+     * Returns the list of hooks this plugin *will* register once the feature
+     * set ships. Exposed as a pure data array so the skeleton can be audited
+     * without side-effects, and so a future `registerHooks()` can simply
+     * iterate this list and call Hooks::add(...) per entry.
+     *
+     * Shape: [hook_name, callback_method, priority]
+     *
+     * @return list<array{hook: string, method: string, priority: int, description: string}>
+     */
+    public function plannedHooks(): array
+    {
+        return [
+            [
+                'hook'        => 'search.unified.sources',
+                'method'      => 'addArchivalSources',
+                'priority'    => 10,
+                'description' => 'Contribute archival_units + authority_records to unified search',
+            ],
+            [
+                'hook'        => 'admin.menu.render',
+                'method'      => 'addAdminMenu',
+                'priority'    => 10,
+                'description' => 'Add "Archivi" section to the admin sidebar',
+            ],
+            [
+                'hook'        => 'libri.authority.resolve',
+                'method'      => 'resolveAuthority',
+                'priority'    => 10,
+                'description' => 'Share authority_records with the legacy `libri.autori` table',
+            ],
+        ];
+    }
+
+    /**
+     * Create archival tables if they do not exist. Uses the global mysqli
+     * connection conventionally exposed as `Database::getInstance()->getMysqli()`
+     * in Pinakes — keep in sync with the host's DI container when wiring.
+     *
+     * Schema is intentionally minimal: core ISAD(G) 3.1-3.5 fields only.
+     * Extensions (3.6 note area, 3.7 control area, finding aids) will land
+     * in follow-up migrations once CRUD is in place.
+     */
+    private function ensureSchema(): void
+    {
+        // TODO: wire to the host's Database service (see app/Support/Database.php).
+        // Deliberately not executing raw queries here yet — the skeleton ships
+        // the DDL as string constants so reviewers can audit schema intent
+        // before we touch production DBs.
+    }
+
+    /**
+     * DDL for the `archival_units` hierarchical table.
+     * Exposed as a string so tests and reviewers can inspect intent.
+     *
+     * ISAD(G) crosswalk (selected):
+     *   reference_code         → 3.1.1 Reference code
+     *   formal_title           → 3.1.2 Title (241*a in ABA format)
+     *   constructed_title      → 3.1.2 Title (245*a — title given by archivist)
+     *   date_start/date_end    → 3.1.3 Dates of creation
+     *   predominant_dates      → 3.1.3 Dates — predominant
+     *   level                  → 3.1.4 Level of description
+     *   extent                 → 3.1.5 Extent and medium
+     *   scope_content          → 3.3.1 Scope and content / Abstract
+     *   appraisal              → 3.3.2 Appraisal / destruction
+     *   accruals               → 3.3.3 Accruals
+     *   arrangement_system     → 3.3.4 System of arrangement
+     *   access_conditions      → 3.4.1 Conditions governing access
+     *   reproduction_rules     → 3.4.2 Conditions governing reproduction
+     *   language_codes         → 3.4.3 Language/scripts
+     *   finding_aids           → 3.4.5 Finding aids
+     *   originals_location     → 3.5.1 Existence and location of originals
+     *   copies_location        → 3.5.2 Existence and location of copies
+     *   related_units          → 3.5.3 Related units of description
+     *   archival_history       → 3.2.3 Archival history
+     *   acquisition_source     → 3.2.4 Immediate source of acquisition
+     *   registration_date      → 3.7.3 Date(s) of descriptions
+     */
+    public static function ddlArchivalUnits(): string
+    {
+        return <<<'SQL'
+        CREATE TABLE IF NOT EXISTS archival_units (
+            id                  BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            parent_id           BIGINT UNSIGNED NULL,
+            reference_code      VARCHAR(64)  NOT NULL,
+            institution_code    VARCHAR(16)  NOT NULL DEFAULT 'PINAKES',
+            level               ENUM('fonds','series','file','item') NOT NULL,
+            formal_title        VARCHAR(500) NULL,
+            constructed_title   VARCHAR(500) NOT NULL,
+            date_start          SMALLINT NULL,
+            date_end            SMALLINT NULL,
+            predominant_dates   VARCHAR(255) NULL,
+            date_gaps           VARCHAR(255) NULL,
+            extent              VARCHAR(500) NULL,
+            scope_content       TEXT NULL,
+            appraisal           TEXT NULL,
+            accruals            ENUM('none','completed','ongoing','irregular') NULL,
+            arrangement_system  VARCHAR(255) NULL,
+            access_conditions   VARCHAR(255) NULL,
+            reproduction_rules  VARCHAR(255) NULL,
+            language_codes      VARCHAR(64)  NULL,
+            finding_aids        TEXT NULL,
+            originals_location  VARCHAR(500) NULL,
+            copies_location     VARCHAR(500) NULL,
+            related_units       TEXT NULL,
+            archival_history    TEXT NULL,
+            acquisition_source  VARCHAR(500) NULL,
+            physical_location   VARCHAR(255) NULL,
+            material_status     ENUM('unclassified','cataloguing','completed') NOT NULL DEFAULT 'unclassified',
+            registration_date   DATE NULL,
+            created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            deleted_at          TIMESTAMP NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uq_reference (institution_code, reference_code),
+            KEY idx_parent (parent_id),
+            KEY idx_level (level),
+            KEY idx_dates (date_start, date_end),
+            KEY idx_deleted (deleted_at),
+            FULLTEXT KEY ft_search (formal_title, constructed_title, scope_content, archival_history),
+            CONSTRAINT fk_archival_parent FOREIGN KEY (parent_id) REFERENCES archival_units(id) ON DELETE SET NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL;
+    }
+
+    /**
+     * DDL for `authority_records` (ISAAR(CPF)).
+     *
+     * Kept separate from the existing `autori` table because ISAAR covers
+     * corporate bodies + families in addition to persons, and carries a
+     * richer element set (dates of existence, history, functions, mandates).
+     *
+     * ISAAR(CPF) crosswalk (selected):
+     *   type                 → 5.1.1 Type of entity (person/corporate/family)
+     *   authorised_form      → 5.1.2 Authorized form of name
+     *   parallel_forms       → 5.1.3 Parallel forms of name
+     *   other_forms          → 5.1.5 Other forms of name
+     *   identifiers          → 5.1.6 Identifiers
+     *   dates_of_existence   → 5.2.1 Dates of existence (birth/death, founded/dissolved)
+     *   history              → 5.2.2 History
+     *   places               → 5.2.3 Places
+     *   legal_status         → 5.2.4 Legal status
+     *   functions            → 5.2.5 Functions, occupations, activities
+     *   mandates             → 5.2.6 Mandates / sources of authority
+     *   internal_structure   → 5.2.7 Internal structure / genealogy
+     *   general_context      → 5.2.8 General context
+     */
+    public static function ddlAuthorityRecords(): string
+    {
+        return <<<'SQL'
+        CREATE TABLE IF NOT EXISTS authority_records (
+            id                 BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            type               ENUM('person','corporate','family') NOT NULL,
+            authorised_form    VARCHAR(500) NOT NULL,
+            parallel_forms     TEXT NULL,
+            other_forms        TEXT NULL,
+            identifiers        VARCHAR(500) NULL,
+            dates_of_existence VARCHAR(255) NULL,
+            history            TEXT NULL,
+            places             TEXT NULL,
+            legal_status       VARCHAR(255) NULL,
+            functions          TEXT NULL,
+            mandates           TEXT NULL,
+            internal_structure TEXT NULL,
+            general_context    TEXT NULL,
+            gender             ENUM('female','male','other','unknown') NULL,
+            external_refs      TEXT NULL,
+            created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+            deleted_at         TIMESTAMP NULL,
+            PRIMARY KEY (id),
+            KEY idx_type (type),
+            KEY idx_deleted (deleted_at),
+            FULLTEXT KEY ft_search (authorised_form, parallel_forms, history, functions)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL;
+    }
+
+    /**
+     * DDL for the many-to-many link between archival_units and authority_records.
+     * Mirrors MARC fields 610/700/710 (subject + added entry) from ABA format.
+     */
+    public static function ddlArchivalAuthorityLinks(): string
+    {
+        return <<<'SQL'
+        CREATE TABLE IF NOT EXISTS archival_unit_authority (
+            archival_unit_id BIGINT UNSIGNED NOT NULL,
+            authority_id     BIGINT UNSIGNED NOT NULL,
+            role             ENUM('creator','subject','recipient','custodian','associated') NOT NULL DEFAULT 'subject',
+            PRIMARY KEY (archival_unit_id, authority_id, role),
+            KEY idx_authority (authority_id, role),
+            CONSTRAINT fk_aua_unit FOREIGN KEY (archival_unit_id) REFERENCES archival_units(id) ON DELETE CASCADE,
+            CONSTRAINT fk_aua_auth FOREIGN KEY (authority_id)     REFERENCES authority_records(id) ON DELETE CASCADE
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+        SQL;
+    }
+}

--- a/storage/plugins/archives/README.md
+++ b/storage/plugins/archives/README.md
@@ -1,6 +1,6 @@
 # Archives plugin — ISAD(G) / ISAAR(CPF) support for Pinakes
 
-**Status: SKELETON (v0.1.0-skeleton)** — schema design + metadata only. No CRUD UI, no MARCXML I/O, no unified search integration yet.
+**Status: PHASE 1a — schema creation** (v0.1.0). Activation creates the three tables (`archival_units`, `authority_records`, `archival_unit_authority`) via `ensureSchema()`. No CRUD UI, no MARCXML I/O, no unified search integration yet.
 
 Tracks issue [#103](https://github.com/fabiodalez-dev/Pinakes/issues/103).
 

--- a/storage/plugins/archives/README.md
+++ b/storage/plugins/archives/README.md
@@ -12,7 +12,7 @@ The canonical real-world mapping of ISAD(G) onto a MARC-like serialisation comes
 
 ## Data model (skeleton)
 
-Three tables (DDL exposed as string constants in `ArchivesPlugin::ddl*()` methods — NOT yet executed; review before enabling):
+Three tables (DDL exposed via `ArchivesPlugin::ddl*()` methods and executed by `ensureSchema()` when `onActivate()` fires — review before enabling the plugin):
 
 ### `archival_units` (hierarchical)
 

--- a/storage/plugins/archives/README.md
+++ b/storage/plugins/archives/README.md
@@ -1,0 +1,108 @@
+# Archives plugin — ISAD(G) / ISAAR(CPF) support for Pinakes
+
+**Status: SKELETON (v0.1.0-skeleton)** — schema design + metadata only. No CRUD UI, no MARCXML I/O, no unified search integration yet.
+
+Tracks issue [#103](https://github.com/fabiodalez-dev/Pinakes/issues/103).
+
+## Why this plugin
+
+Pinakes today models a flat bibliographic record (`libri` — ISBN/EAN/Dewey). Institutions that hold **archival material** (fonds, series, files, items) and **photographic collections** need a different, hierarchical model — standardised internationally as [ISAD(G)](https://www.ica.org/en/isadg-general-international-standard-archival-description-second-edition) for descriptions and [ISAAR(CPF)](https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd) for authority records (persons / corporate bodies / families).
+
+The canonical real-world mapping of ISAD(G) onto a MARC-like serialisation comes from the [ABA archive format](https://github.com/fabiodalez-dev/Pinakes/issues/103) (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen) — designed by Hans Uwe Petersen and Reindex, drawing inspiration from the Swedish ARKIS II. This plugin adopts the same field crosswalk so future MARCXML import/export is a mechanical translation.
+
+## Data model (skeleton)
+
+Three tables (DDL exposed as string constants in `ArchivesPlugin::ddl*()` methods — NOT yet executed; review before enabling):
+
+### `archival_units` (hierarchical)
+
+Self-referencing tree; each row is a record at one of four ISAD(G) levels:
+
+| Level | `level` value | ISAD term | Example |
+|---|---|---|---|
+| 1 | `fonds` | Fonds / Archive collection | "Dansk Metalarbejderforbund Arkiv" (1884-2003) |
+| 2 | `series` | Archive series | "Cirkulærer og skrivelser" (1895-1986) |
+| 3 | `file` | Archive file | "Udsendte cirkulærer" |
+| 4 | `item` | Archive item | "Cirkulær 1910-07-15, J. Jensen to branches" |
+
+Column → ISAD(G) crosswalk (selected):
+
+| Column | ISAD(G) | ABA MARC |
+|---|---|---|
+| `reference_code` | 3.1.1 Reference code | `001*a` |
+| `institution_code` | 3.1.1 Reference code | `001*b` |
+| `formal_title` | 3.1.2 Title (formal) | `241*a` |
+| `constructed_title` | 3.1.2 Title (constructed) | `245*a` |
+| `date_start` / `date_end` | 3.1.3 Dates of creation | `008*a` / `008*z`, `260*c` |
+| `predominant_dates` | 3.1.3 — Predominant dates | `501*a` |
+| `date_gaps` | 3.1.3 — Significant gaps | `501*b` |
+| `level` | 3.1.4 Level of description | `008*c` |
+| `extent` | 3.1.5 Extent and medium | `300*a`, `300*n` |
+| `scope_content` | 3.3.1 Scope and content | `504*a` |
+| `appraisal` | 3.3.2 Appraisal, destruction | `521*a`, `521*b` |
+| `accruals` | 3.3.3 Accruals | `521*d` |
+| `arrangement_system` | 3.3.4 System of arrangement | `512*c` |
+| `access_conditions` | 3.4.1 Conditions governing access | `513*a`, `518*a` |
+| `reproduction_rules` | 3.4.2 Conditions governing reproduction | `518*b` |
+| `language_codes` | 3.4.3 Language / scripts | `008*l`, `041*a` |
+| `finding_aids` | 3.4.5 Finding aids | `526*a` |
+| `originals_location` | 3.5.1 Existence of originals | `529*a` |
+| `copies_location` | 3.5.2 Existence of copies | `529*b`, `529*c` |
+| `related_units` | 3.5.3 Related units | `525*a` |
+| `archival_history` | 3.2.3 Archival history | `520*a` |
+| `acquisition_source` | 3.2.4 Immediate source of acquisition | `520*b` |
+| `registration_date` | 3.7.3 Date(s) of descriptions | `512*a` |
+
+Soft-delete (`deleted_at`) aligned with Pinakes' `libri` convention.
+
+### `authority_records` (ISAAR(CPF))
+
+Separate from the existing `autori` table because ISAAR covers **persons + corporate bodies + families** and carries a richer element set. Authority records are shared between `libri` and `archival_units` via the link table.
+
+| Column | ISAAR(CPF) |
+|---|---|
+| `type` | 5.1.1 Type of entity (`person`/`corporate`/`family`) |
+| `authorised_form` | 5.1.2 Authorised form of name |
+| `parallel_forms` | 5.1.3 Parallel forms |
+| `other_forms` | 5.1.5 Other forms |
+| `identifiers` | 5.1.6 Identifiers |
+| `dates_of_existence` | 5.2.1 Dates of existence |
+| `history` | 5.2.2 History |
+| `places` | 5.2.3 Places |
+| `legal_status` | 5.2.4 Legal status |
+| `functions` | 5.2.5 Functions, occupations, activities |
+| `mandates` | 5.2.6 Mandates / sources of authority |
+| `internal_structure` | 5.2.7 Internal structure / genealogy |
+| `general_context` | 5.2.8 General context |
+
+### `archival_unit_authority` (link table)
+
+M:N relation with a `role` enum — `creator` / `subject` / `recipient` / `custodian` / `associated`. Mirrors MARC 100/600/700/710 semantics in the ABA format.
+
+## Roadmap
+
+| Phase | Scope | Est. effort |
+|---|---|---|
+| **1 — MVP archives CRUD** | Execute the DDL, basic CRUD for `archival_units`, tree-view frontend, 10 core ISAD(G) fields | 2-3 weeks |
+| **2 — Authority records** | `authority_records` CRUD, linkage to both archival_units and libri.autori, biographical UI | 1-2 weeks |
+| **3 — Unified search** | Cross-entity index (libri + archival_units + authority_records), unified results page | 1 week |
+| **4 — MARCXML I/O** | Import (ABA format + generic MARC21-archive), export, optional Z39.50 server | 2 weeks |
+| **5 — Photographic items** | Extend archival_units with image-specific fields (from ABA billedmarc); thumbnails, EXIF | 1-2 weeks |
+
+## Planned hooks
+
+Currently data-only (see `ArchivesPlugin::plannedHooks()`):
+
+| Hook | Purpose |
+|---|---|
+| `search.unified.sources` | Contribute archival_units + authority_records to unified search results |
+| `admin.menu.render` | Add "Archivi" entry to the admin sidebar |
+| `libri.authority.resolve` | Share authority_records with the existing `libri.autori` column |
+
+## References
+
+- ICA — [ISAD(G) 2nd ed.](https://www.ica.org/en/isadg-general-international-standard-archival-description-second-edition)
+- ICA — [ISAAR(CPF) 2nd ed.](https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd)
+- ABA archive format (Hans Uwe Petersen, 2006) — see PDFs attached to issue #103
+- ARKIS II (Swedish National Archives)
+- [danMARC2](https://www.kat-format.dk/danMARC2) — Danish library MARC variant

--- a/storage/plugins/archives/plugin.json
+++ b/storage/plugins/archives/plugin.json
@@ -1,0 +1,38 @@
+{
+  "name": "archives",
+  "display_name": "Archives (ISAD(G) / ISAAR(CPF))",
+  "description": "Gestione di materiale archivistico e fotografico seguendo gli standard internazionali ISAD(G) (General International Standard Archival Description) e ISAAR(CPF) (authority record per persone, enti, famiglie). Modello gerarchico a 4 livelli — Fondo → Serie → Fascicolo → Unità. Ispirato al formato ABA (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen) e a ARKIS II degli Archivi Nazionali Svedesi.",
+  "version": "0.1.0-skeleton",
+  "author": "Fabiodalez",
+  "author_url": "",
+  "plugin_url": "https://github.com/fabiodalez-dev/Pinakes/issues/103",
+  "main_file": "wrapper.php",
+  "requires_php": "8.1",
+  "requires_app": "0.5.9",
+  "metadata": {
+    "category": "archives",
+    "tags": [
+      "isad-g",
+      "isaar-cpf",
+      "marc21",
+      "danmarc2",
+      "archives",
+      "authority-records",
+      "hierarchical"
+    ],
+    "priority": 10,
+    "features": [
+      "Modello gerarchico a 4 livelli (Fonds / Series / File / Item)",
+      "Mapping completo ISAD(G) 3.1-3.7 → campi MARC-like",
+      "Authority records ISAAR(CPF) per persone/enti/famiglie",
+      "Unified search cross-entity (libri + archivi + authority)",
+      "Import/export MARCXML (roadmap)"
+    ],
+    "optional": true,
+    "status": "skeleton",
+    "references": [
+      "https://www.ica.org/en/isadg-general-international-standard-archival-description-second-edition",
+      "https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd"
+    ]
+  }
+}

--- a/storage/plugins/archives/plugin.json
+++ b/storage/plugins/archives/plugin.json
@@ -2,7 +2,7 @@
   "name": "archives",
   "display_name": "Archives (ISAD(G) / ISAAR(CPF))",
   "description": "Gestione di materiale archivistico e fotografico seguendo gli standard internazionali ISAD(G) (General International Standard Archival Description) e ISAAR(CPF) (authority record per persone, enti, famiglie). Modello gerarchico a 4 livelli — Fondo → Serie → Fascicolo → Unità. Ispirato al formato ABA (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen) e a ARKIS II degli Archivi Nazionali Svedesi.",
-  "version": "0.1.0-skeleton",
+  "version": "0.1.0",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "https://github.com/fabiodalez-dev/Pinakes/issues/103",
@@ -29,7 +29,7 @@
       "Import/export MARCXML (roadmap)"
     ],
     "optional": true,
-    "status": "skeleton",
+    "status": "phase-1a",
     "references": [
       "https://www.ica.org/en/isadg-general-international-standard-archival-description-second-edition",
       "https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd"

--- a/storage/plugins/archives/wrapper.php
+++ b/storage/plugins/archives/wrapper.php
@@ -1,22 +1,68 @@
 <?php
-declare(strict_types=1);
 
 /**
  * Archives plugin wrapper.
  *
- * Skeleton for issue #103 — implements an ISAD(G) / ISAAR(CPF) data model on
- * top of Pinakes, allowing archival material (fonds → series → files → items)
- * to coexist with the bibliographic `libri` table and support unified search
- * across collections.
+ * Supports two instantiation paths, mirroring the Discogs plugin:
+ *   1. Namespaced direct loading via App\Plugins\Archives\ArchivesPlugin
+ *   2. PluginManager via the global unnamespaced ArchivesPlugin proxy
  *
- * Inspired by the ABA (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen)
- * archive format mapping ISAD(G)/ISAAR(CPF) onto an extended danMARC2.
+ * PluginManager::getPluginClassName('archives') → 'ArchivesPlugin' (no
+ * namespace), so we expose a thin forwarding class in the global namespace
+ * that constructs the real namespaced plugin.
  *
- * Current status: SKELETON — schema creation + hook registration only.
- * No CRUD UI, no MARCXML I/O, no unified search integration yet.
- * See storage/plugins/archives/README.md for the roadmap.
+ * Phase 1a (issue #103) — schema creation is real; hook wiring, CRUD UI,
+ * MARCXML I/O, and unified search are roadmapped (see README.md).
  */
 
 require_once __DIR__ . '/ArchivesPlugin.php';
 
-return new \App\Plugins\Archives\ArchivesPlugin();
+if (!class_exists('ArchivesPlugin', false)) {
+    class ArchivesPlugin
+    {
+        /** @var \App\Plugins\Archives\ArchivesPlugin */
+        private $instance;
+
+        public function __construct(mysqli $db, \App\Support\HookManager $hookManager)
+        {
+            $this->instance = new \App\Plugins\Archives\ArchivesPlugin($db, $hookManager);
+        }
+
+        public function onActivate(): void
+        {
+            $this->instance->onActivate();
+            \App\Support\SecureLogger::debug('[Archives] Plugin activated');
+        }
+
+        public function onDeactivate(): void
+        {
+            $this->instance->onDeactivate();
+            \App\Support\SecureLogger::debug('[Archives] Plugin deactivated');
+        }
+
+        public function onInstall(): void
+        {
+            \App\Support\SecureLogger::debug('[Archives] Plugin installed');
+        }
+
+        public function onUninstall(): void
+        {
+            \App\Support\SecureLogger::debug('[Archives] Plugin uninstalled');
+        }
+
+        /**
+         * Forward any other method calls (e.g. ensureSchema, plannedHooks,
+         * getHookManager) to the namespaced instance so PluginManager can
+         * introspect the plugin.
+         *
+         * @param array<int, mixed> $args
+         */
+        public function __call(string $method, array $args): mixed
+        {
+            if (is_callable([$this->instance, $method])) {
+                return call_user_func_array([$this->instance, $method], $args);
+            }
+            throw new \BadMethodCallException("Method {$method} does not exist on ArchivesPlugin");
+        }
+    }
+}

--- a/storage/plugins/archives/wrapper.php
+++ b/storage/plugins/archives/wrapper.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Archives plugin wrapper.
+ *
+ * Skeleton for issue #103 — implements an ISAD(G) / ISAAR(CPF) data model on
+ * top of Pinakes, allowing archival material (fonds → series → files → items)
+ * to coexist with the bibliographic `libri` table and support unified search
+ * across collections.
+ *
+ * Inspired by the ABA (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen)
+ * archive format mapping ISAD(G)/ISAAR(CPF) onto an extended danMARC2.
+ *
+ * Current status: SKELETON — schema creation + hook registration only.
+ * No CRUD UI, no MARCXML I/O, no unified search integration yet.
+ * See storage/plugins/archives/README.md for the roadmap.
+ */
+
+require_once __DIR__ . '/ArchivesPlugin.php';
+
+return new \App\Plugins\Archives\ArchivesPlugin();

--- a/tests/archives-plugin.unit.php
+++ b/tests/archives-plugin.unit.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Unit test for the Archives plugin (issue #103, phase 1a).
+ *
+ * Scope: regression assertions on the DDL strings emitted by the plugin.
+ * Constants and bundled-list membership are verified elsewhere (by PHPStan
+ * at compile time, and by the plugin-integrity E2E regression at runtime),
+ * so this file focuses on what PHPStan *cannot* determine statically:
+ * the content of the DDL strings that will hit the production database
+ * when an admin activates the plugin.
+ *
+ * Run:
+ *   php tests/archives-plugin.unit.php
+ * Exits 0 on success, 1 on any failure.
+ */
+
+require_once __DIR__ . '/../app/Support/Hooks.php';
+require_once __DIR__ . '/../app/Support/HookManager.php';
+require_once __DIR__ . '/../app/Support/SecureLogger.php';
+require_once __DIR__ . '/../storage/plugins/archives/ArchivesPlugin.php';
+
+use App\Plugins\Archives\ArchivesPlugin;
+
+$failed = 0;
+$passed = 0;
+
+$check = static function (bool $cond, string $label) use (&$failed, &$passed): void {
+    if ($cond) {
+        $passed++;
+        echo "  OK  $label\n";
+    } else {
+        $failed++;
+        echo "  FAIL $label\n";
+    }
+};
+
+echo "DDL string shape — archival_units:\n";
+$ddl = ArchivesPlugin::ddlArchivalUnits();
+$check(str_contains($ddl, 'CREATE TABLE IF NOT EXISTS archival_units'), 'CREATE TABLE IF NOT EXISTS');
+$check(str_contains($ddl, 'parent_id'), 'parent_id column (hierarchy)');
+$check(str_contains($ddl, "ENUM('fonds','series','file','item')"), 'level enum matches LEVELS constant');
+$check(str_contains($ddl, 'FOREIGN KEY (parent_id) REFERENCES archival_units(id)'), 'self-referencing FK for tree');
+$check(str_contains($ddl, 'deleted_at'), 'soft-delete column aligned with libri convention');
+$check(str_contains($ddl, 'FULLTEXT KEY ft_search'), 'full-text index for unified search');
+$check(str_contains($ddl, 'UNIQUE KEY uq_reference (institution_code, reference_code)'), 'composite unique on institution+reference');
+$check(str_contains($ddl, 'ENGINE=InnoDB'), 'InnoDB engine for FK support');
+$check(str_contains($ddl, 'utf8mb4'), 'utf8mb4 charset for full Unicode');
+
+echo "\nDDL string shape — authority_records:\n";
+$ddl2 = ArchivesPlugin::ddlAuthorityRecords();
+$check(str_contains($ddl2, 'CREATE TABLE IF NOT EXISTS authority_records'), 'CREATE TABLE IF NOT EXISTS');
+$check(str_contains($ddl2, "ENUM('person','corporate','family')"), 'type enum matches AUTHORITY_TYPES');
+$check(str_contains($ddl2, 'dates_of_existence'), 'ISAAR 5.2.1 dates column');
+$check(str_contains($ddl2, 'functions'), 'ISAAR 5.2.5 functions column');
+$check(str_contains($ddl2, 'FULLTEXT KEY ft_search'), 'full-text index for unified search');
+
+echo "\nDDL string shape — archival_unit_authority link:\n";
+$ddl3 = ArchivesPlugin::ddlArchivalAuthorityLinks();
+$check(str_contains($ddl3, 'CREATE TABLE IF NOT EXISTS archival_unit_authority'), 'CREATE TABLE IF NOT EXISTS');
+$check(str_contains($ddl3, "ENUM('creator','subject','recipient','custodian','associated')"), 'role enum covers ISAD relationships');
+$check(str_contains($ddl3, 'ON DELETE CASCADE'), 'cascade delete when a unit or authority is removed');
+$check(str_contains($ddl3, 'PRIMARY KEY (archival_unit_id, authority_id, role)'), 'composite PK prevents duplicate role links');
+
+echo "\nplannedHooks() source-level checks:\n";
+$source = file_get_contents(__DIR__ . '/../storage/plugins/archives/ArchivesPlugin.php');
+$check($source !== false && str_contains($source, "'search.unified.sources'"),   'plannedHooks lists search.unified.sources');
+$check($source !== false && str_contains($source, "'admin.menu.render'"),        'plannedHooks lists admin.menu.render');
+$check($source !== false && str_contains($source, "'libri.authority.resolve'"),  'plannedHooks lists libri.authority.resolve');
+
+echo "\nClass reflection — DI contract:\n";
+$reflection = new ReflectionClass(ArchivesPlugin::class);
+$ctor = $reflection->getConstructor();
+$check($ctor !== null, 'constructor is defined');
+if ($ctor !== null) {
+    $params = $ctor->getParameters();
+    $check(count($params) === 2, 'constructor takes 2 params (db, hookManager)');
+    $check(isset($params[0]) && (string) $params[0]->getType() === 'mysqli', 'first param is mysqli');
+    $check(isset($params[1]) && (string) $params[1]->getType() === 'App\\Support\\HookManager', 'second param is HookManager');
+}
+$check($reflection->hasMethod('ensureSchema'), 'ensureSchema method exists');
+$check($reflection->hasMethod('plannedHooks'), 'plannedHooks method exists');
+$check($reflection->hasMethod('getHookManager'), 'getHookManager method exists');
+
+echo "\n================================\n";
+echo "Passed: $passed   Failed: $failed\n";
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
Tracks issue #103 (Hans Uwe Petersen — archival + photographic items).

Introduces a new bundled plugin `archives` implementing the hierarchical ISAD(G) model and ISAAR(CPF) authority records on top of Pinakes. The design mirrors the ABA (Copenhagen) crosswalk of ISAD(G) onto an extended danMARC2 — mechanical translation to MARCXML is therefore a follow-up rather than a rewrite.

## What ships here

### Skeleton (commit `064962b`)
- `storage/plugins/archives/plugin.json` — metadata, `optional:true`
- `storage/plugins/archives/wrapper.php` — bootstrap
- `storage/plugins/archives/ArchivesPlugin.php` — namespaced class with `LEVELS`, `AUTHORITY_TYPES`, `plannedHooks()` + three DDL emitters
- `storage/plugins/archives/README.md` — overview + ISAD(G) → column crosswalk (~30 fields mapped)
- `app/Support/BundledPlugins::LIST` — grows 9 → 10, `archives` inserted alphabetically
- `.gitignore` whitelist for the new plugin directory

### Phase 1a (commit `f1ddbb2`)
- `ArchivesPlugin::__construct(mysqli, HookManager)` — conforms to `PluginManager::runPluginMethod()` (PluginManager.php:878)
- `ensureSchema()` executes the three DDLs via `$db->query()` with try/catch + SecureLogger; returns `['created' => [...], 'failed' => [...]]` so callers know which tables made it
- Global `ArchivesPlugin` proxy class in `wrapper.php` (DiscogsPlugin pattern) forwards lifecycle hooks to the namespaced instance
- `getHookManager()` testable accessor for DI verification
- `onDeactivate()` is an explicit no-op — archival data survives deactivation; DROP is reserved for a future explicit Uninstall action

### Unit test (commit `c5786db`)
- `tests/archives-plugin.unit.php` — 28 assertions, pure PHP, no DB
- Covers DDL string shape (what will hit production), `plannedHooks()` source inclusion, DI contract via Reflection
- `.gitignore` whitelist `tests/*.unit.php` (mirrors the one in PR #102)

## Schema overview

Three tables, all InnoDB / utf8mb4, with soft-delete (`deleted_at`) aligned with Pinakes' `libri` convention:

| Table | Purpose |
|---|---|
| `archival_units` | Hierarchical records (fonds → series → file → item) with self-referencing `parent_id` + FK, ISAD(G) 3.1-3.5 fields |
| `authority_records` | Persons / corporate bodies / families per ISAAR(CPF) — separate from `autori` because ISAAR covers organisations and has a richer element set |
| `archival_unit_authority` | M:N link with `role` enum (creator / subject / recipient / custodian / associated) |

Full-text indexes on both content tables to lay groundwork for phase 3 unified search.

## Roadmap (see README.md)

| Phase | Scope | In this PR? |
|---|---|---|
| **1a** | Schema backbone + DI + unit tests | ✅ |
| **1b** | `ArchivesController` + routes + views + sidebar entry | — |
| **1c** | i18n (IT/EN/DE) + Playwright E2E | — |
| **2** | Authority records CRUD + linkage to `libri.autori` | — |
| **3** | Unified cross-entity search | — |
| **4** | MARCXML import/export | — |
| **5** | Photographic items extension (ABA billedmarc) | — |

## Safety notes

- `optional: true` in plugin.json — plugin is bundled but **disabled by default**. Admins must explicitly activate it via `/admin/plugins` before any DDL touches the database.
- The three DDLs use `CREATE TABLE IF NOT EXISTS` so re-activation is idempotent.
- Activation failures are logged via `SecureLogger`, not thrown, so a partial success is visible in the log and the admin can retry.
- PHPStan level 5: clean.
- Unit test: 28/28 green.

## Test plan

- [x] `php tests/archives-plugin.unit.php` — 28/28 assertions pass
- [x] PHPStan level 5 clean on plugin + wrapper + unit test
- [ ] Activate plugin against a fresh Pinakes install → verify 3 tables created
- [ ] Re-activate plugin → verify no duplicate-table errors (idempotency)
- [ ] Deactivate → verify tables are preserved
- [ ] Plugin-integrity regression (`tests/plugin-integrity.spec.js`) passes with 10 bundled plugins

@coderabbitai full review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aggiunto il plugin Archives per la gestione di unità archivistiche e record di autorità, con supporto per strutture gerarchiche.

* **Documentation**
  * Aggiunta documentazione completa per il plugin Archives.

* **Tests**
  * Aggiunti test unitari di validazione.

* **Chores**
  * Aggiornato .gitignore per il tracciamento dei file del plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->