### PR TITLE
fix(libri_collane): align defaults + add CHECK constraint (v0.5.9.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and private collections. It focuses on automation, extensibility, and a usable public catalog without requiring a web team.
 
-[![Version](https://img.shields.io/badge/version-0.5.9.5-0ea5e9?style=for-the-badge)](version.json)
+[![Version](https://img.shields.io/badge/version-0.5.9.6-0ea5e9?style=for-the-badge)](version.json)
 [![Installer Ready](https://img.shields.io/badge/one--click_install-ready-22c55e?style=for-the-badge&logo=azurepipelines&logoColor=white)](installer)
 [![License](https://img.shields.io/badge/License-GPL--3.0-orange?style=for-the-badge)](LICENSE)
 
@@ -24,7 +24,13 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 ---
 
-## What's New in v0.5.9 (current series, latest patch: v0.5.9.5)
+## What's New in v0.5.9 (current series, latest patch: v0.5.9.6)
+
+### Membership consistency hardening (v0.5.9.6)
+
+- `libri_collane` now enforces a CHECK constraint (`chk_lc_principale_consistency`) so a row can never have `tipo_appartenenza='principale'` together with `is_principale=0` (or vice versa). Pre-fix the column defaults silently allowed that contradictory state.
+- The column default for `is_principale` was aligned to `1` to match the `'principale'` default of `tipo_appartenenza`, removing the foot-gun for any future plugin/CSV/scraper that omits the flag.
+- Existing rows are realigned in-place by an idempotent migration; no data loss, no manual steps required.
 
 ### Series groups and cycles (v0.5.9.5)
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,16 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 ---
 
-## What's New in v0.5.9 (current series, latest patch: v0.5.9.6)
+## What's New in v0.5.9.6
 
-### Membership consistency hardening (v0.5.9.6)
+> This is the latest patch in the v0.5.9 series. All v0.5.9.x changes are listed below newest-first.
+
+### Membership consistency hardening + performance indexes (v0.5.9.6)
 
 - `libri_collane` now enforces a CHECK constraint (`chk_lc_principale_consistency`) so a row can never have `tipo_appartenenza='principale'` together with `is_principale=0` (or vice versa). Pre-fix the column defaults silently allowed that contradictory state.
 - The column default for `is_principale` was aligned to `1` to match the `'principale'` default of `tipo_appartenenza`, removing the foot-gun for any future plugin/CSV/scraper that omits the flag.
 - Existing rows are realigned in-place by an idempotent migration; no data loss, no manual steps required.
+- Six performance indexes backfilled for existing installations via `migrate_0.5.9.6.sql`: `idx_origine` and `idx_libro_utente` on `prestiti`; `idx_tipo_utente` on `utenti`; `idx_stato_libro`, `idx_queue_position` on `prenotazioni`. Fresh installs already had these via `schema.sql`; upgrades from any prior version now receive them automatically.
 
 ### Series groups and cycles (v0.5.9.5)
 

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -1160,7 +1160,6 @@ class DataIntegrity {
                 'idx_stato' => ['columns' => ['stato']],
                 'idx_stato_libro' => ['columns' => ['stato', 'libro_id']],
                 'idx_queue_position' => ['columns' => ['queue_position']],
-                'idx_data_scadenza' => ['columns' => ['data_scadenza_prenotazione']],
             ],
         ];
     }

--- a/installer/database/migrations/migrate_0.5.9.6.sql
+++ b/installer/database/migrations/migrate_0.5.9.6.sql
@@ -50,7 +50,7 @@ SET @chk_lc_exists = (
       AND CONSTRAINT_TYPE = 'CHECK'
 );
 SET @sql = IF(@chk_lc_exists = 0,
-    "ALTER TABLE libri_collane ADD CONSTRAINT chk_lc_principale_consistency CHECK ((tipo_appartenenza = 'principale' AND is_principale = 1) OR (tipo_appartenenza <> 'principale' AND is_principale = 0))",
+    'ALTER TABLE libri_collane ADD CONSTRAINT chk_lc_principale_consistency CHECK ((tipo_appartenenza = \'principale\' AND is_principale = 1) OR (tipo_appartenenza <> \'principale\' AND is_principale = 0))',
     'SELECT 1');
 PREPARE stmt FROM @sql;
 EXECUTE stmt;

--- a/installer/database/migrations/migrate_0.5.9.6.sql
+++ b/installer/database/migrations/migrate_0.5.9.6.sql
@@ -1,0 +1,57 @@
+-- Migration script for Pinakes 0.5.9.6
+-- =============================================================================
+-- CR review (round on PR #114, 0.5.9.5 → 0.5.9.6): align libri_collane
+-- defaults and add a CHECK constraint that prevents contradictory
+-- principal-membership rows.
+--
+-- Pre-fix the table accepted (and would default to) a state where
+-- tipo_appartenenza='principale' AND is_principale=0 — two contradictory
+-- truths about the same membership. No production code path triggers this
+-- today (all INSERTs/UPSERTs set both fields explicitly), but a future
+-- plugin/CSV/scraper that omits is_principale would land that contradiction.
+--
+-- Three idempotent steps:
+--   1) Backfill any pre-existing rows whose two fields disagree.
+--   2) Update is_principale's column default to 1 (matches tipo default).
+--   3) Add chk_lc_principale_consistency CHECK so future inserts cannot
+--      reintroduce the contradictory state.
+--
+-- Adding the CHECK after the backfill guarantees the ALTER never aborts on
+-- legacy data. Requires MySQL 8.0.16+ for CHECK enforcement; older versions
+-- silently parse but don't enforce — same caveat as chk_collane_tipo.
+-- =============================================================================
+
+-- Step 1: backfill — fix any row whose is_principale doesn't match tipo_appartenenza.
+UPDATE libri_collane
+   SET is_principale = IF(tipo_appartenenza = 'principale', 1, 0)
+ WHERE (tipo_appartenenza = 'principale' AND is_principale <> 1)
+    OR (tipo_appartenenza <> 'principale' AND is_principale <> 0);
+
+-- Step 2: align column default to 1 (idempotent: only run if currently 0).
+SET @current_default = (
+    SELECT COLUMN_DEFAULT FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'libri_collane'
+      AND COLUMN_NAME = 'is_principale'
+);
+SET @sql = IF(@current_default IS NOT NULL AND @current_default <> '1',
+    'ALTER TABLE libri_collane ALTER COLUMN is_principale SET DEFAULT 1',
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Step 3: add CHECK constraint (idempotent via INFORMATION_SCHEMA guard).
+SET @chk_lc_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+    WHERE CONSTRAINT_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'libri_collane'
+      AND CONSTRAINT_NAME = 'chk_lc_principale_consistency'
+      AND CONSTRAINT_TYPE = 'CHECK'
+);
+SET @sql = IF(@chk_lc_exists = 0,
+    "ALTER TABLE libri_collane ADD CONSTRAINT chk_lc_principale_consistency CHECK ((tipo_appartenenza = 'principale' AND is_principale = 1) OR (tipo_appartenenza <> 'principale' AND is_principale = 0))",
+    'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/installer/database/migrations/migrate_0.5.9.6.sql
+++ b/installer/database/migrations/migrate_0.5.9.6.sql
@@ -55,3 +55,42 @@ SET @sql = IF(@chk_lc_exists = 0,
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
+
+-- Steps 4-9: performance indexes present in schema.sql for fresh installs,
+-- backfilled here for upgrade paths that may have missed them.
+
+-- Step 4: prestiti.origine
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prestiti' AND INDEX_NAME = 'idx_origine');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_origine ON prestiti (origine)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Step 5: prestiti (libro_id, utente_id)
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prestiti' AND INDEX_NAME = 'idx_libro_utente');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_libro_utente ON prestiti (libro_id, utente_id)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Step 6: utenti.tipo_utente
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'utenti' AND INDEX_NAME = 'idx_tipo_utente');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_tipo_utente ON utenti (tipo_utente)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Step 7: prenotazioni (stato, libro_id)
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prenotazioni' AND INDEX_NAME = 'idx_stato_libro');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_stato_libro ON prenotazioni (stato, libro_id)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Step 8: prenotazioni.queue_position
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prenotazioni' AND INDEX_NAME = 'idx_queue_position');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_queue_position ON prenotazioni (queue_position)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Step 9: prenotazioni.data_scadenza_prenotazione
+SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prenotazioni' AND INDEX_NAME = 'idx_data_scadenza');
+SET @sql = IF(@idx = 0, 'CREATE INDEX idx_data_scadenza ON prenotazioni (data_scadenza_prenotazione)', 'SELECT 1');
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/installer/database/migrations/migrate_0.5.9.6.sql
+++ b/installer/database/migrations/migrate_0.5.9.6.sql
@@ -90,7 +90,10 @@ SET @sql = IF(@idx = 0, 'CREATE INDEX idx_queue_position ON prenotazioni (queue_
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- Step 9: prenotazioni.data_scadenza_prenotazione
+-- Guard by column name (not index name) to avoid duplicating
+-- idx_prenotazioni_data_scadenza_prenotazione already present in schema.sql.
 SET @idx = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prenotazioni' AND INDEX_NAME = 'idx_data_scadenza');
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prenotazioni'
+      AND COLUMN_NAME = 'data_scadenza_prenotazione' AND INDEX_NAME <> 'PRIMARY');
 SET @sql = IF(@idx = 0, 'CREATE INDEX idx_data_scadenza ON prenotazioni (data_scadenza_prenotazione)', 'SELECT 1');
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -662,6 +662,9 @@ CREATE TABLE `prenotazioni` (
   KEY `libro_id` (`libro_id`),
   KEY `utente_id` (`utente_id`),
   KEY `idx_prenotazioni_data_scadenza_prenotazione` (`data_scadenza_prenotazione`),
+  KEY `idx_stato_libro` (`stato`,`libro_id`),
+  KEY `idx_queue_position` (`queue_position`),
+  KEY `idx_data_scadenza` (`data_scadenza_prenotazione`),
   CONSTRAINT `prenotazioni_ibfk_1` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`),
   CONSTRAINT `prenotazioni_ibfk_2` FOREIGN KEY (`utente_id`) REFERENCES `utenti` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -699,6 +702,8 @@ CREATE TABLE `prestiti` (
   KEY `idx_prestiti_stato_origine` (`stato`,`origine`),
   KEY `idx_copia_id` (`copia_id`),
   KEY `idx_prestiti_pickup_deadline` (`pickup_deadline`),
+  KEY `idx_origine` (`origine`),
+  KEY `idx_libro_utente` (`libro_id`,`utente_id`),
   CONSTRAINT `fk_prestiti_copia` FOREIGN KEY (`copia_id`) REFERENCES `copie` (`id`) ON DELETE RESTRICT,
   CONSTRAINT `prestiti_ibfk_1` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`),
   CONSTRAINT `prestiti_ibfk_2` FOREIGN KEY (`utente_id`) REFERENCES `utenti` (`id`),

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -664,7 +664,6 @@ CREATE TABLE `prenotazioni` (
   KEY `idx_prenotazioni_data_scadenza_prenotazione` (`data_scadenza_prenotazione`),
   KEY `idx_stato_libro` (`stato`,`libro_id`),
   KEY `idx_queue_position` (`queue_position`),
-  KEY `idx_data_scadenza` (`data_scadenza_prenotazione`),
   CONSTRAINT `prenotazioni_ibfk_1` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`),
   CONSTRAINT `prenotazioni_ibfk_2` FOREIGN KEY (`utente_id`) REFERENCES `utenti` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -910,7 +910,7 @@ CREATE TABLE `libri_collane` (
   `collana_id` int NOT NULL,
   `numero_serie` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `tipo_appartenenza` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'principale',
-  `is_principale` tinyint(1) NOT NULL DEFAULT '0',
+  `is_principale` tinyint(1) NOT NULL DEFAULT '1',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
@@ -918,7 +918,11 @@ CREATE TABLE `libri_collane` (
   KEY `idx_lc_collana` (`collana_id`),
   KEY `idx_lc_principale` (`libro_id`,`is_principale`),
   CONSTRAINT `fk_lc_collana` FOREIGN KEY (`collana_id`) REFERENCES `collane` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_lc_libro` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_lc_libro` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `chk_lc_principale_consistency` CHECK (
+    (`tipo_appartenenza` = 'principale' AND `is_principale` = 1)
+    OR (`tipo_appartenenza` <> 'principale' AND `is_principale` = 0)
+  )
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/storage/plugins/api-book-scraper/plugin.json
+++ b/storage/plugins/api-book-scraper/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "scraping",
     "priority": 3,

--- a/storage/plugins/archives/plugin.json
+++ b/storage/plugins/archives/plugin.json
@@ -37,5 +37,5 @@
       "https://www.ica.org/en/isaar-cpf-international-standard-archival-authority-record-corporate-bodies-persons-and-families-2nd"
     ]
   },
-  "max_app_version": "0.5.9.5"
+  "max_app_version": "0.5.9.6"
 }

--- a/storage/plugins/deezer/plugin.json
+++ b/storage/plugins/deezer/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.5.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "scraping",
     "tags": [

--- a/storage/plugins/dewey-editor/plugin.json
+++ b/storage/plugins/dewey-editor/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "DeweyEditorPlugin.php",
   "requires_php": "7.4",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "settings": false,
   "metadata": {
     "category": "admin",

--- a/storage/plugins/digital-library/plugin.json
+++ b/storage/plugins/digital-library/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "media",
     "priority": 10,

--- a/storage/plugins/discogs/plugin.json
+++ b/storage/plugins/discogs/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.5.4",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "optional": true,
     "category": "scraping",

--- a/storage/plugins/goodlib/plugin.json
+++ b/storage/plugins/goodlib/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "discovery",
     "priority": 10,

--- a/storage/plugins/musicbrainz/plugin.json
+++ b/storage/plugins/musicbrainz/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "8.0",
   "requires_app": "0.5.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "scraping",
     "tags": [

--- a/storage/plugins/open-library/plugin.json
+++ b/storage/plugins/open-library/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "wrapper.php",
   "requires_php": "7.4",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "metadata": {
     "category": "scraping",
     "tags": [

--- a/storage/plugins/z39-server/plugin.json
+++ b/storage/plugins/z39-server/plugin.json
@@ -9,7 +9,7 @@
   "main_file": "Z39ServerPlugin.php",
   "requires_php": "7.4",
   "requires_app": "0.4.0",
-  "max_app_version": "0.5.9.5",
+  "max_app_version": "0.5.9.6",
   "settings": true,
   "metadata": {
     "category": "protocol",

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.5.9.5",
+  "version": "0.5.9.6",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Summary

Closes the last open finding from the CodeRabbit review on PR #114 (round 9): `libri_collane` had inconsistent column defaults (`tipo_appartenenza='principale'` paired with `is_principale=0`), and no DB-level guard against that contradictory state.

The other 6 findings from the same review batch were already addressed on `main` in CR R8 (atomic membership-check + update, M:N pre-check, REG-2 soft-delete probe, `nullableCycleOrder` accepts 0, BulkEnrich single-transaction, `ordine_ciclo min=0`).

## Changes

- **`schema.sql`** — bump `is_principale` default `0` → `1` so the column-level defaults can never produce a row with `tipo_appartenenza='principale' AND is_principale=0`. Add `chk_lc_principale_consistency` CHECK enforcing `(tipo='principale' AND is_principale=1) OR (tipo<>'principale' AND is_principale=0)` (MySQL 8.0.16+, same caveat as `chk_collane_tipo`).
- **`migrate_0.5.9.6.sql`** (new) — three idempotent steps for existing installs:
  1. Backfill any pre-existing contradictory rows.
  2. `ALTER COLUMN ... SET DEFAULT 1` (guarded by `INFORMATION_SCHEMA.COLUMNS`).
  3. `ADD CONSTRAINT chk_lc_principale_consistency` (guarded by `INFORMATION_SCHEMA.TABLE_CONSTRAINTS`).
- **`migrate_0.5.9.5.sql`** — **untouched** on purpose. Released migrations are immutable; the updater tracks them by version in the `migrations` table and would not re-run a modified `0.5.9.5`. Users upgrading from `<0.5.9.5` still get the old default initially, then the `0.5.9.6` migration realigns them.
- **Version bump** — `version.json`, README badge + section, `max_app_version` on 10 bundled plugin manifests.

## Why a CHECK and not just code-side validation

Every current INSERT/UPSERT explicitly sets both fields, so this is purely a defensive measure for future plugins/CSV imports/scrapers that might omit `is_principale` and rely on defaults. The CHECK turns a latent foot-gun into an immediate, observable error at the DB.

## Test plan

End-to-end verification on the local install:

- [x] Corrupt one real row to `(principale, 0)` → migration's backfill UPDATE fixes it before the CHECK is added (so the `ADD CONSTRAINT` doesn't abort).
- [x] CHECK rejects `INSERT ... (principale, 0)` with error 3819.
- [x] CHECK rejects `INSERT ... (secondaria, 1)` with error 3819.
- [x] Default `INSERT (libro_id, collana_id)` lands `(principale, 1)` (consistent).
- [x] Re-running `migrate_0.5.9.6.sql` is a clean no-op (exit 0, only `SELECT 1` fallbacks).
- [x] `tests/series-collane-crud.spec.js` — 35/35 passed with CHECK active.
- [x] `tests/persistent-seed-crud.spec.js` — 19/19 passed (run from prior session).
- [x] PHPStan level 5 on `Updater.php` + `Installer.php` — 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Introdotti vincoli di integrità per garantire coerenza nelle collezioni e aggiornato il valore predefinito del flag principale per evitare stati contraddittori.
  * Aggiunta migrazione idempotente che riallinea i dati esistenti senza perdita.
  * Introdotti indici opzionali per migliorare le prestazioni di ricerche e operazioni su prenotazioni e prestiti.

* **Chores**
  * Aggiornata la versione dell’app a v0.5.9.6 e allineata la documentazione.
  * Aggiornata la compatibilità dichiarata dei plugin alla nuova versione.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->