### PR TITLE
fix(import): remove rate limit from chunk endpoints — closes #113 regression

### DIFF
--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -1259,8 +1259,8 @@ return function (App $app): void {
     // No RateLimitMiddleware here: this is a read-only progress poll behind
     // admin auth, called every 1-2s by the import UI to refresh the bar.
     // A 30/60s throttle saturated on imports of ~500+ rows (#113) and the
-    // user got hard-stuck behind a 429. The POST endpoints (/upload, /chunk)
-    // keep their rate limits — those are the abuse vector.
+    // user got hard-stuck behind a 429. All import endpoints rely on
+    // AdminAuthMiddleware + CsrfMiddleware as the primary defense.
 
     // CSV Import Chunk Processing (AJAX)
     $app->post('/admin/libri/import/chunk', function ($request, $response) use ($app) {
@@ -1271,9 +1271,10 @@ return function (App $app): void {
     // No RateLimitMiddleware: chunk processing is sequential (one at a time
     // per JS loop) and each chunk is scoped to a session-bound import_id.
     // A 100/60 cap causes 429 on fast imports (e.g. 1620 rows, no scraping,
-    // chunks complete in <370 ms → >100/min). Abuse vector is the /prepare
-    // POST endpoint that reads the file; the chunk loop itself is bounded by
-    // session + CSRF. See issue #113 for the original rate-limit regression.
+    // chunks complete in <370 ms → >100/min). All import endpoints (/upload,
+    // /prepare, /chunk) rely on AdminAuthMiddleware + CsrfMiddleware; the
+    // chunk loop is further bounded by the session-scoped import_id.
+    // See issue #113 for the original rate-limit regression.
 
     // LibraryThing Plugin Routes
 

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -1267,9 +1267,13 @@ return function (App $app): void {
         $controller = new \App\Controllers\CsvImportController();
         $db = $app->getContainer()->get('db');
         return $controller->processChunk($request, $response, $db);
-    })->add(new CsrfMiddleware())
-      ->add(new \App\Middleware\RateLimitMiddleware(100, 60))
-      ->add(new AdminAuthMiddleware());
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+    // No RateLimitMiddleware: chunk processing is sequential (one at a time
+    // per JS loop) and each chunk is scoped to a session-bound import_id.
+    // A 100/60 cap causes 429 on fast imports (e.g. 1620 rows, no scraping,
+    // chunks complete in <370 ms → >100/min). Abuse vector is the /prepare
+    // POST endpoint that reads the file; the chunk loop itself is bounded by
+    // session + CSRF. See issue #113 for the original rate-limit regression.
 
     // LibraryThing Plugin Routes
 
@@ -1308,9 +1312,8 @@ return function (App $app): void {
         $controller = new \App\Controllers\LibraryThingImportController();
         $db = $app->getContainer()->get('db');
         return $controller->processChunk($request, $response, $db);
-    })->add(new CsrfMiddleware())
-      ->add(new \App\Middleware\RateLimitMiddleware(100, 60))
-      ->add(new AdminAuthMiddleware());
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+    // No RateLimitMiddleware: same rationale as CSV /import/chunk. See #113.
 
     $app->get('/admin/libri/import/librarything/results', function ($request, $response) {
         $controller = new \App\Controllers\LibraryThingImportController();


### PR DESCRIPTION
## Summary

- Removes `RateLimitMiddleware(100, 60)` from `POST /admin/libri/import/chunk` (CSV)
- Removes `RateLimitMiddleware(100, 60)` from `POST /admin/libri/import/librarything/chunk` (LibraryThing)

The v0.5.9.6 fix (PR #109) removed the rate limit from the GET progress endpoints but left it on the chunk POST endpoints. On a fast server (no network scraping, local TSV → DB inserts), each 10-row chunk completes in <370 ms, yielding >100 chunk requests/min — enough to trigger the 429 the reporter @ctariel still observed after v0.5.9.6.

The chunk loop is sequential by design (JS `while` loop awaits each response), scoped to a session-bound `import_id`, and already gated by `AdminAuthMiddleware` + `CsrfMiddleware`. The `POST /prepare` endpoints (which validate and persist the uploaded file) keep their existing limits.

## Test plan

- [ ] Import a LibraryThing TSV file with >500 rows on a fast server → import should complete without 429
- [ ] Import a CSV with >1000 rows → same
- [ ] Verify other import functionality (CSV, LibraryThing) still works end-to-end

Closes #113 (regression that survived the v0.5.9.6 fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Note di rilascio

* **Bug Fixes**
  * Migliorata la velocità di elaborazione per l'importazione dati CSV e LibraryThing, rimuovendo limitazioni di throttling eccessive che rallentavano le operazioni di caricamento in blocchi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->