### PR TITLE
fix(installer): add zip extension to requirements check (#117)

### DIFF
--- a/installer/classes/Validator.php
+++ b/installer/classes/Validator.php
@@ -133,7 +133,8 @@ class Validator {
             'mbstring' => extension_loaded('mbstring'),
             'json' => extension_loaded('json'),
             'gd' => extension_loaded('gd'),
-            'fileinfo' => extension_loaded('fileinfo')
+            'fileinfo' => extension_loaded('fileinfo'),
+            'zip' => extension_loaded('zip')
         ];
 
         $allMet = true;

--- a/installer/steps/step1.php
+++ b/installer/steps/step1.php
@@ -13,6 +13,7 @@ $requirements = [
     'JSON Extension' => extension_loaded('json'),
     'GD Extension' => extension_loaded('gd'),
     'Fileinfo Extension' => extension_loaded('fileinfo'),
+    'Zip Extension' => extension_loaded('zip'),
 ];
 
 // Auto-fix permissions if requested


### PR DESCRIPTION
## Summary

- Adds `extension_loaded('zip')` to the installer step-1 requirements list (UI)
- Adds `'zip' => extension_loaded('zip')` to `Validator::validateSystemRequirements()` (logic)

The `Updater` already guards against missing `ZipArchive` at runtime, but the installer never surfaced this as a missing requirement. Users who installed on a server without the zip extension would only discover the gap when applying an update (HTTP 500), not at install time.

## Test plan

- [ ] Deploy on a server without the `zip` PHP extension → installer step 1 should now show "Zip Extension ✗ Not met" and block the "Next" button
- [ ] Deploy on a server with the `zip` extension → no change in behaviour, requirement shows ✓

Fixes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove Funzionalità**
  * Il processo di installazione ora verifica la presenza dell'estensione PHP zip e blocca l'installazione se manca.
  * La schermata "Requisiti di Sistema" mostra lo stato "soddisfatto / non soddisfatto" per l'estensione zip, migliorando la diagnostica pre-installazione.
* **Correzioni**
  * Validazione dei requisiti migliorata per riportare errori più chiari relativi all'estensione zip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->