### PR TITLE
feat(archives): unified admin search now surfaces archival units

### DIFF
--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -199,7 +199,8 @@ class SearchController
             $publisherResults = $this->searchPublishers($db, $q);
             $results = array_merge($results, $publisherResults);
 
-            // Allow active plugins (e.g. Archives) to append extra result sets.
+            // Cap core results to leave headroom for plugin sources.
+            $results = array_slice($results, 0, 15);
             $results = \App\Support\Hooks::apply('search.unified.sources', $results, [$q]);
 
             // Note: User search is excluded from frontend unified search to keep admin data separate.

--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -199,6 +199,9 @@ class SearchController
             $publisherResults = $this->searchPublishers($db, $q);
             $results = array_merge($results, $publisherResults);
 
+            // Allow active plugins (e.g. Archives) to append extra result sets.
+            $results = \App\Support\Hooks::apply('search.unified.sources', $results, [$q]);
+
             // Note: User search is excluded from frontend unified search to keep admin data separate.
         }
 

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -112,10 +112,22 @@ class PluginManager
                     }
                     SecureLogger::info("[PluginManager] Updated bundled plugin: $pluginName $dbVersion → $diskVersion");
 
-                    // Re-register hooks only if plugin is active
+                    // Re-register hooks only if plugin is active.
+                    // Use a single instance (instantiatePlugin sets pluginId
+                    // before calling onActivate) — runPluginMethod() creates
+                    // a fresh object and would leave pluginId null, causing
+                    // hook registration to skip DB writes.
                     if ((int) ($row['is_active'] ?? 0) === 1) {
                         try {
-                            $this->runPluginMethod($pluginName, 'onActivate');
+                            $upgradeInstance = $this->instantiatePlugin([
+                                'id'        => (int) $row['id'],
+                                'name'      => $pluginName,
+                                'path'      => $pluginName,
+                                'main_file' => $pluginMeta['main_file'] ?? 'wrapper.php',
+                            ]);
+                            if (method_exists($upgradeInstance, 'onActivate')) {
+                                $upgradeInstance->onActivate();
+                            }
                         } catch (\Throwable $e) {
                             SecureLogger::warning("[PluginManager] Note: onActivate failed during upgrade for $pluginName: " . $e->getMessage());
                         }

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -129,7 +129,24 @@ class PluginManager
                                 $upgradeInstance->onActivate();
                             }
                         } catch (\Throwable $e) {
-                            SecureLogger::warning("[PluginManager] Note: onActivate failed during upgrade for $pluginName: " . $e->getMessage());
+                            $revertStmt = $this->db->prepare(
+                                "UPDATE plugins SET version = ? WHERE id = ?"
+                            );
+                            if ($revertStmt !== false) {
+                                $revertStmt->bind_param('si', $dbVersion, $updId);
+                                $revertStmt->execute();
+                                $revertStmt->close();
+                            } else {
+                                SecureLogger::error("[PluginManager] Failed to prepare bundled plugin upgrade rollback for $pluginName", [
+                                    'db_error' => $this->db->error,
+                                ]);
+                            }
+                            SecureLogger::warning("[PluginManager] Note: onActivate failed during upgrade for $pluginName; version rolled back to $dbVersion: " . $e->getMessage());
+                            throw new \RuntimeException(
+                                "Bundled plugin upgrade lifecycle failed for $pluginName",
+                                0,
+                                $e
+                            );
                         }
                     }
                 }

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -149,6 +149,27 @@ class PluginManager
                             );
                         }
                     }
+                } elseif ($diskVersion === $dbVersion && (int) ($row['is_active'] ?? 0) === 1) {
+                    // Same version re-deploy: hooks added to the code but not yet in DB
+                    // (e.g. merging branches that extend the same plugin version).
+                    // ensureSchema uses DELETE+INSERT so calling onActivate is idempotent.
+                    // autoRegisterBundledPlugins runs only on admin plugin-page visits,
+                    // so this extra work is acceptable.
+                    try {
+                        $syncInstance = $this->instantiatePlugin([
+                            'id'        => (int) $row['id'],
+                            'name'      => $pluginName,
+                            'path'      => $pluginName,
+                            'main_file' => $pluginMeta['main_file'] ?? 'wrapper.php',
+                        ]);
+                        if (method_exists($syncInstance, 'onActivate')) {
+                            $syncInstance->onActivate();
+                        }
+                    } catch (\Throwable $e) {
+                        // Non-fatal: log and continue. Hooks may be stale but the
+                        // plugin keeps running with whatever is currently in the DB.
+                        SecureLogger::warning("[PluginManager] Hook re-sync skipped for $pluginName (same version): " . $e->getMessage());
+                    }
                 }
                 continue;
             }

--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -895,6 +895,13 @@ $htmlLang = substr($currentLocale, 0, 2);
                       iconClass = 'fas fa-building';
                       iconColor = 'text-orange-500';
                       break;
+                    case 'archive':
+                      iconClass = 'fas fa-archive';
+                      iconColor = 'text-green-600';
+                      if (item.identifier) {
+                        identifierHtml = `<div class="text-xs text-gray-500 dark:text-gray-400 font-mono mt-0.5">${escapeHtml(String(item.identifier))}</div>`;
+                      }
+                      break;
                     case 'user':
                       iconClass = 'fas fa-user';
                       iconColor = 'text-pink-500';
@@ -1134,6 +1141,13 @@ $htmlLang = substr($currentLocale, 0, 2);
                     case 'publisher':
                       iconClass = 'fas fa-building';
                       iconColor = 'text-orange-500';
+                      break;
+                    case 'archive':
+                      iconClass = 'fas fa-archive';
+                      iconColor = 'text-green-600';
+                      if (item.identifier) {
+                        identifierHtml = `<div class="text-xs text-gray-500 font-mono mt-0.5">${escapeHtml(String(item.identifier))}</div>`;
+                      }
                       break;
                     case 'user':
                       iconClass = 'fas fa-user';

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -141,8 +141,9 @@ class ArchivesPlugin
                 . '. See app.log for the mysqli error emitted during each CREATE TABLE.'
             );
         }
-        $this->registerHookInDb('app.routes.register', 'registerRoutes',       10);
-        $this->registerHookInDb('admin.menu.render',   'renderAdminMenuEntry', 10);
+        $this->registerHookInDb('app.routes.register',    'registerRoutes',       10);
+        $this->registerHookInDb('admin.menu.render',      'renderAdminMenuEntry', 10);
+        $this->registerHookInDb('search.unified.sources', 'addArchivalSources',   10);
     }
 
     /**
@@ -3981,6 +3982,58 @@ class ArchivesPlugin
                 'description' => 'Share authority_records with the legacy `libri.autori` table',
             ],
         ];
+    }
+
+    /**
+     * Filter hook: search.unified.sources
+     *
+     * Appends archival_units that match $q (via LIKE on title + scope_content)
+     * to the unified admin-search results array. Uses LIKE rather than FULLTEXT
+     * so that short reference codes ("IT-MI-1") and year fragments ("1943") are
+     * found reliably regardless of MySQL's minimum full-text word length.
+     *
+     * Called by SearchController::unifiedSearch() via Hooks::apply().
+     * Signature matches the HookManager::applyFilters() call convention:
+     * the first argument is the accumulated $results array; subsequent
+     * positional arguments come from the $args array passed to Hooks::apply().
+     *
+     * @param list<array<string, mixed>> $results
+     * @return list<array<string, mixed>>
+     */
+    public function addArchivalSources(array $results, string $q): array
+    {
+        if ($q === '') {
+            return $results;
+        }
+        $s    = '%' . $q . '%';
+        $stmt = $this->db->prepare(
+            'SELECT id, reference_code, constructed_title
+               FROM archival_units
+              WHERE deleted_at IS NULL
+                AND (constructed_title LIKE ? OR formal_title LIKE ? OR scope_content LIKE ?)
+              ORDER BY constructed_title
+              LIMIT 5'
+        );
+        if ($stmt === false) {
+            return $results;
+        }
+        $stmt->bind_param('sss', $s, $s, $s);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        if ($res instanceof \mysqli_result) {
+            while ($row = $res->fetch_assoc()) {
+                $results[] = [
+                    'id'         => (int) $row['id'],
+                    'label'      => (string) ($row['constructed_title'] ?? ''),
+                    'identifier' => (string) ($row['reference_code'] ?? ''),
+                    'type'       => 'archive',
+                    'url'        => url('/admin/archives/' . (int) $row['id']),
+                ];
+            }
+            $res->free();
+        }
+        $stmt->close();
+        return $results;
     }
 
     /**

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -141,9 +141,16 @@ class ArchivesPlugin
                 . '. See app.log for the mysqli error emitted during each CREATE TABLE.'
             );
         }
-        $this->registerHookInDb('app.routes.register',    'registerRoutes',       10);
-        $this->registerHookInDb('admin.menu.render',      'renderAdminMenuEntry', 10);
-        $this->registerHookInDb('search.unified.sources', 'addArchivalSources',   10);
+        $this->db->begin_transaction();
+        try {
+            $this->registerHookInDb('app.routes.register',    'registerRoutes',       10);
+            $this->registerHookInDb('admin.menu.render',      'renderAdminMenuEntry', 10);
+            $this->registerHookInDb('search.unified.sources', 'addArchivalSources',   10);
+            $this->db->commit();
+        } catch (\Throwable $e) {
+            $this->db->rollback();
+            throw $e;
+        }
     }
 
     /**

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -188,14 +188,18 @@ class ArchivesPlugin
              VALUES (?, ?, ?, ?, ?, 1, NOW())'
         );
         if ($stmt === false) {
-            SecureLogger::error('[Archives] prepare() failed: ' . $this->db->error);
-            return;
+            $err = $this->db->error;
+            SecureLogger::error('[Archives] prepare() failed: ' . $err);
+            throw new \RuntimeException('[Archives] prepare() failed for hook ' . $hookName . ': ' . $err);
         }
         // PluginManager instantiates the global proxy class (no namespace).
         $callbackClass = 'ArchivesPlugin';
         $stmt->bind_param('isssi', $this->pluginId, $hookName, $callbackClass, $method, $priority);
         if (!$stmt->execute()) {
-            SecureLogger::error('[Archives] hook insert failed: ' . $stmt->error);
+            $err = $stmt->error;
+            $stmt->close();
+            SecureLogger::error('[Archives] hook insert failed: ' . $err);
+            throw new \RuntimeException('[Archives] hook insert failed for ' . $hookName . ': ' . $err);
         }
         $stmt->close();
     }

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -3998,8 +3998,9 @@ class ArchivesPlugin
     /**
      * Filter hook: search.unified.sources
      *
-     * Appends archival_units that match $q (via LIKE on title + scope_content)
-     * to the unified admin-search results array. Uses LIKE rather than FULLTEXT
+     * Appends archival_units that match $q (via LIKE on reference_code, title
+     * and scope_content) to the unified admin-search results array. Uses LIKE
+     * rather than FULLTEXT
      * so that short reference codes ("IT-MI-1") and year fragments ("1943") are
      * found reliably regardless of MySQL's minimum full-text word length.
      *
@@ -4016,19 +4017,24 @@ class ArchivesPlugin
         if ($q === '') {
             return $results;
         }
-        $s    = '%' . $q . '%';
+        $searchPattern = '%' . $q . '%';
         $stmt = $this->db->prepare(
             'SELECT id, reference_code, constructed_title
                FROM archival_units
               WHERE deleted_at IS NULL
-                AND (constructed_title LIKE ? OR formal_title LIKE ? OR scope_content LIKE ?)
+                AND (
+                    reference_code LIKE ?
+                    OR constructed_title LIKE ?
+                    OR formal_title LIKE ?
+                    OR scope_content LIKE ?
+                )
               ORDER BY constructed_title
               LIMIT 5'
         );
         if ($stmt === false) {
             return $results;
         }
-        $stmt->bind_param('sss', $s, $s, $s);
+        $stmt->bind_param('ssss', $searchPattern, $searchPattern, $searchPattern, $searchPattern);
         $stmt->execute();
         $res = $stmt->get_result();
         if ($res instanceof \mysqli_result) {

--- a/storage/plugins/archives/plugin.json
+++ b/storage/plugins/archives/plugin.json
@@ -2,7 +2,7 @@
   "name": "archives",
   "display_name": "Archives (ISAD(G) / ISAAR(CPF))",
   "description": "Gestione di materiale archivistico e fotografico seguendo gli standard internazionali ISAD(G) (General International Standard Archival Description) e ISAAR(CPF) (authority record per persone, enti, famiglie). Modello gerarchico a 4 livelli — Fondo → Serie → Fascicolo → Unità. Ispirato al formato ABA (Arbejderbevægelsens Bibliotek og Arkiv, Copenhagen) e a ARKIS II degli Archivi Nazionali Svedesi.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "https://github.com/fabiodalez-dev/Pinakes/issues/103",

--- a/tests/archives-plugin.unit.php
+++ b/tests/archives-plugin.unit.php
@@ -68,6 +68,8 @@ $source = file_get_contents(__DIR__ . '/../storage/plugins/archives/ArchivesPlug
 $check($source !== false && str_contains($source, "'search.unified.sources'"),   'plannedHooks lists search.unified.sources');
 $check($source !== false && str_contains($source, "'admin.menu.render'"),        'plannedHooks lists admin.menu.render');
 $check($source !== false && str_contains($source, "'libri.authority.resolve'"),  'plannedHooks lists libri.authority.resolve');
+$check($source !== false && str_contains($source, 'reference_code LIKE ?'),      'unified search matches archival reference_code');
+$check($source !== false && str_contains($source, "bind_param('ssss'"),          'unified search binds reference_code LIKE placeholder');
 
 echo "\nClass reflection — DI contract:\n";
 $reflection = new ReflectionClass(ArchivesPlugin::class);

--- a/tests/plugin-manager.unit.php
+++ b/tests/plugin-manager.unit.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Source-level regression checks for PluginManager lifecycle behavior.
+ *
+ * Run:
+ *   php tests/plugin-manager.unit.php
+ */
+
+$failed = 0;
+$passed = 0;
+
+$check = static function (bool $cond, string $label) use (&$failed, &$passed): void {
+    if ($cond) {
+        $passed++;
+        echo "  OK  $label\n";
+    } else {
+        $failed++;
+        echo "  FAIL $label\n";
+    }
+};
+
+$source = file_get_contents(__DIR__ . '/../app/Support/PluginManager.php');
+
+echo "PluginManager bundled upgrade lifecycle:\n";
+$check($source !== false && str_contains($source, '$this->instantiatePlugin(['), 'upgrade path instantiates one plugin instance');
+$check($source !== false && str_contains($source, '$upgradeInstance->onActivate();'), 'upgrade path reruns onActivate');
+$check($source !== false && str_contains($source, 'UPDATE plugins SET version = ? WHERE id = ?'), 'failed upgrade rolls version back');
+$check($source !== false && str_contains($source, "bind_param('si', \$dbVersion, \$updId)"), 'rollback restores previous DB version for the same plugin id');
+$check($source !== false && str_contains($source, 'Bundled plugin upgrade lifecycle failed'), 'failed lifecycle propagates an explicit error');
+
+echo "\n================================\n";
+echo "Passed: $passed   Failed: $failed\n";
+exit($failed > 0 ? 1 : 0);

--- a/tests/plugin-manager.unit.php
+++ b/tests/plugin-manager.unit.php
@@ -30,6 +30,12 @@ $check($source !== false && str_contains($source, 'UPDATE plugins SET version = 
 $check($source !== false && str_contains($source, "bind_param('si', \$dbVersion, \$updId)"), 'rollback restores previous DB version for the same plugin id');
 $check($source !== false && str_contains($source, 'Bundled plugin upgrade lifecycle failed'), 'failed lifecycle propagates an explicit error');
 
+echo "\nPluginManager same-version hook re-sync:\n";
+$check($source !== false && str_contains($source, "\$diskVersion === \$dbVersion"), 'same-version branch exists');
+$check($source !== false && str_contains($source, '$syncInstance->onActivate();'), 'same-version branch calls onActivate to re-sync hooks');
+$hasWarn = $source !== false && str_contains($source, 'Hook re-sync skipped');
+$check($hasWarn, 'same-version failure is non-fatal (warning, no rethrow)');
+
 echo "\n================================\n";
 echo "Passed: $passed   Failed: $failed\n";
 exit($failed > 0 ? 1 : 0);

--- a/tests/same-version-hook-sync.spec.js
+++ b/tests/same-version-hook-sync.spec.js
@@ -1,0 +1,48 @@
+// @ts-check
+/**
+ * Regression test for the same-version hook re-sync edge case.
+ *
+ * Scenario: a bundled plugin is at disk_version == db_version but plugin_hooks
+ * is empty (simulating a same-version re-deploy that added a new hook which was
+ * never registered because autoRegisterBundledPlugins skipped onActivate).
+ *
+ * The fix (PluginManager elseif branch) must call onActivate when:
+ *   disk_version === db_version AND is_active === 1
+ *
+ * This test just triggers the code path by navigating to /admin/plugins.
+ * The reinstall-test.sh step verifies hook count before/after via MySQL.
+ *
+ * Requires env vars: E2E_BASE_URL, E2E_ADMIN_EMAIL, E2E_ADMIN_PASS
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const BASE  = process.env.E2E_BASE_URL;
+const EMAIL = process.env.E2E_ADMIN_EMAIL;
+const PASS  = process.env.E2E_ADMIN_PASS;
+
+test.skip(!BASE || !EMAIL || !PASS, 'Set E2E_BASE_URL, E2E_ADMIN_EMAIL, E2E_ADMIN_PASS');
+
+test('visit /admin/plugins to trigger autoRegisterBundledPlugins hook re-sync', async ({ page }) => {
+    await page.goto(BASE + '/accedi', { waitUntil: 'domcontentloaded' });
+
+    if (page.url().includes('/installer/')) {
+        throw new Error('App not installed — run installer first');
+    }
+
+    await page.getByRole('textbox', { name: /email/i }).fill(EMAIL);
+    await page.getByRole('textbox', { name: /password/i }).fill(PASS);
+    await page.getByRole('button', { name: /accedi/i }).click();
+    await page.waitForURL(/admin\/dashboard/, { timeout: 20_000 });
+
+    // This page load calls getAllPlugins() → autoRegisterBundledPlugins()
+    // which must execute the elseif(diskVersion === dbVersion && is_active) branch
+    // and call onActivate() to restore the missing hooks.
+    await page.goto(BASE + '/admin/plugins', { waitUntil: 'domcontentloaded' });
+
+    // Verify the page loaded correctly (not a 500 error)
+    await expect(page.locator('body')).not.toContainText('500');
+    await expect(page.locator('body')).not.toContainText('Fatal error');
+    const title = await page.title();
+    expect(title).not.toBe('404 Not Found');
+});


### PR DESCRIPTION
## Summary

- `SearchController::unifiedSearch()` now applies a `search.unified.sources` filter hook after the existing books/authors/publishers queries, so active plugins can append their own result sets without touching the controller
- `ArchivesPlugin` registers `addArchivalSources` for that hook in `onActivate()` (stored in `plugin_hooks` DB table, same pattern as `app.routes.register`)
- `addArchivalSources()` searches `archival_units` via LIKE on `constructed_title`, `formal_title`, and `scope_content` (ISAD(G) 3.3.1) and returns results in the unified format with `type: 'archive'`
- `layout.php` handles the new `type: 'archive'` in both desktop and mobile search dropdowns with a green archive icon (`fas fa-archive`) and the `reference_code` as the identifier sub-line

## Design decisions

**LIKE vs FULLTEXT:** `addArchivalSources` uses LIKE instead of FULLTEXT. Short reference codes (`IT-MI-1`), year fragments (`1943`), and partial call numbers work correctly with LIKE but are silently dropped by MySQL FULLTEXT (minimum word length + stopword list). FULLTEXT is still used in the dedicated `/admin/archives/search` page where users write longer queries.

**Hook pattern:** The `search.unified.sources` filter hook was already documented in `ArchivesPlugin::plannedHooks()` — this commit promotes it from "planned" to "active". New plugins can contribute to unified search with zero changes to `SearchController`.

## Test plan

- [ ] Activate Archives plugin → create one archival unit
- [ ] Type a matching word in the admin search bar → archive result appears with green icon and reference code
- [ ] Deactivate Archives plugin → archive results disappear from unified search
- [ ] Mobile search bar shows archive results too
- [ ] Short queries (2 chars) work

Part of #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove Funzionalità**
  * La ricerca unificata ora include risultati dagli archivi come fonte aggiuntiva (fino a 5 risultati aggiunti dai plugin).
  * I risultati archivio mostrano un'icona dedicata e l'identificatore nell'anteprima.
  * La ricerca considera titoli formali, titoli costruiti e descrizioni di contenuto per gli archivi.
  * La risposta finale di ricerca è limitata a un massimo di 20 risultati.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->