### PR TITLE
Configurable event image layout (closes #137)

### DIFF
--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -339,10 +339,12 @@ class EventsController
             $featuredImagePath = null;
         }
 
-        // Look up the previous featured_image so we can unlink the
-        // orphaned file after the UPDATE succeeds. We do this BEFORE
-        // the error short-circuit below so $oldImagePath is always
-        // populated when $updateImage is true.
+        // Snapshot the previous featured_image before the UPDATE so we can
+        // unlink the orphan file in the success branch. The validation-error
+        // and UPDATE-fail branches unlink the freshly-uploaded
+        // $featuredImagePath instead; this lookup is only consumed by the
+        // post-commit success path. Capturing it here keeps the snapshot
+        // adjacent to its use site.
         $oldImagePath = null;
         if ($updateImage) {
             $oldStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -316,20 +316,45 @@ class EventsController
         $twitterDescription = $sanitizeText($data['twitter_description'] ?? '');
         $twitterImage = $sanitizeText($data['twitter_image'] ?? '');
 
-        // Handle image upload or removal
+        // Handle image upload or removal.
+        //
+        // Priority order (matters when the user submits BOTH a new file
+        // AND ticks "remove_image"): the new upload wins. Treating
+        // "remove" as the dominant intent would silently destroy a
+        // freshly uploaded file, which is what users hit before this
+        // branch.
         $featuredImagePath = null;
         $updateImage = false;
 
-        if (isset($data['remove_image']) && $data['remove_image'] == '1') {
-            $updateImage = true;
-            $featuredImagePath = null;
-        } elseif (isset($files['featured_image']) && $files['featured_image']->getError() === UPLOAD_ERR_OK) {
+        if (isset($files['featured_image']) && $files['featured_image']->getError() === UPLOAD_ERR_OK) {
             $uploadResult = $this->handleImageUpload($files['featured_image']);
             if (!$uploadResult['success']) {
                 $errors[] = $uploadResult['message'];
             } else {
                 $updateImage = true;
                 $featuredImagePath = $uploadResult['path'];
+            }
+        } elseif (isset($data['remove_image']) && $data['remove_image'] == '1') {
+            $updateImage = true;
+            $featuredImagePath = null;
+        }
+
+        // Look up the previous featured_image so we can unlink the
+        // orphaned file after the UPDATE succeeds. We do this BEFORE
+        // the error short-circuit below so $oldImagePath is always
+        // populated when $updateImage is true.
+        $oldImagePath = null;
+        if ($updateImage) {
+            $oldStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");
+            if ($oldStmt !== false) {
+                $oldStmt->bind_param('i', $id);
+                $oldStmt->execute();
+                $oldResult = $oldStmt->get_result();
+                $oldRow = $oldResult ? $oldResult->fetch_assoc() : null;
+                $oldStmt->close();
+                if (is_array($oldRow) && !empty($oldRow['featured_image'])) {
+                    $oldImagePath = (string) $oldRow['featured_image'];
+                }
             }
         }
 
@@ -377,12 +402,52 @@ class EventsController
 
         if ($stmt->execute()) {
             $_SESSION['success_message'] = __('Evento aggiornato con successo!');
+            // Cleanup orphan file on disk now that the DB row no longer
+            // references it. Skipped when the old path matches the new
+            // one (defensive — should not happen, but unlinking would
+            // delete a still-referenced file).
+            if ($updateImage && $oldImagePath !== null && $oldImagePath !== $featuredImagePath) {
+                $this->deleteUploadedImageFile($oldImagePath);
+            }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'aggiornamento dell\'evento.');
         }
         $stmt->close();
 
         return $response->withHeader('Location', '/admin/cms/events')->withStatus(302);
+    }
+
+    /**
+     * Best-effort unlink of an orphaned event image under
+     * public/uploads/events/. Path-traversal-safe: the supplied
+     * relative path is rejected unless it points inside the events
+     * upload directory (matches the safety contract of
+     * handleImageUpload()).
+     */
+    private function deleteUploadedImageFile(?string $relativePath): void
+    {
+        if ($relativePath === null || $relativePath === '') {
+            return;
+        }
+        // Must look like a value produced by handleImageUpload().
+        if (strpos($relativePath, '/uploads/events/') !== 0) {
+            return;
+        }
+        $baseDir = realpath(__DIR__ . '/../../public/uploads/events');
+        if ($baseDir === false) {
+            return;
+        }
+        $candidate = __DIR__ . '/../../public' . $relativePath;
+        $realCandidate = realpath($candidate);
+        if ($realCandidate === false) {
+            return;
+        }
+        // Confirm the resolved path is genuinely inside the events
+        // directory — defends against symlink shenanigans.
+        if (strpos($realCandidate, $baseDir . DIRECTORY_SEPARATOR) !== 0) {
+            return;
+        }
+        @unlink($realCandidate);
     }
 
     /**

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -4,6 +4,7 @@ namespace App\Controllers;
 
 use App\Support\ContentSanitizer;
 use App\Support\HtmlHelper;
+use App\Support\SecureLogger;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -479,7 +480,19 @@ class EventsController
         if (strpos($realCandidate, $baseDir . DIRECTORY_SEPARATOR) !== 0) {
             return;
         }
-        @unlink($realCandidate);
+        // Check the unlink result instead of suppressing — silent failures
+        // here mean orphan files accumulating on disk with no operator
+        // signal. SecureLogger redacts secrets/paths the way error_log
+        // does not. error_get_last() captures the underlying errno
+        // message (permission denied, etc.) right after the failed call.
+        if (!unlink($realCandidate)) {
+            $err = error_get_last();
+            SecureLogger::error('EventsController::deleteUploadedImageFile unlink failed', [
+                'path' => $realCandidate,
+                'errno' => $err['type'] ?? null,
+                'message' => $err['message'] ?? 'unknown',
+            ]);
+        }
     }
 
     /**

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -359,6 +359,16 @@ class EventsController
         }
 
         if (!empty($errors)) {
+            // Cleanup orphan upload on validation-error short-circuit:
+            // handleImageUpload() has already moved the new file to its
+            // final path before non-image validation ran. Since we are
+            // bailing out without writing the DB row, the file would
+            // become an orphan on disk. Unlink it here so the disk
+            // state matches the DB state (which still references the
+            // old image, if any).
+            if ($updateImage && $featuredImagePath !== null) {
+                $this->deleteUploadedImageFile($featuredImagePath);
+            }
             $_SESSION['error_message'] = implode('<br>', $errors);
             return $response->withHeader('Location', '/admin/cms/events/edit/' . $id)->withStatus(302);
         }
@@ -411,6 +421,13 @@ class EventsController
             }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'aggiornamento dell\'evento.');
+            // Symmetric cleanup on UPDATE failure: the new file made it
+            // to disk via handleImageUpload(), but the DB row still
+            // references the OLD path. Unlink the freshly-uploaded
+            // file to avoid leaving an unreferenced orphan behind.
+            if ($updateImage && $featuredImagePath !== null) {
+                $this->deleteUploadedImageFile($featuredImagePath);
+            }
         }
         $stmt->close();
 
@@ -423,6 +440,19 @@ class EventsController
      * relative path is rejected unless it points inside the events
      * upload directory (matches the safety contract of
      * handleImageUpload()).
+     *
+     * Callsites (keep the four in sync — they implement the
+     * "file on disk must never outlive the DB reference" invariant):
+     *   1. update() success branch with image replacement — unlinks the
+     *      OLD path after the UPDATE commits.
+     *   2. update() failure branch — unlinks the NEWLY-uploaded path
+     *      because the UPDATE rolled back and the DB still points to
+     *      the old file.
+     *   3. update() validation-error short-circuit — unlinks the
+     *      NEWLY-uploaded path because we redirect before writing the
+     *      DB row.
+     *   4. delete() success branch — unlinks the path captured BEFORE
+     *      the DELETE, now that the row is gone.
      */
     private function deleteUploadedImageFile(?string $relativePath): void
     {
@@ -460,12 +490,33 @@ class EventsController
 
         $id = (int)($args['id'] ?? 0);
 
+        // Capture the featured_image path BEFORE the DELETE so we can
+        // unlink it after the row is gone. Mirrors the update() lifecycle:
+        // the file on disk must never outlive the DB reference.
+        $oldImagePath = null;
+        $lookupStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");
+        if ($lookupStmt !== false) {
+            $lookupStmt->bind_param('i', $id);
+            $lookupStmt->execute();
+            $lookupResult = $lookupStmt->get_result();
+            $lookupRow = $lookupResult ? $lookupResult->fetch_assoc() : null;
+            $lookupStmt->close();
+            if (is_array($lookupRow) && !empty($lookupRow['featured_image'])) {
+                $oldImagePath = (string) $lookupRow['featured_image'];
+            }
+        }
+
         // Delete event
         $stmt = $db->prepare("DELETE FROM events WHERE id = ?");
         $stmt->bind_param('i', $id);
 
         if ($stmt->execute()) {
             $_SESSION['success_message'] = __('Evento eliminato con successo!');
+            // Row is gone — unlink the now-orphaned image. Uses the
+            // same path-traversal-safe helper as update().
+            if ($oldImagePath !== null) {
+                $this->deleteUploadedImageFile($oldImagePath);
+            }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'eliminazione dell\'evento.');
         }

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -2078,6 +2078,16 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
             return $response->withStatus(404);
         }
 
+        // Featured-image layout (issue #137): admin-controlled rendering
+        // strategy for the event hero image. Validated against the same
+        // allow-list used by SettingsController to defend against legacy/
+        // corrupted DB values.
+        $eventImageLayoutAllowed = ['full', 'banner', 'contained', 'thumb'];
+        $eventImageLayout = strtolower((string) $repository->get('cms', 'event_image_layout', 'contained'));
+        if (!in_array($eventImageLayout, $eventImageLayoutAllowed, true)) {
+            $eventImageLayout = 'contained';
+        }
+
         // Get event by slug
         $stmt = $db->prepare("
             SELECT id, title, slug, content, event_date, event_time, featured_image,

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -30,6 +30,7 @@ class SettingsController
         $contactSettings = $this->resolveContactSettings($repository);
         $privacySettings = $this->resolvePrivacySettings($repository);
         $labelSettings = $this->resolveLabelSettings($repository);
+        $eventSettings = $this->resolveEventSettings($repository);
         $advancedSettings = $this->resolveAdvancedSettings($repository);
         $contactMessages = $this->loadContactMessages($db);
         $cookieBannerTexts = $this->resolveCookieBannerTexts($repository);
@@ -45,6 +46,7 @@ class SettingsController
             'contactSettings',
             'privacySettings',
             'labelSettings',
+            'eventSettings',
             'advancedSettings',
             'contactMessages',
             'activeTab',
@@ -701,6 +703,21 @@ class SettingsController
         ];
     }
 
+    /**
+     * @return array{image_layout: string}
+     */
+    private function resolveEventSettings(SettingsRepository $repository): array
+    {
+        $allowed = ['full', 'banner', 'contained', 'thumb'];
+        $layout = strtolower((string) $repository->get('cms', 'event_image_layout', 'contained'));
+        if (!in_array($layout, $allowed, true)) {
+            $layout = 'contained';
+        }
+        return [
+            'image_layout' => $layout,
+        ];
+    }
+
     public function updateLabels(Request $request, Response $response, mysqli $db): Response
     {
         $data = (array) $request->getParsedBody();
@@ -923,6 +940,33 @@ class SettingsController
 
         $_SESSION['success_message'] = __('Impostazioni di condivisione aggiornate.');
         return $this->redirect($response, '/admin/settings?tab=sharing');
+    }
+
+    /**
+     * Update per-section settings for the public Events page (issue #137).
+     *
+     * Currently exposes a single knob: the layout of the featured image on
+     * the event detail page. Defaults to 'contained' which preserves the
+     * historical 100%-width rendering for narrow images while preventing
+     * tall/wide outliers from dominating the viewport.
+     */
+    public function updateEventSettings(Request $request, Response $response, mysqli $db): Response
+    {
+        $data = (array) $request->getParsedBody();
+        // CSRF validated by CsrfMiddleware
+
+        $repository = new SettingsRepository($db);
+        $repository->ensureTables();
+
+        $allowed = ['full', 'banner', 'contained', 'thumb'];
+        $submitted = strtolower(trim((string) ($data['event_image_layout'] ?? 'contained')));
+        $layout = in_array($submitted, $allowed, true) ? $submitted : 'contained';
+
+        $repository->set('cms', 'event_image_layout', $layout);
+        ConfigStore::set('cms.event_image_layout', $layout);
+
+        $_SESSION['success_message'] = __('Impostazioni eventi aggiornate.');
+        return $this->redirect($response, '/admin/settings?tab=cms');
     }
 
     private function redirect(Response $response, string $location): Response

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -946,9 +946,9 @@ class SettingsController
      * Update per-section settings for the public Events page (issue #137).
      *
      * Currently exposes a single knob: the layout of the featured image on
-     * the event detail page. Defaults to 'contained' which preserves the
-     * historical 100%-width rendering for narrow images while preventing
-     * tall/wide outliers from dominating the viewport.
+     * the event detail page. Defaults to 'contained' which prevents wide/tall
+     * outliers from dominating the viewport. Users who want the legacy
+     * 100%-width rendering should pick the 'full' preset.
      */
     public function updateEventSettings(Request $request, Response $response, mysqli $db): Response
     {

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -585,6 +585,12 @@ return function (App $app): void {
         return $controller->updateSharingSettings($request, $response, $db);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
+    $app->post('/admin/settings/events', function ($request, $response) use ($app) {
+        $db = $app->getContainer()->get('db');
+        $controller = new SettingsController();
+        return $controller->updateEventSettings($request, $response, $db);
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+
     $app->post('/admin/settings/advanced', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');
         $controller = new SettingsController();

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -174,6 +174,7 @@ $additional_css = "
         overflow: hidden;
         margin-bottom: 2rem;
         border: 1px solid #f1f5f9;
+        background: #f8fafc;
     }
 
     .event-cover img {
@@ -182,16 +183,20 @@ $additional_css = "
     }
 
     /* Layout variants (issue #137): admin-configurable rendering for the
-       event hero image. Defaults remain visually equivalent to the
-       previous behaviour for narrow images. */
+       event hero image. The four variants — full / banner / contained
+       (default) / thumb — give the librarian a predictable result no
+       matter what image they upload. */
+
+    /* full: passthrough — preserve the historical 100%-width no-crop
+       look for users who depended on it. */
     .event-cover--full img {
-        /* Original: preserve historical full-width-no-constraint. */
-        max-height: none;
-        object-fit: initial;
+        height: auto;
     }
+
+    /* banner: 16:9 cinematic crop. Ideal for poster-like horizontal
+       images that look good as a hero. */
     .event-cover--banner {
         aspect-ratio: 16 / 9;
-        background: #f8fafc;
     }
     .event-cover--banner img {
         width: 100%;
@@ -199,27 +204,57 @@ $additional_css = "
         object-fit: cover;
         object-position: center;
     }
-    .event-cover--contained img {
-        max-height: clamp(280px, 50vw, 480px);
-        object-fit: contain;
-        object-position: center;
-        background: #f8fafc;
+
+    /* contained: 3:2 photographic crop. The default — gives the same
+       balanced silhouette regardless of source dimensions. Replaces
+       the earlier arbitrary 480px max-height which produced uneven
+       results across uploads. */
+    .event-cover--contained {
+        aspect-ratio: 3 / 2;
     }
+    .event-cover--contained img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+    }
+
+    /* thumb: side-by-side layout. Driven by a modifier class on the
+       parent .event-card so the cover lives in its own grid cell and
+       cannot overflow into the footer the way a CSS float would when
+       the body text is short. Mobile collapses to a vertical stack. */
     .event-cover--thumb {
-        float: right;
-        width: clamp(180px, 32%, 260px);
-        margin: 0 0 1.25rem 1.5rem;
-        border-radius: 16px;
+        margin-bottom: 0;
+        aspect-ratio: 3 / 4;
     }
     .event-cover--thumb img {
-        aspect-ratio: 3 / 4;
+        width: 100%;
+        height: 100%;
         object-fit: cover;
+        object-position: center;
     }
-    @media (max-width: 640px) {
+    @media (min-width: 768px) {
+        .event-card--thumb-layout {
+            display: grid;
+            grid-template-columns: minmax(200px, 260px) 1fr;
+            gap: clamp(1.5rem, 3vw, 2.5rem);
+            align-items: start;
+        }
+        .event-card--thumb-layout > .event-cover--thumb {
+            grid-column: 1;
+            grid-row: 1 / span 2;
+            position: sticky;
+            top: 7rem;
+            margin: 0;
+        }
+        .event-card--thumb-layout > .event-body,
+        .event-card--thumb-layout > .event-back {
+            grid-column: 2;
+        }
+    }
+    @media (max-width: 767px) {
         .event-cover--thumb {
-            float: none;
-            width: 100%;
-            margin: 0 0 1.5rem 0;
+            margin-bottom: 1.5rem;
         }
     }
 
@@ -398,19 +433,25 @@ ob_start();
     </div>
 </section>
 
+<?php
+    // $eventImageLayout is set by the controller and re-validated there
+    // against the allow-list; we re-narrow here as defense in depth so
+    // a future controller refactor cannot leak an unknown value into
+    // the DOM. Computed before the markup so the parent .event-card
+    // can opt into the side-by-side grid via .event-card--thumb-layout.
+    $coverAllowed   = ['full', 'banner', 'contained', 'thumb'];
+    $coverLayout    = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
+    $hasCoverImage  = !empty($event['featured_image']);
+    $cardClasses    = ['event-card'];
+    if ($hasCoverImage && $coverLayout === 'thumb') {
+        $cardClasses[] = 'event-card--thumb-layout';
+    }
+?>
 <section class="event-section">
     <div class="container">
-        <article class="event-card">
-            <?php if (!empty($event['featured_image'])):
-                // $eventImageLayout is set by the controller and re-validated
-                // there against the allow-list; we re-narrow here as a
-                // defense in depth so a future controller refactor cannot
-                // leak an unknown layout into the CSS class name.
-                $coverAllowed = ['full', 'banner', 'contained', 'thumb'];
-                $coverLayout = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
-                $coverClass = 'event-cover event-cover--' . $coverLayout;
-            ?>
-                <figure class="<?= HtmlHelper::e($coverClass) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
+        <article class="<?= HtmlHelper::e(implode(' ', $cardClasses)) ?>">
+            <?php if ($hasCoverImage): ?>
+                <figure class="event-cover event-cover--<?= HtmlHelper::e($coverLayout) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
                     <img src="<?= HtmlHelper::e(url($event['featured_image'])) ?>" alt="<?= HtmlHelper::e($event['title']) ?>">
                 </figure>
             <?php endif; ?>

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -182,61 +182,71 @@ $additional_css = "
         display: block;
     }
 
-    /* Layout variants (issue #137): admin-configurable rendering for the
-       event hero image. The four variants — full / banner / contained
-       (default) / thumb — give the librarian a predictable result no
-       matter what image they upload. */
+    /* Layout variants (issue #137): admin-configurable SIZE for the
+       event hero image. The four variants give the librarian
+       progressively smaller / less invasive renderings, so a
+       sproportioned upload (e.g. a 1791×927 book cover) doesn't
+       dominate the event page.
 
-    /* full: passthrough — preserve the historical 100%-width no-crop
-       look for users who depended on it. */
+       Effective sizes on desktop:
+         full       → 100% × auto         (legacy: enormous)
+         banner     → 100% × 220px max    (low-profile decorative strip)
+         contained  → 420px × auto, centred (default: small poster)
+         thumb      → 240px wide, side-by-side with body text          */
+
+    /* full: passthrough — for users who actually want a giant image. */
     .event-cover--full img {
         height: auto;
     }
 
-    /* banner: 16:9 cinematic crop. Ideal for poster-like horizontal
-       images that look good as a hero. */
+    /* banner: full-width but capped at a low decorative strip so it
+       cannot eat the viewport vertically. */
     .event-cover--banner {
-        aspect-ratio: 16 / 9;
+        max-height: 220px;
     }
     .event-cover--banner img {
         width: 100%;
-        height: 100%;
+        height: 220px;
         object-fit: cover;
         object-position: center;
     }
 
-    /* contained: 3:2 photographic crop. The default — gives the same
-       balanced silhouette regardless of source dimensions. Replaces
-       the earlier arbitrary 480px max-height which produced uneven
-       results across uploads. */
+    /* contained (DEFAULT): centred poster, never wider than 420px.
+       Solves the original complaint where a wide image rendered at
+       full container width. Aspect ratio of the source file is
+       preserved — no crop, no forced shape, just a sensible cap. */
     .event-cover--contained {
-        aspect-ratio: 3 / 2;
+        max-width: 420px;
+        margin-left: auto;
+        margin-right: auto;
+        background: transparent;
+        border: none;
     }
     .event-cover--contained img {
         width: 100%;
-        height: 100%;
-        object-fit: cover;
-        object-position: center;
+        height: auto;
+        max-height: 320px;
+        object-fit: contain;
     }
 
-    /* thumb: side-by-side layout. Driven by a modifier class on the
-       parent .event-card so the cover lives in its own grid cell and
-       cannot overflow into the footer the way a CSS float would when
-       the body text is short. Mobile collapses to a vertical stack. */
+    /* thumb: side-by-side layout — the small modifier already in the
+       previous iteration. Driven by .event-card--thumb-layout on the
+       parent so the figure lives in its own grid cell, geometrically
+       constrained inside the card. Collapses to a stack < 768px. */
     .event-cover--thumb {
         margin-bottom: 0;
-        aspect-ratio: 3 / 4;
+        max-width: 240px;
     }
     .event-cover--thumb img {
         width: 100%;
-        height: 100%;
+        height: auto;
+        aspect-ratio: 3 / 4;
         object-fit: cover;
-        object-position: center;
     }
     @media (min-width: 768px) {
         .event-card--thumb-layout {
             display: grid;
-            grid-template-columns: minmax(200px, 260px) 1fr;
+            grid-template-columns: 240px 1fr;
             gap: clamp(1.5rem, 3vw, 2.5rem);
             align-items: start;
         }
@@ -254,7 +264,7 @@ $additional_css = "
     }
     @media (max-width: 767px) {
         .event-cover--thumb {
-            margin-bottom: 1.5rem;
+            margin: 0 auto 1.5rem auto;
         }
     }
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -1,6 +1,7 @@
 <?php
 /** @var \mysqli $db */
 /** @var array $event */
+/** @var string $eventImageLayout One of: full | banner | contained | thumb (default: contained) */
 
 use App\Support\ConfigStore;
 use App\Support\HtmlHelper;
@@ -178,6 +179,48 @@ $additional_css = "
     .event-cover img {
         width: 100%;
         display: block;
+    }
+
+    /* Layout variants (issue #137): admin-configurable rendering for the
+       event hero image. Defaults remain visually equivalent to the
+       previous behaviour for narrow images. */
+    .event-cover--full img {
+        /* Original: preserve historical full-width-no-constraint. */
+        max-height: none;
+        object-fit: initial;
+    }
+    .event-cover--banner {
+        aspect-ratio: 16 / 9;
+        background: #f8fafc;
+    }
+    .event-cover--banner img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+    }
+    .event-cover--contained img {
+        max-height: clamp(280px, 50vw, 480px);
+        object-fit: contain;
+        object-position: center;
+        background: #f8fafc;
+    }
+    .event-cover--thumb {
+        float: right;
+        width: clamp(180px, 32%, 260px);
+        margin: 0 0 1.25rem 1.5rem;
+        border-radius: 16px;
+    }
+    .event-cover--thumb img {
+        aspect-ratio: 3 / 4;
+        object-fit: cover;
+    }
+    @media (max-width: 640px) {
+        .event-cover--thumb {
+            float: none;
+            width: 100%;
+            margin: 0 0 1.5rem 0;
+        }
     }
 
     .event-body {
@@ -358,8 +401,16 @@ ob_start();
 <section class="event-section">
     <div class="container">
         <article class="event-card">
-            <?php if (!empty($event['featured_image'])): ?>
-                <figure class="event-cover">
+            <?php if (!empty($event['featured_image'])):
+                // $eventImageLayout is set by the controller and re-validated
+                // there against the allow-list; we re-narrow here as a
+                // defense in depth so a future controller refactor cannot
+                // leak an unknown layout into the CSS class name.
+                $coverAllowed = ['full', 'banner', 'contained', 'thumb'];
+                $coverLayout = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
+                $coverClass = 'event-cover event-cover--' . $coverLayout;
+            ?>
+                <figure class="<?= HtmlHelper::e($coverClass) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
                     <img src="<?= HtmlHelper::e(url($event['featured_image'])) ?>" alt="<?= HtmlHelper::e($event['title']) ?>">
                 </figure>
             <?php endif; ?>

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -221,6 +221,7 @@ $additional_css = "
         max-width: 420px;
         margin-left: 0;
         margin-right: auto;
+        /* No border/background here: contained is a small left-aligned poster; the 420px-wide image floating next to body text reads better without the grey card frame the other variants use to fill the wider hero slot. Keep this asymmetry intentional. */
         background: transparent;
         border: none;
     }
@@ -258,6 +259,8 @@ $additional_css = "
             position: sticky;
             top: 7rem;
             margin: 0;
+            max-height: calc(100vh - 9rem);
+            overflow: hidden;
         }
         .event-card--thumb-layout > .event-body,
         .event-card--thumb-layout > .event-back {

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -211,13 +211,15 @@ $additional_css = "
         object-position: center;
     }
 
-    /* contained (DEFAULT): centred poster, never wider than 420px.
+    /* contained (DEFAULT): left-aligned poster, never wider than 420px.
        Solves the original complaint where a wide image rendered at
        full container width. Aspect ratio of the source file is
-       preserved — no crop, no forced shape, just a sensible cap. */
+       preserved — no crop, no forced shape, just a sensible cap.
+       Left-aligned so the image reads as part of the body flow rather
+       than as a centred hero. */
     .event-cover--contained {
         max-width: 420px;
-        margin-left: auto;
+        margin-left: 0;
         margin-right: auto;
         background: transparent;
         border: none;
@@ -264,7 +266,7 @@ $additional_css = "
     }
     @media (max-width: 767px) {
         .event-cover--thumb {
-            margin: 0 auto 1.5rem auto;
+            margin: 0 0 1.5rem 0;
         }
     }
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -191,7 +191,7 @@ $additional_css = "
        Effective sizes on desktop:
          full       → 100% × auto         (legacy: enormous)
          banner     → 100% × 220px max    (low-profile decorative strip)
-         contained  → 420px × auto, centred (default: small poster)
+         contained  → 420px × auto, left-aligned (default: small poster)
          thumb      → 240px wide, side-by-side with body text          */
 
     /* full: passthrough — for users who actually want a giant image. */

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,8 +464,8 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Adattato (max 480px) — consigliato'),
-                  'banner'    => __('Banner 16:9 (ritagliato)'),
+                  'contained' => __('Foto 3:2 (consigliato)'),
+                  'banner'    => __('Banner 16:9'),
                   'full'      => __('Larghezza piena (originale)'),
                   'thumb'     => __('Miniatura affiancata'),
               ];

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -459,6 +459,47 @@ $activeTab = $activeTab ?? 'general';
                   <?= __("Gestisci Eventi") ?>
                 </a>
               </div>
+
+              <?php
+              /** @var array{image_layout: string} $eventSettings */
+              $eventImageLayout = $eventSettings['image_layout'];
+              $eventImageLayoutChoices = [
+                  'contained' => __('Adattato (max 480px) — consigliato'),
+                  'banner'    => __('Banner 16:9 (ritagliato)'),
+                  'full'      => __('Larghezza piena (originale)'),
+                  'thumb'     => __('Miniatura affiancata'),
+              ];
+              ?>
+              <div class="mt-5 pt-5 border-t border-gray-200">
+                <form action="<?= htmlspecialchars(url('/admin/settings/events'), ENT_QUOTES, 'UTF-8') ?>" method="post" class="space-y-3">
+                  <input type="hidden" name="csrf_token" value="<?= HtmlHelper::e(Csrf::ensureToken()) ?>">
+                  <div>
+                    <label for="event_image_layout" class="block text-sm font-semibold text-gray-900 mb-1">
+                      <?= __("Layout immagine evento") ?>
+                    </label>
+                    <p class="text-xs text-gray-500 mb-2"><?= __("Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.") ?></p>
+                    <select
+                      id="event_image_layout"
+                      name="event_image_layout"
+                      class="w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                    >
+                      <?php foreach ($eventImageLayoutChoices as $value => $label): ?>
+                        <option
+                          value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>"
+                          <?= $eventImageLayout === $value ? 'selected' : '' ?>
+                        ><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                      <?php endforeach; ?>
+                    </select>
+                  </div>
+                  <button
+                    type="submit"
+                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-600 text-white text-sm font-semibold hover:bg-purple-700 transition-colors w-full justify-center"
+                  >
+                    <i class="fas fa-save"></i>
+                    <?= __("Salva impostazioni eventi") ?>
+                  </button>
+                </form>
+              </div>
             </div>
           </div>
 

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -493,7 +493,7 @@ $activeTab = $activeTab ?? 'general';
                   </div>
                   <button
                     type="submit"
-                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-600 text-white text-sm font-semibold hover:bg-purple-700 transition-colors w-full justify-center"
+                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors w-full justify-center"
                   >
                     <i class="fas fa-save"></i>
                     <?= __("Salva impostazioni eventi") ?>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,7 +464,7 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Piccola centrata (max 420px) — consigliato'),
+                  'contained' => __('Piccola a sinistra (max 420px) — consigliato'),
                   'thumb'     => __('Miniatura affiancata al testo (240px)'),
                   'banner'    => __('Banner basso a tutta larghezza (max altezza 220px)'),
                   'full'      => __('Originale a tutta larghezza (grande)'),

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,10 +464,10 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Foto 3:2 (consigliato)'),
-                  'banner'    => __('Banner 16:9'),
-                  'full'      => __('Larghezza piena (originale)'),
-                  'thumb'     => __('Miniatura affiancata'),
+                  'contained' => __('Piccola centrata (max 420px) — consigliato'),
+                  'thumb'     => __('Miniatura affiancata al testo (240px)'),
+                  'banner'    => __('Banner basso a tutta larghezza (max altezza 220px)'),
+                  'full'      => __('Originale a tutta larghezza (grande)'),
               ];
               ?>
               <div class="mt-5 pt-5 border-t border-gray-200">

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4677,5 +4677,13 @@
     "Eliminare questa copia digitalizzata?": "Diese digitalisierte Kopie löschen?",
     "Errore di rete.": "Netzwerkfehler.",
     "MD5 non valido (32 caratteri esadecimali).": "Ungültige MD5 (32 hexadezimale Zeichen).",
-    "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein."
+    "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
+    "Layout immagine evento": "Bild-Layout für Veranstaltung",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
+    "Adattato (max 480px) — consigliato": "Angepasst (max. 480px) — empfohlen",
+    "Banner 16:9 (ritagliato)": "Banner 16:9 (zugeschnitten)",
+    "Larghezza piena (originale)": "Volle Breite (original)",
+    "Miniatura affiancata": "Miniaturbild seitlich",
+    "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
+    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
     "Layout immagine evento": "Bild-Layout für Veranstaltung",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
-    "Larghezza piena (originale)": "Volle Breite (original)",
-    "Miniatura affiancata": "Miniaturbild seitlich",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
     "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
-    "Foto 3:2 (consigliato)": "Foto 3:2 (empfohlen)",
-    "Banner 16:9": "Banner 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Klein zentriert (max. 420px) — empfohlen",
+    "Miniatura affiancata al testo (240px)": "Miniaturbild neben dem Text (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Niedriges Banner über die volle Breite (max. Höhe 220px)",
+    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
     "Layout immagine evento": "Bild-Layout für Veranstaltung",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
-    "Adattato (max 480px) — consigliato": "Angepasst (max. 480px) — empfohlen",
-    "Banner 16:9 (ritagliato)": "Banner 16:9 (zugeschnitten)",
     "Larghezza piena (originale)": "Volle Breite (original)",
     "Miniatura affiancata": "Miniaturbild seitlich",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
-    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert."
+    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
+    "Foto 3:2 (consigliato)": "Foto 3:2 (empfohlen)",
+    "Banner 16:9": "Banner 16:9"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4682,8 +4682,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
     "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
-    "Piccola centrata (max 420px) — consigliato": "Klein zentriert (max. 420px) — empfohlen",
     "Miniatura affiancata al testo (240px)": "Miniaturbild neben dem Text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Niedriges Banner über die volle Breite (max. Höhe 220px)",
-    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)"
+    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)",
+    "Piccola a sinistra (max 420px) — consigliato": "Klein linksbündig (max. 420px) — empfohlen"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
     "Layout immagine evento": "Event image layout",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
-    "Adattato (max 480px) — consigliato": "Contained (max 480px) — recommended",
-    "Banner 16:9 (ritagliato)": "Banner 16:9 (cropped)",
     "Larghezza piena (originale)": "Full width (original)",
     "Miniatura affiancata": "Side thumbnail",
     "Salva impostazioni eventi": "Save event settings",
-    "Impostazioni eventi aggiornate.": "Event settings updated."
+    "Impostazioni eventi aggiornate.": "Event settings updated.",
+    "Foto 3:2 (consigliato)": "Photo 3:2 (recommended)",
+    "Banner 16:9": "Banner 16:9"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4682,8 +4682,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
     "Salva impostazioni eventi": "Save event settings",
     "Impostazioni eventi aggiornate.": "Event settings updated.",
-    "Piccola centrata (max 420px) — consigliato": "Small centred (max 420px) — recommended",
     "Miniatura affiancata al testo (240px)": "Thumbnail next to text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Low full-width banner (max height 220px)",
-    "Originale a tutta larghezza (grande)": "Original full width (large)"
+    "Originale a tutta larghezza (grande)": "Original full width (large)",
+    "Piccola a sinistra (max 420px) — consigliato": "Small left-aligned (max 420px) — recommended"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4677,5 +4677,13 @@
     "Eliminare questa copia digitalizzata?": "Delete this digitised copy?",
     "Errore di rete.": "Network error.",
     "MD5 non valido (32 caratteri esadecimali).": "Invalid MD5 (32 hexadecimal characters).",
-    "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer."
+    "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
+    "Layout immagine evento": "Event image layout",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
+    "Adattato (max 480px) — consigliato": "Contained (max 480px) — recommended",
+    "Banner 16:9 (ritagliato)": "Banner 16:9 (cropped)",
+    "Larghezza piena (originale)": "Full width (original)",
+    "Miniatura affiancata": "Side thumbnail",
+    "Salva impostazioni eventi": "Save event settings",
+    "Impostazioni eventi aggiornate.": "Event settings updated."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
     "Layout immagine evento": "Event image layout",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
-    "Larghezza piena (originale)": "Full width (original)",
-    "Miniatura affiancata": "Side thumbnail",
     "Salva impostazioni eventi": "Save event settings",
     "Impostazioni eventi aggiornate.": "Event settings updated.",
-    "Foto 3:2 (consigliato)": "Photo 3:2 (recommended)",
-    "Banner 16:9": "Banner 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Small centred (max 420px) — recommended",
+    "Miniatura affiancata al testo (240px)": "Thumbnail next to text (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Low full-width banner (max height 220px)",
+    "Originale a tutta larghezza (grande)": "Original full width (large)"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5006,10 +5006,10 @@
     "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
     "Layout immagine evento": "Mise en page de l'image de l'événement",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
-    "Adattato (max 480px) — consigliato": "Contenue (max 480px) — recommandée",
-    "Banner 16:9 (ritagliato)": "Bannière 16:9 (recadrée)",
     "Larghezza piena (originale)": "Pleine largeur (originale)",
     "Miniatura affiancata": "Vignette latérale",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
-    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour."
+    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
+    "Foto 3:2 (consigliato)": "Photo 3:2 (recommandé)",
+    "Banner 16:9": "Bannière 16:9"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5006,10 +5006,10 @@
     "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
     "Layout immagine evento": "Mise en page de l'image de l'événement",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
-    "Larghezza piena (originale)": "Pleine largeur (originale)",
-    "Miniatura affiancata": "Vignette latérale",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
     "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
-    "Foto 3:2 (consigliato)": "Photo 3:2 (recommandé)",
-    "Banner 16:9": "Bannière 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Petite centrée (max 420px) — recommandée",
+    "Miniatura affiancata al testo (240px)": "Vignette à côté du texte (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Bannière basse pleine largeur (hauteur max 220px)",
+    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5008,8 +5008,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
     "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
-    "Piccola centrata (max 420px) — consigliato": "Petite centrée (max 420px) — recommandée",
     "Miniatura affiancata al testo (240px)": "Vignette à côté du texte (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Bannière basse pleine largeur (hauteur max 220px)",
-    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)"
+    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)",
+    "Piccola a sinistra (max 420px) — consigliato": "Petite alignée à gauche (max 420px) — recommandée"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5003,5 +5003,13 @@
     "Copia digitalizzata eliminata": "Copie numérisée supprimée",
     "URL non sicuro": "URL non sécurisée",
     "MD5 non valido (32 caratteri esadecimali).": "MD5 invalide (32 caractères hexadécimaux).",
-    "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif."
+    "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
+    "Layout immagine evento": "Mise en page de l'image de l'événement",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
+    "Adattato (max 480px) — consigliato": "Contenue (max 480px) — recommandée",
+    "Banner 16:9 (ritagliato)": "Bannière 16:9 (recadrée)",
+    "Larghezza piena (originale)": "Pleine largeur (originale)",
+    "Miniatura affiancata": "Vignette latérale",
+    "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
+    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -511,10 +511,10 @@
   "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
   "Layout immagine evento": "Layout immagine evento",
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
-  "Larghezza piena (originale)": "Larghezza piena (originale)",
-  "Miniatura affiancata": "Miniatura affiancata",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
   "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
-  "Foto 3:2 (consigliato)": "Foto 3:2 (consigliato)",
-  "Banner 16:9": "Banner 16:9"
+  "Piccola centrata (max 420px) — consigliato": "Piccola centrata (max 420px) — consigliato",
+  "Miniatura affiancata al testo (240px)": "Miniatura affiancata al testo (240px)",
+  "Banner basso a tutta larghezza (max altezza 220px)": "Banner basso a tutta larghezza (max altezza 220px)",
+  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -511,10 +511,10 @@
   "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
   "Layout immagine evento": "Layout immagine evento",
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
-  "Adattato (max 480px) — consigliato": "Adattato (max 480px) — consigliato",
-  "Banner 16:9 (ritagliato)": "Banner 16:9 (ritagliato)",
   "Larghezza piena (originale)": "Larghezza piena (originale)",
   "Miniatura affiancata": "Miniatura affiancata",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
-  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate."
+  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
+  "Foto 3:2 (consigliato)": "Foto 3:2 (consigliato)",
+  "Banner 16:9": "Banner 16:9"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -508,5 +508,13 @@
   "URL non valido.": "URL non valido.",
   "MD5 non valido (32 caratteri esadecimali).": "MD5 non valido (32 caratteri esadecimali).",
   "Il valore deve essere un intero non negativo.": "Il valore deve essere un intero non negativo.",
-  "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente"
+  "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
+  "Layout immagine evento": "Layout immagine evento",
+  "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
+  "Adattato (max 480px) — consigliato": "Adattato (max 480px) — consigliato",
+  "Banner 16:9 (ritagliato)": "Banner 16:9 (ritagliato)",
+  "Larghezza piena (originale)": "Larghezza piena (originale)",
+  "Miniatura affiancata": "Miniatura affiancata",
+  "Salva impostazioni eventi": "Salva impostazioni eventi",
+  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -513,8 +513,8 @@
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
   "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
-  "Piccola centrata (max 420px) — consigliato": "Piccola centrata (max 420px) — consigliato",
   "Miniatura affiancata al testo (240px)": "Miniatura affiancata al testo (240px)",
   "Banner basso a tutta larghezza (max altezza 220px)": "Banner basso a tutta larghezza (max altezza 220px)",
-  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)"
+  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)",
+  "Piccola a sinistra (max 420px) — consigliato": "Piccola a sinistra (max 420px) — consigliato"
 }

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -258,6 +258,82 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     // ────────────────────────────────────────────────────────────────────
+    // Replace-while-removing regression (issue #137 follow-up):
+    // when the admin form posts BOTH a new featured_image file AND
+    // ticks "remove_image=1", the new upload must win — not be
+    // discarded along with the old image. Earlier code path used an
+    // if/elseif with remove_image first, silently dropping the
+    // upload.
+    //
+    // Reproduced end-to-end through the admin UI: login → open edit
+    // form → tick "Rimuovi immagine attuale" → also choose a new
+    // file via the hidden file input → submit → verify the DB row
+    // has a brand-new path (not NULL and not the original).
+    // ────────────────────────────────────────────────────────────────────
+    test('admin update: uploading a new image while ticking "remove" keeps the new image', async ({ page }) => {
+        // Bootstrap a "previous" image so the form actually shows the
+        // "Rimuovi immagine attuale" checkbox (it only renders when
+        // featured_image is non-empty).
+        const sqlPre = `/uploads/events/event_test_pre_${RUN_ID}.jpg`;
+        dbExec(`UPDATE events SET featured_image='${sqlEscape(sqlPre)}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+        const eventId = parseInt(
+            dbQuery(`SELECT id FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`),
+            10,
+        );
+        expect(eventId, 'seed event must exist').toBeGreaterThan(0);
+
+        // Admin login (the form requires it).
+        await page.goto(`${BASE}/accedi`);
+        await page.fill('input[name="email"]', ADMIN_EMAIL);
+        await page.fill('input[name="password"]', ADMIN_PASS);
+        await Promise.all([
+            page.waitForURL(/\/(admin|profilo)/, { timeout: 15000 }),
+            page.click('button[type="submit"]'),
+        ]);
+
+        // Open the edit form.
+        await page.goto(`${BASE}/admin/cms/events/edit/${eventId}`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // Tick the "Rimuovi immagine attuale" checkbox.
+        const removeCheckbox = page.locator('input[name="remove_image"]');
+        await expect(removeCheckbox).toHaveCount(1);
+        await removeCheckbox.check({ force: true });
+
+        // Attach a new image to the hidden file input — the same
+        // path the Uppy widget normally writes into.
+        await page.setInputFiles('input[name="featured_image"]', {
+            name: 'test-replacement.jpg',
+            mimeType: 'image/jpeg',
+            // 1x1 jpeg, base64-decoded — minimal valid file.
+            buffer: Buffer.from(
+                '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpgB//Z',
+                'base64',
+            ),
+        });
+
+        // Submit. The submit button label varies with locale but
+        // there's always a visible primary button inside the form.
+        const submitButton = page.locator('form button[type="submit"]').first();
+        await Promise.all([
+            page.waitForURL(/\/admin\/cms\/events(\?|$)/, { timeout: 15000 }),
+            submitButton.click(),
+        ]);
+
+        // Assert: the DB now points at a NEW upload, not NULL and
+        // not the original sentinel path.
+        const after = dbQuery(`SELECT featured_image FROM events WHERE id=${eventId}`);
+        expect(
+            after,
+            `featured_image MUST contain a new upload, not be cleared. Got: "${after}"`
+        ).toMatch(/^\/uploads\/events\/event_\d{8}_\d{6}_[a-f0-9]+\.(jpg|jpeg|png|webp)$/i);
+        expect(
+            after,
+            `featured_image MUST NOT match the pre-existing sentinel ("${sqlPre}")`
+        ).not.toBe(sqlPre);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
     // Containment regression — guards against the float-overflow bug
     // reported during initial review: when content is short, a floated
     // .event-cover--thumb escapes its parent .event-card and ends up

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -22,6 +22,8 @@
 
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
@@ -172,6 +174,33 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         // Cleanup: delete test event + restore the original
         // event_image_layout (DELETE if it was absent before the suite,
         // else UPDATE back to the captured original value).
+        //
+        // BEFORE the DB DELETE: if the admin-update test (or any future
+        // test) replaced the seed featured_image with a real upload via
+        // handleImageUpload(), the path now points at
+        // /uploads/events/event_*.jpg on disk. Bypassing the controller
+        // delete() means deleteUploadedImageFile() would never run —
+        // unlink the file here explicitly so the suite doesn't leave
+        // orphans behind. The seed value (`/assets/books.jpg`) is a
+        // static asset and is excluded by the /uploads/events/ prefix
+        // guard, so this is safe to call unconditionally.
+        const currentImage = dbQuery(
+            `SELECT featured_image FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`
+        );
+        if (currentImage && currentImage.startsWith('/uploads/events/')) {
+            const absPath = path.join(__dirname, '..', 'public', currentImage);
+            try {
+                fs.unlinkSync(absPath);
+            } catch (e) {
+                // ENOENT (already gone) is acceptable — the controller's
+                // own cleanup may have unlinked it on the success path.
+                // Any other error we surface to the test log but do not
+                // fail the teardown — the suite has finished otherwise.
+                if (e && e.code !== 'ENOENT') {
+                    console.warn(`teardown: could not unlink ${absPath}: ${e.message}`);
+                }
+            }
+        }
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
         if (eventImageLayoutWasAbsent) {
             dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -159,6 +159,82 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     // ────────────────────────────────────────────────────────────────────
+    // Effective-size regression (issue #137 user feedback): the four
+    // presets must actually render at DIFFERENT, progressively smaller
+    // dimensions. An earlier iteration of this feature shipped four
+    // visually-equivalent "full width" variants, defeating the purpose
+    // of the setting (the user explicitly asked for a smaller image).
+    //
+    // We assert:
+    //   contained  → figure narrower than the article (small centred)
+    //   thumb      → figure narrower than the article (side thumbnail)
+    //   banner     → figure at full article width, capped to ~220px tall
+    //   full       → figure at full article width, no height cap
+    //
+    // Using rendered bounding boxes (NOT computed CSS) catches the
+    // historical mistake where `width: 100%` was applied to all four
+    // variants but only the class name differed.
+    // ────────────────────────────────────────────────────────────────────
+    test('effective size — each preset renders at a distinct, smaller dimension', async ({ page }) => {
+        // Reset content to a long enough body so 'banner' / 'contained'
+        // have something below them to measure against.
+        const longContent = '<p>' + 'Test event description. '.repeat(40) + '</p>';
+        const sqlSafeLong = longContent.replace(/'/g, "\\'");
+        dbExec(`UPDATE events SET content='${sqlSafeLong}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+
+        await page.setViewportSize({ width: 1280, height: 900 });
+
+        async function measure(layout) {
+            setLayout(layout);
+            await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+            const card = page.locator('article.event-card').first();
+            const fig  = page.locator('figure.event-cover').first();
+            await expect(card).toBeVisible();
+            await expect(fig).toBeVisible();
+            const cardBox = await card.boundingBox();
+            const figBox  = await fig.boundingBox();
+            return { cardWidth: cardBox.width, figWidth: figBox.width, figHeight: figBox.height };
+        }
+
+        const full      = await measure('full');
+        const banner    = await measure('banner');
+        const contained = await measure('contained');
+        const thumb     = await measure('thumb');
+
+        // full: figure width equals the inner card width (within padding tolerance)
+        expect(
+            full.figWidth,
+            `full layout: figure should fill the card width (got ${full.figWidth}px, card ${full.cardWidth}px)`
+        ).toBeGreaterThan(full.cardWidth * 0.85);
+
+        // banner: width like full, height ~ 220px (within ±5px CSS rendering tolerance)
+        expect(
+            banner.figWidth,
+            `banner layout: figure should be full-width (got ${banner.figWidth}px, card ${banner.cardWidth}px)`
+        ).toBeGreaterThan(banner.cardWidth * 0.85);
+        expect(
+            banner.figHeight,
+            `banner layout: figure height must be capped to ~220px (got ${banner.figHeight}px)`
+        ).toBeLessThanOrEqual(225);
+
+        // contained: max-width 420px, NARROWER than the card
+        expect(
+            contained.figWidth,
+            `contained layout: figure must be ≤ 420px wide (got ${contained.figWidth}px) — the whole point of the default preset`
+        ).toBeLessThanOrEqual(420);
+        expect(
+            contained.figWidth,
+            `contained layout: figure must be visibly narrower than the card (got ${contained.figWidth}px vs card ${contained.cardWidth}px)`
+        ).toBeLessThan(contained.cardWidth * 0.7);
+
+        // thumb: ~240px wide (grid column), NARROWER than the card
+        expect(
+            thumb.figWidth,
+            `thumb layout: figure must be ≤ 240px wide (got ${thumb.figWidth}px)`
+        ).toBeLessThanOrEqual(245);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
     // Containment regression — guards against the float-overflow bug
     // reported during initial review: when content is short, a floated
     // .event-cover--thumb escapes its parent .event-card and ends up

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -157,4 +157,51 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         setLayout('thumb');
         await expectLayout(page, 'thumb');
     });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Containment regression — guards against the float-overflow bug
+    // reported during initial review: when content is short, a floated
+    // .event-cover--thumb escapes its parent .event-card and ends up
+    // visually on top of the page footer.
+    //
+    // The grid-based refactor places the figure in its own row/column,
+    // so geometrically the figure can never extend below its parent
+    // article. The test asserts that invariant at desktop width.
+    // ────────────────────────────────────────────────────────────────────
+    test('thumb layout: short-body event keeps the figure inside its article (no float overflow)', async ({ page }) => {
+        setLayout('thumb');
+
+        // Shrink the event content so a CSS float would expose the bug.
+        const shortContent = '<p>Breve.</p>';
+        const sqlSafe = shortContent.replace(/'/g, "\\'");
+        dbExec(`UPDATE events SET content='${sqlSafe}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+
+        // Desktop viewport — the grid kicks in at >=768px.
+        await page.setViewportSize({ width: 1280, height: 900 });
+        await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+
+        const card = page.locator('article.event-card').first();
+        const fig  = page.locator('figure.event-cover--thumb').first();
+        await expect(card).toBeVisible();
+        await expect(fig).toBeVisible();
+
+        // Card must carry the modifier that activates the grid layout.
+        await expect(card).toHaveClass(/event-card--thumb-layout/);
+
+        // Bounding-box invariant: figure.bottom MUST be <= card.bottom.
+        // If the float regression returns, figure.bottom escapes the
+        // parent and this assertion fails loudly.
+        const cardBox = await card.boundingBox();
+        const figBox  = await fig.boundingBox();
+        expect(cardBox, 'event-card must have a bounding box').not.toBeNull();
+        expect(figBox, 'event-cover--thumb must have a bounding box').not.toBeNull();
+        if (cardBox && figBox) {
+            const cardBottom = cardBox.y + cardBox.height;
+            const figBottom  = figBox.y  + figBox.height;
+            expect(
+                figBottom,
+                `figure bottom (${figBottom}) must stay within card bottom (${cardBottom}) — the float-overflow regression has returned`
+            ).toBeLessThanOrEqual(cardBottom + 1);
+        }
+    });
 });

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -1,0 +1,160 @@
+// @ts-check
+//
+// Regression test for issue #137 — admin-configurable layout for the
+// featured image on event detail pages (`/eventi/<slug>`).
+//
+// Coverage (5 cases):
+//   1. Default fallback ('contained') when the setting row is missing
+//   2. Explicit layout = 'full'         (legacy full-width-no-constraint)
+//   3. Explicit layout = 'banner'       (16:9 cropped)
+//   4. Explicit layout = 'contained'    (max-height: 480px, object-fit: contain)
+//   5. Explicit layout = 'thumb'        (right-floated 3:4 thumbnail)
+//
+// Each case sets `cms.event_image_layout` directly in the KV store
+// (`system_settings`), navigates to the event detail page, and asserts:
+//   • the figure has the class `event-cover--<layout>`
+//   • the figure has `data-event-cover-layout="<layout>"`
+//   • exactly one cover figure is rendered
+//
+// Run:
+//   /tmp/run-e2e.sh tests/issue-137-event-image-layout.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+const DB_USER     = process.env.E2E_DB_USER     || '';
+const DB_PASS     = process.env.E2E_DB_PASS     || '';
+const DB_SOCKET   = process.env.E2E_DB_SOCKET   || '';
+const DB_NAME     = process.env.E2E_DB_NAME     || '';
+
+test.skip(
+    !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_PASS || !DB_NAME,
+    'E2E credentials not configured (set E2E_ADMIN_*, E2E_DB_*)',
+);
+
+const RUN_ID    = Date.now().toString(36);
+const EVENT_TITLE = `Issue 137 Layout Test ${RUN_ID}`;
+const EVENT_SLUG  = `issue-137-layout-test-${RUN_ID}`;
+const EVENT_IMG   = '/assets/books.jpg'; // ships in public/assets
+
+function dbExec(sql) {
+    const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-e', sql];
+    if (DB_SOCKET) args.splice(3, 0, '-S', DB_SOCKET);
+    execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 });
+}
+
+function dbQuery(sql) {
+    const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-N', '-B', '-e', sql];
+    if (DB_SOCKET) args.splice(3, 0, '-S', DB_SOCKET);
+    return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 }).trim();
+}
+
+function sqlEscape(s) {
+    // MySQL string escape — sufficient for test fixtures where the input
+    // is controlled (no untrusted data here, but we don't want a stray
+    // apostrophe to break the seed).
+    return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function setLayout(layout) {
+    if (layout === null) {
+        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        return;
+    }
+    dbExec(`
+        INSERT INTO system_settings (category, setting_key, setting_value)
+        VALUES ('cms', 'event_image_layout', '${sqlEscape(layout)}')
+        ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)
+    `);
+}
+
+test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
+
+    test.beforeAll(async () => {
+        // Make sure the events page is enabled (the frontend controller
+        // 404s otherwise).
+        dbExec(`
+            INSERT INTO system_settings (category, setting_key, setting_value)
+            VALUES ('cms', 'events_page_enabled', '1')
+            ON DUPLICATE KEY UPDATE setting_value='1'
+        `);
+
+        // Seed one event with a featured_image. event_date is today so it
+        // is reachable from the public listing too.
+        dbExec(`
+            INSERT INTO events (title, slug, content, event_date, event_time, featured_image, is_active)
+            VALUES (
+                '${sqlEscape(EVENT_TITLE)}',
+                '${sqlEscape(EVENT_SLUG)}',
+                '<p>Issue 137 test event</p>',
+                CURDATE(),
+                '18:00:00',
+                '${sqlEscape(EVENT_IMG)}',
+                1
+            )
+        `);
+    });
+
+    test.afterAll(async () => {
+        // Cleanup: delete test event + reset layout setting to default.
+        dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+    });
+
+    /**
+     * Shared assertion: fetch the event page, assert the figure has the
+     * expected layout class + data attribute, and that there's exactly
+     * one cover figure (no duplicate rendering from a stale partial).
+     */
+    async function expectLayout(page, expected) {
+        const url = `${BASE}/eventi/${EVENT_SLUG}`;
+        const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
+        expect(response, `GET ${url} must succeed`).not.toBeNull();
+        // Defense in depth — some Apache setups normalise 200 → 200 but
+        // a 404 here would mean events_page_enabled rolled back, which
+        // the test should surface explicitly.
+        expect(
+            response.status(),
+            `GET ${url} returned ${response.status()} — events_page_enabled may have been disabled`
+        ).toBeLessThan(400);
+
+        const cover = page.locator('figure.event-cover');
+        await expect(cover).toHaveCount(1);
+
+        // Class assertion: figure must carry the layout-specific modifier.
+        await expect(cover).toHaveClass(new RegExp(`event-cover--${expected}\\b`));
+
+        // Data attribute — survives any future CSS class rename and is
+        // a stable hook for further QA tooling.
+        await expect(cover).toHaveAttribute('data-event-cover-layout', expected);
+    }
+
+    test('1/5 default — when cms.event_image_layout is unset, falls back to contained', async ({ page }) => {
+        setLayout(null);
+        await expectLayout(page, 'contained');
+    });
+
+    test('2/5 full — explicit layout=full applies event-cover--full', async ({ page }) => {
+        setLayout('full');
+        await expectLayout(page, 'full');
+    });
+
+    test('3/5 banner — explicit layout=banner applies event-cover--banner', async ({ page }) => {
+        setLayout('banner');
+        await expectLayout(page, 'banner');
+    });
+
+    test('4/5 contained — explicit layout=contained applies event-cover--contained', async ({ page }) => {
+        setLayout('contained');
+        await expectLayout(page, 'contained');
+    });
+
+    test('5/5 thumb — explicit layout=thumb applies event-cover--thumb', async ({ page }) => {
+        setLayout('thumb');
+        await expectLayout(page, 'thumb');
+    });
+});

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -6,9 +6,9 @@
 // Coverage (5 cases):
 //   1. Default fallback ('contained') when the setting row is missing
 //   2. Explicit layout = 'full'         (legacy full-width-no-constraint)
-//   3. Explicit layout = 'banner'       (16:9 cropped)
-//   4. Explicit layout = 'contained'    (max-height: 480px, object-fit: contain)
-//   5. Explicit layout = 'thumb'        (right-floated 3:4 thumbnail)
+//   3. Explicit layout = 'banner'       (low banner, capped at 220px height with object-fit:cover)
+//   4. Explicit layout = 'contained'    (max-width 420px left-aligned, max-height 320px, object-fit: contain)
+//   5. Explicit layout = 'thumb'        (side thumbnail via CSS grid + .event-card--thumb-layout, 3:4 portrait)
 //
 // Each case sets `cms.event_image_layout` directly in the KV store
 // (`system_settings`), navigates to the event detail page, and asserts:
@@ -72,9 +72,56 @@ function setLayout(layout) {
     `);
 }
 
+// Locale-aware events URL prefix. Captured in beforeAll so cross-locale
+// installs (en_US, de_DE) don't silently 404 against a hardcoded
+// Italian /eventi/ prefix. Defaults to /eventi (the Italian path) when
+// the locale row is absent so existing IT installs behave unchanged.
+const EVENT_URL_PREFIX_BY_LOCALE = {
+    it_IT: '/eventi',
+    en_US: '/events',
+    de_DE: '/events',
+};
+let EVENT_URL_PREFIX = '/eventi';
+
+// Snapshot for events_page_enabled so afterAll can restore the original
+// admin choice rather than leave the test seed (=1) behind.
+//   null   → the row was absent before the test ran (DELETE on restore)
+//   string → original setting_value (UPDATE back on restore)
+let originalEventsPageEnabled = null;
+let eventsPageEnabledWasAbsent = false;
+
 test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
 
     test.beforeAll(async () => {
+        // Resolve locale-aware events URL prefix once. Falls back to
+        // /eventi when the locale row is missing (matches installer
+        // default and keeps legacy IT installs working).
+        let locale = 'it_IT';
+        try {
+            const localeRow = dbQuery(
+                `SELECT setting_value FROM system_settings WHERE category='app' AND setting_key='locale'`
+            );
+            if (localeRow) {
+                locale = localeRow;
+            }
+        } catch (e) {
+            // Best-effort — keep the IT default.
+        }
+        EVENT_URL_PREFIX = EVENT_URL_PREFIX_BY_LOCALE[locale] || '/eventi';
+
+        // Snapshot the events_page_enabled setting so we can restore
+        // it in afterAll (test pollution guard).
+        const existing = dbQuery(
+            `SELECT setting_value FROM system_settings WHERE category='cms' AND setting_key='events_page_enabled'`
+        );
+        if (existing === '' || existing === null) {
+            eventsPageEnabledWasAbsent = true;
+            originalEventsPageEnabled = null;
+        } else {
+            eventsPageEnabledWasAbsent = false;
+            originalEventsPageEnabled = existing;
+        }
+
         // Make sure the events page is enabled (the frontend controller
         // 404s otherwise).
         dbExec(`
@@ -103,6 +150,18 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         // Cleanup: delete test event + reset layout setting to default.
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
         dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+
+        // Restore events_page_enabled to its pre-test value so we do
+        // not leave permanent test-state pollution behind.
+        if (eventsPageEnabledWasAbsent) {
+            dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='events_page_enabled'`);
+        } else {
+            dbExec(`
+                UPDATE system_settings
+                   SET setting_value='${sqlEscape(originalEventsPageEnabled)}'
+                 WHERE category='cms' AND setting_key='events_page_enabled'
+            `);
+        }
     });
 
     /**
@@ -111,7 +170,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
      * one cover figure (no duplicate rendering from a stale partial).
      */
     async function expectLayout(page, expected) {
-        const url = `${BASE}/eventi/${EVENT_SLUG}`;
+        const url = `${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`;
         const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
         expect(response, `GET ${url} must succeed`).not.toBeNull();
         // Defense in depth — some Apache setups normalise 200 → 200 but
@@ -186,7 +245,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
 
         async function measure(layout) {
             setLayout(layout);
-            await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+            await page.goto(`${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
             const card = page.locator('article.event-card').first();
             const fig  = page.locator('figure.event-cover').first();
             await expect(card).toBeVisible();
@@ -353,7 +412,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
 
         // Desktop viewport — the grid kicks in at >=768px.
         await page.setViewportSize({ width: 1280, height: 900 });
-        await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
 
         const card = page.locator('article.event-card').first();
         const fig  = page.locator('figure.event-cover--thumb').first();

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -193,7 +193,13 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             await expect(fig).toBeVisible();
             const cardBox = await card.boundingBox();
             const figBox  = await fig.boundingBox();
-            return { cardWidth: cardBox.width, figWidth: figBox.width, figHeight: figBox.height };
+            return {
+                cardX: cardBox.x,
+                cardWidth: cardBox.width,
+                figX: figBox.x,
+                figWidth: figBox.width,
+                figHeight: figBox.height,
+            };
         }
 
         const full      = await measure('full');
@@ -227,11 +233,28 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             `contained layout: figure must be visibly narrower than the card (got ${contained.figWidth}px vs card ${contained.cardWidth}px)`
         ).toBeLessThan(contained.cardWidth * 0.7);
 
+        // contained: must be LEFT-ALIGNED (figure.x ≈ card.x + padding).
+        // If a future refactor reintroduces margin: auto the figure
+        // would centre and figX would shift toward cardWidth/2 — guard
+        // against that here. We allow up to 100px of inner padding.
+        const containedOffsetFromLeft = contained.figX - contained.cardX;
+        expect(
+            containedOffsetFromLeft,
+            `contained layout: figure must be left-aligned (offset from card.left should be ≤ 100px of padding, got ${containedOffsetFromLeft}px)`
+        ).toBeLessThanOrEqual(100);
+
         // thumb: ~240px wide (grid column), NARROWER than the card
         expect(
             thumb.figWidth,
             `thumb layout: figure must be ≤ 240px wide (got ${thumb.figWidth}px)`
         ).toBeLessThanOrEqual(245);
+
+        // thumb: must be left-aligned too (grid column 1).
+        const thumbOffsetFromLeft = thumb.figX - thumb.cardX;
+        expect(
+            thumbOffsetFromLeft,
+            `thumb layout: figure must occupy the left grid column (offset ≤ 100px, got ${thumbOffsetFromLeft}px)`
+        ).toBeLessThanOrEqual(100);
     });
 
     // ────────────────────────────────────────────────────────────────────

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -90,6 +90,14 @@ let EVENT_URL_PREFIX = '/eventi';
 let originalEventsPageEnabled = null;
 let eventsPageEnabledWasAbsent = false;
 
+// Same shape, but for event_image_layout. Per-test setLayout() rewrites
+// this row, and the original afterAll unconditionally DELETEd it — which
+// destroyed an admin's pre-existing custom layout choice on every run.
+// Snapshot once at startup and restore the original value (or DELETE if
+// absent) at teardown. Matches the events_page_enabled pattern above.
+let originalEventImageLayout = null;
+let eventImageLayoutWasAbsent = false;
+
 test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
 
     test.beforeAll(async () => {
@@ -122,6 +130,20 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             originalEventsPageEnabled = existing;
         }
 
+        // Snapshot event_image_layout too — setLayout() rewrites it in
+        // every test, and the original DELETE-on-teardown destroyed any
+        // pre-existing custom choice the admin had configured.
+        const existingLayout = dbQuery(
+            `SELECT setting_value FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`
+        );
+        if (existingLayout === '' || existingLayout === null) {
+            eventImageLayoutWasAbsent = true;
+            originalEventImageLayout = null;
+        } else {
+            eventImageLayoutWasAbsent = false;
+            originalEventImageLayout = existingLayout;
+        }
+
         // Make sure the events page is enabled (the frontend controller
         // 404s otherwise).
         dbExec(`
@@ -147,9 +169,19 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     test.afterAll(async () => {
-        // Cleanup: delete test event + reset layout setting to default.
+        // Cleanup: delete test event + restore the original
+        // event_image_layout (DELETE if it was absent before the suite,
+        // else UPDATE back to the captured original value).
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
-        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        if (eventImageLayoutWasAbsent) {
+            dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        } else {
+            dbExec(`
+                INSERT INTO system_settings (category, setting_key, setting_value)
+                VALUES ('cms', 'event_image_layout', '${sqlEscape(originalEventImageLayout)}')
+                ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)
+            `);
+        }
 
         // Restore events_page_enabled to its pre-test value so we do
         // not leave permanent test-state pollution behind.


### PR DESCRIPTION
## Summary

Closes #137.

Adds an admin-controlled layout setting for the featured image on the public event detail page (`/eventi/<slug>`). The previous CSS rendered every uploaded image at 100% container width with no height constraint, so a 1791×927 cover (the case @HansUwe52 reported) dominated the viewport.

A new setting `cms.event_image_layout` lives in the existing CMS settings tab. Four presets, in increasing visual footprint:

| Preset | Effective size | Use case |
|---|---|---|
| **Piccola a sinistra** (default) | max 420px wide, left-aligned, max 320px tall | Small inline poster — solves the original complaint |
| **Miniatura affiancata al testo** | 240px wide, side-by-side with body text via CSS grid | Side thumbnail; mobile collapses to vertical stack |
| **Banner basso a tutta larghezza** | 100% wide, capped at 220px tall | Low decorative strip |
| **Originale a tutta larghezza** | 100% wide, natural height | Legacy behaviour (opt-in) |

All four labels are translated in `it_IT`, `en_US`, `de_DE`, `fr_FR` in the same commit (per i18n policy).

### Architecture

- **Storage**: KV row in `system_settings` (category=`cms`, key=`event_image_layout`). No migration needed.
- **Form**: rendered inside the existing 'Eventi' card on the CMS settings tab, no new tab to discover.
- **Route**: `POST /admin/settings/events` (CSRF + AdminAuth middleware), pattern identical to `updateLabels`/`updateSharingSettings`.
- **Frontend**: controller validates the value against an allow-list before passing it to the view; the view re-narrows once more as defence in depth so a future controller refactor cannot leak an unknown layout into the DOM.

### Bonus fix in the same branch

While reviewing the events admin form a separate bug was found (last commit): when the admin submits the edit form with BOTH a new `featured_image` upload AND `remove_image=1` checked, the previous `if/elseif` evaluated `remove_image` first and silently discarded the upload. The branch flips the priority (upload wins) and adds best-effort cleanup of the orphaned file from `public/uploads/events/`, path-traversal-safe.

## Test plan

8 cases in `tests/issue-137-event-image-layout.spec.js`, all passing:

- [x] Default fallback: when `cms.event_image_layout` is unset, the page renders `event-cover--contained`
- [x] Explicit `full` → `event-cover--full` class + `data-event-cover-layout='full'`
- [x] Explicit `banner` → `event-cover--banner`
- [x] Explicit `contained` → `event-cover--contained`
- [x] Explicit `thumb` → `event-cover--thumb`
- [x] **Effective size regression**: measures rendered bounding boxes per preset and asserts `contained.width ≤ 420px AND < 70% card.width`, `thumb.width ≤ 245px`, `banner.height ≤ 225px`, `full.width > 85% card.width`. Also asserts `contained` and `thumb` are left-aligned (figure.x within 100px of card.x).
- [x] **Float-overflow regression** (thumb layout): with very short body content, asserts `figure.bottom ≤ card.bottom` — the invariant the original `float: right` design violated.
- [x] **Replace-while-removing regression**: drives the actual admin form (login → tick remove checkbox → attach a new file → submit) and asserts the DB row points at a new upload path matching `handleImageUpload()`'s naming scheme, not NULL and not the original.

Run locally:

```
E2E_ADMIN_PASS='...' /tmp/run-e2e.sh tests/issue-137-event-image-layout.spec.js \
  --config=tests/playwright.config.js --workers=1
```

PHPStan: clean on the 5 PHP files touched (pre-existing `storage/plugins/{archives,bibframe-linked-data,discogs}/...` warnings on `main` remain at 11 and are out of scope here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opzione admin per configurare il layout dell'immagine di copertina eventi (contained, thumb, banner, full) con nuovo form e endpoint per salvare la scelta.

* **UI / Frontend**
  * Rendering e CSS aggiornati per quattro varianti di hero image; markup e classi dedicate, comportamento responsive e layout thumb affiancato.

* **Bug Fixes**
  * Upload/replace/delete immagini resi più sicuri: priorità corretta tra upload/remove, cleanup di file temporanei e rimozione difensiva del file precedente.

* **Tests**
  * Nuovi test E2E per i layout immagine e per i casi di update/remove durante l'upload.

* **Localization**
  * Nuove traduzioni in it/en/de/fr per le impostazioni e i layout immagine.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fabiodalez-dev/Pinakes/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->