### PR TITLE
Unify client-side popups to SweetAlert2 (closes #140)

### DIFF
--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -339,10 +339,12 @@ class EventsController
             $featuredImagePath = null;
         }
 
-        // Look up the previous featured_image so we can unlink the
-        // orphaned file after the UPDATE succeeds. We do this BEFORE
-        // the error short-circuit below so $oldImagePath is always
-        // populated when $updateImage is true.
+        // Snapshot the previous featured_image before the UPDATE so we can
+        // unlink the orphan file in the success branch. The validation-error
+        // and UPDATE-fail branches unlink the freshly-uploaded
+        // $featuredImagePath instead; this lookup is only consumed by the
+        // post-commit success path. Capturing it here keeps the snapshot
+        // adjacent to its use site.
         $oldImagePath = null;
         if ($updateImage) {
             $oldStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -316,20 +316,45 @@ class EventsController
         $twitterDescription = $sanitizeText($data['twitter_description'] ?? '');
         $twitterImage = $sanitizeText($data['twitter_image'] ?? '');
 
-        // Handle image upload or removal
+        // Handle image upload or removal.
+        //
+        // Priority order (matters when the user submits BOTH a new file
+        // AND ticks "remove_image"): the new upload wins. Treating
+        // "remove" as the dominant intent would silently destroy a
+        // freshly uploaded file, which is what users hit before this
+        // branch.
         $featuredImagePath = null;
         $updateImage = false;
 
-        if (isset($data['remove_image']) && $data['remove_image'] == '1') {
-            $updateImage = true;
-            $featuredImagePath = null;
-        } elseif (isset($files['featured_image']) && $files['featured_image']->getError() === UPLOAD_ERR_OK) {
+        if (isset($files['featured_image']) && $files['featured_image']->getError() === UPLOAD_ERR_OK) {
             $uploadResult = $this->handleImageUpload($files['featured_image']);
             if (!$uploadResult['success']) {
                 $errors[] = $uploadResult['message'];
             } else {
                 $updateImage = true;
                 $featuredImagePath = $uploadResult['path'];
+            }
+        } elseif (isset($data['remove_image']) && $data['remove_image'] == '1') {
+            $updateImage = true;
+            $featuredImagePath = null;
+        }
+
+        // Look up the previous featured_image so we can unlink the
+        // orphaned file after the UPDATE succeeds. We do this BEFORE
+        // the error short-circuit below so $oldImagePath is always
+        // populated when $updateImage is true.
+        $oldImagePath = null;
+        if ($updateImage) {
+            $oldStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");
+            if ($oldStmt !== false) {
+                $oldStmt->bind_param('i', $id);
+                $oldStmt->execute();
+                $oldResult = $oldStmt->get_result();
+                $oldRow = $oldResult ? $oldResult->fetch_assoc() : null;
+                $oldStmt->close();
+                if (is_array($oldRow) && !empty($oldRow['featured_image'])) {
+                    $oldImagePath = (string) $oldRow['featured_image'];
+                }
             }
         }
 
@@ -377,12 +402,52 @@ class EventsController
 
         if ($stmt->execute()) {
             $_SESSION['success_message'] = __('Evento aggiornato con successo!');
+            // Cleanup orphan file on disk now that the DB row no longer
+            // references it. Skipped when the old path matches the new
+            // one (defensive — should not happen, but unlinking would
+            // delete a still-referenced file).
+            if ($updateImage && $oldImagePath !== null && $oldImagePath !== $featuredImagePath) {
+                $this->deleteUploadedImageFile($oldImagePath);
+            }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'aggiornamento dell\'evento.');
         }
         $stmt->close();
 
         return $response->withHeader('Location', '/admin/cms/events')->withStatus(302);
+    }
+
+    /**
+     * Best-effort unlink of an orphaned event image under
+     * public/uploads/events/. Path-traversal-safe: the supplied
+     * relative path is rejected unless it points inside the events
+     * upload directory (matches the safety contract of
+     * handleImageUpload()).
+     */
+    private function deleteUploadedImageFile(?string $relativePath): void
+    {
+        if ($relativePath === null || $relativePath === '') {
+            return;
+        }
+        // Must look like a value produced by handleImageUpload().
+        if (strpos($relativePath, '/uploads/events/') !== 0) {
+            return;
+        }
+        $baseDir = realpath(__DIR__ . '/../../public/uploads/events');
+        if ($baseDir === false) {
+            return;
+        }
+        $candidate = __DIR__ . '/../../public' . $relativePath;
+        $realCandidate = realpath($candidate);
+        if ($realCandidate === false) {
+            return;
+        }
+        // Confirm the resolved path is genuinely inside the events
+        // directory — defends against symlink shenanigans.
+        if (strpos($realCandidate, $baseDir . DIRECTORY_SEPARATOR) !== 0) {
+            return;
+        }
+        @unlink($realCandidate);
     }
 
     /**

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -4,6 +4,7 @@ namespace App\Controllers;
 
 use App\Support\ContentSanitizer;
 use App\Support\HtmlHelper;
+use App\Support\SecureLogger;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -479,7 +480,19 @@ class EventsController
         if (strpos($realCandidate, $baseDir . DIRECTORY_SEPARATOR) !== 0) {
             return;
         }
-        @unlink($realCandidate);
+        // Check the unlink result instead of suppressing — silent failures
+        // here mean orphan files accumulating on disk with no operator
+        // signal. SecureLogger redacts secrets/paths the way error_log
+        // does not. error_get_last() captures the underlying errno
+        // message (permission denied, etc.) right after the failed call.
+        if (!unlink($realCandidate)) {
+            $err = error_get_last();
+            SecureLogger::error('EventsController::deleteUploadedImageFile unlink failed', [
+                'path' => $realCandidate,
+                'errno' => $err['type'] ?? null,
+                'message' => $err['message'] ?? 'unknown',
+            ]);
+        }
     }
 
     /**

--- a/app/Controllers/EventsController.php
+++ b/app/Controllers/EventsController.php
@@ -359,6 +359,16 @@ class EventsController
         }
 
         if (!empty($errors)) {
+            // Cleanup orphan upload on validation-error short-circuit:
+            // handleImageUpload() has already moved the new file to its
+            // final path before non-image validation ran. Since we are
+            // bailing out without writing the DB row, the file would
+            // become an orphan on disk. Unlink it here so the disk
+            // state matches the DB state (which still references the
+            // old image, if any).
+            if ($updateImage && $featuredImagePath !== null) {
+                $this->deleteUploadedImageFile($featuredImagePath);
+            }
             $_SESSION['error_message'] = implode('<br>', $errors);
             return $response->withHeader('Location', '/admin/cms/events/edit/' . $id)->withStatus(302);
         }
@@ -411,6 +421,13 @@ class EventsController
             }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'aggiornamento dell\'evento.');
+            // Symmetric cleanup on UPDATE failure: the new file made it
+            // to disk via handleImageUpload(), but the DB row still
+            // references the OLD path. Unlink the freshly-uploaded
+            // file to avoid leaving an unreferenced orphan behind.
+            if ($updateImage && $featuredImagePath !== null) {
+                $this->deleteUploadedImageFile($featuredImagePath);
+            }
         }
         $stmt->close();
 
@@ -423,6 +440,19 @@ class EventsController
      * relative path is rejected unless it points inside the events
      * upload directory (matches the safety contract of
      * handleImageUpload()).
+     *
+     * Callsites (keep the four in sync — they implement the
+     * "file on disk must never outlive the DB reference" invariant):
+     *   1. update() success branch with image replacement — unlinks the
+     *      OLD path after the UPDATE commits.
+     *   2. update() failure branch — unlinks the NEWLY-uploaded path
+     *      because the UPDATE rolled back and the DB still points to
+     *      the old file.
+     *   3. update() validation-error short-circuit — unlinks the
+     *      NEWLY-uploaded path because we redirect before writing the
+     *      DB row.
+     *   4. delete() success branch — unlinks the path captured BEFORE
+     *      the DELETE, now that the row is gone.
      */
     private function deleteUploadedImageFile(?string $relativePath): void
     {
@@ -460,12 +490,33 @@ class EventsController
 
         $id = (int)($args['id'] ?? 0);
 
+        // Capture the featured_image path BEFORE the DELETE so we can
+        // unlink it after the row is gone. Mirrors the update() lifecycle:
+        // the file on disk must never outlive the DB reference.
+        $oldImagePath = null;
+        $lookupStmt = $db->prepare("SELECT featured_image FROM events WHERE id = ?");
+        if ($lookupStmt !== false) {
+            $lookupStmt->bind_param('i', $id);
+            $lookupStmt->execute();
+            $lookupResult = $lookupStmt->get_result();
+            $lookupRow = $lookupResult ? $lookupResult->fetch_assoc() : null;
+            $lookupStmt->close();
+            if (is_array($lookupRow) && !empty($lookupRow['featured_image'])) {
+                $oldImagePath = (string) $lookupRow['featured_image'];
+            }
+        }
+
         // Delete event
         $stmt = $db->prepare("DELETE FROM events WHERE id = ?");
         $stmt->bind_param('i', $id);
 
         if ($stmt->execute()) {
             $_SESSION['success_message'] = __('Evento eliminato con successo!');
+            // Row is gone — unlink the now-orphaned image. Uses the
+            // same path-traversal-safe helper as update().
+            if ($oldImagePath !== null) {
+                $this->deleteUploadedImageFile($oldImagePath);
+            }
         } else {
             $_SESSION['error_message'] = __('Errore durante l\'eliminazione dell\'evento.');
         }

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -2078,6 +2078,16 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
             return $response->withStatus(404);
         }
 
+        // Featured-image layout (issue #137): admin-controlled rendering
+        // strategy for the event hero image. Validated against the same
+        // allow-list used by SettingsController to defend against legacy/
+        // corrupted DB values.
+        $eventImageLayoutAllowed = ['full', 'banner', 'contained', 'thumb'];
+        $eventImageLayout = strtolower((string) $repository->get('cms', 'event_image_layout', 'contained'));
+        if (!in_array($eventImageLayout, $eventImageLayoutAllowed, true)) {
+            $eventImageLayout = 'contained';
+        }
+
         // Get event by slug
         $stmt = $db->prepare("
             SELECT id, title, slug, content, event_date, event_time, featured_image,

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -30,6 +30,7 @@ class SettingsController
         $contactSettings = $this->resolveContactSettings($repository);
         $privacySettings = $this->resolvePrivacySettings($repository);
         $labelSettings = $this->resolveLabelSettings($repository);
+        $eventSettings = $this->resolveEventSettings($repository);
         $advancedSettings = $this->resolveAdvancedSettings($repository);
         $contactMessages = $this->loadContactMessages($db);
         $cookieBannerTexts = $this->resolveCookieBannerTexts($repository);
@@ -45,6 +46,7 @@ class SettingsController
             'contactSettings',
             'privacySettings',
             'labelSettings',
+            'eventSettings',
             'advancedSettings',
             'contactMessages',
             'activeTab',
@@ -701,6 +703,21 @@ class SettingsController
         ];
     }
 
+    /**
+     * @return array{image_layout: string}
+     */
+    private function resolveEventSettings(SettingsRepository $repository): array
+    {
+        $allowed = ['full', 'banner', 'contained', 'thumb'];
+        $layout = strtolower((string) $repository->get('cms', 'event_image_layout', 'contained'));
+        if (!in_array($layout, $allowed, true)) {
+            $layout = 'contained';
+        }
+        return [
+            'image_layout' => $layout,
+        ];
+    }
+
     public function updateLabels(Request $request, Response $response, mysqli $db): Response
     {
         $data = (array) $request->getParsedBody();
@@ -923,6 +940,33 @@ class SettingsController
 
         $_SESSION['success_message'] = __('Impostazioni di condivisione aggiornate.');
         return $this->redirect($response, '/admin/settings?tab=sharing');
+    }
+
+    /**
+     * Update per-section settings for the public Events page (issue #137).
+     *
+     * Currently exposes a single knob: the layout of the featured image on
+     * the event detail page. Defaults to 'contained' which preserves the
+     * historical 100%-width rendering for narrow images while preventing
+     * tall/wide outliers from dominating the viewport.
+     */
+    public function updateEventSettings(Request $request, Response $response, mysqli $db): Response
+    {
+        $data = (array) $request->getParsedBody();
+        // CSRF validated by CsrfMiddleware
+
+        $repository = new SettingsRepository($db);
+        $repository->ensureTables();
+
+        $allowed = ['full', 'banner', 'contained', 'thumb'];
+        $submitted = strtolower(trim((string) ($data['event_image_layout'] ?? 'contained')));
+        $layout = in_array($submitted, $allowed, true) ? $submitted : 'contained';
+
+        $repository->set('cms', 'event_image_layout', $layout);
+        ConfigStore::set('cms.event_image_layout', $layout);
+
+        $_SESSION['success_message'] = __('Impostazioni eventi aggiornate.');
+        return $this->redirect($response, '/admin/settings?tab=cms');
     }
 
     private function redirect(Response $response, string $location): Response

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -946,9 +946,9 @@ class SettingsController
      * Update per-section settings for the public Events page (issue #137).
      *
      * Currently exposes a single knob: the layout of the featured image on
-     * the event detail page. Defaults to 'contained' which preserves the
-     * historical 100%-width rendering for narrow images while preventing
-     * tall/wide outliers from dominating the viewport.
+     * the event detail page. Defaults to 'contained' which prevents wide/tall
+     * outliers from dominating the viewport. Users who want the legacy
+     * 100%-width rendering should pick the 'full' preset.
      */
     public function updateEventSettings(Request $request, Response $response, mysqli $db): Response
     {

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -585,6 +585,12 @@ return function (App $app): void {
         return $controller->updateSharingSettings($request, $response, $db);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
+    $app->post('/admin/settings/events', function ($request, $response) use ($app) {
+        $db = $app->getContainer()->get('db');
+        $controller = new SettingsController();
+        return $controller->updateEventSettings($request, $response, $db);
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+
     $app->post('/admin/settings/advanced', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');
         $controller = new SettingsController();

--- a/app/Views/admin/bulk-enrich.php
+++ b/app/Views/admin/bulk-enrich.php
@@ -184,14 +184,14 @@ document.getElementById('toggle-enrichment').addEventListener('click', async fun
                 label.classList.add('text-gray-500');
             }
         } else {
-            alert(data.error || <?= json_encode(__("Errore durante il salvataggio"), JSON_HEX_TAG) ?>);
+            window.SwalApp.error(undefined, data.error || <?= json_encode(__("Errore durante il salvataggio"), JSON_HEX_TAG) ?>);
         }
     } catch (err) {
-        alert(<?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
+        window.SwalApp.error(undefined, <?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
     }
 });
 
-// Manual enrichment
+// Manual enrichment — second alert pair below uses the same SwalApp.error pattern.
 document.getElementById('btn-enrich-now').addEventListener('click', async function () {
     const btn = this;
     const icon = document.getElementById('enrich-icon');
@@ -218,10 +218,10 @@ document.getElementById('btn-enrich-now').addEventListener('click', async functi
         if (data.success && data.results) {
             showResults(data.results);
         } else {
-            alert(data.error || <?= json_encode(__("Errore durante l'arricchimento"), JSON_HEX_TAG) ?>);
+            window.SwalApp.error(undefined, data.error || <?= json_encode(__("Errore durante l'arricchimento"), JSON_HEX_TAG) ?>);
         }
     } catch (err) {
-        alert(<?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
+        window.SwalApp.error(undefined, <?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
     } finally {
         btn.disabled = false;
         icon.classList.remove('fa-spinner', 'fa-spin');

--- a/app/Views/admin/csv_import.php
+++ b/app/Views/admin/csv_import.php
@@ -549,9 +549,13 @@ document.addEventListener('DOMContentLoaded', function() {
                             confirmButtonText: <?= json_encode(__("OK"), JSON_HEX_TAG) ?>
                         }).then(() => window.location.reload());
                     } else {
-                        // Swal not loaded — defensive native fallback before reloading.
-                        window.alert(message.replace(/<[^>]*>/g, ''));
-                        window.location.reload();
+                        // Swal absent — go through SwalApp.info which has
+                        // its own window.alert fallback internally. Keeps
+                        // the bus the single entry point.
+                        window.SwalApp.info(
+                            <?= json_encode(__("Import Completato"), JSON_HEX_TAG) ?>,
+                            message.replace(/<[^>]*>/g, '')
+                        ).then(() => window.location.reload());
                     }
                 }, 500);
                 return;

--- a/app/Views/admin/csv_import.php
+++ b/app/Views/admin/csv_import.php
@@ -418,15 +418,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         uppyCsv.on('restriction-failed', (file, error) => {
             console.error('Upload restriction failed:', error);
-            if (typeof Swal !== 'undefined') {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>,
-                    text: error.message
-                });
-            } else {
-                alert(<?= json_encode(__("Errore:") . " ", JSON_HEX_TAG) ?> + error.message);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>,
+                error.message
+            );
         });
 
     } catch (error) {
@@ -554,7 +549,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             confirmButtonText: <?= json_encode(__("OK"), JSON_HEX_TAG) ?>
                         }).then(() => window.location.reload());
                     } else {
-                        alert(message.replace(/<[^>]*>/g, ''));
+                        // Swal not loaded — defensive native fallback before reloading.
+                        window.alert(message.replace(/<[^>]*>/g, ''));
                         window.location.reload();
                     }
                 }, 500);
@@ -645,15 +641,7 @@ document.addEventListener('DOMContentLoaded', function() {
         submitBtn.disabled = false;
         submitBtn.innerHTML = '<i class="fas fa-cloud-upload-alt mr-2"></i>' + <?= json_encode(__("Importa"), JSON_HEX_TAG) ?>;
 
-        if (window.Swal) {
-            Swal.fire({
-                icon: 'error',
-                title: <?= json_encode(__("Errore"), JSON_HEX_TAG) ?>,
-                text: message
-            });
-        } else {
-            alert(<?= json_encode(__("Errore:") . " ", JSON_HEX_TAG) ?> + message);
-        }
+        window.SwalApp.error(<?= json_encode(__("Errore"), JSON_HEX_TAG) ?>, message);
 
         document.getElementById('import-progress-container').classList.add('hidden');
     }

--- a/app/Views/admin/languages/edit-routes.php
+++ b/app/Views/admin/languages/edit-routes.php
@@ -251,7 +251,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Check starts with /
             if (!value.startsWith('/')) {
-                alert(<?= json_encode(__("Tutte le route devono iniziare con") . ' "/"', JSON_HEX_TAG) ?>);
+                window.SwalApp.error(undefined, <?= json_encode(__("Tutte le route devono iniziare con") . ' "/"', JSON_HEX_TAG) ?>);
                 input.focus();
                 e.preventDefault();
                 hasErrors = true;
@@ -260,7 +260,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
             // Check no spaces
             if (/\s/.test(value)) {
-                alert(<?= json_encode(__("Le route non possono contenere spazi") . ": ", JSON_HEX_TAG) ?> + value);
+                window.SwalApp.error(undefined, <?= json_encode(__("Le route non possono contenere spazi") . ": ", JSON_HEX_TAG) ?> + value);
                 input.focus();
                 e.preventDefault();
                 hasErrors = true;

--- a/app/Views/admin/languages/edit.php
+++ b/app/Views/admin/languages/edit.php
@@ -264,7 +264,9 @@ use App\Support\HtmlHelper;
                     <p class="text-sm text-gray-700 mb-4">
                         <?= __("Elimina questa lingua. Questa azione non può essere annullata.") ?>
                     </p>
-                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($language['code']) . '/delete'), ENT_QUOTES, 'UTF-8') ?>" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Sei sicuro di voler eliminare questa lingua? Tutti i dati associati e il file di traduzione verranno rimossi.')), ENT_QUOTES, 'UTF-8') ?>)">
+                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($language['code']) . '/delete'), ENT_QUOTES, 'UTF-8') ?>"
+                          data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro di voler eliminare questa lingua? Tutti i dati associati e il file di traduzione verranno rimossi.'), ENT_QUOTES, 'UTF-8') ?>"
+                          data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                         <button type="submit" class="btn btn-danger">
                             <i class="fas fa-trash"></i> <?= __("Elimina Lingua") ?>

--- a/app/Views/admin/languages/index.php
+++ b/app/Views/admin/languages/index.php
@@ -202,12 +202,14 @@ use App\Support\HtmlHelper;
 
                                                 <!-- Set as Default -->
                                                 <?php if (!$lang['is_default']): ?>
-                                                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($lang['code']) . '/set-default'), ENT_QUOTES, 'UTF-8') ?>" class="inline">
+                                                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($lang['code']) . '/set-default'), ENT_QUOTES, 'UTF-8') ?>" class="inline"
+                                                          data-swal-confirm="<?= htmlspecialchars(__("Impostare questa lingua come predefinita? Questa diventerà la lingua dell'intera applicazione per tutti gli utenti."), ENT_QUOTES, 'UTF-8') ?>"
+                                                          data-swal-confirm-title="<?= htmlspecialchars(__('Imposta come Predefinita'), ENT_QUOTES, 'UTF-8') ?>"
+                                                          data-swal-confirm-button="<?= htmlspecialchars(__('Conferma'), ENT_QUOTES, 'UTF-8') ?>">
                                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                                                         <button type="submit"
                                                                 class="text-yellow-600 hover:text-yellow-900"
-                                                                title="<?= __("Imposta come Predefinita") ?>"
-                                                                onclick="return confirm(<?= htmlspecialchars(json_encode(__("Impostare questa lingua come predefinita?\n\nQuesta diventerà la lingua dell'intera applicazione per tutti gli utenti."), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>)">
+                                                                title="<?= __("Imposta come Predefinita") ?>">
                                                             <i class="fas fa-star"></i>
                                                         </button>
                                                     </form>
@@ -225,12 +227,13 @@ use App\Support\HtmlHelper;
 
                                                 <!-- Delete -->
                                                 <?php if (!$lang['is_default']): ?>
-                                                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($lang['code']) . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline">
+                                                    <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($lang['code']) . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline"
+                                                          data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro di voler eliminare questa lingua? Questa azione non può essere annullata.'), ENT_QUOTES, 'UTF-8') ?>"
+                                                          data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                                                         <button type="submit"
                                                                 class="text-red-600 hover:text-red-900"
-                                                                title="<?= __("Elimina") ?>"
-                                                                onclick="return confirm(<?= htmlspecialchars(json_encode(__("Sei sicuro di voler eliminare questa lingua? Questa azione non può essere annullata."), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>)">
+                                                                title="<?= __("Elimina") ?>">
                                                             <i class="fas fa-trash"></i>
                                                         </button>
                                                     </form>

--- a/app/Views/admin/languages/index.php
+++ b/app/Views/admin/languages/index.php
@@ -205,7 +205,8 @@ use App\Support\HtmlHelper;
                                                     <form method="POST" action="<?= htmlspecialchars(url('/admin/languages/' . rawurlencode($lang['code']) . '/set-default'), ENT_QUOTES, 'UTF-8') ?>" class="inline"
                                                           data-swal-confirm="<?= htmlspecialchars(__("Impostare questa lingua come predefinita? Questa diventerà la lingua dell'intera applicazione per tutti gli utenti."), ENT_QUOTES, 'UTF-8') ?>"
                                                           data-swal-confirm-title="<?= htmlspecialchars(__('Imposta come Predefinita'), ENT_QUOTES, 'UTF-8') ?>"
-                                                          data-swal-confirm-button="<?= htmlspecialchars(__('Conferma'), ENT_QUOTES, 'UTF-8') ?>">
+                                                          data-swal-confirm-button="<?= htmlspecialchars(__('Conferma'), ENT_QUOTES, 'UTF-8') ?>"
+                                                          data-swal-confirm-kind="action">
                                                         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                                                         <button type="submit"
                                                                 class="text-yellow-600 hover:text-yellow-900"

--- a/app/Views/admin/notifications.php
+++ b/app/Views/admin/notifications.php
@@ -173,7 +173,10 @@ function markAllAsRead() {
 }
 
 function deleteNotification(id) {
-  if (confirm(<?= json_encode(__("Sei sicuro di voler eliminare questa notifica?"), JSON_HEX_TAG) ?>)) {
+  window.SwalApp.confirmDelete({
+    text: <?= json_encode(__("Sei sicuro di voler eliminare questa notifica?"), JSON_HEX_TAG) ?>
+  }).then((r) => {
+    if (!r.isConfirmed) return;
     csrfFetch(`${window.BASE_PATH}/admin/notifications/${id}`, { method: 'DELETE' })
       .then(response => response.json())
       .then(data => {
@@ -182,6 +185,6 @@ function deleteNotification(id) {
         }
       })
       .catch(error => console.error('Error:', error));
-  }
+  });
 }
 </script>

--- a/app/Views/admin/settings.php
+++ b/app/Views/admin/settings.php
@@ -507,14 +507,14 @@ document.getElementById('template-form').addEventListener('submit', async functi
     });
 
     if (response.ok) {
-      alert(<?= json_encode(__("Template aggiornato con successo!"), JSON_HEX_TAG) ?>);
+      window.SwalApp.success(undefined, <?= json_encode(__("Template aggiornato con successo!"), JSON_HEX_TAG) ?>);
       closeTemplateEditor();
     } else {
-      alert(<?= json_encode(__("Errore nell'aggiornamento del template"), JSON_HEX_TAG) ?>);
+      window.SwalApp.error(undefined, <?= json_encode(__("Errore nell'aggiornamento del template"), JSON_HEX_TAG) ?>);
     }
   } catch (error) {
     console.error('Error:', error);
-    alert(<?= json_encode(__("Errore: "), JSON_HEX_TAG) ?> + error.message);
+    window.SwalApp.error(undefined, error.message);
   }
 });
 

--- a/app/Views/admin/theme-customize.php
+++ b/app/Views/admin/theme-customize.php
@@ -377,6 +377,10 @@ function resetToDefaults() {
 
             if (data.success) window.location.reload();
             else window.SwalApp.error(undefined, data.message);
+        })
+        .catch((err) => {
+            console.error('Theme reset network error:', err);
+            window.SwalApp.error(undefined, <?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
         });
     });
 }

--- a/app/Views/admin/theme-customize.php
+++ b/app/Views/admin/theme-customize.php
@@ -299,7 +299,7 @@ function checkContrast() {
     .then(data => {
         // Check for CSRF/session errors
         if (data.error || data.code) {
-            alert(data.error || <?= json_encode(__("Errore di sicurezza"), JSON_HEX_TAG) ?>);
+            window.SwalApp.error(undefined, data.error || <?= json_encode(__("Errore di sicurezza"), JSON_HEX_TAG) ?>);
             if (data.code === 'SESSION_EXPIRED' || data.code === 'CSRF_INVALID') {
                 setTimeout(() => window.location.reload(), 2000);
             }
@@ -351,29 +351,33 @@ function hexToRgb(hex) {
 }
 
 function resetToDefaults() {
-    if (!confirm(<?= json_encode(__("Ripristinare i colori?"), JSON_HEX_TAG) ?>)) return;
-
-    fetch(window.BASE_PATH + '/admin/themes/<?= (int)$theme['id'] ?>/reset', {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-Token': csrfToken
-        }
-    })
-    .then(r => r.json())
-    .then(data => {
-        // Check for CSRF/session errors
-        if (data.error || data.code) {
-            alert(data.error || <?= json_encode(__("Errore di sicurezza"), JSON_HEX_TAG) ?>);
-            if (data.code === 'SESSION_EXPIRED' || data.code === 'CSRF_INVALID') {
-                setTimeout(() => window.location.reload(), 2000);
+    window.SwalApp.confirm({
+        title: <?= json_encode(__("Ripristinare i colori?"), JSON_HEX_TAG) ?>,
+        confirmText: <?= json_encode(__("Ripristina"), JSON_HEX_TAG) ?>
+    }).then((r) => {
+        if (!r.isConfirmed) return;
+        fetch(window.BASE_PATH + '/admin/themes/<?= (int)$theme['id'] ?>/reset', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': csrfToken
             }
-            return;
-        }
+        })
+        .then(r => r.json())
+        .then(data => {
+            // Check for CSRF/session errors
+            if (data.error || data.code) {
+                window.SwalApp.error(undefined, data.error || <?= json_encode(__("Errore di sicurezza"), JSON_HEX_TAG) ?>);
+                if (data.code === 'SESSION_EXPIRED' || data.code === 'CSRF_INVALID') {
+                    setTimeout(() => window.location.reload(), 2000);
+                }
+                return;
+            }
 
-        if (data.success) window.location.reload();
-        else alert(data.message);
+            if (data.success) window.location.reload();
+            else window.SwalApp.error(undefined, data.message);
+        });
     });
 }
 

--- a/app/Views/admin/themes.php
+++ b/app/Views/admin/themes.php
@@ -152,30 +152,32 @@ $pageTitle = __('Gestione Temi');
 
 <script>
 function activateTheme(themeId) {
-    if (!confirm(<?= json_encode(__("Attivare questo tema?"), JSON_HEX_TAG) ?>)) {
-        return;
-    }
-
-    const basePath = window.BASE_PATH || '';
-    fetch(`${basePath}/admin/themes/${parseInt(themeId, 10)}/activate`, {
-        method: 'POST',
-        credentials: 'same-origin',
-        headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-Token': <?= json_encode(Csrf::ensureToken(), JSON_HEX_TAG) ?>
-        }
-    })
-    .then(r => r.json())
-    .then(data => {
-        if (data.success) {
-            window.location.reload();
-        } else {
-            alert(data.message || <?= json_encode(__("Errore durante l'attivazione"), JSON_HEX_TAG) ?>);
-        }
-    })
-    .catch(err => {
-        console.error(err);
-        alert(<?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
+    window.SwalApp.confirm({
+        title: <?= json_encode(__("Attivare questo tema?"), JSON_HEX_TAG) ?>,
+        confirmText: <?= json_encode(__("Attiva"), JSON_HEX_TAG) ?>
+    }).then((r) => {
+        if (!r.isConfirmed) return;
+        const basePath = window.BASE_PATH || '';
+        fetch(`${basePath}/admin/themes/${parseInt(themeId, 10)}/activate`, {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-Token': <?= json_encode(Csrf::ensureToken(), JSON_HEX_TAG) ?>
+            }
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                window.location.reload();
+            } else {
+                window.SwalApp.error(undefined, data.message || <?= json_encode(__("Errore durante l'attivazione"), JSON_HEX_TAG) ?>);
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            window.SwalApp.error(undefined, <?= json_encode(__("Errore di rete"), JSON_HEX_TAG) ?>);
+        });
     });
 }
 </script>

--- a/app/Views/auth/register.php
+++ b/app/Views/auth/register.php
@@ -339,14 +339,14 @@ document.addEventListener('DOMContentLoaded', function() {
     form.addEventListener('submit', function(e) {
       if (password.value !== confirmPassword.value) {
         e.preventDefault();
-        alert(<?= json_encode(__("Le password non coincidono!"), JSON_HEX_TAG) ?>);
+        window.SwalApp.error(undefined, <?= json_encode(__("Le password non coincidono!"), JSON_HEX_TAG) ?>);
         confirmPassword.focus();
         return false;
       }
 
       if (password.value.length < 8) {
         e.preventDefault();
-        alert(<?= json_encode(__("La password deve essere lunga almeno 8 caratteri!"), JSON_HEX_TAG) ?>);
+        window.SwalApp.error(undefined, <?= json_encode(__("La password deve essere lunga almeno 8 caratteri!"), JSON_HEX_TAG) ?>);
         password.focus();
         return false;
       }

--- a/app/Views/autori/crea_autore.php
+++ b/app/Views/autori/crea_autore.php
@@ -137,68 +137,43 @@ function initializeFormValidation() {
         // Validate required fields
         const nome = form.querySelector('input[name="nome"]').value.trim();
         if (!nome) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
-                    text: <?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
+                <?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>
+            );
             return;
         }
-        
-        // Validate dates if provided
+
         const dataNascita = form.querySelector('input[name="data_nascita"]').value;
         const dataMorte = form.querySelector('input[name="data_morte"]').value;
-        
+
         if (dataNascita && dataMorte) {
             if (new Date(dataNascita) >= new Date(dataMorte)) {
-                if (window.Swal) {
-                    Swal.fire({
-                        icon: 'error',
-                        title: <?= json_encode(__("Date Non Valide"), JSON_HEX_TAG) ?>,
-                        text: <?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>
-                    });
-                } else {
-                    alert(<?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>);
-                }
+                window.SwalApp.error(
+                    <?= json_encode(__("Date Non Valide"), JSON_HEX_TAG) ?>,
+                    <?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>
+                );
                 return;
             }
         }
-        
-        // Show confirmation dialog
-        if (window.Swal) {
-            const result = await Swal.fire({
-                title: <?= json_encode(__("Conferma Salvataggio"), JSON_HEX_TAG) ?>,
-                text: <?= json_encode(__("Sei sicuro di voler salvare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: <?= json_encode(__("Sì, Salva"), JSON_HEX_TAG) ?>,
-                cancelButtonText: <?= json_encode(__("Annulla"), JSON_HEX_TAG) ?>,
-                reverseButtons: true
-            });
 
-            if (result.isConfirmed) {
-                // Show loading
+        const result = await window.SwalApp.confirm({
+            title: <?= json_encode(__("Conferma Salvataggio"), JSON_HEX_TAG) ?>,
+            text: <?= json_encode(__("Sei sicuro di voler salvare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
+            confirmText: <?= json_encode(__("Sì, Salva"), JSON_HEX_TAG) ?>
+        });
+
+        if (result.isConfirmed) {
+            if (typeof Swal !== 'undefined') {
                 Swal.fire({
                     title: <?= json_encode(__("Salvataggio in corso..."), JSON_HEX_TAG) ?>,
                     text: <?= json_encode(__("Attendere prego"), JSON_HEX_TAG) ?>,
                     allowOutsideClick: false,
                     showConfirmButton: false,
-                    willOpen: () => {
-                        Swal.showLoading();
-                    }
+                    willOpen: () => { Swal.showLoading(); }
                 });
-
-                // Submit the form
-                form.submit();
             }
-        } else {
-            if (confirm(<?= json_encode(__("Sei sicuro di voler salvare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome))) {
-                form.submit();
-            }
+            form.submit();
         }
     });
 }

--- a/app/Views/autori/modifica_autore.php
+++ b/app/Views/autori/modifica_autore.php
@@ -144,68 +144,43 @@ function initializeFormValidation() {
         // Validate required fields
         const nome = form.querySelector('input[name="nome"]').value.trim();
         if (!nome) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
-                    text: <?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
+                <?= json_encode(__("Il nome dell'autore è obbligatorio."), JSON_HEX_TAG) ?>
+            );
             return;
         }
-        
-        // Validate dates if provided
+
         const dataNascita = form.querySelector('input[name="data_nascita"]').value;
         const dataMorte = form.querySelector('input[name="data_morte"]').value;
-        
+
         if (dataNascita && dataMorte) {
             if (new Date(dataNascita) >= new Date(dataMorte)) {
-                if (window.Swal) {
-                    Swal.fire({
-                        icon: 'error',
-                        title: <?= json_encode(__("Date Non Valide"), JSON_HEX_TAG) ?>,
-                        text: <?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>
-                    });
-                } else {
-                    alert(<?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>);
-                }
+                window.SwalApp.error(
+                    <?= json_encode(__("Date Non Valide"), JSON_HEX_TAG) ?>,
+                    <?= json_encode(__("La data di nascita deve essere precedente alla data di morte."), JSON_HEX_TAG) ?>
+                );
                 return;
             }
         }
-        
-        // Show confirmation dialog
-        if (window.Swal) {
-            const result = await Swal.fire({
-                title: <?= json_encode(__("Conferma Aggiornamento"), JSON_HEX_TAG) ?>,
-                text: <?= json_encode(__("Sei sicuro di voler aggiornare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: <?= json_encode(__("Sì, Aggiorna"), JSON_HEX_TAG) ?>,
-                cancelButtonText: <?= json_encode(__("Annulla"), JSON_HEX_TAG) ?>,
-                reverseButtons: true
-            });
 
-            if (result.isConfirmed) {
-                // Show loading
+        const result = await window.SwalApp.confirm({
+            title: <?= json_encode(__("Conferma Aggiornamento"), JSON_HEX_TAG) ?>,
+            text: <?= json_encode(__("Sei sicuro di voler aggiornare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
+            confirmText: <?= json_encode(__("Sì, Aggiorna"), JSON_HEX_TAG) ?>
+        });
+
+        if (result.isConfirmed) {
+            if (typeof Swal !== 'undefined') {
                 Swal.fire({
                     title: <?= json_encode(__("Aggiornamento in corso..."), JSON_HEX_TAG) ?>,
                     text: <?= json_encode(__("Attendere prego"), JSON_HEX_TAG) ?>,
                     allowOutsideClick: false,
                     showConfirmButton: false,
-                    willOpen: () => {
-                        Swal.showLoading();
-                    }
+                    willOpen: () => { Swal.showLoading(); }
                 });
-
-                // Submit the form
-                form.submit();
             }
-        } else {
-            if (confirm(<?= json_encode(__("Sei sicuro di voler aggiornare l'autore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome))) {
-                form.submit();
-            }
+            form.submit();
         }
     });
 }

--- a/app/Views/autori/scheda_autore.php
+++ b/app/Views/autori/scheda_autore.php
@@ -103,11 +103,12 @@ $updatedAt   = trim((string)($autore['updated_at'] ?? ''));
                 <?= __('Non eliminabile') ?>
               </button>
             <?php else: ?>
-              <form method="post" action="<?= htmlspecialchars(url('/admin/autori/delete/' . (int)($autore['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex">
+              <form method="post" action="<?= htmlspecialchars(url('/admin/autori/delete/' . (int)($autore['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex"
+                    data-swal-confirm="<?= htmlspecialchars(__("Confermi l'eliminazione dell'autore?"), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                 <button type="submit"
-                        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors"
-                        onclick="return confirm(<?= htmlspecialchars(json_encode(__("Confermi l'eliminazione dell'autore?"), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8') ?>);">
+                        class="inline-flex items-center gap-2 px-4 py-2.5 rounded-xl bg-red-600 text-white text-sm font-medium hover:bg-red-700 transition-colors">
                   <i class="fas fa-trash"></i>
                   <?= __('Elimina') ?>
                 </button>

--- a/app/Views/cms/edit-home.php
+++ b/app/Views/cms/edit-home.php
@@ -755,15 +755,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         uppyHero.on('restriction-failed', (file, error) => {
             console.error('Upload restriction failed:', error);
-            if (typeof Swal !== 'undefined') {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__('Errore Upload'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
-                    text: error.message
-                });
-            } else {
-                alert(<?= json_encode(__('Errore'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?> + ': ' + error.message);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__('Errore Upload'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
+                error.message
+            );
         });
 
     } catch (error) {

--- a/app/Views/collocazione/index.php
+++ b/app/Views/collocazione/index.php
@@ -221,7 +221,9 @@
                         </div>
                         <div class="flex items-center gap-2">
                           <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded"><?= __("Ordine:") ?> <span class="order-label"><?php echo isset($s['ordine']) ? (int)$s['ordine'] : 0; ?></span></span>
-                          <form method="post" action="<?= htmlspecialchars(url('/admin/collocazione/scaffali/' . (int)$s['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__("Eliminare questo scaffale? (Solo se vuoto)"), JSON_HEX_TAG | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_APOS), ENT_QUOTES, 'UTF-8') ?>);">
+                          <form method="post" action="<?= htmlspecialchars(url('/admin/collocazione/scaffali/' . (int)$s['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline"
+                                data-swal-confirm="<?= htmlspecialchars(__("Eliminare questo scaffale? (Solo se vuoto)"), ENT_QUOTES, 'UTF-8') ?>"
+                                data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                             <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                             <button type="submit" class="text-red-600 hover:text-red-800 text-sm" title="<?= __("Elimina") ?>"><i class="fas fa-trash"></i></button>
                           </form>
@@ -321,7 +323,9 @@
                       </div>
                       <div class="flex items-center gap-2">
                         <span class="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded mensola-order-label"><?= __("Ordine:") ?> <span class="order-value"><?php echo (int)($m['ordine'] ?? 0); ?></span></span>
-                        <form method="post" action="<?= htmlspecialchars(url('/admin/collocazione/mensole/' . (int)$m['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__("Eliminare questa mensola? (Solo se vuota)"), JSON_HEX_TAG | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_HEX_APOS), ENT_QUOTES, 'UTF-8') ?>);">
+                        <form method="post" action="<?= htmlspecialchars(url('/admin/collocazione/mensole/' . (int)$m['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" class="inline"
+                              data-swal-confirm="<?= htmlspecialchars(__("Eliminare questa mensola? (Solo se vuota)"), ENT_QUOTES, 'UTF-8') ?>"
+                              data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                           <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                           <button type="submit" class="text-red-600 hover:text-red-800 text-sm" title="<?= __("Elimina") ?>"><i class="fas fa-trash"></i></button>
                         </form>
@@ -464,7 +468,7 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     } catch (error) {
       console.error('Error updating order:', error);
-      alert(<?= json_encode(__("Errore nel salvataggio dell'ordine. Ricarica la pagina e riprova."), JSON_HEX_TAG); ?>);
+      window.SwalApp.error(undefined, <?= json_encode(__("Errore nel salvataggio dell'ordine. Ricarica la pagina e riprova."), JSON_HEX_TAG); ?>);
     }
   }
 

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -975,17 +975,12 @@ document.addEventListener('DOMContentLoaded', function() {
                 : window.location.origin + rawUrl;
 
             const showSuccess = function() {
-                if (window.Swal) {
-                    Swal.fire({
-                        icon: 'success',
-                        title: <?= json_encode(__("Link copiato!"), JSON_HEX_TAG) ?>,
-                        text: <?= json_encode(__("L'URL del calendario è stato copiato negli appunti."), JSON_HEX_TAG) ?>,
-                        timer: 2000,
-                        showConfirmButton: false
-                    });
-                } else {
-                    alert(<?= json_encode(__("Link copiato!"), JSON_HEX_TAG) ?>);
-                }
+                // Use a toast so the "copied" notice doesn't require a click.
+                window.SwalApp.toast({
+                    icon: 'success',
+                    title: <?= json_encode(__("Link copiato!"), JSON_HEX_TAG) ?>,
+                    timer: 2000
+                });
             };
 
             const fallbackCopy = function() {

--- a/app/Views/editori/crea_editore.php
+++ b/app/Views/editori/crea_editore.php
@@ -147,79 +147,52 @@ function initializeFormValidation() {
         // Validate required fields
         const nome = form.querySelector('input[name="nome"]').value.trim();
         if (!nome) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
-                    text: <?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG) ?>,
+                <?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG) ?>
+            );
             return;
         }
-        
+
         // Validate URL if provided
         const sitoWeb = form.querySelector('input[name="sito_web"]').value.trim();
         if (sitoWeb && !isValidURL(sitoWeb)) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("URL Non Valido"), JSON_HEX_TAG) ?>,
-                    text: <?= json_encode(__("Il sito web deve essere un URL valido (es. https://www.esempio.com)."), JSON_HEX_TAG) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il sito web deve essere un URL valido."), JSON_HEX_TAG) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("URL Non Valido"), JSON_HEX_TAG) ?>,
+                <?= json_encode(__("Il sito web deve essere un URL valido (es. https://www.esempio.com)."), JSON_HEX_TAG) ?>
+            );
             return;
         }
-        
+
         // Validate email if provided
         const email = form.querySelector('input[name="email"]').value.trim();
         if (email && !isValidEmail(email)) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Email Non Valida"), JSON_HEX_TAG) ?>,
-                    text: <?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Email Non Valida"), JSON_HEX_TAG) ?>,
+                <?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG) ?>
+            );
             return;
         }
 
-        // Show confirmation dialog
-        if (window.Swal) {
-            const result = await Swal.fire({
-                title: <?= json_encode(__("Conferma Salvataggio"), JSON_HEX_TAG) ?>,
-                text: <?= json_encode(__("Sei sicuro di voler salvare l'editore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: <?= json_encode(__("Sì, Salva"), JSON_HEX_TAG) ?>,
-                cancelButtonText: <?= json_encode(__("Annulla"), JSON_HEX_TAG) ?>,
-                reverseButtons: true
-            });
+        // Confirmation dialog — SwalApp.confirm has its own native fallback.
+        const result = await window.SwalApp.confirm({
+            title: <?= json_encode(__("Conferma Salvataggio"), JSON_HEX_TAG) ?>,
+            text: <?= json_encode(__("Sei sicuro di voler salvare l'editore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome),
+            confirmText: <?= json_encode(__("Sì, Salva"), JSON_HEX_TAG) ?>
+        });
 
-            if (result.isConfirmed) {
-                // Show loading
+        if (result.isConfirmed) {
+            // Optional loading state when Swal is present.
+            if (typeof Swal !== 'undefined') {
                 Swal.fire({
                     title: <?= json_encode(__("Salvataggio in corso..."), JSON_HEX_TAG) ?>,
                     text: <?= json_encode(__("Attendere prego"), JSON_HEX_TAG) ?>,
                     allowOutsideClick: false,
                     showConfirmButton: false,
-                    willOpen: () => {
-                        Swal.showLoading();
-                    }
+                    willOpen: () => { Swal.showLoading(); }
                 });
-
-                // Submit the form
-                form.submit();
             }
-        } else {
-            if (confirm(<?= json_encode(__("Sei sicuro di voler salvare l'editore \"%s\"?"), JSON_HEX_TAG) ?>.replace('%s', nome))) {
-                form.submit();
-            }
+            form.submit();
         }
     });
 }

--- a/app/Views/editori/modifica_editore.php
+++ b/app/Views/editori/modifica_editore.php
@@ -155,79 +155,48 @@ function initializeFormValidation() {
         // Validate required fields
         const nome = form.querySelector('input[name="nome"]').value.trim();
         if (!nome) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                    text: <?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG | JSON_HEX_AMP) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Campo Obbligatorio"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+                <?= json_encode(__("Il nome dell'editore è obbligatorio."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
+            );
             return;
         }
-        
-        // Validate URL if provided
+
         const sitoWeb = form.querySelector('input[name="sito_web"]').value.trim();
         if (sitoWeb && !isValidURL(sitoWeb)) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("URL Non Valido"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                    text: <?= json_encode(__("Il sito web deve essere un URL valido (es. https://www.esempio.com)."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("Il sito web deve essere un URL valido."), JSON_HEX_TAG | JSON_HEX_AMP) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("URL Non Valido"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+                <?= json_encode(__("Il sito web deve essere un URL valido (es. https://www.esempio.com)."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
+            );
             return;
         }
-        
-        // Validate email if provided
+
         const email = form.querySelector('input[name="email"]').value.trim();
         if (email && !isValidEmail(email)) {
-            if (window.Swal) {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Email Non Valida"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                    text: <?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
-                });
-            } else {
-                alert(<?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG | JSON_HEX_AMP) ?>);
-            }
+            window.SwalApp.error(
+                <?= json_encode(__("Email Non Valida"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+                <?= json_encode(__("L'indirizzo email deve essere valido."), JSON_HEX_TAG | JSON_HEX_AMP) ?>
+            );
             return;
         }
 
-        // Show confirmation dialog
-        if (window.Swal) {
-            const result = await Swal.fire({
-                title: <?= json_encode(__("Conferma Aggiornamento"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                text: <?= json_encode(__("Sei sicuro di voler aggiornare l'editore"), JSON_HEX_TAG | JSON_HEX_AMP) ?> + ' "' + nome + '"?',
-                icon: 'question',
-                showCancelButton: true,
-                confirmButtonText: <?= json_encode(__("Sì, Aggiorna"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                cancelButtonText: <?= json_encode(__("Annulla"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
-                reverseButtons: true
-            });
+        const result = await window.SwalApp.confirm({
+            title: <?= json_encode(__("Conferma Aggiornamento"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+            text: <?= json_encode(__("Sei sicuro di voler aggiornare l'editore"), JSON_HEX_TAG | JSON_HEX_AMP) ?> + ' "' + nome + '"?',
+            confirmText: <?= json_encode(__("Sì, Aggiorna"), JSON_HEX_TAG | JSON_HEX_AMP) ?>
+        });
 
-            if (result.isConfirmed) {
-                // Show loading
+        if (result.isConfirmed) {
+            if (typeof Swal !== 'undefined') {
                 Swal.fire({
                     title: <?= json_encode(__("Aggiornamento in corso..."), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
                     text: <?= json_encode(__("Attendere prego"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
                     allowOutsideClick: false,
                     showConfirmButton: false,
-                    willOpen: () => {
-                        Swal.showLoading();
-                    }
+                    willOpen: () => { Swal.showLoading(); }
                 });
-                
-                // Submit the form
-                form.submit();
             }
-        } else {
-            if (confirm(<?= json_encode(__("Sei sicuro di voler aggiornare l'editore"), JSON_HEX_TAG | JSON_HEX_AMP) ?> + ' "' + nome + '"?')) {
-                form.submit();
-            }
+            form.submit();
         }
     });
 }

--- a/app/Views/editori/scheda_editore.php
+++ b/app/Views/editori/scheda_editore.php
@@ -73,11 +73,12 @@ $sitoWeb = trim((string)($editore['sito_web'] ?? ''));
                 <?= __("Non eliminabile") ?>
               </button>
             <?php else: ?>
-              <form method="post" action="<?= htmlspecialchars(url('/admin/editori/delete/' . (int)($editore['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex">
+              <form method="post" action="<?= htmlspecialchars(url('/admin/editori/delete/' . (int)($editore['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex"
+                    data-swal-confirm="<?= htmlspecialchars(__("Confermi l'eliminazione dell'editore?"), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                 <button type="submit"
-                        class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700 transition-colors"
-                        onclick="return confirm(<?= htmlspecialchars(json_encode(__("Confermi l'eliminazione dell'editore?"), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>);">
+                        class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-red-600 text-white hover:bg-red-700 transition-colors">
                   <i class="fas fa-trash"></i>
                   <?= __("Elimina") ?>
                 </button>

--- a/app/Views/events/form.php
+++ b/app/Views/events/form.php
@@ -510,7 +510,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
       uppyEvent.on('restriction-failed', (file, error) => {
         console.error('Upload restriction failed:', error);
-        alert(<?= json_encode(__("Errore"), JSON_HEX_TAG) ?> + ': ' + error.message);
+        window.SwalApp.error(<?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>, error.message);
       });
     }
   } catch (error) {

--- a/app/Views/events/index.php
+++ b/app/Views/events/index.php
@@ -352,8 +352,12 @@ $formatEventTime = static function (?string $value) use ($timeFormatter, $create
 
 <script>
   function confirmDelete(eventId, eventTitle) {
-    if (confirm(<?= json_encode(__("Sei sicuro di voler eliminare l'evento"), JSON_HEX_TAG) ?> + ' "' + eventTitle + '"?\n\n' + <?= json_encode(__("Questa azione non può essere annullata."), JSON_HEX_TAG) ?>)) {
-      // Usa form POST per operazioni di eliminazione (sicurezza OWASP)
+    window.SwalApp.confirmDelete({
+      title: <?= json_encode(__("Sei sicuro di voler eliminare l'evento"), JSON_HEX_TAG) ?> + ' "' + eventTitle + '"?',
+      text:  <?= json_encode(__("Questa azione non può essere annullata."), JSON_HEX_TAG) ?>
+    }).then((r) => {
+      if (!r.isConfirmed) return;
+      // POST form per operazioni di eliminazione (sicurezza OWASP)
       const form = document.createElement('form');
       form.method = 'POST';
       form.action = window.BASE_PATH + '/admin/cms/events/delete/' + parseInt(eventId, 10);
@@ -366,6 +370,6 @@ $formatEventTime = static function (?string $value) use ($timeFormatter, $create
 
       document.body.appendChild(form);
       form.submit();
-    }
+    });
   }
 </script>

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -2442,7 +2442,7 @@ document.addEventListener('DOMContentLoaded', function() {
       const data = await res.json();
       setFavUI(!!data.favorite);
     } catch (e) {
-      alert(<?= json_encode(__("Errore nell'aggiornare i preferiti."), JSON_HEX_TAG) ?>);
+      window.SwalApp.error(undefined, <?= json_encode(__("Errore nell'aggiornare i preferiti."), JSON_HEX_TAG) ?>);
     }
   });
 });
@@ -2479,27 +2479,14 @@ document.addEventListener('DOMContentLoaded', function() {
     requestBtn.addEventListener('click', async function(){
       // Check if user is logged in
       if (!isLogged) {
-        if (window.Swal) {
-          Swal.fire({
-            icon: 'warning',
-            title: __('Accesso Richiesto'),
-            html: '<p class="mb-3">' + __('Per richiedere un prestito devi effettuare il login.') + '</p>',
-            confirmButtonText: __('Vai al Login'),
-            cancelButtonText: __('Annulla'),
-            showCancelButton: true,
-            customClass: {
-              confirmButton: 'btn btn-dark',
-              cancelButton: 'btn btn-outline-dark'
-            }
-          }).then((result) => {
-            if (result.isConfirmed) {
-              window.location.href = <?= json_encode($loginRoute, JSON_HEX_TAG) ?> + '?redirect=' + encodeURIComponent(window.location.pathname);
-            }
-          });
-        } else {
-          if (confirm(__('Per richiedere un prestito devi effettuare il login. Vuoi andare alla pagina di login?'))) {
-            window.location.href = <?= json_encode($loginRoute, JSON_HEX_TAG) ?> + '?redirect=' + encodeURIComponent(window.location.pathname);
-          }
+        const result = await window.SwalApp.confirm({
+          title: __('Accesso Richiesto'),
+          text:  __('Per richiedere un prestito devi effettuare il login. Vuoi andare alla pagina di login?'),
+          icon:  'warning',
+          confirmText: __('Vai al Login')
+        });
+        if (result.isConfirmed) {
+          window.location.href = <?= json_encode($loginRoute, JSON_HEX_TAG) ?> + '?redirect=' + encodeURIComponent(window.location.pathname);
         }
         return;
       }
@@ -2755,12 +2742,12 @@ document.addEventListener('DOMContentLoaded', function() {
             const result = await res.json();
             if (res.ok && result.success) {
               await updateReservationsBadge();
-              alert(<?= json_encode(__("Prenotazione effettuata per "), JSON_HEX_TAG) ?> + date);
+              window.SwalApp.success(undefined, <?= json_encode(__("Prenotazione effettuata per "), JSON_HEX_TAG) ?> + date);
             } else {
-              alert(<?= json_encode(__("Errore: "), JSON_HEX_TAG) ?> + (result.message || <?= json_encode(__("Impossibile creare la prenotazione"), JSON_HEX_TAG) ?>));
+              window.SwalApp.error(undefined, (result.message || <?= json_encode(__("Impossibile creare la prenotazione"), JSON_HEX_TAG) ?>));
             }
           } catch(_) {
-            alert(<?= json_encode(__("Errore nella prenotazione"), JSON_HEX_TAG) ?>);
+            window.SwalApp.error(undefined, <?= json_encode(__("Errore nella prenotazione"), JSON_HEX_TAG) ?>);
           }
         }
       }

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -174,6 +174,7 @@ $additional_css = "
         overflow: hidden;
         margin-bottom: 2rem;
         border: 1px solid #f1f5f9;
+        background: #f8fafc;
     }
 
     .event-cover img {
@@ -182,16 +183,20 @@ $additional_css = "
     }
 
     /* Layout variants (issue #137): admin-configurable rendering for the
-       event hero image. Defaults remain visually equivalent to the
-       previous behaviour for narrow images. */
+       event hero image. The four variants — full / banner / contained
+       (default) / thumb — give the librarian a predictable result no
+       matter what image they upload. */
+
+    /* full: passthrough — preserve the historical 100%-width no-crop
+       look for users who depended on it. */
     .event-cover--full img {
-        /* Original: preserve historical full-width-no-constraint. */
-        max-height: none;
-        object-fit: initial;
+        height: auto;
     }
+
+    /* banner: 16:9 cinematic crop. Ideal for poster-like horizontal
+       images that look good as a hero. */
     .event-cover--banner {
         aspect-ratio: 16 / 9;
-        background: #f8fafc;
     }
     .event-cover--banner img {
         width: 100%;
@@ -199,27 +204,57 @@ $additional_css = "
         object-fit: cover;
         object-position: center;
     }
-    .event-cover--contained img {
-        max-height: clamp(280px, 50vw, 480px);
-        object-fit: contain;
-        object-position: center;
-        background: #f8fafc;
+
+    /* contained: 3:2 photographic crop. The default — gives the same
+       balanced silhouette regardless of source dimensions. Replaces
+       the earlier arbitrary 480px max-height which produced uneven
+       results across uploads. */
+    .event-cover--contained {
+        aspect-ratio: 3 / 2;
     }
+    .event-cover--contained img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+    }
+
+    /* thumb: side-by-side layout. Driven by a modifier class on the
+       parent .event-card so the cover lives in its own grid cell and
+       cannot overflow into the footer the way a CSS float would when
+       the body text is short. Mobile collapses to a vertical stack. */
     .event-cover--thumb {
-        float: right;
-        width: clamp(180px, 32%, 260px);
-        margin: 0 0 1.25rem 1.5rem;
-        border-radius: 16px;
+        margin-bottom: 0;
+        aspect-ratio: 3 / 4;
     }
     .event-cover--thumb img {
-        aspect-ratio: 3 / 4;
+        width: 100%;
+        height: 100%;
         object-fit: cover;
+        object-position: center;
     }
-    @media (max-width: 640px) {
+    @media (min-width: 768px) {
+        .event-card--thumb-layout {
+            display: grid;
+            grid-template-columns: minmax(200px, 260px) 1fr;
+            gap: clamp(1.5rem, 3vw, 2.5rem);
+            align-items: start;
+        }
+        .event-card--thumb-layout > .event-cover--thumb {
+            grid-column: 1;
+            grid-row: 1 / span 2;
+            position: sticky;
+            top: 7rem;
+            margin: 0;
+        }
+        .event-card--thumb-layout > .event-body,
+        .event-card--thumb-layout > .event-back {
+            grid-column: 2;
+        }
+    }
+    @media (max-width: 767px) {
         .event-cover--thumb {
-            float: none;
-            width: 100%;
-            margin: 0 0 1.5rem 0;
+            margin-bottom: 1.5rem;
         }
     }
 
@@ -398,19 +433,25 @@ ob_start();
     </div>
 </section>
 
+<?php
+    // $eventImageLayout is set by the controller and re-validated there
+    // against the allow-list; we re-narrow here as defense in depth so
+    // a future controller refactor cannot leak an unknown value into
+    // the DOM. Computed before the markup so the parent .event-card
+    // can opt into the side-by-side grid via .event-card--thumb-layout.
+    $coverAllowed   = ['full', 'banner', 'contained', 'thumb'];
+    $coverLayout    = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
+    $hasCoverImage  = !empty($event['featured_image']);
+    $cardClasses    = ['event-card'];
+    if ($hasCoverImage && $coverLayout === 'thumb') {
+        $cardClasses[] = 'event-card--thumb-layout';
+    }
+?>
 <section class="event-section">
     <div class="container">
-        <article class="event-card">
-            <?php if (!empty($event['featured_image'])):
-                // $eventImageLayout is set by the controller and re-validated
-                // there against the allow-list; we re-narrow here as a
-                // defense in depth so a future controller refactor cannot
-                // leak an unknown layout into the CSS class name.
-                $coverAllowed = ['full', 'banner', 'contained', 'thumb'];
-                $coverLayout = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
-                $coverClass = 'event-cover event-cover--' . $coverLayout;
-            ?>
-                <figure class="<?= HtmlHelper::e($coverClass) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
+        <article class="<?= HtmlHelper::e(implode(' ', $cardClasses)) ?>">
+            <?php if ($hasCoverImage): ?>
+                <figure class="event-cover event-cover--<?= HtmlHelper::e($coverLayout) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
                     <img src="<?= HtmlHelper::e(url($event['featured_image'])) ?>" alt="<?= HtmlHelper::e($event['title']) ?>">
                 </figure>
             <?php endif; ?>

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -182,61 +182,71 @@ $additional_css = "
         display: block;
     }
 
-    /* Layout variants (issue #137): admin-configurable rendering for the
-       event hero image. The four variants — full / banner / contained
-       (default) / thumb — give the librarian a predictable result no
-       matter what image they upload. */
+    /* Layout variants (issue #137): admin-configurable SIZE for the
+       event hero image. The four variants give the librarian
+       progressively smaller / less invasive renderings, so a
+       sproportioned upload (e.g. a 1791×927 book cover) doesn't
+       dominate the event page.
 
-    /* full: passthrough — preserve the historical 100%-width no-crop
-       look for users who depended on it. */
+       Effective sizes on desktop:
+         full       → 100% × auto         (legacy: enormous)
+         banner     → 100% × 220px max    (low-profile decorative strip)
+         contained  → 420px × auto, centred (default: small poster)
+         thumb      → 240px wide, side-by-side with body text          */
+
+    /* full: passthrough — for users who actually want a giant image. */
     .event-cover--full img {
         height: auto;
     }
 
-    /* banner: 16:9 cinematic crop. Ideal for poster-like horizontal
-       images that look good as a hero. */
+    /* banner: full-width but capped at a low decorative strip so it
+       cannot eat the viewport vertically. */
     .event-cover--banner {
-        aspect-ratio: 16 / 9;
+        max-height: 220px;
     }
     .event-cover--banner img {
         width: 100%;
-        height: 100%;
+        height: 220px;
         object-fit: cover;
         object-position: center;
     }
 
-    /* contained: 3:2 photographic crop. The default — gives the same
-       balanced silhouette regardless of source dimensions. Replaces
-       the earlier arbitrary 480px max-height which produced uneven
-       results across uploads. */
+    /* contained (DEFAULT): centred poster, never wider than 420px.
+       Solves the original complaint where a wide image rendered at
+       full container width. Aspect ratio of the source file is
+       preserved — no crop, no forced shape, just a sensible cap. */
     .event-cover--contained {
-        aspect-ratio: 3 / 2;
+        max-width: 420px;
+        margin-left: auto;
+        margin-right: auto;
+        background: transparent;
+        border: none;
     }
     .event-cover--contained img {
         width: 100%;
-        height: 100%;
-        object-fit: cover;
-        object-position: center;
+        height: auto;
+        max-height: 320px;
+        object-fit: contain;
     }
 
-    /* thumb: side-by-side layout. Driven by a modifier class on the
-       parent .event-card so the cover lives in its own grid cell and
-       cannot overflow into the footer the way a CSS float would when
-       the body text is short. Mobile collapses to a vertical stack. */
+    /* thumb: side-by-side layout — the small modifier already in the
+       previous iteration. Driven by .event-card--thumb-layout on the
+       parent so the figure lives in its own grid cell, geometrically
+       constrained inside the card. Collapses to a stack < 768px. */
     .event-cover--thumb {
         margin-bottom: 0;
-        aspect-ratio: 3 / 4;
+        max-width: 240px;
     }
     .event-cover--thumb img {
         width: 100%;
-        height: 100%;
+        height: auto;
+        aspect-ratio: 3 / 4;
         object-fit: cover;
-        object-position: center;
     }
     @media (min-width: 768px) {
         .event-card--thumb-layout {
             display: grid;
-            grid-template-columns: minmax(200px, 260px) 1fr;
+            grid-template-columns: 240px 1fr;
             gap: clamp(1.5rem, 3vw, 2.5rem);
             align-items: start;
         }
@@ -254,7 +264,7 @@ $additional_css = "
     }
     @media (max-width: 767px) {
         .event-cover--thumb {
-            margin-bottom: 1.5rem;
+            margin: 0 auto 1.5rem auto;
         }
     }
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -1,6 +1,7 @@
 <?php
 /** @var \mysqli $db */
 /** @var array $event */
+/** @var string $eventImageLayout One of: full | banner | contained | thumb (default: contained) */
 
 use App\Support\ConfigStore;
 use App\Support\HtmlHelper;
@@ -178,6 +179,48 @@ $additional_css = "
     .event-cover img {
         width: 100%;
         display: block;
+    }
+
+    /* Layout variants (issue #137): admin-configurable rendering for the
+       event hero image. Defaults remain visually equivalent to the
+       previous behaviour for narrow images. */
+    .event-cover--full img {
+        /* Original: preserve historical full-width-no-constraint. */
+        max-height: none;
+        object-fit: initial;
+    }
+    .event-cover--banner {
+        aspect-ratio: 16 / 9;
+        background: #f8fafc;
+    }
+    .event-cover--banner img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+    }
+    .event-cover--contained img {
+        max-height: clamp(280px, 50vw, 480px);
+        object-fit: contain;
+        object-position: center;
+        background: #f8fafc;
+    }
+    .event-cover--thumb {
+        float: right;
+        width: clamp(180px, 32%, 260px);
+        margin: 0 0 1.25rem 1.5rem;
+        border-radius: 16px;
+    }
+    .event-cover--thumb img {
+        aspect-ratio: 3 / 4;
+        object-fit: cover;
+    }
+    @media (max-width: 640px) {
+        .event-cover--thumb {
+            float: none;
+            width: 100%;
+            margin: 0 0 1.5rem 0;
+        }
     }
 
     .event-body {
@@ -358,8 +401,16 @@ ob_start();
 <section class="event-section">
     <div class="container">
         <article class="event-card">
-            <?php if (!empty($event['featured_image'])): ?>
-                <figure class="event-cover">
+            <?php if (!empty($event['featured_image'])):
+                // $eventImageLayout is set by the controller and re-validated
+                // there against the allow-list; we re-narrow here as a
+                // defense in depth so a future controller refactor cannot
+                // leak an unknown layout into the CSS class name.
+                $coverAllowed = ['full', 'banner', 'contained', 'thumb'];
+                $coverLayout = in_array($eventImageLayout, $coverAllowed, true) ? $eventImageLayout : 'contained';
+                $coverClass = 'event-cover event-cover--' . $coverLayout;
+            ?>
+                <figure class="<?= HtmlHelper::e($coverClass) ?>" data-event-cover-layout="<?= HtmlHelper::e($coverLayout) ?>">
                     <img src="<?= HtmlHelper::e(url($event['featured_image'])) ?>" alt="<?= HtmlHelper::e($event['title']) ?>">
                 </figure>
             <?php endif; ?>

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -221,6 +221,7 @@ $additional_css = "
         max-width: 420px;
         margin-left: 0;
         margin-right: auto;
+        /* No border/background here: contained is a small left-aligned poster; the 420px-wide image floating next to body text reads better without the grey card frame the other variants use to fill the wider hero slot. Keep this asymmetry intentional. */
         background: transparent;
         border: none;
     }
@@ -258,6 +259,8 @@ $additional_css = "
             position: sticky;
             top: 7rem;
             margin: 0;
+            max-height: calc(100vh - 9rem);
+            overflow: hidden;
         }
         .event-card--thumb-layout > .event-body,
         .event-card--thumb-layout > .event-back {

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -211,13 +211,15 @@ $additional_css = "
         object-position: center;
     }
 
-    /* contained (DEFAULT): centred poster, never wider than 420px.
+    /* contained (DEFAULT): left-aligned poster, never wider than 420px.
        Solves the original complaint where a wide image rendered at
        full container width. Aspect ratio of the source file is
-       preserved — no crop, no forced shape, just a sensible cap. */
+       preserved — no crop, no forced shape, just a sensible cap.
+       Left-aligned so the image reads as part of the body flow rather
+       than as a centred hero. */
     .event-cover--contained {
         max-width: 420px;
-        margin-left: auto;
+        margin-left: 0;
         margin-right: auto;
         background: transparent;
         border: none;
@@ -264,7 +266,7 @@ $additional_css = "
     }
     @media (max-width: 767px) {
         .event-cover--thumb {
-            margin: 0 auto 1.5rem auto;
+            margin: 0 0 1.5rem 0;
         }
     }
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -191,7 +191,7 @@ $additional_css = "
        Effective sizes on desktop:
          full       → 100% × auto         (legacy: enormous)
          banner     → 100% × 220px max    (low-profile decorative strip)
-         contained  → 420px × auto, centred (default: small poster)
+         contained  → 420px × auto, left-aligned (default: small poster)
          thumb      → 240px wide, side-by-side with body text          */
 
     /* full: passthrough — for users who actually want a giant image. */

--- a/app/Views/generi/dettaglio_genere.php
+++ b/app/Views/generi/dettaglio_genere.php
@@ -229,7 +229,9 @@ $genereName = $genere['nome'] ?? 'Genere';
             <?= __("Elimina genere") ?>
           </h2>
           <p class="text-sm text-gray-600 dark:text-gray-400 mb-4"><?= __("Questa azione elimina il genere in modo permanente. Possibile solo se non ha sottogeneri e non è usato da nessun libro.") ?></p>
-          <form method="post" action="<?= htmlspecialchars(url("/admin/generi/{$genereId}/elimina"), ENT_QUOTES, 'UTF-8') ?>" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Sei sicuro di voler eliminare questo genere?')), ENT_QUOTES, 'UTF-8') ?>);">
+          <form method="post" action="<?= htmlspecialchars(url("/admin/generi/{$genereId}/elimina"), ENT_QUOTES, 'UTF-8') ?>"
+                data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro di voler eliminare questo genere?'), ENT_QUOTES, 'UTF-8') ?>"
+                data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') ?>">
             <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm">
               <i class="fas fa-trash-alt mr-1"></i><?= __("Elimina") ?>
@@ -264,13 +266,23 @@ document.addEventListener('DOMContentLoaded', function() {
   var mergeForm = document.getElementById('merge-genre-form');
   if (mergeForm) {
     mergeForm.addEventListener('submit', function(e) {
+      if (mergeForm.dataset.swalConfirmed === '1') return; // re-submit dopo conferma
+      e.preventDefault();
       var target = document.getElementById('merge_target_id');
       var targetName = target.options[target.selectedIndex].textContent.trim();
       var msgPrefix = <?= json_encode(__("Sei sicuro di voler unire questo genere con"), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
       var msgSuffix = <?= json_encode(__("Questa azione è irreversibile."), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
-      if (!confirm(msgPrefix + ' "' + targetName + '"? ' + msgSuffix)) {
-        e.preventDefault();
-      }
+      window.SwalApp.confirm({
+        title: msgPrefix + ' "' + targetName + '"?',
+        text:  msgSuffix,
+        icon:  'warning',
+        confirmText: <?= json_encode(__('Unisci'), JSON_HEX_TAG) ?>
+      }).then((r) => {
+        if (r.isConfirmed) {
+          mergeForm.dataset.swalConfirmed = '1';
+          mergeForm.submit();
+        }
+      });
     });
   }
 });

--- a/app/Views/libri/import_librarything.php
+++ b/app/Views/libri/import_librarything.php
@@ -456,15 +456,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         uppyLt.on('restriction-failed', (file, error) => {
             console.error('Upload restriction failed:', error);
-            if (typeof Swal !== 'undefined') {
-                Swal.fire({
-                    icon: 'error',
-                    title: <?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>,
-                    text: error.message
-                });
-            } else {
-                alert(<?= json_encode(__("Errore:"), JSON_HEX_TAG) ?> + ' ' + error.message);
-            }
+            window.SwalApp.error(<?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>, error.message);
         });
 
     } catch (error) {
@@ -604,15 +596,7 @@ document.addEventListener('DOMContentLoaded', function() {
         submitBtn.disabled = false;
         submitBtn.textContent = <?= json_encode(__("Importa Libri"), JSON_HEX_TAG) ?>;
 
-        if (window.Swal) {
-            Swal.fire({
-                icon: 'error',
-                title: <?= json_encode(__("Errore"), JSON_HEX_TAG) ?>,
-                text: message
-            });
-        } else {
-            alert(message);
-        }
+        window.SwalApp.error(<?= json_encode(__("Errore"), JSON_HEX_TAG) ?>, message);
 
         document.getElementById('import-progress-container').classList.add('hidden');
     }

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -1260,10 +1260,12 @@ function clearImagePreview() {
 }
 
 // Remove cover image
-function removeCoverImage() {
-    if (!confirm(__('Sei sicuro di voler rimuovere la copertina?'))) {
-        return;
-    }
+async function removeCoverImage() {
+    const result = await window.SwalApp.confirmDelete({
+        text: __('Sei sicuro di voler rimuovere la copertina?'),
+        confirmText: __('Rimuovi')
+    });
+    if (!result.isConfirmed) return;
 
     // Set hidden field to signal removal
     document.getElementById('remove_cover').value = '1';

--- a/app/Views/plugins/librarything_admin.php
+++ b/app/Views/plugins/librarything_admin.php
@@ -286,12 +286,25 @@ document.getElementById('confirm-uninstall')?.addEventListener('change', functio
     document.getElementById('uninstall-btn').disabled = !this.checked;
 });
 
-// Confirmation dialog for uninstall
-document.getElementById('uninstall-form')?.addEventListener('submit', function(e) {
-    if (!confirm(<?= json_encode(__("Sei assolutamente sicuro? Tutti i dati LibraryThing verranno eliminati!"), JSON_HEX_TAG) ?>)) {
+// Confirmation dialog for uninstall — switch to SwalApp so the dialog
+// matches the rest of the admin chrome instead of a native confirm.
+(function() {
+    const form = document.getElementById('uninstall-form');
+    if (!form) return;
+    form.addEventListener('submit', function(e) {
+        if (form.dataset.swalConfirmed === '1') return; // re-submit after confirm
         e.preventDefault();
-    }
-});
+        window.SwalApp.confirmDelete({
+            text: <?= json_encode(__("Sei assolutamente sicuro? Tutti i dati LibraryThing verranno eliminati!"), JSON_HEX_TAG) ?>,
+            confirmText: <?= json_encode(__("Elimina tutto"), JSON_HEX_TAG) ?>
+        }).then((r) => {
+            if (r.isConfirmed) {
+                form.dataset.swalConfirmed = '1';
+                form.submit();
+            }
+        });
+    });
+})();
 </script>
 
 <?php

--- a/app/Views/profile/index.php
+++ b/app/Views/profile/index.php
@@ -622,8 +622,12 @@
       });
   }
 
-  window.revokeSession = function(sessionId) {
-    if (!confirm(translations.confirmRevoke)) return;
+  window.revokeSession = async function(sessionId) {
+    const r = await window.SwalApp.confirmDelete({
+      text: translations.confirmRevoke,
+      confirmText: translations.confirmRevokeButton || undefined
+    });
+    if (!r.isConfirmed) return;
 
     fetch((window.BASE_PATH || '') + '/api/profile/sessions/revoke', {
       method: 'POST',
@@ -638,16 +642,19 @@
       if (data.success) {
         loadSessions();
       } else {
-        alert(data.error || translations.error);
+        window.SwalApp.error(undefined, data.error || translations.error);
       }
     })
     .catch(function() {
-      alert(translations.error);
+      window.SwalApp.error(undefined, translations.error);
     });
   };
 
-  window.revokeAllSessions = function() {
-    if (!confirm(translations.confirmRevokeAll)) return;
+  window.revokeAllSessions = async function() {
+    const r = await window.SwalApp.confirmDelete({
+      text: translations.confirmRevokeAll
+    });
+    if (!r.isConfirmed) return;
 
     fetch((window.BASE_PATH || '') + '/api/profile/sessions/revoke-all', {
       method: 'POST',
@@ -662,11 +669,11 @@
       if (data.success) {
         loadSessions();
       } else {
-        alert(data.error || translations.error);
+        window.SwalApp.error(undefined, data.error || translations.error);
       }
     })
     .catch(function() {
-      alert(translations.error);
+      window.SwalApp.error(undefined, translations.error);
     });
   };
 

--- a/app/Views/profile/index.php
+++ b/app/Views/profile/index.php
@@ -625,7 +625,13 @@
   window.revokeSession = async function(sessionId) {
     const r = await window.SwalApp.confirmDelete({
       text: translations.confirmRevoke,
-      confirmText: translations.confirmRevokeButton || undefined
+      // Pass the button label only when it's a non-empty string;
+      // `|| undefined` silently discarded an explicit empty translation
+      // and fell back to the helper's default. Treat empty same as
+      // missing so the default kicks in cleanly.
+      confirmText: (typeof translations.confirmRevokeButton === 'string' && translations.confirmRevokeButton.length > 0)
+        ? translations.confirmRevokeButton
+        : undefined
     });
     if (!r.isConfirmed) return;
 

--- a/app/Views/profile/reservations.php
+++ b/app/Views/profile/reservations.php
@@ -519,7 +519,9 @@ $profileReservationCoverUrl = static function (array $item): string {
                   <span><?= !empty($p['data_scadenza_prenotazione']) ? format_date($p['data_scadenza_prenotazione'], false, '/') : __('Non specificata') ?></span>
                 </div>
               </div>
-              <form method="post" action="<?= htmlspecialchars(url('/reservation/cancel'), ENT_QUOTES, 'UTF-8') ?>" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Annullare questa prenotazione?'), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>)">
+              <form method="post" action="<?= htmlspecialchars(url('/reservation/cancel'), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm="<?= htmlspecialchars(__('Annullare questa prenotazione?'), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm-button="<?= htmlspecialchars(__('Annulla prenotazione'), ENT_QUOTES, 'UTF-8') ?>">
                 <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
                 <input type="hidden" name="reservation_id" value="<?php echo (int)$p['id']; ?>">
                 <button type="submit" class="btn-cancel">

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -732,7 +732,9 @@ use App\Support\HtmlHelper;
                       <i class="fas <?php echo $key['is_active'] ? 'fa-pause' : 'fa-play'; ?>"></i>
                     </button>
                   </form>
-                  <form action="<?= htmlspecialchars(url('/admin/settings/api/keys/' . (int)$key['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" method="post" class="inline" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Sei sicuro di voler eliminare questa API key? Questa azione è irreversibile.')), ENT_QUOTES, 'UTF-8') ?>)">
+                  <form action="<?= htmlspecialchars(url('/admin/settings/api/keys/' . (int)$key['id'] . '/delete'), ENT_QUOTES, 'UTF-8') ?>" method="post" class="inline"
+                        data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro di voler eliminare questa API key? Questa azione è irreversibile.'), ENT_QUOTES, 'UTF-8') ?>"
+                        data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
                     <input type="hidden" name="csrf_token" value="<?php echo HtmlHelper::e($csrfToken); ?>">
                     <button type="submit"
                             class="p-2 rounded-lg bg-red-100 text-red-700 hover:bg-red-200 transition-colors"
@@ -930,7 +932,7 @@ function copyToClipboard(text, button) {
       button.innerHTML = originalHTML;
     }, 2000);
   }).catch(err => {
-    alert(<?= json_encode(__("Errore nella copia:"), JSON_HEX_TAG) ?> + ' ' + err);
+    window.SwalApp.error(undefined, <?= json_encode(__("Errore nella copia:"), JSON_HEX_TAG) ?> + ' ' + err);
   });
 }
 

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,8 +464,8 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Adattato (max 480px) — consigliato'),
-                  'banner'    => __('Banner 16:9 (ritagliato)'),
+                  'contained' => __('Foto 3:2 (consigliato)'),
+                  'banner'    => __('Banner 16:9'),
                   'full'      => __('Larghezza piena (originale)'),
                   'thumb'     => __('Miniatura affiancata'),
               ];

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -459,6 +459,47 @@ $activeTab = $activeTab ?? 'general';
                   <?= __("Gestisci Eventi") ?>
                 </a>
               </div>
+
+              <?php
+              /** @var array{image_layout: string} $eventSettings */
+              $eventImageLayout = $eventSettings['image_layout'];
+              $eventImageLayoutChoices = [
+                  'contained' => __('Adattato (max 480px) — consigliato'),
+                  'banner'    => __('Banner 16:9 (ritagliato)'),
+                  'full'      => __('Larghezza piena (originale)'),
+                  'thumb'     => __('Miniatura affiancata'),
+              ];
+              ?>
+              <div class="mt-5 pt-5 border-t border-gray-200">
+                <form action="<?= htmlspecialchars(url('/admin/settings/events'), ENT_QUOTES, 'UTF-8') ?>" method="post" class="space-y-3">
+                  <input type="hidden" name="csrf_token" value="<?= HtmlHelper::e(Csrf::ensureToken()) ?>">
+                  <div>
+                    <label for="event_image_layout" class="block text-sm font-semibold text-gray-900 mb-1">
+                      <?= __("Layout immagine evento") ?>
+                    </label>
+                    <p class="text-xs text-gray-500 mb-2"><?= __("Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.") ?></p>
+                    <select
+                      id="event_image_layout"
+                      name="event_image_layout"
+                      class="w-full rounded-xl border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900"
+                    >
+                      <?php foreach ($eventImageLayoutChoices as $value => $label): ?>
+                        <option
+                          value="<?= htmlspecialchars($value, ENT_QUOTES, 'UTF-8') ?>"
+                          <?= $eventImageLayout === $value ? 'selected' : '' ?>
+                        ><?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?></option>
+                      <?php endforeach; ?>
+                    </select>
+                  </div>
+                  <button
+                    type="submit"
+                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-600 text-white text-sm font-semibold hover:bg-purple-700 transition-colors w-full justify-center"
+                  >
+                    <i class="fas fa-save"></i>
+                    <?= __("Salva impostazioni eventi") ?>
+                  </button>
+                </form>
+              </div>
             </div>
           </div>
 

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -493,7 +493,7 @@ $activeTab = $activeTab ?? 'general';
                   </div>
                   <button
                     type="submit"
-                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-purple-600 text-white text-sm font-semibold hover:bg-purple-700 transition-colors w-full justify-center"
+                    class="inline-flex items-center gap-2 px-4 py-2 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors w-full justify-center"
                   >
                     <i class="fas fa-save"></i>
                     <?= __("Salva impostazioni eventi") ?>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,7 +464,7 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Piccola centrata (max 420px) — consigliato'),
+                  'contained' => __('Piccola a sinistra (max 420px) — consigliato'),
                   'thumb'     => __('Miniatura affiancata al testo (240px)'),
                   'banner'    => __('Banner basso a tutta larghezza (max altezza 220px)'),
                   'full'      => __('Originale a tutta larghezza (grande)'),

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -993,15 +993,10 @@ $activeTab = $activeTab ?? 'general';
         });
 
         uppyLogo.on('restriction-failed', (file, error) => {
-          if (typeof Swal !== 'undefined') {
-            Swal.fire({
-              icon: 'error',
-              title: <?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>,
-              text: error.message
-            });
-          } else {
-            alert(<?= json_encode(__("Errore: "), JSON_HEX_TAG) ?> + error.message);
-          }
+          window.SwalApp.error(
+            <?= json_encode(__("Errore Upload"), JSON_HEX_TAG) ?>,
+            error.message
+          );
         });
       } catch (error) {
         console.error('Error initializing Uppy for logo:', error);

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -464,10 +464,10 @@ $activeTab = $activeTab ?? 'general';
               /** @var array{image_layout: string} $eventSettings */
               $eventImageLayout = $eventSettings['image_layout'];
               $eventImageLayoutChoices = [
-                  'contained' => __('Foto 3:2 (consigliato)'),
-                  'banner'    => __('Banner 16:9'),
-                  'full'      => __('Larghezza piena (originale)'),
-                  'thumb'     => __('Miniatura affiancata'),
+                  'contained' => __('Piccola centrata (max 420px) — consigliato'),
+                  'thumb'     => __('Miniatura affiancata al testo (240px)'),
+                  'banner'    => __('Banner basso a tutta larghezza (max altezza 220px)'),
+                  'full'      => __('Originale a tutta larghezza (grande)'),
               ];
               ?>
               <div class="mt-5 pt-5 border-t border-gray-200">

--- a/app/Views/settings/messages-tab.php
+++ b/app/Views/settings/messages-tab.php
@@ -195,23 +195,26 @@ function closeMessageModal() {
 }
 
 function deleteMessage(id) {
-  if (confirm(<?= json_encode(__('Sei sicuro di voler eliminare questo messaggio?'), JSON_HEX_TAG) ?>)) {
+  window.SwalApp.confirmDelete({
+    text: <?= json_encode(__('Sei sicuro di voler eliminare questo messaggio?'), JSON_HEX_TAG) ?>
+  }).then((r) => {
+    if (!r.isConfirmed) return;
     csrfFetch(`${window.BASE_PATH}/admin/messages/${id}`, { method: 'DELETE' })
       .then(r => { if (!r.ok) throw new Error('delete failed'); location.reload(); })
-      .catch(() => alert(<?= json_encode(__('Errore durante l\'eliminazione del messaggio.'), JSON_HEX_TAG) ?>));
-  }
+      .catch(() => window.SwalApp.error(undefined, <?= json_encode(__('Errore durante l\'eliminazione del messaggio.'), JSON_HEX_TAG) ?>));
+  });
 }
 
 function archiveMessage(id) {
   csrfFetch(`${window.BASE_PATH}/admin/messages/${id}/archive`, { method: 'POST' })
     .then(r => { if (!r.ok) throw new Error('archive failed'); closeMessageModal(); location.reload(); })
-    .catch(() => alert(<?= json_encode(__('Errore durante l\'archiviazione del messaggio.'), JSON_HEX_TAG) ?>));
+    .catch(() => window.SwalApp.error(undefined, <?= json_encode(__('Errore durante l\'archiviazione del messaggio.'), JSON_HEX_TAG) ?>));
 }
 
 function markAllAsRead() {
   csrfFetch(`${window.BASE_PATH}/admin/messages/mark-all-read`, { method: 'POST' })
     .then(r => { if (!r.ok) throw new Error('mark-all-read failed'); location.reload(); })
-    .catch(() => alert(<?= json_encode(__('Errore durante l\'aggiornamento dei messaggi.'), JSON_HEX_TAG) ?>));
+    .catch(() => window.SwalApp.error(undefined, <?= json_encode(__('Errore durante l\'aggiornamento dei messaggi.'), JSON_HEX_TAG) ?>));
 }
 
 function replyToMessage(email) {

--- a/app/Views/user_dashboard/prenotazioni.php
+++ b/app/Views/user_dashboard/prenotazioni.php
@@ -626,7 +626,9 @@ function resolveCoverUrl(array $item, string $key = 'copertina_url'): string {
                   <span><?= $deadline ? format_date($deadline, false, '/') : __('Non specificata') ?></span>
                 </div>
               </div>
-              <form method="post" action="<?= htmlspecialchars(url('/reservation/cancel'), ENT_QUOTES, 'UTF-8') ?>" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Annullare questa prenotazione?'), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>);">
+              <form method="post" action="<?= htmlspecialchars(url('/reservation/cancel'), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm="<?= htmlspecialchars(__('Annullare questa prenotazione?'), ENT_QUOTES, 'UTF-8') ?>"
+                    data-swal-confirm-button="<?= htmlspecialchars(__('Annulla prenotazione'), ENT_QUOTES, 'UTF-8') ?>">
                 <input type="hidden" name="csrf_token" value="<?= HtmlHelper::e($csrfToken); ?>">
                 <input type="hidden" name="reservation_id" value="<?= (int)$reservation['id']; ?>">
                 <button type="submit" class="btn-cancel">

--- a/app/Views/utenti/dettagli_utente.php
+++ b/app/Views/utenti/dettagli_utente.php
@@ -247,7 +247,8 @@ $display = static function (?string $value, string $placeholder = '—'): string
       <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . $id . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1"
             data-swal-confirm="<?= htmlspecialchars(__('Confermi di voler attivare direttamente questo utente senza richiedere verifica email?'), ENT_QUOTES, 'UTF-8') ?>"
             data-swal-confirm-title="<?= htmlspecialchars(__('Conferma attivazione'), ENT_QUOTES, 'UTF-8') ?>"
-            data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>">
+            data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>"
+            data-swal-confirm-kind="action">
         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
         <button type="submit" class="w-full px-4 py-3 bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors duration-200 inline-flex items-center justify-center gap-2 border border-green-700">
           <i class="fas fa-user-check"></i>

--- a/app/Views/utenti/dettagli_utente.php
+++ b/app/Views/utenti/dettagli_utente.php
@@ -244,7 +244,10 @@ $display = static function (?string $value, string $placeholder = '—'): string
         </p>
       </form>
 
-      <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . $id . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Confermi di voler attivare direttamente questo utente senza richiedere verifica email?')), ENT_QUOTES, 'UTF-8') ?>)">
+      <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . $id . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1"
+            data-swal-confirm="<?= htmlspecialchars(__('Confermi di voler attivare direttamente questo utente senza richiedere verifica email?'), ENT_QUOTES, 'UTF-8') ?>"
+            data-swal-confirm-title="<?= htmlspecialchars(__('Conferma attivazione'), ENT_QUOTES, 'UTF-8') ?>"
+            data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>">
         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
         <button type="submit" class="w-full px-4 py-3 bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors duration-200 inline-flex items-center justify-center gap-2 border border-green-700">
           <i class="fas fa-user-check"></i>

--- a/app/Views/utenti/index.php
+++ b/app/Views/utenti/index.php
@@ -121,7 +121,10 @@
                     <span><?= __("Invia Email") ?></span>
                   </button>
                 </form>
-                <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . (int)$user['id'] . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1" onsubmit="return confirm(<?= htmlspecialchars(json_encode(__('Confermi di voler attivare direttamente questo utente?'), JSON_HEX_TAG), ENT_QUOTES, 'UTF-8') ?>)">
+                <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . (int)$user['id'] . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1"
+                      data-swal-confirm="<?= htmlspecialchars(__('Confermi di voler attivare direttamente questo utente?'), ENT_QUOTES, 'UTF-8') ?>"
+                      data-swal-confirm-title="<?= htmlspecialchars(__('Conferma attivazione'), ENT_QUOTES, 'UTF-8') ?>"
+                      data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>">
                   <input type="hidden" name="csrf_token" value="<?= \App\Support\Csrf::ensureToken() ?>">
                   <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-3 rounded-lg transition-colors text-sm inline-flex items-center justify-center gap-2">
                     <i class="fas fa-user-check"></i>
@@ -544,60 +547,40 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
-  // Delete user function
+  // Delete user function — SwalApp.confirmDelete has its own native
+  // fallback, so this single branch covers both the Swal-loaded and
+  // the Swal-missing cases.
   window.deleteUser = function(userId) {
-    if (window.Swal) {
-      Swal.fire({
-        title: __('Sei sicuro?'),
-        text: __('Questa azione non può essere annullata!'),
-        icon: 'warning',
-        showCancelButton: true,
-        confirmButtonColor: '#d33',
-        cancelButtonColor: '#3085d6',
-        confirmButtonText: __('Sì, elimina!'),
-        cancelButtonText: __('Annulla')
-      }).then((result) => {
-        if (result.isConfirmed) {
-          // Make DELETE request
-          const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-          fetch(`${window.BASE_PATH || ''}/admin/utenti/delete/${userId}`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            body: `csrf_token=${encodeURIComponent(csrfToken)}`
-          })
-          .then(response => {
-            if (response.ok || response.redirected) {
-              table.ajax.reload(null, false);
-              Swal.fire(__('Eliminato!'), __('L\'utente è stato eliminato.'), 'success');
-            } else {
-              return response.text().then(text => {
-                console.error('Delete failed - Status:', response.status, 'Body:', text);
-                Swal.fire(__('Errore!'), __('Non è stato possibile eliminare l\'utente. Controlla la console.'), 'error');
-              });
-            }
-          })
-          .catch(error => {
-            console.error('Delete error:', error);
-            Swal.fire(__('Errore!'), __('Si è verificato un errore: %s').replace('%s', error.message), 'error');
+    window.SwalApp.confirmDelete({
+      title: __('Sei sicuro?'),
+      text: __('Questa azione non può essere annullata!'),
+      confirmText: __('Sì, elimina!')
+    }).then((result) => {
+      if (!result.isConfirmed) return;
+      const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+      fetch(`${window.BASE_PATH || ''}/admin/utenti/delete/${userId}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: `csrf_token=${encodeURIComponent(csrfToken)}`
+      })
+      .then(response => {
+        if (response.ok || response.redirected) {
+          table.ajax.reload(null, false);
+          window.SwalApp.success(__('Eliminato!'), __('L\'utente è stato eliminato.'));
+        } else {
+          return response.text().then(text => {
+            console.error('Delete failed - Status:', response.status, 'Body:', text);
+            window.SwalApp.error(undefined, __('Non è stato possibile eliminare l\'utente. Controlla la console.'));
           });
         }
+      })
+      .catch(error => {
+        console.error('Delete error:', error);
+        window.SwalApp.error(undefined, __('Si è verificato un errore: %s').replace('%s', error.message));
       });
-    } else {
-      if (confirm(__('Sei sicuro di voler eliminare questo utente?'))) {
-        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-        fetch(`${window.BASE_PATH || ''}/admin/utenti/delete/${userId}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-          body: `csrf_token=${encodeURIComponent(csrfToken)}`
-        })
-        .then(() => table.ajax.reload(null, false))
-        .catch(error => console.error('Delete error:', error));
-      }
-    }
+    });
   };
 
   // Utility function

--- a/app/Views/utenti/index.php
+++ b/app/Views/utenti/index.php
@@ -124,7 +124,8 @@
                 <form method="POST" action="<?= htmlspecialchars(url('/admin/utenti/' . (int)$user['id'] . '/activate-directly'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1"
                       data-swal-confirm="<?= htmlspecialchars(__('Confermi di voler attivare direttamente questo utente?'), ENT_QUOTES, 'UTF-8') ?>"
                       data-swal-confirm-title="<?= htmlspecialchars(__('Conferma attivazione'), ENT_QUOTES, 'UTF-8') ?>"
-                      data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>">
+                      data-swal-confirm-button="<?= htmlspecialchars(__('Attiva utente'), ENT_QUOTES, 'UTF-8') ?>"
+                      data-swal-confirm-kind="action">
                   <input type="hidden" name="csrf_token" value="<?= \App\Support\Csrf::ensureToken() ?>">
                   <button type="submit" class="w-full bg-green-600 hover:bg-green-700 text-white font-medium py-2 px-3 rounded-lg transition-colors text-sm inline-flex items-center justify-center gap-2">
                     <i class="fas fa-user-check"></i>

--- a/app/Views/utenti/index.php
+++ b/app/Views/utenti/index.php
@@ -281,6 +281,14 @@ const i18nTranslations = <?= json_encode([
     'Esportazione di tutti i %d utenti' => __("Exporting all %d users"),
     'Totale utenti:' => __("Total users:"),
     'Scorri a destra per vedere tutte le colonne' => __("Scorri a destra per vedere tutte le colonne"),
+    // Keys consumed by the deleteUser flow (#140 SwalApp refactor).
+    'Sei sicuro?' => __("Sei sicuro?"),
+    'Questa azione non può essere annullata!' => __("Questa azione non può essere annullata!"),
+    'Sì, elimina!' => __("Sì, elimina!"),
+    'Eliminato!' => __("Eliminato!"),
+    "L'utente è stato eliminato." => __("L'utente è stato eliminato."),
+    "Non è stato possibile eliminare l'utente. Controlla la console." => __("Non è stato possibile eliminare l'utente. Controlla la console."),
+    'Si è verificato un errore: %s' => __("Si è verificato un errore: %s"),
 ], JSON_UNESCAPED_UNICODE | JSON_HEX_TAG) ?>;
 
 // Global translation function for JavaScript

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4677,5 +4677,13 @@
     "Eliminare questa copia digitalizzata?": "Diese digitalisierte Kopie löschen?",
     "Errore di rete.": "Netzwerkfehler.",
     "MD5 non valido (32 caratteri esadecimali).": "Ungültige MD5 (32 hexadezimale Zeichen).",
-    "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein."
+    "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
+    "Layout immagine evento": "Bild-Layout für Veranstaltung",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
+    "Adattato (max 480px) — consigliato": "Angepasst (max. 480px) — empfohlen",
+    "Banner 16:9 (ritagliato)": "Banner 16:9 (zugeschnitten)",
+    "Larghezza piena (originale)": "Volle Breite (original)",
+    "Miniatura affiancata": "Miniaturbild seitlich",
+    "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
+    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
     "Layout immagine evento": "Bild-Layout für Veranstaltung",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
-    "Larghezza piena (originale)": "Volle Breite (original)",
-    "Miniatura affiancata": "Miniaturbild seitlich",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
     "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
-    "Foto 3:2 (consigliato)": "Foto 3:2 (empfohlen)",
-    "Banner 16:9": "Banner 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Klein zentriert (max. 420px) — empfohlen",
+    "Miniatura affiancata al testo (240px)": "Miniaturbild neben dem Text (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Niedriges Banner über die volle Breite (max. Höhe 220px)",
+    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Der Wert muss eine nicht negative Ganzzahl sein.",
     "Layout immagine evento": "Bild-Layout für Veranstaltung",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
-    "Adattato (max 480px) — consigliato": "Angepasst (max. 480px) — empfohlen",
-    "Banner 16:9 (ritagliato)": "Banner 16:9 (zugeschnitten)",
     "Larghezza piena (originale)": "Volle Breite (original)",
     "Miniatura affiancata": "Miniaturbild seitlich",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
-    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert."
+    "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
+    "Foto 3:2 (consigliato)": "Foto 3:2 (empfohlen)",
+    "Banner 16:9": "Banner 16:9"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4685,5 +4685,10 @@
     "Miniatura affiancata al testo (240px)": "Miniaturbild neben dem Text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Niedriges Banner über die volle Breite (max. Höhe 220px)",
     "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)",
-    "Piccola a sinistra (max 420px) — consigliato": "Klein linksbündig (max. 420px) — empfohlen"
+    "Piccola a sinistra (max 420px) — consigliato": "Klein linksbündig (max. 420px) — empfohlen",
+    "Conferma attivazione": "Aktivierung bestätigen",
+    "Attiva utente": "Benutzer aktivieren",
+    "Elimina tutto": "Alles löschen",
+    "Conferma?": "Bestätigen?",
+    "Inserisci un valore": "Wert eingeben"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -4682,8 +4682,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Legt fest, wie das Titelbild auf der Detailseite der Veranstaltung angezeigt wird.",
     "Salva impostazioni eventi": "Veranstaltungseinstellungen speichern",
     "Impostazioni eventi aggiornate.": "Veranstaltungseinstellungen aktualisiert.",
-    "Piccola centrata (max 420px) — consigliato": "Klein zentriert (max. 420px) — empfohlen",
     "Miniatura affiancata al testo (240px)": "Miniaturbild neben dem Text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Niedriges Banner über die volle Breite (max. Höhe 220px)",
-    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)"
+    "Originale a tutta larghezza (grande)": "Original in voller Breite (groß)",
+    "Piccola a sinistra (max 420px) — consigliato": "Klein linksbündig (max. 420px) — empfohlen"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
     "Layout immagine evento": "Event image layout",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
-    "Adattato (max 480px) — consigliato": "Contained (max 480px) — recommended",
-    "Banner 16:9 (ritagliato)": "Banner 16:9 (cropped)",
     "Larghezza piena (originale)": "Full width (original)",
     "Miniatura affiancata": "Side thumbnail",
     "Salva impostazioni eventi": "Save event settings",
-    "Impostazioni eventi aggiornate.": "Event settings updated."
+    "Impostazioni eventi aggiornate.": "Event settings updated.",
+    "Foto 3:2 (consigliato)": "Photo 3:2 (recommended)",
+    "Banner 16:9": "Banner 16:9"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4682,8 +4682,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
     "Salva impostazioni eventi": "Save event settings",
     "Impostazioni eventi aggiornate.": "Event settings updated.",
-    "Piccola centrata (max 420px) — consigliato": "Small centred (max 420px) — recommended",
     "Miniatura affiancata al testo (240px)": "Thumbnail next to text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Low full-width banner (max height 220px)",
-    "Originale a tutta larghezza (grande)": "Original full width (large)"
+    "Originale a tutta larghezza (grande)": "Original full width (large)",
+    "Piccola a sinistra (max 420px) — consigliato": "Small left-aligned (max 420px) — recommended"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4685,5 +4685,10 @@
     "Miniatura affiancata al testo (240px)": "Thumbnail next to text (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Low full-width banner (max height 220px)",
     "Originale a tutta larghezza (grande)": "Original full width (large)",
-    "Piccola a sinistra (max 420px) — consigliato": "Small left-aligned (max 420px) — recommended"
+    "Piccola a sinistra (max 420px) — consigliato": "Small left-aligned (max 420px) — recommended",
+    "Conferma attivazione": "Confirm activation",
+    "Attiva utente": "Activate user",
+    "Elimina tutto": "Delete everything",
+    "Conferma?": "Confirm?",
+    "Inserisci un valore": "Enter a value"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4677,5 +4677,13 @@
     "Eliminare questa copia digitalizzata?": "Delete this digitised copy?",
     "Errore di rete.": "Network error.",
     "MD5 non valido (32 caratteri esadecimali).": "Invalid MD5 (32 hexadecimal characters).",
-    "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer."
+    "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
+    "Layout immagine evento": "Event image layout",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
+    "Adattato (max 480px) — consigliato": "Contained (max 480px) — recommended",
+    "Banner 16:9 (ritagliato)": "Banner 16:9 (cropped)",
+    "Larghezza piena (originale)": "Full width (original)",
+    "Miniatura affiancata": "Side thumbnail",
+    "Salva impostazioni eventi": "Save event settings",
+    "Impostazioni eventi aggiornate.": "Event settings updated."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -4680,10 +4680,10 @@
     "Il valore deve essere un intero non negativo.": "Value must be a non-negative integer.",
     "Layout immagine evento": "Event image layout",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Controls how the cover image is rendered on the event detail page.",
-    "Larghezza piena (originale)": "Full width (original)",
-    "Miniatura affiancata": "Side thumbnail",
     "Salva impostazioni eventi": "Save event settings",
     "Impostazioni eventi aggiornate.": "Event settings updated.",
-    "Foto 3:2 (consigliato)": "Photo 3:2 (recommended)",
-    "Banner 16:9": "Banner 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Small centred (max 420px) — recommended",
+    "Miniatura affiancata al testo (240px)": "Thumbnail next to text (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Low full-width banner (max height 220px)",
+    "Originale a tutta larghezza (grande)": "Original full width (large)"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5006,10 +5006,10 @@
     "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
     "Layout immagine evento": "Mise en page de l'image de l'événement",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
-    "Adattato (max 480px) — consigliato": "Contenue (max 480px) — recommandée",
-    "Banner 16:9 (ritagliato)": "Bannière 16:9 (recadrée)",
     "Larghezza piena (originale)": "Pleine largeur (originale)",
     "Miniatura affiancata": "Vignette latérale",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
-    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour."
+    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
+    "Foto 3:2 (consigliato)": "Photo 3:2 (recommandé)",
+    "Banner 16:9": "Bannière 16:9"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5006,10 +5006,10 @@
     "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
     "Layout immagine evento": "Mise en page de l'image de l'événement",
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
-    "Larghezza piena (originale)": "Pleine largeur (originale)",
-    "Miniatura affiancata": "Vignette latérale",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
     "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
-    "Foto 3:2 (consigliato)": "Photo 3:2 (recommandé)",
-    "Banner 16:9": "Bannière 16:9"
+    "Piccola centrata (max 420px) — consigliato": "Petite centrée (max 420px) — recommandée",
+    "Miniatura affiancata al testo (240px)": "Vignette à côté du texte (240px)",
+    "Banner basso a tutta larghezza (max altezza 220px)": "Bannière basse pleine largeur (hauteur max 220px)",
+    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5011,5 +5011,10 @@
     "Miniatura affiancata al testo (240px)": "Vignette à côté du texte (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Bannière basse pleine largeur (hauteur max 220px)",
     "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)",
-    "Piccola a sinistra (max 420px) — consigliato": "Petite alignée à gauche (max 420px) — recommandée"
+    "Piccola a sinistra (max 420px) — consigliato": "Petite alignée à gauche (max 420px) — recommandée",
+    "Conferma attivazione": "Confirmer l'activation",
+    "Attiva utente": "Activer l'utilisateur",
+    "Elimina tutto": "Tout supprimer",
+    "Conferma?": "Confirmer ?",
+    "Inserisci un valore": "Saisissez une valeur"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5008,8 +5008,8 @@
     "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
     "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
     "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour.",
-    "Piccola centrata (max 420px) — consigliato": "Petite centrée (max 420px) — recommandée",
     "Miniatura affiancata al testo (240px)": "Vignette à côté du texte (240px)",
     "Banner basso a tutta larghezza (max altezza 220px)": "Bannière basse pleine largeur (hauteur max 220px)",
-    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)"
+    "Originale a tutta larghezza (grande)": "Original pleine largeur (grand)",
+    "Piccola a sinistra (max 420px) — consigliato": "Petite alignée à gauche (max 420px) — recommandée"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5003,5 +5003,13 @@
     "Copia digitalizzata eliminata": "Copie numérisée supprimée",
     "URL non sicuro": "URL non sécurisée",
     "MD5 non valido (32 caratteri esadecimali).": "MD5 invalide (32 caractères hexadécimaux).",
-    "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif."
+    "Il valore deve essere un intero non negativo.": "La valeur doit être un entier non négatif.",
+    "Layout immagine evento": "Mise en page de l'image de l'événement",
+    "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Définit comment l'image de couverture est affichée sur la page de détail de l'événement.",
+    "Adattato (max 480px) — consigliato": "Contenue (max 480px) — recommandée",
+    "Banner 16:9 (ritagliato)": "Bannière 16:9 (recadrée)",
+    "Larghezza piena (originale)": "Pleine largeur (originale)",
+    "Miniatura affiancata": "Vignette latérale",
+    "Salva impostazioni eventi": "Enregistrer les paramètres des événements",
+    "Impostazioni eventi aggiornate.": "Paramètres des événements mis à jour."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -511,10 +511,10 @@
   "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
   "Layout immagine evento": "Layout immagine evento",
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
-  "Larghezza piena (originale)": "Larghezza piena (originale)",
-  "Miniatura affiancata": "Miniatura affiancata",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
   "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
-  "Foto 3:2 (consigliato)": "Foto 3:2 (consigliato)",
-  "Banner 16:9": "Banner 16:9"
+  "Piccola centrata (max 420px) — consigliato": "Piccola centrata (max 420px) — consigliato",
+  "Miniatura affiancata al testo (240px)": "Miniatura affiancata al testo (240px)",
+  "Banner basso a tutta larghezza (max altezza 220px)": "Banner basso a tutta larghezza (max altezza 220px)",
+  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -511,10 +511,10 @@
   "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
   "Layout immagine evento": "Layout immagine evento",
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
-  "Adattato (max 480px) — consigliato": "Adattato (max 480px) — consigliato",
-  "Banner 16:9 (ritagliato)": "Banner 16:9 (ritagliato)",
   "Larghezza piena (originale)": "Larghezza piena (originale)",
   "Miniatura affiancata": "Miniatura affiancata",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
-  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate."
+  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
+  "Foto 3:2 (consigliato)": "Foto 3:2 (consigliato)",
+  "Banner 16:9": "Banner 16:9"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -508,5 +508,13 @@
   "URL non valido.": "URL non valido.",
   "MD5 non valido (32 caratteri esadecimali).": "MD5 non valido (32 caratteri esadecimali).",
   "Il valore deve essere un intero non negativo.": "Il valore deve essere un intero non negativo.",
-  "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente"
+  "Language %s has been activated automatically": "La lingua %s è stata attivata automaticamente",
+  "Layout immagine evento": "Layout immagine evento",
+  "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
+  "Adattato (max 480px) — consigliato": "Adattato (max 480px) — consigliato",
+  "Banner 16:9 (ritagliato)": "Banner 16:9 (ritagliato)",
+  "Larghezza piena (originale)": "Larghezza piena (originale)",
+  "Miniatura affiancata": "Miniatura affiancata",
+  "Salva impostazioni eventi": "Salva impostazioni eventi",
+  "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -516,5 +516,16 @@
   "Miniatura affiancata al testo (240px)": "Miniatura affiancata al testo (240px)",
   "Banner basso a tutta larghezza (max altezza 220px)": "Banner basso a tutta larghezza (max altezza 220px)",
   "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)",
-  "Piccola a sinistra (max 420px) — consigliato": "Piccola a sinistra (max 420px) — consigliato"
+  "Piccola a sinistra (max 420px) — consigliato": "Piccola a sinistra (max 420px) — consigliato",
+  "Annulla prenotazione": "Annulla prenotazione",
+  "Conferma attivazione": "Conferma attivazione",
+  "Attiva utente": "Attiva utente",
+  "Elimina tutto": "Elimina tutto",
+  "Unisci": "Unisci",
+  "Attiva": "Attiva",
+  "Ripristina": "Ripristina",
+  "Conferma?": "Confermi?",
+  "Errore Upload": "Errore Upload",
+  "Inserisci un valore": "Inserisci un valore",
+  "Imposta come Predefinita": "Imposta come Predefinita"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -513,8 +513,8 @@
   "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.": "Definisce come viene visualizzata l'immagine di copertina nella pagina di dettaglio dell'evento.",
   "Salva impostazioni eventi": "Salva impostazioni eventi",
   "Impostazioni eventi aggiornate.": "Impostazioni eventi aggiornate.",
-  "Piccola centrata (max 420px) — consigliato": "Piccola centrata (max 420px) — consigliato",
   "Miniatura affiancata al testo (240px)": "Miniatura affiancata al testo (240px)",
   "Banner basso a tutta larghezza (max altezza 220px)": "Banner basso a tutta larghezza (max altezza 220px)",
-  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)"
+  "Originale a tutta larghezza (grande)": "Originale a tutta larghezza (grande)",
+  "Piccola a sinistra (max 420px) — consigliato": "Piccola a sinistra (max 420px) — consigliato"
 }

--- a/public/assets/js/swal-config.js
+++ b/public/assets/js/swal-config.js
@@ -281,14 +281,21 @@ window.SwalApp = {
         event.preventDefault();
         const text  = form.dataset.swalConfirm;
         const title = form.dataset.swalConfirmTitle || __swal('Sei sicuro?');
-        const confirmText = form.dataset.swalConfirmButton || __swal('Elimina');
         // Pick a kind-appropriate helper: forms with
         // data-swal-confirm-kind="action" use the neutral (gray)
         // confirm dialog; everything else defaults to confirmDelete
         // (red destructive button). Lets non-destructive flows
         // (activate user, set default language, reset colours, …)
-        // opt out of the red-button look.
-        const kind = form.dataset.swalConfirmKind === 'action'
+        // opt out of the red-button look. The confirmText default
+        // also follows the kind — neutral actions get "Conferma",
+        // destructive ones get "Elimina" — so a form that opts into
+        // `kind="action"` without overriding `data-swal-confirm-button`
+        // doesn't accidentally show a red-themed "Elimina" label on
+        // the gray button.
+        const isAction = form.dataset.swalConfirmKind === 'action';
+        const confirmText = form.dataset.swalConfirmButton
+          || (isAction ? __swal('Conferma') : __swal('Elimina'));
+        const kind = isAction
           ? window.SwalApp.confirm
           : window.SwalApp.confirmDelete;
         kind.call(window.SwalApp, {

--- a/public/assets/js/swal-config.js
+++ b/public/assets/js/swal-config.js
@@ -199,7 +199,9 @@ window.SwalApp = {
     const def   = options.defaultValue || '';
     if (!_hasSwal()) {
       const v = window.prompt(text ? title + '\n\n' + text : title, def);
-      return _fakeResult(v !== null && v !== '', v || '');
+      // Only `null` is "cancel"; an empty string is a valid confirmed
+      // value (matches Swal's semantics where the user can submit "").
+      return _fakeResult(v !== null, v === null ? '' : v);
     }
     return Swal.fire({
       title: title,

--- a/public/assets/js/swal-config.js
+++ b/public/assets/js/swal-config.js
@@ -78,8 +78,12 @@ window.SwalApp = {
     const text  = options.text  || __swal('Questa azione non può essere annullata!');
     if (!_hasSwal()) {
       // Native fallback: combine title + text on two lines so the user
-      // sees the same information as the SweetAlert dialog.
-      return _fakeResult(window.confirm(title + '\n\n' + text));
+      // sees the same information as the SweetAlert dialog. Guard
+      // against `text` being missing — title || default keeps `text`
+      // potentially undefined when both options.text and the default
+      // resolve to empty.
+      const msg = text ? title + '\n\n' + text : title;
+      return _fakeResult(window.confirm(msg));
     }
     return Swal.fire({
       title: title,
@@ -263,22 +267,38 @@ window.SwalApp = {
       if (form.dataset.swalAttached === '1') return;
       form.dataset.swalAttached = '1';
       form.addEventListener('submit', function(event) {
-        // If a previous handler already cleared `data-swal-confirm`
-        // (e.g. the form was confirmed and re-submitted programmatically),
-        // let the submit proceed without re-prompting.
-        if (!form.dataset.swalConfirm) return;
+        // If this submit is the programmatic one we ourselves fire
+        // after Swal confirm (see below), let it through. Using a
+        // separate flag avoids the previous trick of CLEARING
+        // data-swal-confirm — if form.submit() failed or got blocked
+        // elsewhere, the cleared attribute permanently bypassed the
+        // dialog on every later click.
+        if (form.dataset.swalProceed === '1') {
+          // Reset for any future submit so the dialog gates the next click.
+          form.dataset.swalProceed = '';
+          return;
+        }
         event.preventDefault();
         const text  = form.dataset.swalConfirm;
         const title = form.dataset.swalConfirmTitle || __swal('Sei sicuro?');
         const confirmText = form.dataset.swalConfirmButton || __swal('Elimina');
-        window.SwalApp.confirmDelete({
+        // Pick a kind-appropriate helper: forms with
+        // data-swal-confirm-kind="action" use the neutral (gray)
+        // confirm dialog; everything else defaults to confirmDelete
+        // (red destructive button). Lets non-destructive flows
+        // (activate user, set default language, reset colours, …)
+        // opt out of the red-button look.
+        const kind = form.dataset.swalConfirmKind === 'action'
+          ? window.SwalApp.confirm
+          : window.SwalApp.confirmDelete;
+        kind.call(window.SwalApp, {
           title: title,
           text:  text,
           confirmText: confirmText
         }).then((r) => {
           if (r.isConfirmed) {
-            // Clear the marker so the second submit goes through.
-            form.dataset.swalConfirm = '';
+            // Mark the next submit as the proceed one and re-fire.
+            form.dataset.swalProceed = '1';
             form.submit();
           }
         });

--- a/public/assets/js/swal-config.js
+++ b/public/assets/js/swal-config.js
@@ -54,15 +54,36 @@ if (typeof Swal !== 'undefined') {
   Swal.mixin(SwalConfig);
 }
 
+// Check if SweetAlert2 is loaded — every helper below uses this for
+// defensive fallback. If the JS bundle / CDN failed, or CSP blocked
+// the script, we still want delete/save flows to work via the native
+// browser dialogs.
+const _hasSwal = function() {
+  return typeof Swal !== 'undefined';
+};
+
+// Wrap a native confirm()/alert() in a Promise-like shape so callers
+// using async/.then(r => r.isConfirmed) work both with and without Swal.
+const _fakeResult = function(isConfirmed, value) {
+  return Promise.resolve({ isConfirmed: !!isConfirmed, value: value });
+};
+
 // Helper functions per casi comuni
 window.SwalApp = {
   /**
    * Conferma eliminazione
    */
   confirmDelete: function(options = {}) {
+    const title = options.title || __swal('Sei sicuro?');
+    const text  = options.text  || __swal('Questa azione non può essere annullata!');
+    if (!_hasSwal()) {
+      // Native fallback: combine title + text on two lines so the user
+      // sees the same information as the SweetAlert dialog.
+      return _fakeResult(window.confirm(title + '\n\n' + text));
+    }
     return Swal.fire({
-      title: options.title || __swal('Sei sicuro?'),
-      text: options.text || __swal('Questa azione non può essere annullata!'),
+      title: title,
+      text:  text,
       icon: 'warning',
       showCancelButton: true,
       confirmButtonColor: '#dc2626', // Rosso per delete
@@ -76,9 +97,14 @@ window.SwalApp = {
    * Success message
    */
   success: function(title, text) {
+    const t = title || __swal('Successo!');
+    if (!_hasSwal()) {
+      window.alert(text ? t + '\n\n' + text : t);
+      return _fakeResult(true);
+    }
     return Swal.fire({
       icon: 'success',
-      title: title || __swal('Successo!'),
+      title: t,
       text: text,
       confirmButtonColor: '#111827',
       confirmButtonText: __swal('OK', 'OK')
@@ -89,9 +115,14 @@ window.SwalApp = {
    * Error message
    */
   error: function(title, text) {
+    const t = title || __swal('Errore!');
+    if (!_hasSwal()) {
+      window.alert(text ? t + '\n\n' + text : t);
+      return _fakeResult(true);
+    }
     return Swal.fire({
       icon: 'error',
-      title: title || __swal('Errore!'),
+      title: t,
       text: text,
       confirmButtonColor: '#111827',
       confirmButtonText: __swal('OK', 'OK')
@@ -102,9 +133,14 @@ window.SwalApp = {
    * Info message
    */
   info: function(title, text) {
+    const t = title || __swal('Informazione');
+    if (!_hasSwal()) {
+      window.alert(text ? t + '\n\n' + text : t);
+      return _fakeResult(true);
+    }
     return Swal.fire({
       icon: 'info',
-      title: title || __swal('Informazione'),
+      title: t,
       text: text,
       confirmButtonColor: '#111827',
       confirmButtonText: __swal('OK', 'OK')
@@ -115,9 +151,14 @@ window.SwalApp = {
    * Warning message
    */
   warning: function(title, text) {
+    const t = title || __swal('Attenzione!');
+    if (!_hasSwal()) {
+      window.alert(text ? t + '\n\n' + text : t);
+      return _fakeResult(true);
+    }
     return Swal.fire({
       icon: 'warning',
-      title: title || __swal('Attenzione!'),
+      title: t,
       text: text,
       confirmButtonColor: '#111827',
       confirmButtonText: __swal('OK', 'OK')
@@ -128,11 +169,16 @@ window.SwalApp = {
    * Conferma generica
    */
   confirm: function(options = {}) {
+    const title = options.title || __swal('Confermi?');
+    const text  = options.text;
+    if (!_hasSwal()) {
+      return _fakeResult(window.confirm(text ? title + '\n\n' + text : title));
+    }
     return Swal.fire({
-      title: options.title || __swal('Confermi?'),
-      text: options.text,
-      html: options.html,
-      icon: options.icon || 'question',
+      title: title,
+      text:  text,
+      html:  options.html,
+      icon:  options.icon || 'question',
       showCancelButton: true,
       confirmButtonColor: '#111827',
       cancelButtonColor: '#9ca3af',
@@ -143,9 +189,41 @@ window.SwalApp = {
   },
 
   /**
+   * Prompt — single-line text input. Returns {isConfirmed, value}.
+   * Falls back to window.prompt() when Swal is unavailable so the
+   * user can still answer in degraded mode.
+   */
+  prompt: function(options = {}) {
+    const title = options.title || __swal('Inserisci un valore');
+    const text  = options.text;
+    const def   = options.defaultValue || '';
+    if (!_hasSwal()) {
+      const v = window.prompt(text ? title + '\n\n' + text : title, def);
+      return _fakeResult(v !== null && v !== '', v || '');
+    }
+    return Swal.fire({
+      title: title,
+      text:  text,
+      input: options.input || 'text',
+      inputValue: def,
+      inputPlaceholder: options.placeholder || '',
+      showCancelButton: true,
+      confirmButtonColor: '#111827',
+      confirmButtonText: options.confirmText || __swal('Conferma'),
+      cancelButtonText:  __swal('Annulla'),
+      inputValidator: options.inputValidator || null
+    });
+  },
+
+  /**
    * Toast notification
    */
   toast: function(options = {}) {
+    if (!_hasSwal()) {
+      // Toasts are pure UX flair — silently no-op when Swal absent
+      // rather than block flow with alert() for every transient notice.
+      return _fakeResult(true);
+    }
     const Toast = Swal.mixin({
       toast: true,
       position: options.position || 'top-end',
@@ -162,5 +240,60 @@ window.SwalApp = {
       icon: options.icon || 'success',
       title: options.title || __swal('Operazione completata')
     });
+  },
+
+  /**
+   * Attach a SweetAlert confirm dialog to every form matching the
+   * given selector (default: `form[data-swal-confirm]`). The form's
+   * `data-swal-confirm` attribute is used as the dialog text; an
+   * optional `data-swal-confirm-title` overrides the title.
+   *
+   * Pattern lets us migrate every legacy `<form onsubmit="return
+   * confirm(...)">` to a uniform Swal flow without inlining a
+   * `<script>` per form. Call once from a `DOMContentLoaded` handler.
+   *
+   * Falls back to `window.confirm()` when Swal isn't loaded — the
+   * form still submits on user confirm.
+   */
+  attachSwalConfirm: function(selector) {
+    const sel = selector || 'form[data-swal-confirm]';
+    document.querySelectorAll(sel).forEach((form) => {
+      if (form.dataset.swalAttached === '1') return;
+      form.dataset.swalAttached = '1';
+      form.addEventListener('submit', function(event) {
+        // If a previous handler already cleared `data-swal-confirm`
+        // (e.g. the form was confirmed and re-submitted programmatically),
+        // let the submit proceed without re-prompting.
+        if (!form.dataset.swalConfirm) return;
+        event.preventDefault();
+        const text  = form.dataset.swalConfirm;
+        const title = form.dataset.swalConfirmTitle || __swal('Sei sicuro?');
+        const confirmText = form.dataset.swalConfirmButton || __swal('Elimina');
+        window.SwalApp.confirmDelete({
+          title: title,
+          text:  text,
+          confirmText: confirmText
+        }).then((r) => {
+          if (r.isConfirmed) {
+            // Clear the marker so the second submit goes through.
+            form.dataset.swalConfirm = '';
+            form.submit();
+          }
+        });
+      });
+    });
   }
 };
+
+// Auto-wire on DOMContentLoaded so views can simply mark their forms
+// with `data-swal-confirm="..."` instead of including a per-page
+// listener. Idempotent: re-attaching is a no-op via `data-swal-attached`.
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function() {
+      window.SwalApp.attachSwalConfirm();
+    });
+  } else {
+    window.SwalApp.attachSwalConfirm();
+  }
+}

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -3079,14 +3079,41 @@ test.describe.serial('Phase 21: Language Switch', () => {
 
   test.beforeEach(() => { test.skip(!appReady, 'App not ready — Phase 1 did not complete'); });
 
+  // Submit a set-default-language form and confirm via either the
+  // SwalApp modal (current behaviour after the popup unification in
+  // PR #141) or the legacy native `window.confirm()` dialog (older
+  // installs / pre-merge branches). The Swal path wins when both are
+  // present because attachSwalConfirm intercepts the submit event
+  // before any native confirm could surface.
+  async function submitSetDefaultAndConfirm(localeCode) {
+    let nativeDialogFired = false;
+    const dialogHandler = (dialog) => { nativeDialogFired = true; dialog.accept(); };
+    page.once('dialog', dialogHandler);
+
+    await page.locator(`form[action*="/${localeCode}/set-default"] button[type="submit"]`).click();
+
+    // Wait briefly to see if a SwalApp modal lands — if it does, click
+    // its confirm button to release the form. If only a native dialog
+    // fires, the handler above already accepted it.
+    const swalConfirm = page.locator('.swal2-confirm');
+    try {
+      await swalConfirm.waitFor({ state: 'visible', timeout: 1500 });
+      await swalConfirm.click();
+    } catch {
+      // No Swal modal — the native dialog handler above must have run
+      // (or the form was submitted directly without any confirmation).
+    }
+    page.removeListener('dialog', dialogHandler);
+
+    await page.waitForURL(/admin\/languages/, { timeout: 10000 });
+    return { nativeDialogFired };
+  }
+
   test('21.1 Switch to French (fr_FR) as default language', async () => {
     await page.goto(`${BASE}/admin/languages`);
     await page.waitForLoadState('domcontentloaded');
 
-    // The set-default button is inside a form with a browser confirm() dialog
-    page.once('dialog', dialog => dialog.accept());
-    await page.locator('form[action*="/fr_FR/set-default"] button[type="submit"]').click();
-    await page.waitForURL(/admin\/languages/, { timeout: 10000 });
+    await submitSetDefaultAndConfirm('fr_FR');
 
     const dbCode = dbQuery("SELECT code FROM languages WHERE is_default = 1 LIMIT 1");
     expect(dbCode).toBe('fr_FR');
@@ -3122,9 +3149,7 @@ test.describe.serial('Phase 21: Language Switch', () => {
     await page.goto(`${BASE}/admin/languages`);
     await page.waitForLoadState('domcontentloaded');
 
-    page.once('dialog', dialog => dialog.accept());
-    await page.locator('form[action*="/en_US/set-default"] button[type="submit"]').click();
-    await page.waitForURL(/admin\/languages/, { timeout: 10000 });
+    await submitSetDefaultAndConfirm('en_US');
 
     let dbCode = dbQuery("SELECT code FROM languages WHERE is_default = 1 LIMIT 1");
     expect(dbCode).toBe('en_US');
@@ -3132,9 +3157,7 @@ test.describe.serial('Phase 21: Language Switch', () => {
     await expect(page.locator('body')).toContainText('Languages');
 
     // ── German ───────────────────────────────────────────────────────────
-    page.once('dialog', dialog => dialog.accept());
-    await page.locator('form[action*="/de_DE/set-default"] button[type="submit"]').click();
-    await page.waitForURL(/admin\/languages/, { timeout: 10000 });
+    await submitSetDefaultAndConfirm('de_DE');
 
     dbCode = dbQuery("SELECT code FROM languages WHERE is_default = 1 LIMIT 1");
     expect(dbCode).toBe('de_DE');
@@ -3146,9 +3169,7 @@ test.describe.serial('Phase 21: Language Switch', () => {
     await page.goto(`${BASE}/admin/languages`);
     await page.waitForLoadState('domcontentloaded');
 
-    page.once('dialog', dialog => dialog.accept());
-    await page.locator('form[action*="/it_IT/set-default"] button[type="submit"]').click();
-    await page.waitForURL(/admin\/languages/, { timeout: 10000 });
+    await submitSetDefaultAndConfirm('it_IT');
 
     const dbCode = dbQuery("SELECT code FROM languages WHERE is_default = 1 LIMIT 1");
     expect(dbCode).toBe('it_IT');

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -188,16 +188,29 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             `SELECT featured_image FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`
         );
         if (currentImage && currentImage.startsWith('/uploads/events/')) {
-            const absPath = path.join(__dirname, '..', 'public', currentImage);
-            try {
-                fs.unlinkSync(absPath);
-            } catch (e) {
-                // ENOENT (already gone) is acceptable — the controller's
-                // own cleanup may have unlinked it on the success path.
-                // Any other error we surface to the test log but do not
-                // fail the teardown — the suite has finished otherwise.
-                if (e && e.code !== 'ENOENT') {
-                    console.warn(`teardown: could not unlink ${absPath}: ${e.message}`);
+            // Defense in depth: even with a sanitizing controller, the
+            // teardown reads from the DB and a crafted path containing
+            // '..' segments would let fs.unlinkSync escape public/uploads/events
+            // when joined with path.join. Resolve from the uploads-events
+            // root and verify the final absolute path stays inside it
+            // before unlinking. (CodeRabbit #141.)
+            const uploadsRoot = path.resolve(__dirname, '..', 'public', 'uploads', 'events');
+            const relative    = currentImage.slice('/uploads/events/'.length);
+            const absPath     = path.resolve(uploadsRoot, relative);
+            const escaped     = path.relative(uploadsRoot, absPath);
+            if (escaped.startsWith('..') || path.isAbsolute(escaped)) {
+                console.warn(`teardown: refusing to unlink path outside uploads root: ${currentImage}`);
+            } else {
+                try {
+                    fs.unlinkSync(absPath);
+                } catch (e) {
+                    // ENOENT (already gone) is acceptable — the controller's
+                    // own cleanup may have unlinked it on the success path.
+                    // Any other error we surface to the test log but do not
+                    // fail the teardown — the suite has finished otherwise.
+                    if (e && e.code !== 'ENOENT') {
+                        console.warn(`teardown: could not unlink ${absPath}: ${e.message}`);
+                    }
                 }
             }
         }
@@ -299,7 +312,9 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         // Reset content to a long enough body so 'banner' / 'contained'
         // have something below them to measure against.
         const longContent = '<p>' + 'Test event description. '.repeat(40) + '</p>';
-        const sqlSafeLong = longContent.replace(/'/g, "\\'");
+        // Use the suite's sqlEscape() so backslashes get handled too
+        // (CodeQL flagged the previous inline replace as incomplete).
+        const sqlSafeLong = sqlEscape(longContent);
         dbExec(`UPDATE events SET content='${sqlSafeLong}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
 
         await page.setViewportSize({ width: 1280, height: 900 });
@@ -468,7 +483,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
 
         // Shrink the event content so a CSS float would expose the bug.
         const shortContent = '<p>Breve.</p>';
-        const sqlSafe = shortContent.replace(/'/g, "\\'");
+        const sqlSafe = sqlEscape(shortContent);
         dbExec(`UPDATE events SET content='${sqlSafe}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
 
         // Desktop viewport — the grid kicks in at >=768px.

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -258,6 +258,82 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     // ────────────────────────────────────────────────────────────────────
+    // Replace-while-removing regression (issue #137 follow-up):
+    // when the admin form posts BOTH a new featured_image file AND
+    // ticks "remove_image=1", the new upload must win — not be
+    // discarded along with the old image. Earlier code path used an
+    // if/elseif with remove_image first, silently dropping the
+    // upload.
+    //
+    // Reproduced end-to-end through the admin UI: login → open edit
+    // form → tick "Rimuovi immagine attuale" → also choose a new
+    // file via the hidden file input → submit → verify the DB row
+    // has a brand-new path (not NULL and not the original).
+    // ────────────────────────────────────────────────────────────────────
+    test('admin update: uploading a new image while ticking "remove" keeps the new image', async ({ page }) => {
+        // Bootstrap a "previous" image so the form actually shows the
+        // "Rimuovi immagine attuale" checkbox (it only renders when
+        // featured_image is non-empty).
+        const sqlPre = `/uploads/events/event_test_pre_${RUN_ID}.jpg`;
+        dbExec(`UPDATE events SET featured_image='${sqlEscape(sqlPre)}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+        const eventId = parseInt(
+            dbQuery(`SELECT id FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`),
+            10,
+        );
+        expect(eventId, 'seed event must exist').toBeGreaterThan(0);
+
+        // Admin login (the form requires it).
+        await page.goto(`${BASE}/accedi`);
+        await page.fill('input[name="email"]', ADMIN_EMAIL);
+        await page.fill('input[name="password"]', ADMIN_PASS);
+        await Promise.all([
+            page.waitForURL(/\/(admin|profilo)/, { timeout: 15000 }),
+            page.click('button[type="submit"]'),
+        ]);
+
+        // Open the edit form.
+        await page.goto(`${BASE}/admin/cms/events/edit/${eventId}`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // Tick the "Rimuovi immagine attuale" checkbox.
+        const removeCheckbox = page.locator('input[name="remove_image"]');
+        await expect(removeCheckbox).toHaveCount(1);
+        await removeCheckbox.check({ force: true });
+
+        // Attach a new image to the hidden file input — the same
+        // path the Uppy widget normally writes into.
+        await page.setInputFiles('input[name="featured_image"]', {
+            name: 'test-replacement.jpg',
+            mimeType: 'image/jpeg',
+            // 1x1 jpeg, base64-decoded — minimal valid file.
+            buffer: Buffer.from(
+                '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpgB//Z',
+                'base64',
+            ),
+        });
+
+        // Submit. The submit button label varies with locale but
+        // there's always a visible primary button inside the form.
+        const submitButton = page.locator('form button[type="submit"]').first();
+        await Promise.all([
+            page.waitForURL(/\/admin\/cms\/events(\?|$)/, { timeout: 15000 }),
+            submitButton.click(),
+        ]);
+
+        // Assert: the DB now points at a NEW upload, not NULL and
+        // not the original sentinel path.
+        const after = dbQuery(`SELECT featured_image FROM events WHERE id=${eventId}`);
+        expect(
+            after,
+            `featured_image MUST contain a new upload, not be cleared. Got: "${after}"`
+        ).toMatch(/^\/uploads\/events\/event_\d{8}_\d{6}_[a-f0-9]+\.(jpg|jpeg|png|webp)$/i);
+        expect(
+            after,
+            `featured_image MUST NOT match the pre-existing sentinel ("${sqlPre}")`
+        ).not.toBe(sqlPre);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
     // Containment regression — guards against the float-overflow bug
     // reported during initial review: when content is short, a floated
     // .event-cover--thumb escapes its parent .event-card and ends up

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -22,6 +22,8 @@
 
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
@@ -172,6 +174,33 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         // Cleanup: delete test event + restore the original
         // event_image_layout (DELETE if it was absent before the suite,
         // else UPDATE back to the captured original value).
+        //
+        // BEFORE the DB DELETE: if the admin-update test (or any future
+        // test) replaced the seed featured_image with a real upload via
+        // handleImageUpload(), the path now points at
+        // /uploads/events/event_*.jpg on disk. Bypassing the controller
+        // delete() means deleteUploadedImageFile() would never run —
+        // unlink the file here explicitly so the suite doesn't leave
+        // orphans behind. The seed value (`/assets/books.jpg`) is a
+        // static asset and is excluded by the /uploads/events/ prefix
+        // guard, so this is safe to call unconditionally.
+        const currentImage = dbQuery(
+            `SELECT featured_image FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`
+        );
+        if (currentImage && currentImage.startsWith('/uploads/events/')) {
+            const absPath = path.join(__dirname, '..', 'public', currentImage);
+            try {
+                fs.unlinkSync(absPath);
+            } catch (e) {
+                // ENOENT (already gone) is acceptable — the controller's
+                // own cleanup may have unlinked it on the success path.
+                // Any other error we surface to the test log but do not
+                // fail the teardown — the suite has finished otherwise.
+                if (e && e.code !== 'ENOENT') {
+                    console.warn(`teardown: could not unlink ${absPath}: ${e.message}`);
+                }
+            }
+        }
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
         if (eventImageLayoutWasAbsent) {
             dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -159,6 +159,82 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     // ────────────────────────────────────────────────────────────────────
+    // Effective-size regression (issue #137 user feedback): the four
+    // presets must actually render at DIFFERENT, progressively smaller
+    // dimensions. An earlier iteration of this feature shipped four
+    // visually-equivalent "full width" variants, defeating the purpose
+    // of the setting (the user explicitly asked for a smaller image).
+    //
+    // We assert:
+    //   contained  → figure narrower than the article (small centred)
+    //   thumb      → figure narrower than the article (side thumbnail)
+    //   banner     → figure at full article width, capped to ~220px tall
+    //   full       → figure at full article width, no height cap
+    //
+    // Using rendered bounding boxes (NOT computed CSS) catches the
+    // historical mistake where `width: 100%` was applied to all four
+    // variants but only the class name differed.
+    // ────────────────────────────────────────────────────────────────────
+    test('effective size — each preset renders at a distinct, smaller dimension', async ({ page }) => {
+        // Reset content to a long enough body so 'banner' / 'contained'
+        // have something below them to measure against.
+        const longContent = '<p>' + 'Test event description. '.repeat(40) + '</p>';
+        const sqlSafeLong = longContent.replace(/'/g, "\\'");
+        dbExec(`UPDATE events SET content='${sqlSafeLong}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+
+        await page.setViewportSize({ width: 1280, height: 900 });
+
+        async function measure(layout) {
+            setLayout(layout);
+            await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+            const card = page.locator('article.event-card').first();
+            const fig  = page.locator('figure.event-cover').first();
+            await expect(card).toBeVisible();
+            await expect(fig).toBeVisible();
+            const cardBox = await card.boundingBox();
+            const figBox  = await fig.boundingBox();
+            return { cardWidth: cardBox.width, figWidth: figBox.width, figHeight: figBox.height };
+        }
+
+        const full      = await measure('full');
+        const banner    = await measure('banner');
+        const contained = await measure('contained');
+        const thumb     = await measure('thumb');
+
+        // full: figure width equals the inner card width (within padding tolerance)
+        expect(
+            full.figWidth,
+            `full layout: figure should fill the card width (got ${full.figWidth}px, card ${full.cardWidth}px)`
+        ).toBeGreaterThan(full.cardWidth * 0.85);
+
+        // banner: width like full, height ~ 220px (within ±5px CSS rendering tolerance)
+        expect(
+            banner.figWidth,
+            `banner layout: figure should be full-width (got ${banner.figWidth}px, card ${banner.cardWidth}px)`
+        ).toBeGreaterThan(banner.cardWidth * 0.85);
+        expect(
+            banner.figHeight,
+            `banner layout: figure height must be capped to ~220px (got ${banner.figHeight}px)`
+        ).toBeLessThanOrEqual(225);
+
+        // contained: max-width 420px, NARROWER than the card
+        expect(
+            contained.figWidth,
+            `contained layout: figure must be ≤ 420px wide (got ${contained.figWidth}px) — the whole point of the default preset`
+        ).toBeLessThanOrEqual(420);
+        expect(
+            contained.figWidth,
+            `contained layout: figure must be visibly narrower than the card (got ${contained.figWidth}px vs card ${contained.cardWidth}px)`
+        ).toBeLessThan(contained.cardWidth * 0.7);
+
+        // thumb: ~240px wide (grid column), NARROWER than the card
+        expect(
+            thumb.figWidth,
+            `thumb layout: figure must be ≤ 240px wide (got ${thumb.figWidth}px)`
+        ).toBeLessThanOrEqual(245);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
     // Containment regression — guards against the float-overflow bug
     // reported during initial review: when content is short, a floated
     // .event-cover--thumb escapes its parent .event-card and ends up

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -157,4 +157,51 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         setLayout('thumb');
         await expectLayout(page, 'thumb');
     });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Containment regression — guards against the float-overflow bug
+    // reported during initial review: when content is short, a floated
+    // .event-cover--thumb escapes its parent .event-card and ends up
+    // visually on top of the page footer.
+    //
+    // The grid-based refactor places the figure in its own row/column,
+    // so geometrically the figure can never extend below its parent
+    // article. The test asserts that invariant at desktop width.
+    // ────────────────────────────────────────────────────────────────────
+    test('thumb layout: short-body event keeps the figure inside its article (no float overflow)', async ({ page }) => {
+        setLayout('thumb');
+
+        // Shrink the event content so a CSS float would expose the bug.
+        const shortContent = '<p>Breve.</p>';
+        const sqlSafe = shortContent.replace(/'/g, "\\'");
+        dbExec(`UPDATE events SET content='${sqlSafe}' WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+
+        // Desktop viewport — the grid kicks in at >=768px.
+        await page.setViewportSize({ width: 1280, height: 900 });
+        await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+
+        const card = page.locator('article.event-card').first();
+        const fig  = page.locator('figure.event-cover--thumb').first();
+        await expect(card).toBeVisible();
+        await expect(fig).toBeVisible();
+
+        // Card must carry the modifier that activates the grid layout.
+        await expect(card).toHaveClass(/event-card--thumb-layout/);
+
+        // Bounding-box invariant: figure.bottom MUST be <= card.bottom.
+        // If the float regression returns, figure.bottom escapes the
+        // parent and this assertion fails loudly.
+        const cardBox = await card.boundingBox();
+        const figBox  = await fig.boundingBox();
+        expect(cardBox, 'event-card must have a bounding box').not.toBeNull();
+        expect(figBox, 'event-cover--thumb must have a bounding box').not.toBeNull();
+        if (cardBox && figBox) {
+            const cardBottom = cardBox.y + cardBox.height;
+            const figBottom  = figBox.y  + figBox.height;
+            expect(
+                figBottom,
+                `figure bottom (${figBottom}) must stay within card bottom (${cardBottom}) — the float-overflow regression has returned`
+            ).toBeLessThanOrEqual(cardBottom + 1);
+        }
+    });
 });

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -1,0 +1,160 @@
+// @ts-check
+//
+// Regression test for issue #137 — admin-configurable layout for the
+// featured image on event detail pages (`/eventi/<slug>`).
+//
+// Coverage (5 cases):
+//   1. Default fallback ('contained') when the setting row is missing
+//   2. Explicit layout = 'full'         (legacy full-width-no-constraint)
+//   3. Explicit layout = 'banner'       (16:9 cropped)
+//   4. Explicit layout = 'contained'    (max-height: 480px, object-fit: contain)
+//   5. Explicit layout = 'thumb'        (right-floated 3:4 thumbnail)
+//
+// Each case sets `cms.event_image_layout` directly in the KV store
+// (`system_settings`), navigates to the event detail page, and asserts:
+//   • the figure has the class `event-cover--<layout>`
+//   • the figure has `data-event-cover-layout="<layout>"`
+//   • exactly one cover figure is rendered
+//
+// Run:
+//   /tmp/run-e2e.sh tests/issue-137-event-image-layout.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+const DB_USER     = process.env.E2E_DB_USER     || '';
+const DB_PASS     = process.env.E2E_DB_PASS     || '';
+const DB_SOCKET   = process.env.E2E_DB_SOCKET   || '';
+const DB_NAME     = process.env.E2E_DB_NAME     || '';
+
+test.skip(
+    !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_PASS || !DB_NAME,
+    'E2E credentials not configured (set E2E_ADMIN_*, E2E_DB_*)',
+);
+
+const RUN_ID    = Date.now().toString(36);
+const EVENT_TITLE = `Issue 137 Layout Test ${RUN_ID}`;
+const EVENT_SLUG  = `issue-137-layout-test-${RUN_ID}`;
+const EVENT_IMG   = '/assets/books.jpg'; // ships in public/assets
+
+function dbExec(sql) {
+    const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-e', sql];
+    if (DB_SOCKET) args.splice(3, 0, '-S', DB_SOCKET);
+    execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 });
+}
+
+function dbQuery(sql) {
+    const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-N', '-B', '-e', sql];
+    if (DB_SOCKET) args.splice(3, 0, '-S', DB_SOCKET);
+    return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 }).trim();
+}
+
+function sqlEscape(s) {
+    // MySQL string escape — sufficient for test fixtures where the input
+    // is controlled (no untrusted data here, but we don't want a stray
+    // apostrophe to break the seed).
+    return String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function setLayout(layout) {
+    if (layout === null) {
+        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        return;
+    }
+    dbExec(`
+        INSERT INTO system_settings (category, setting_key, setting_value)
+        VALUES ('cms', 'event_image_layout', '${sqlEscape(layout)}')
+        ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)
+    `);
+}
+
+test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
+
+    test.beforeAll(async () => {
+        // Make sure the events page is enabled (the frontend controller
+        // 404s otherwise).
+        dbExec(`
+            INSERT INTO system_settings (category, setting_key, setting_value)
+            VALUES ('cms', 'events_page_enabled', '1')
+            ON DUPLICATE KEY UPDATE setting_value='1'
+        `);
+
+        // Seed one event with a featured_image. event_date is today so it
+        // is reachable from the public listing too.
+        dbExec(`
+            INSERT INTO events (title, slug, content, event_date, event_time, featured_image, is_active)
+            VALUES (
+                '${sqlEscape(EVENT_TITLE)}',
+                '${sqlEscape(EVENT_SLUG)}',
+                '<p>Issue 137 test event</p>',
+                CURDATE(),
+                '18:00:00',
+                '${sqlEscape(EVENT_IMG)}',
+                1
+            )
+        `);
+    });
+
+    test.afterAll(async () => {
+        // Cleanup: delete test event + reset layout setting to default.
+        dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
+        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+    });
+
+    /**
+     * Shared assertion: fetch the event page, assert the figure has the
+     * expected layout class + data attribute, and that there's exactly
+     * one cover figure (no duplicate rendering from a stale partial).
+     */
+    async function expectLayout(page, expected) {
+        const url = `${BASE}/eventi/${EVENT_SLUG}`;
+        const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
+        expect(response, `GET ${url} must succeed`).not.toBeNull();
+        // Defense in depth — some Apache setups normalise 200 → 200 but
+        // a 404 here would mean events_page_enabled rolled back, which
+        // the test should surface explicitly.
+        expect(
+            response.status(),
+            `GET ${url} returned ${response.status()} — events_page_enabled may have been disabled`
+        ).toBeLessThan(400);
+
+        const cover = page.locator('figure.event-cover');
+        await expect(cover).toHaveCount(1);
+
+        // Class assertion: figure must carry the layout-specific modifier.
+        await expect(cover).toHaveClass(new RegExp(`event-cover--${expected}\\b`));
+
+        // Data attribute — survives any future CSS class rename and is
+        // a stable hook for further QA tooling.
+        await expect(cover).toHaveAttribute('data-event-cover-layout', expected);
+    }
+
+    test('1/5 default — when cms.event_image_layout is unset, falls back to contained', async ({ page }) => {
+        setLayout(null);
+        await expectLayout(page, 'contained');
+    });
+
+    test('2/5 full — explicit layout=full applies event-cover--full', async ({ page }) => {
+        setLayout('full');
+        await expectLayout(page, 'full');
+    });
+
+    test('3/5 banner — explicit layout=banner applies event-cover--banner', async ({ page }) => {
+        setLayout('banner');
+        await expectLayout(page, 'banner');
+    });
+
+    test('4/5 contained — explicit layout=contained applies event-cover--contained', async ({ page }) => {
+        setLayout('contained');
+        await expectLayout(page, 'contained');
+    });
+
+    test('5/5 thumb — explicit layout=thumb applies event-cover--thumb', async ({ page }) => {
+        setLayout('thumb');
+        await expectLayout(page, 'thumb');
+    });
+});

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -6,9 +6,9 @@
 // Coverage (5 cases):
 //   1. Default fallback ('contained') when the setting row is missing
 //   2. Explicit layout = 'full'         (legacy full-width-no-constraint)
-//   3. Explicit layout = 'banner'       (16:9 cropped)
-//   4. Explicit layout = 'contained'    (max-height: 480px, object-fit: contain)
-//   5. Explicit layout = 'thumb'        (right-floated 3:4 thumbnail)
+//   3. Explicit layout = 'banner'       (low banner, capped at 220px height with object-fit:cover)
+//   4. Explicit layout = 'contained'    (max-width 420px left-aligned, max-height 320px, object-fit: contain)
+//   5. Explicit layout = 'thumb'        (side thumbnail via CSS grid + .event-card--thumb-layout, 3:4 portrait)
 //
 // Each case sets `cms.event_image_layout` directly in the KV store
 // (`system_settings`), navigates to the event detail page, and asserts:
@@ -72,9 +72,56 @@ function setLayout(layout) {
     `);
 }
 
+// Locale-aware events URL prefix. Captured in beforeAll so cross-locale
+// installs (en_US, de_DE) don't silently 404 against a hardcoded
+// Italian /eventi/ prefix. Defaults to /eventi (the Italian path) when
+// the locale row is absent so existing IT installs behave unchanged.
+const EVENT_URL_PREFIX_BY_LOCALE = {
+    it_IT: '/eventi',
+    en_US: '/events',
+    de_DE: '/events',
+};
+let EVENT_URL_PREFIX = '/eventi';
+
+// Snapshot for events_page_enabled so afterAll can restore the original
+// admin choice rather than leave the test seed (=1) behind.
+//   null   → the row was absent before the test ran (DELETE on restore)
+//   string → original setting_value (UPDATE back on restore)
+let originalEventsPageEnabled = null;
+let eventsPageEnabledWasAbsent = false;
+
 test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
 
     test.beforeAll(async () => {
+        // Resolve locale-aware events URL prefix once. Falls back to
+        // /eventi when the locale row is missing (matches installer
+        // default and keeps legacy IT installs working).
+        let locale = 'it_IT';
+        try {
+            const localeRow = dbQuery(
+                `SELECT setting_value FROM system_settings WHERE category='app' AND setting_key='locale'`
+            );
+            if (localeRow) {
+                locale = localeRow;
+            }
+        } catch (e) {
+            // Best-effort — keep the IT default.
+        }
+        EVENT_URL_PREFIX = EVENT_URL_PREFIX_BY_LOCALE[locale] || '/eventi';
+
+        // Snapshot the events_page_enabled setting so we can restore
+        // it in afterAll (test pollution guard).
+        const existing = dbQuery(
+            `SELECT setting_value FROM system_settings WHERE category='cms' AND setting_key='events_page_enabled'`
+        );
+        if (existing === '' || existing === null) {
+            eventsPageEnabledWasAbsent = true;
+            originalEventsPageEnabled = null;
+        } else {
+            eventsPageEnabledWasAbsent = false;
+            originalEventsPageEnabled = existing;
+        }
+
         // Make sure the events page is enabled (the frontend controller
         // 404s otherwise).
         dbExec(`
@@ -103,6 +150,18 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
         // Cleanup: delete test event + reset layout setting to default.
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
         dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+
+        // Restore events_page_enabled to its pre-test value so we do
+        // not leave permanent test-state pollution behind.
+        if (eventsPageEnabledWasAbsent) {
+            dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='events_page_enabled'`);
+        } else {
+            dbExec(`
+                UPDATE system_settings
+                   SET setting_value='${sqlEscape(originalEventsPageEnabled)}'
+                 WHERE category='cms' AND setting_key='events_page_enabled'
+            `);
+        }
     });
 
     /**
@@ -111,7 +170,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
      * one cover figure (no duplicate rendering from a stale partial).
      */
     async function expectLayout(page, expected) {
-        const url = `${BASE}/eventi/${EVENT_SLUG}`;
+        const url = `${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`;
         const response = await page.goto(url, { waitUntil: 'domcontentloaded' });
         expect(response, `GET ${url} must succeed`).not.toBeNull();
         // Defense in depth — some Apache setups normalise 200 → 200 but
@@ -186,7 +245,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
 
         async function measure(layout) {
             setLayout(layout);
-            await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+            await page.goto(`${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
             const card = page.locator('article.event-card').first();
             const fig  = page.locator('figure.event-cover').first();
             await expect(card).toBeVisible();
@@ -353,7 +412,7 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
 
         // Desktop viewport — the grid kicks in at >=768px.
         await page.setViewportSize({ width: 1280, height: 900 });
-        await page.goto(`${BASE}/eventi/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`${BASE}${EVENT_URL_PREFIX}/${EVENT_SLUG}`, { waitUntil: 'domcontentloaded' });
 
         const card = page.locator('article.event-card').first();
         const fig  = page.locator('figure.event-cover--thumb').first();

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -193,7 +193,13 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             await expect(fig).toBeVisible();
             const cardBox = await card.boundingBox();
             const figBox  = await fig.boundingBox();
-            return { cardWidth: cardBox.width, figWidth: figBox.width, figHeight: figBox.height };
+            return {
+                cardX: cardBox.x,
+                cardWidth: cardBox.width,
+                figX: figBox.x,
+                figWidth: figBox.width,
+                figHeight: figBox.height,
+            };
         }
 
         const full      = await measure('full');
@@ -227,11 +233,28 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             `contained layout: figure must be visibly narrower than the card (got ${contained.figWidth}px vs card ${contained.cardWidth}px)`
         ).toBeLessThan(contained.cardWidth * 0.7);
 
+        // contained: must be LEFT-ALIGNED (figure.x ≈ card.x + padding).
+        // If a future refactor reintroduces margin: auto the figure
+        // would centre and figX would shift toward cardWidth/2 — guard
+        // against that here. We allow up to 100px of inner padding.
+        const containedOffsetFromLeft = contained.figX - contained.cardX;
+        expect(
+            containedOffsetFromLeft,
+            `contained layout: figure must be left-aligned (offset from card.left should be ≤ 100px of padding, got ${containedOffsetFromLeft}px)`
+        ).toBeLessThanOrEqual(100);
+
         // thumb: ~240px wide (grid column), NARROWER than the card
         expect(
             thumb.figWidth,
             `thumb layout: figure must be ≤ 240px wide (got ${thumb.figWidth}px)`
         ).toBeLessThanOrEqual(245);
+
+        // thumb: must be left-aligned too (grid column 1).
+        const thumbOffsetFromLeft = thumb.figX - thumb.cardX;
+        expect(
+            thumbOffsetFromLeft,
+            `thumb layout: figure must occupy the left grid column (offset ≤ 100px, got ${thumbOffsetFromLeft}px)`
+        ).toBeLessThanOrEqual(100);
     });
 
     // ────────────────────────────────────────────────────────────────────

--- a/tests/issue-137-event-image-layout.spec.js
+++ b/tests/issue-137-event-image-layout.spec.js
@@ -90,6 +90,14 @@ let EVENT_URL_PREFIX = '/eventi';
 let originalEventsPageEnabled = null;
 let eventsPageEnabledWasAbsent = false;
 
+// Same shape, but for event_image_layout. Per-test setLayout() rewrites
+// this row, and the original afterAll unconditionally DELETEd it — which
+// destroyed an admin's pre-existing custom layout choice on every run.
+// Snapshot once at startup and restore the original value (or DELETE if
+// absent) at teardown. Matches the events_page_enabled pattern above.
+let originalEventImageLayout = null;
+let eventImageLayoutWasAbsent = false;
+
 test.describe.serial('Issue #137 — admin-configurable event image layout', () => {
 
     test.beforeAll(async () => {
@@ -122,6 +130,20 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
             originalEventsPageEnabled = existing;
         }
 
+        // Snapshot event_image_layout too — setLayout() rewrites it in
+        // every test, and the original DELETE-on-teardown destroyed any
+        // pre-existing custom choice the admin had configured.
+        const existingLayout = dbQuery(
+            `SELECT setting_value FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`
+        );
+        if (existingLayout === '' || existingLayout === null) {
+            eventImageLayoutWasAbsent = true;
+            originalEventImageLayout = null;
+        } else {
+            eventImageLayoutWasAbsent = false;
+            originalEventImageLayout = existingLayout;
+        }
+
         // Make sure the events page is enabled (the frontend controller
         // 404s otherwise).
         dbExec(`
@@ -147,9 +169,19 @@ test.describe.serial('Issue #137 — admin-configurable event image layout', () 
     });
 
     test.afterAll(async () => {
-        // Cleanup: delete test event + reset layout setting to default.
+        // Cleanup: delete test event + restore the original
+        // event_image_layout (DELETE if it was absent before the suite,
+        // else UPDATE back to the captured original value).
         dbExec(`DELETE FROM events WHERE slug='${sqlEscape(EVENT_SLUG)}'`);
-        dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        if (eventImageLayoutWasAbsent) {
+            dbExec(`DELETE FROM system_settings WHERE category='cms' AND setting_key='event_image_layout'`);
+        } else {
+            dbExec(`
+                INSERT INTO system_settings (category, setting_key, setting_value)
+                VALUES ('cms', 'event_image_layout', '${sqlEscape(originalEventImageLayout)}')
+                ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)
+            `);
+        }
 
         // Restore events_page_enabled to its pre-test value so we do
         // not leave permanent test-state pollution behind.

--- a/tests/pr-136-archives-ric-cm-additional.spec.js
+++ b/tests/pr-136-archives-ric-cm-additional.spec.js
@@ -1,0 +1,280 @@
+// @ts-check
+//
+// Complementary regression suite for PR #136 (feat/ric-cm-archives,
+// closes #122). The PR already ships ~51 tests across 4 new spec
+// files (phase5-admin-ui, phase6-oai-ric-o, ric-jsonld, upload-assets).
+// This file targets the modifications those don't cover:
+//
+//   - Migration file presence + version-≤-release invariant
+//     (CLAUDE.md ABSOLUTE RULE #6)
+//   - ensureSchema() pattern in ArchivesPlugin and OaiPmhServerPlugin
+//     (CLAUDE.md "Plugin Schema Rule — ABSOLUTE")
+//   - plugin.json version bumps (archives 1.2.x → 1.5.0,
+//     oai-pmh-server 1.0.0 → 1.1.0)
+//   - Migration content sanity (new tables/cols mentioned)
+//   - Locale key presence for admin UI strings introduced by Phase 5
+//
+// The tests run against the PR branch's tip via `git show
+// origin/feat/ric-cm-archives:<path>`, so they work from any checked-out
+// branch — caller doesn't need to switch branches first. When the
+// branch is checked out locally, the same checks pass against the
+// working tree (so the tests double as a pre-push gate on the PR
+// branch).
+//
+// Run:
+//   /tmp/run-e2e.sh tests/pr-136-archives-ric-cm-additional.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const REPO = path.resolve(__dirname, '..');
+const PR_BRANCH = 'feat/ric-cm-archives';
+
+// Resolve the source of truth ONCE up front:
+//   - If HEAD is on the PR branch  → working tree (so tests double as
+//                                    a pre-push gate on the branch).
+//   - Else                         → `git show origin/PR_BRANCH:<path>`
+//                                    (so the tests work from ANY other
+//                                    branch without checking out).
+// This avoids the trap of preferring the local working tree when the
+// caller is on a different branch — the local files there are NOT the
+// ones the PR is shipping.
+function getCurrentBranch() {
+    try {
+        return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
+            cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']
+        }).trim();
+    } catch { return ''; }
+}
+
+const onPrBranch = (getCurrentBranch() === PR_BRANCH);
+
+function readPrFile(relPath) {
+    if (onPrBranch) {
+        const local = path.join(REPO, relPath);
+        if (!fs.existsSync(local)) return null;
+        return fs.readFileSync(local, 'utf8');
+    }
+    // execFileSync (safe — no shell interpolation; args are array).
+    try {
+        const out = execFileSync('git', ['show', `origin/${PR_BRANCH}:${relPath}`], {
+            cwd: REPO, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']
+        });
+        return out;
+    } catch {
+        return null;
+    }
+}
+
+// Returns true if `origin/feat/ric-cm-archives` is reachable locally
+// (was fetched at some point). Used to skip cleanly on installs where
+// the branch hasn't been fetched yet.
+function prBranchReachable() {
+    try {
+        execFileSync('git', ['rev-parse', '--verify', `origin/${PR_BRANCH}`], {
+            cwd: REPO, stdio: 'ignore'
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+const branchReachable = prBranchReachable();
+
+// ═══════════════════════════════════════════════════════════════════
+// PR #136 — RiC-CM full roadmap — additional contract checks
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[STATIC] PR #136 RiC-CM contract checks', () => {
+
+    test.skip(!branchReachable, `origin/${PR_BRANCH} not fetched — run: git fetch origin ${PR_BRANCH}`);
+
+    // R1 — Migration files for Phases 2/3/4/cleanup are all present
+    test('R1: phase-2/3/4 + cleanup migration files exist on the PR branch', async () => {
+        const expected = [
+            'installer/database/migrations/migrate_0.7.08.sql',
+            'installer/database/migrations/migrate_0.7.09.sql',
+            'installer/database/migrations/migrate_0.7.10.sql',
+            'installer/database/migrations/migrate_0.7.12.sql',
+        ];
+        for (const f of expected) {
+            const c = readPrFile(f);
+            expect(c, `${f} must exist`).not.toBeNull();
+            expect(c.length).toBeGreaterThan(0);
+        }
+    });
+
+    // R2 — version.json release matches the highest migration version
+    test('R2: version.json release ≥ highest migration file version (CLAUDE.md ABSOLUTE RULE #6)', async () => {
+        const versionJson = readPrFile('version.json');
+        expect(versionJson).not.toBeNull();
+        const version = JSON.parse(versionJson).version;
+        // CLAUDE.md: "NEVER name a migration file with a version higher
+        // than the release version" — updater uses version_compare()
+        // with <= so higher-version migrations are silently skipped.
+        // The release ships migrate_0.7.12.sql → version.json must be ≥ 0.7.12.
+        // Use semver-like comparison via PHP's version_compare semantics:
+        // split by '.', compare segment by segment.
+        function cmp(a, b) {
+            const aa = a.split('.').map(Number);
+            const bb = b.split('.').map(Number);
+            for (let i = 0; i < Math.max(aa.length, bb.length); i++) {
+                const x = aa[i] || 0, y = bb[i] || 0;
+                if (x !== y) return x - y;
+            }
+            return 0;
+        }
+        expect(cmp(version, '0.7.12')).toBeGreaterThanOrEqual(0);
+    });
+
+    // R3 — migrate_0.7.08.sql creates the agent fields (Phase 2 schema)
+    test('R3: migrate_0.7.08.sql adds Phase 2 agent columns/tables', async () => {
+        const sql = readPrFile('installer/database/migrations/migrate_0.7.08.sql');
+        expect(sql).not.toBeNull();
+        // Per PR body: "+4 cols on authority_records, +2 tables".
+        expect(sql).toMatch(/authority_records/i);
+        // At least one ALTER TABLE adding columns.
+        expect(sql).toMatch(/ALTER TABLE/i);
+    });
+
+    // R4 — migrate_0.7.09.sql creates Phase 3 activity tables
+    test('R4: migrate_0.7.09.sql creates archive_activities + archive_unit_activities tables', async () => {
+        const sql = readPrFile('installer/database/migrations/migrate_0.7.09.sql');
+        expect(sql).not.toBeNull();
+        expect(sql).toMatch(/archive_activities/i);
+        expect(sql).toMatch(/archive_unit_activities/i);
+        // CREATE TABLE IF NOT EXISTS (idempotent — re-runnable on partial fail).
+        expect(sql).toMatch(/CREATE TABLE\s+IF NOT EXISTS/i);
+    });
+
+    // R5 — migrate_0.7.10.sql creates Phase 4 places + relations
+    test('R5: migrate_0.7.10.sql creates archive_places + archive_relations tables', async () => {
+        const sql = readPrFile('installer/database/migrations/migrate_0.7.10.sql');
+        expect(sql).not.toBeNull();
+        expect(sql).toMatch(/archive_places/i);
+        expect(sql).toMatch(/archive_relations/i);
+    });
+
+    // R6 — migrate_0.7.12.sql drops the reserved-but-unused place_id col
+    test('R6: migrate_0.7.12.sql drops archive_activities.place_id (reserved-but-unused cleanup)', async () => {
+        const sql = readPrFile('installer/database/migrations/migrate_0.7.12.sql');
+        expect(sql).not.toBeNull();
+        expect(sql).toMatch(/ALTER TABLE\s+archive_activities/i);
+        expect(sql).toMatch(/DROP\s+COLUMN\s+(?:IF EXISTS\s+)?place_id/i);
+    });
+
+    // R7 — ArchivesPlugin implements ensureSchema() called from BOTH
+    // onActivate() and onInstall() (CLAUDE.md "Plugin Schema Rule — ABSOLUTE")
+    test('R7: ArchivesPlugin.ensureSchema() is called from onActivate() AND onInstall()', async () => {
+        const src = readPrFile('storage/plugins/archives/ArchivesPlugin.php');
+        expect(src).not.toBeNull();
+        // Must declare the helper.
+        expect(src).toMatch(/function\s+ensureSchema\s*\(/);
+        // Must call it from both lifecycle hooks. Locate each method
+        // body and check the helper is invoked inside.
+        const activateMatch = src.match(/function\s+onActivate[\s\S]*?\n {4}\}/);
+        const installMatch  = src.match(/function\s+onInstall[\s\S]*?\n {4}\}/);
+        expect(activateMatch, 'onActivate() must exist').not.toBeNull();
+        expect(installMatch,  'onInstall() must exist').not.toBeNull();
+        expect(activateMatch[0]).toMatch(/(?:\$this->)?ensureSchema\s*\(/);
+        expect(installMatch[0]).toMatch(/(?:\$this->)?ensureSchema\s*\(/);
+        // ensureSchema body must use CREATE TABLE IF NOT EXISTS (idempotent).
+        expect(src).toMatch(/CREATE TABLE\s+IF NOT EXISTS/i);
+    });
+
+    // R8 — OaiPmhServerPlugin also follows the ensureSchema pattern
+    test('R8: OaiPmhServerPlugin follows ensureSchema() pattern (called from both hooks)', async () => {
+        const src = readPrFile('storage/plugins/oai-pmh-server/OaiPmhServerPlugin.php');
+        expect(src).not.toBeNull();
+        // The OAI-PMH plugin tracks ric-o prefix subscriptions in a
+        // table — ensureSchema covers it. If the plugin doesn't create
+        // tables, the helper may be absent — accept that case.
+        const hasEnsureSchema = /function\s+ensureSchema\s*\(/.test(src);
+        if (!hasEnsureSchema) {
+            // No tables = no need for the helper. Sanity-check that
+            // no CREATE TABLE is hiding in the plugin source then.
+            expect(src).not.toMatch(/CREATE TABLE/i);
+            return;
+        }
+        const activateMatch = src.match(/function\s+onActivate[\s\S]*?\n {4}\}/);
+        const installMatch  = src.match(/function\s+onInstall[\s\S]*?\n {4}\}/);
+        if (activateMatch && installMatch) {
+            expect(activateMatch[0]).toMatch(/(?:\$this->)?ensureSchema\s*\(/);
+            expect(installMatch[0]).toMatch(/(?:\$this->)?ensureSchema\s*\(/);
+        }
+    });
+
+    // R9 — archives plugin.json version bumped to ≥ 1.5.0
+    test('R9: archives plugin.json version is ≥ 1.5.0', async () => {
+        const pj = readPrFile('storage/plugins/archives/plugin.json');
+        expect(pj).not.toBeNull();
+        const parsed = JSON.parse(pj);
+        const version = parsed.version;
+        expect(version).toBeTruthy();
+        function cmp(a, b) {
+            const aa = a.split('.').map(Number);
+            const bb = b.split('.').map(Number);
+            for (let i = 0; i < Math.max(aa.length, bb.length); i++) {
+                const x = aa[i] || 0, y = bb[i] || 0;
+                if (x !== y) return x - y;
+            }
+            return 0;
+        }
+        expect(cmp(version, '1.5.0')).toBeGreaterThanOrEqual(0);
+    });
+
+    // R10 — oai-pmh-server plugin.json version bumped to ≥ 1.1.0
+    test('R10: oai-pmh-server plugin.json version is ≥ 1.1.0', async () => {
+        const pj = readPrFile('storage/plugins/oai-pmh-server/plugin.json');
+        expect(pj).not.toBeNull();
+        const parsed = JSON.parse(pj);
+        const version = parsed.version;
+        expect(version).toBeTruthy();
+        function cmp(a, b) {
+            const aa = a.split('.').map(Number);
+            const bb = b.split('.').map(Number);
+            for (let i = 0; i < Math.max(aa.length, bb.length); i++) {
+                const x = aa[i] || 0, y = bb[i] || 0;
+                if (x !== y) return x - y;
+            }
+            return 0;
+        }
+        expect(cmp(version, '1.1.0')).toBeGreaterThanOrEqual(0);
+    });
+
+    // R11 — RicJsonLdBuilder exports the expected RiC-O entity types
+    test('R11: RicJsonLdBuilder references the RiC-O entity types declared by the PR', async () => {
+        const src = readPrFile('storage/plugins/archives/RicJsonLdBuilder.php');
+        expect(src).not.toBeNull();
+        // Phase 2: agents. Phase 3: activities. Phase 4: places + relations.
+        // RiC-O class names in the spec.
+        expect(src).toMatch(/RecordResource|RecordSet/i);  // archival units
+        expect(src).toMatch(/Agent|CorporateBody|Person/i);
+        expect(src).toMatch(/Activity/i);
+        expect(src).toMatch(/Place/i);
+        // JSON-LD context.
+        expect(src).toMatch(/@context|@type/);
+    });
+
+    // R12 — Phase 6: OAI-PMH ric-o metadataPrefix is advertised
+    test('R12: OaiPmhServerPlugin advertises metadataPrefix=ric-o (Phase 6)', async () => {
+        const src = readPrFile('storage/plugins/oai-pmh-server/OaiPmhServerPlugin.php');
+        expect(src).not.toBeNull();
+        // The plugin must include ric-o in its ListMetadataFormats output
+        // OR have a route handler that accepts metadataPrefix=ric-o.
+        expect(src).toMatch(/ric-o/);
+    });
+
+    // R13 — README "What's new" updated for v0.7.12
+    test('R13: README mentions v0.7.12 or RiC-CM in the recent-history section', async () => {
+        const readme = readPrFile('README.md');
+        expect(readme).not.toBeNull();
+        // Either the version number OR the feature label must be in the
+        // README — surfaces the release to anyone landing on the repo.
+        const mentioned = /0\.7\.12|RiC-CM|Records in Contexts/i.test(readme);
+        expect(mentioned).toBe(true);
+    });
+});

--- a/tests/pr-139-event-image-additional.spec.js
+++ b/tests/pr-139-event-image-additional.spec.js
@@ -1,0 +1,208 @@
+// @ts-check
+//
+// Complementary regression suite for PR #139 (feat/event-image-layout-setting,
+// closes #137). The dedicated `issue-137-event-image-layout.spec.js` covers
+// the 4 visual presets + admin update + thumb overflow + i18n keys. This
+// file targets the *other* modifications shipped in #139 that the layout
+// tests don't exercise:
+//
+//   - EventsController orphan-cleanup symmetry across 4 callsites
+//   - deleteUploadedImageFile path-traversal hardening
+//   - Locale key completeness across it/en/de/fr
+//   - cms.event_image_layout schema invariants
+//   - Settings tab routing / form action
+//   - Frontend CSS class set per preset
+//
+// Block S (Static) — no login, no DB. Runs against repo files only.
+// Block H (HTTP)   — admin login + HTTP request, no UI clicks.
+//
+// Run:
+//   /tmp/run-e2e.sh tests/pr-139-event-image-additional.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+const REPO        = path.resolve(__dirname, '..');
+
+function readRepoFile(rel) {
+    return fs.readFileSync(path.join(REPO, rel), 'utf8');
+}
+
+async function tryLoginAsAdmin(page) {
+    await page.goto(`${BASE}/accedi`);
+    await page.fill('input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.click('button[type="submit"]');
+    try {
+        await page.waitForURL(/\/(admin|profilo)/, { timeout: 10000 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK S — Static contract checks (no login, no HTTP)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[STATIC] PR #139 controller + assets contract', () => {
+
+    // S1 — All four deleteUploadedImageFile callsites present in EventsController
+    test('S1: EventsController calls deleteUploadedImageFile at 4 expected callsites', async () => {
+        const src = readRepoFile('app/Controllers/EventsController.php');
+        const callCount = (src.match(/\$this->deleteUploadedImageFile\(/g) || []).length;
+        expect(callCount).toBeGreaterThanOrEqual(4);
+        // The contract docblock must mention all four lifecycle slots so a
+        // future refactor that drops one is loud.
+        expect(src).toMatch(/update\(\) success branch with image replacement/);
+        expect(src).toMatch(/update\(\) failure branch/);
+        expect(src).toMatch(/update\(\) validation-error short-circuit/);
+        expect(src).toMatch(/delete\(\) success branch/);
+    });
+
+    // S2 — deleteUploadedImageFile rejects paths that don't start with /uploads/events/
+    test('S2: deleteUploadedImageFile early-return on bad relative-path prefix', async () => {
+        const src = readRepoFile('app/Controllers/EventsController.php');
+        const fn = src.match(/private function deleteUploadedImageFile[\s\S]*?\n {4}\}/);
+        expect(fn).not.toBeNull();
+        expect(fn[0]).toMatch(/strpos\(\$relativePath, ['"]\/uploads\/events\/['"]\) !== 0/);
+        // Plus a realpath-containment check that defends against symlinks.
+        expect(fn[0]).toMatch(/realpath/);
+        expect(fn[0]).toMatch(/strpos\(\$realCandidate.*\$baseDir/);
+    });
+
+    // S3 — Unlink failures go to SecureLogger, not error_log (CLAUDE.md rule)
+    test('S3: unlink failure uses SecureLogger::error not error_log', async () => {
+        const src = readRepoFile('app/Controllers/EventsController.php');
+        const fn = src.match(/private function deleteUploadedImageFile[\s\S]*?\n {4}\}/);
+        expect(fn[0]).toMatch(/SecureLogger::error\(/);
+        expect(fn[0]).not.toMatch(/error_log\(/);
+        // error_get_last() must be captured to provide the OS-level errno.
+        expect(fn[0]).toMatch(/error_get_last\(\)/);
+    });
+
+    // S4 — Locale key completeness for layout option strings (all 4 JSONs)
+    test('S4: layout option labels exist in all 4 locale JSONs', async () => {
+        const locales = ['it_IT', 'en_US', 'de_DE', 'fr_FR'];
+        const keys = [
+            'Piccola a sinistra (max 420px) — consigliato',
+            'Miniatura affiancata al testo (240px)',
+            'Banner basso a tutta larghezza (max altezza 220px)',
+            'Originale a tutta larghezza (grande)',
+        ];
+        const report = {};
+        for (const lang of locales) {
+            const blob = readRepoFile(`locale/${lang}.json`);
+            for (const k of keys) {
+                report[`${lang}::${k.substring(0, 30)}`] = blob.includes(k);
+            }
+        }
+        const fails = Object.entries(report).filter(([k, v]) => !v && !k.startsWith('it_IT::'));
+        if (fails.length > 0) {
+            console.log('Missing locale entries:', fails.map(([k]) => k));
+        }
+        // it_IT is the source language: keys MUST appear there.
+        const itFails = Object.entries(report).filter(([k, v]) => !v && k.startsWith('it_IT::'));
+        expect(itFails).toEqual([]);
+    });
+
+    // S5 — settings/index.php exposes the 4 layout choices
+    test('S5: settings/index.php declares the 4-preset layout enum', async () => {
+        const src = readRepoFile('app/Views/settings/index.php');
+        expect(src).toMatch(/\$eventImageLayoutChoices\s*=\s*\[/);
+        for (const preset of ['full', 'banner', 'contained', 'thumb']) {
+            expect(src).toMatch(new RegExp(`['"]${preset}['"]\\s*=>`));
+        }
+    });
+
+    // S6 — event-detail.php renders distinct CSS class per preset
+    test('S6: event-detail.php emits event-cover--<preset> class', async () => {
+        const src = readRepoFile('app/Views/frontend/event-detail.php');
+        for (const preset of ['full', 'banner', 'contained', 'thumb']) {
+            expect(src).toMatch(new RegExp(`event-cover--${preset}`));
+        }
+        // Plus the wrapper class for the side-by-side thumb layout.
+        expect(src).toMatch(/event-card--thumb-layout/);
+    });
+
+    // S7 — Frontend CSS includes responsive collapse for thumb layout (mobile)
+    test('S7: thumb layout has @media collapse to vertical stack on small screens', async () => {
+        const src = readRepoFile('app/Views/frontend/event-detail.php');
+        // The thumb preset uses CSS grid in landscape and must collapse to
+        // a single column at small viewports.
+        expect(src).toMatch(/@media[^{]*max-width[^{]*\)\s*\{/);
+        // The mobile breakpoint should specifically restyle the thumb layout
+        // (either the grid-template-columns or the event-card--thumb-layout class).
+        const mediaBlocks = src.match(/@media[\s\S]*?\}\s*\}/g) || [];
+        const hasThumbResponsive = mediaBlocks.some(b => b.includes('thumb-layout') || b.includes('event-cover--thumb'));
+        expect(hasThumbResponsive).toBe(true);
+    });
+
+    // S8 — SettingsController persists cms.event_image_layout
+    test('S8: SettingsController has a handler that writes event_image_layout', async () => {
+        const src = readRepoFile('app/Controllers/SettingsController.php');
+        expect(src).toMatch(/event_image_layout/);
+        // Mandatory: persists via a settings-write API (repository->set,
+        // ConfigStore::set, SettingsService, or direct system_settings).
+        expect(src).toMatch(/->set\(['"]cms['"]|ConfigStore::set|system_settings|SettingsService|setSetting|saveSetting|updateSetting/i);
+        // Plus an allow-list filter: untrusted POST input must be
+        // validated against the 4 known preset values before persistence.
+        expect(src).toMatch(/in_array\(\$submitted,\s*\$allowed/);
+    });
+
+    // S9 — web.php declares the events-settings POST route
+    test('S9: routes/web.php has POST /admin/settings/events route', async () => {
+        const src = readRepoFile('app/Routes/web.php');
+        expect(src).toMatch(/\/admin\/settings\/events/);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK H — HTTP-level checks (admin login required)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[HTTP] PR #139 admin-side behavior', () => {
+
+    test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E credentials not configured');
+
+    let context, page;
+    test.beforeAll(async ({ browser }) => {
+        context = await browser.newContext();
+        page = await context.newPage();
+        const ok = await tryLoginAsAdmin(page);
+        if (!ok) test.skip(true, 'Admin login failed');
+    });
+
+    test.afterAll(async () => {
+        if (context) await context.close();
+    });
+
+    // H1 — Settings page exposes the layout picker
+    test('H1: admin/settings?tab=cms renders the event-image-layout radio group', async () => {
+        await page.goto(`${BASE}/admin/settings?tab=cms`);
+        await page.waitForLoadState('domcontentloaded');
+        const radios = page.locator('input[type="radio"][name*="event_image_layout"], input[type="radio"][name*="image_layout"]');
+        const n = await radios.count();
+        if (n === 0) {
+            const sel = page.locator('select[name*="event_image_layout"], select[name*="image_layout"]');
+            expect(await sel.count()).toBeGreaterThan(0);
+        } else {
+            expect(n).toBeGreaterThanOrEqual(4);
+        }
+    });
+
+    // H2 — Settings form posts to the events route
+    test('H2: settings form for events-layout posts to /admin/settings/events', async () => {
+        await page.goto(`${BASE}/admin/settings?tab=cms`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[action*="/admin/settings/events"]').first();
+        const count = await form.count();
+        test.skip(count === 0, 'Events settings form not rendered on this install');
+        // Form must include a CSRF token (CLAUDE.md mandatory rule).
+        const csrf = form.locator('input[name="csrf_token"]');
+        expect(await csrf.count()).toBeGreaterThan(0);
+    });
+});

--- a/tests/sweetalert2-comprehensive.spec.js
+++ b/tests/sweetalert2-comprehensive.spec.js
@@ -1,0 +1,595 @@
+// @ts-check
+//
+// Comprehensive regression suite for SweetAlert2 unification (PR #141 +
+// UX follow-ups). 25 reusable tests organised into 5 contract blocks:
+//
+//   A. Bus contract           — window.SwalApp shape + native fallbacks      [6]
+//   B. Attribute-bus contract — attachSwalConfirm wiring, idempotence, gates [5]
+//   C. Kind routing           — confirmDelete vs confirm + confirmText def   [3]
+//   D. i18n & attribute pass  — data-swal-* propagation + revoke edge case   [3]
+//   E. Refactored views       — per-page attribute assertions (admin login)  [8]
+//
+// Blocks A–D run against a static HTML harness (no login, no DB) by
+// loading the on-disk `swal-config.js` into a synthetic page and
+// stubbing `window.Swal`. They are the fast, deterministic core.
+//
+// Block E loads the actual admin pages and only asserts that the
+// rendered HTML carries the expected `data-swal-confirm*` attributes
+// (it does NOT click through — DB-state independent). Each test is
+// guarded with `test.skip(...)` so missing credentials / missing DB
+// state collapse cleanly to a skip rather than a hard fail.
+//
+// Run:
+//   /tmp/run-e2e.sh tests/sweetalert2-comprehensive.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+//
+// Run just the no-login core:
+//   /tmp/run-e2e.sh tests/sweetalert2-comprehensive.spec.js \
+//     --config=tests/playwright.config.js --workers=1 \
+//     --grep "BUS|ATTRIBUTE|KIND|I18N"
+
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+
+// ─── Static harness ─────────────────────────────────────────────────
+// Loads the on-disk swal-config.js into a synthetic page with Swal
+// stubbed. Returns a Page instance ready for evaluate() / click().
+//
+// `opts.swal` controls the Swal stub:
+//   - 'present'  (default) — Swal.fire returns {isConfirmed:true} so
+//                            confirm/confirmDelete resolve truthy.
+//   - 'cancel'             — Swal.fire returns {isConfirmed:false}.
+//   - 'absent'             — `window.Swal` is undefined → native
+//                            fallback path is exercised.
+//
+// `opts.forms` is the inline form markup injected into <body>.
+async function loadHarness(page, opts = {}) {
+    const swalMode = opts.swal || 'present';
+    const formsHtml = opts.forms || '';
+    const swalConfigSrc = fs.readFileSync(
+        path.resolve(__dirname, '..', 'public/assets/js/swal-config.js'),
+        'utf8'
+    );
+
+    // The static harness uses an in-page `Swal` stub. Its `mixin`
+    // returns the stub itself (so Toast.fire works). `fire` returns a
+    // deterministic result the test controls.
+    const swalStubBody = swalMode === 'absent'
+        ? '// Swal absent — native fallback path'
+        : `
+            window.__swalCalls = [];
+            window.Swal = {
+                fire: function(opts) {
+                    window.__swalCalls.push(opts);
+                    return Promise.resolve({
+                        isConfirmed: ${swalMode === 'present' ? 'true' : 'false'},
+                        value: ${swalMode === 'present' ? '"stub-value"' : 'undefined'},
+                        dismiss: ${swalMode === 'cancel' ? '"cancel"' : 'undefined'}
+                    });
+                },
+                isVisible: function(){ return false; },
+                mixin: function(){ return this; },
+                showLoading: function(){},
+                close: function(){}
+            };
+        `;
+
+    const html = `<!doctype html><html><head><meta charset="utf-8"></head><body>
+        ${formsHtml}
+        <script>${swalStubBody}</script>
+        <script>${swalConfigSrc}<` + `/script>
+    </body></html>`;
+
+    await page.setContent(html);
+    await page.waitForLoadState('domcontentloaded');
+    // The swal-config.js bottom block re-runs attachSwalConfirm() if
+    // document.readyState !== 'loading'. We give it one tick to land.
+    await page.waitForTimeout(80);
+}
+
+// Login helper for Block E. Mirrors the pattern in
+// tests/sweetalert2-popups.spec.js. Returns true on success, false
+// (with a test.skip-style abort) when credentials are wrong.
+async function tryLoginAsAdmin(page) {
+    await page.goto(`${BASE}/accedi`);
+    await page.fill('input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.click('button[type="submit"]');
+    // Wait briefly for either /admin/* /profilo or the error reload.
+    try {
+        await page.waitForURL(/\/(admin|profilo)/, { timeout: 10000 });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK A — Bus contract (6 tests, no login)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[BUS] window.SwalApp contract', () => {
+
+    test('A1: SwalApp exposes the expected method surface', async ({ page }) => {
+        await loadHarness(page);
+        const surface = await page.evaluate(() => {
+            const bus = window.SwalApp;
+            return {
+                exists: typeof bus === 'object' && bus !== null,
+                confirmDelete:        typeof bus.confirmDelete,
+                confirm:              typeof bus.confirm,
+                prompt:               typeof bus.prompt,
+                success:              typeof bus.success,
+                error:                typeof bus.error,
+                info:                 typeof bus.info,
+                warning:              typeof bus.warning,
+                toast:                typeof bus.toast,
+                attachSwalConfirm:    typeof bus.attachSwalConfirm,
+            };
+        });
+        expect(surface.exists).toBe(true);
+        for (const fn of ['confirmDelete', 'confirm', 'prompt', 'success', 'error', 'info', 'warning', 'toast', 'attachSwalConfirm']) {
+            expect(surface[fn], `SwalApp.${fn} must be a function`).toBe('function');
+        }
+    });
+
+    test('A2: confirmDelete returns Promise<{isConfirmed,value}>', async ({ page }) => {
+        await loadHarness(page);
+        const result = await page.evaluate(async () => {
+            const r = await window.SwalApp.confirmDelete({ text: 'test' });
+            return { hasShape: typeof r === 'object' && 'isConfirmed' in r, isConfirmed: r.isConfirmed };
+        });
+        expect(result.hasShape).toBe(true);
+        expect(result.isConfirmed).toBe(true); // Swal stub resolves truthy
+    });
+
+    test('A3: confirm returns Promise<{isConfirmed,value}>', async ({ page }) => {
+        await loadHarness(page, { swal: 'cancel' });
+        const result = await page.evaluate(async () => {
+            const r = await window.SwalApp.confirm({ title: 'q?', text: 'sure?' });
+            return { hasShape: typeof r === 'object' && 'isConfirmed' in r, isConfirmed: r.isConfirmed };
+        });
+        expect(result.hasShape).toBe(true);
+        expect(result.isConfirmed).toBe(false); // 'cancel' stub
+    });
+
+    test('A4: prompt empty-string semantics (native fallback)', async ({ page }) => {
+        await loadHarness(page, { swal: 'absent' });
+        // window.prompt is auto-dismissed (returns null) by the test
+        // browser when no handler is installed — exercise both branches
+        // via dialog handler.
+        // First call: dismiss (null) → isConfirmed=false, value=''
+        page.once('dialog', d => d.dismiss());
+        const dismissed = await page.evaluate(async () => {
+            const r = await window.SwalApp.prompt({ title: 't' });
+            return { isConfirmed: r.isConfirmed, value: r.value };
+        });
+        expect(dismissed.isConfirmed).toBe(false);
+        expect(dismissed.value).toBe('');
+
+        // Second call: accept with empty string → isConfirmed=true, value=''
+        page.once('dialog', d => d.accept(''));
+        const accepted = await page.evaluate(async () => {
+            const r = await window.SwalApp.prompt({ title: 't' });
+            return { isConfirmed: r.isConfirmed, value: r.value };
+        });
+        expect(accepted.isConfirmed).toBe(true);
+        expect(accepted.value).toBe('');
+    });
+
+    test('A5: error/success/info/warning return Promises (no throw) when Swal absent', async ({ page }) => {
+        await loadHarness(page, { swal: 'absent' });
+        // Auto-accept any native alert() the fallbacks raise.
+        page.on('dialog', d => d.accept());
+        const result = await page.evaluate(async () => {
+            const checks = {};
+            for (const name of ['error', 'success', 'info', 'warning']) {
+                try {
+                    const r = await window.SwalApp[name]('title', 'body');
+                    checks[name] = (r && typeof r === 'object' && 'isConfirmed' in r);
+                } catch (e) {
+                    checks[name] = `THREW: ${e.message}`;
+                }
+            }
+            return checks;
+        });
+        expect(result.error).toBe(true);
+        expect(result.success).toBe(true);
+        expect(result.info).toBe(true);
+        expect(result.warning).toBe(true);
+    });
+
+    test('A6: toast no-ops gracefully when Swal absent', async ({ page }) => {
+        await loadHarness(page, { swal: 'absent' });
+        // toast must not throw even with Swal stripped; it returns a
+        // fake result so awaiters don't hang.
+        const safe = await page.evaluate(async () => {
+            try {
+                const r = await window.SwalApp.toast({ title: 'x', icon: 'success' });
+                return { threw: false, result: r };
+            } catch (e) {
+                return { threw: true, message: e.message };
+            }
+        });
+        expect(safe.threw).toBe(false);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK B — attachSwalConfirm contract (5 tests, no login)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[ATTRIBUTE] data-swal-confirm auto-wire', () => {
+
+    const FORM = `
+        <form id="f" method="post" action="javascript:void(0)"
+              data-swal-confirm="Sei sicuro?"
+              data-swal-confirm-button="Procedi">
+            <button id="b" type="submit">Submit</button>
+        </form>
+    `;
+
+    test('B1: forms with data-swal-confirm are auto-wired at DOMContentLoaded', async ({ page }) => {
+        await loadHarness(page, { forms: FORM });
+        const wired = await page.evaluate(() => {
+            const f = document.getElementById('f');
+            return f && f.dataset.swalAttached === '1';
+        });
+        expect(wired).toBe(true);
+    });
+
+    test('B2: attachSwalConfirm is idempotent (re-run = no-op)', async ({ page }) => {
+        await loadHarness(page, { forms: FORM });
+        // Inject a tracer that counts how many listeners get added the
+        // second time. attachSwalConfirm guards via data-swal-attached.
+        const submits = await page.evaluate(() => {
+            window.SwalApp.attachSwalConfirm(); // re-run
+            window.SwalApp.attachSwalConfirm(); // and again
+            // If non-idempotent, multiple listeners fire and form.submit
+            // is called multiple times after one confirm click. We
+            // simulate the gate path manually:
+            const f = document.getElementById('f');
+            let submitCount = 0;
+            f.submit = function() { submitCount++; };
+            // Mark proceed so the listener path lets the submit through
+            f.dataset.swalProceed = '1';
+            f.requestSubmit ? f.requestSubmit() : f.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+            // After one synthetic submit, swalProceed branch resets it
+            // and returns. submitCount should still be 0 because the
+            // listener body returns; if multiple listeners attached,
+            // each one fires the same return path — still 0 either way.
+            // The strictest signal is data-swal-attached === '1' (set
+            // once) and the listener body not double-running.
+            return { attached: f.dataset.swalAttached, submitCount };
+        });
+        expect(submits.attached).toBe('1');
+    });
+
+    test('B3: cancel keeps form untouched (no submit)', async ({ page }) => {
+        await loadHarness(page, { swal: 'cancel', forms: FORM });
+        await page.evaluate(() => {
+            const f = document.getElementById('f');
+            window.__submitted = false;
+            f.submit = function() { window.__submitted = true; };
+        });
+        await page.click('#b');
+        await page.waitForTimeout(120);
+        const submitted = await page.evaluate(() => window.__submitted);
+        expect(submitted).toBe(false);
+    });
+
+    test('B4: confirm calls form.submit programmatically', async ({ page }) => {
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.evaluate(() => {
+            const f = document.getElementById('f');
+            window.__submitted = false;
+            f.submit = function() { window.__submitted = true; };
+        });
+        await page.click('#b');
+        await page.waitForTimeout(120);
+        const submitted = await page.evaluate(() => window.__submitted);
+        expect(submitted).toBe(true);
+    });
+
+    test('B5: one-shot data-swal-proceed: re-click re-shows dialog', async ({ page }) => {
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        const events = await page.evaluate(async () => {
+            const f = document.getElementById('f');
+            // After the confirm path runs, we expect data-swal-proceed
+            // to be temporarily set, then cleared when the proceed
+            // submit fires. Track its values across the lifecycle.
+            const events = [];
+            f.submit = function() {
+                events.push({ event: 'submit-called', swalProceed: f.dataset.swalProceed });
+                // The proceed listener should reset it to '' on the
+                // wrapper handler's re-entry; we simulate the wrapper
+                // re-entry by dispatching submit again with proceed=1.
+                const evt = new Event('submit', { cancelable: true, bubbles: true });
+                f.dispatchEvent(evt);
+                events.push({ event: 'second-dispatch', swalProceed: f.dataset.swalProceed });
+            };
+
+            // Click the submit button — Swal stub resolves isConfirmed:true,
+            // so the wrapper sets swalProceed='1' and calls f.submit().
+            document.getElementById('b').click();
+            await new Promise(r => setTimeout(r, 100));
+            return events;
+        });
+        // First call to submit() must have swalProceed='1' (the proceed
+        // marker). After the second dispatch, the wrapper's "if
+        // swalProceed==='1' clear+return" branch must have reset it.
+        expect(events.length).toBeGreaterThanOrEqual(1);
+        expect(events[0].event).toBe('submit-called');
+        expect(events[0].swalProceed).toBe('1');
+        if (events.length >= 2) {
+            expect(events[1].swalProceed).toBe(''); // cleared by re-entry
+        }
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK C — Kind routing & confirmText default (3 tests, no login)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[KIND] confirmDelete vs confirm routing', () => {
+
+    test('C1: default form (no kind) routes through confirmDelete (red)', async ({ page }) => {
+        const FORM = `<form id="f" method="post" action="javascript:void(0)" data-swal-confirm="d"><button type="submit" id="b">x</button></form>`;
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.click('#b');
+        await page.waitForTimeout(80);
+        // The Swal stub captured the .fire opts. confirmDelete configures
+        // showCancelButton:true + confirmButtonColor (red) + icon:'warning'.
+        const fire = await page.evaluate(() => window.__swalCalls[0]);
+        expect(fire).toBeTruthy();
+        // confirmDelete sets icon='warning' AND showCancelButton=true AND
+        // confirmButtonText='Elimina' by default; the red colour comes
+        // from SwalConfig.confirmButtonColor when the kind helper passes
+        // through. Check the markers we control: button text default.
+        expect(fire.confirmButtonText).toBe('Elimina');
+        expect(fire.showCancelButton).toBe(true);
+    });
+
+    test('C2: kind="action" routes through confirm (neutral gray)', async ({ page }) => {
+        const FORM = `<form id="f" method="post" action="javascript:void(0)" data-swal-confirm="a" data-swal-confirm-kind="action"><button type="submit" id="b">x</button></form>`;
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.click('#b');
+        await page.waitForTimeout(80);
+        const fire = await page.evaluate(() => window.__swalCalls[0]);
+        expect(fire).toBeTruthy();
+        // confirm() defaults to 'Conferma' button text and neutral
+        // confirmButtonColor (#6b7280 gray in swal-config.js).
+        expect(fire.confirmButtonText).toBe('Conferma');
+        expect(fire.showCancelButton).toBe(true);
+    });
+
+    test('C3: data-swal-confirm-button override wins for both kinds', async ({ page }) => {
+        const FORM = `
+            <form id="d" method="post" action="javascript:void(0)" data-swal-confirm="x" data-swal-confirm-button="Rimuovi"><button type="submit" id="bd">x</button></form>
+            <form id="a" method="post" action="javascript:void(0)" data-swal-confirm="x" data-swal-confirm-kind="action" data-swal-confirm-button="Procedi"><button type="submit" id="ba">x</button></form>
+        `;
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.click('#bd');
+        await page.waitForTimeout(80);
+        await page.click('#ba');
+        await page.waitForTimeout(80);
+        const calls = await page.evaluate(() => window.__swalCalls);
+        expect(calls).toHaveLength(2);
+        expect(calls[0].confirmButtonText).toBe('Rimuovi');  // destructive override
+        expect(calls[1].confirmButtonText).toBe('Procedi');  // action override
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK D — i18n & attribute propagation (3 tests, no login)
+// ═══════════════════════════════════════════════════════════════════
+test.describe('[I18N] data-swal-* attribute propagation', () => {
+
+    test('D1: data-swal-confirm-title overrides default title', async ({ page }) => {
+        const FORM = `<form id="f" method="post" action="javascript:void(0)" data-swal-confirm="msg" data-swal-confirm-title="Custom Title"><button type="submit" id="b">x</button></form>`;
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.click('#b');
+        await page.waitForTimeout(80);
+        const fire = await page.evaluate(() => window.__swalCalls[0]);
+        expect(fire.title).toBe('Custom Title');
+    });
+
+    test('D2: data-swal-confirm body text is forwarded to Swal.fire opts.text', async ({ page }) => {
+        const FORM = `<form id="f" method="post" action="javascript:void(0)" data-swal-confirm="Body message €é à"><button type="submit" id="b">x</button></form>`;
+        await loadHarness(page, { swal: 'present', forms: FORM });
+        await page.click('#b');
+        await page.waitForTimeout(80);
+        const fire = await page.evaluate(() => window.__swalCalls[0]);
+        // confirmDelete uses html or text — the kind helper passes
+        // through whichever the bus chooses. Accept either field.
+        const body = fire.text || fire.html;
+        expect(body).toContain('Body message');
+        // Verify diacritics survive the data-attr → JS round-trip.
+        expect(body).toContain('é');
+    });
+
+    test('D3: revokeSession confirmButton edge case (undefined/empty falls back)', async ({ page }) => {
+        // Mirrors profile/index.php:632–633 pattern: confirmText is
+        // derived from translations.confirmRevokeButton ONLY when it
+        // is a non-empty string; otherwise SwalApp default applies.
+        await loadHarness(page);
+        const calls = await page.evaluate(async () => {
+            const calls = [];
+            const cases = [
+                undefined,
+                '',
+                null,
+                'Custom Revoke'
+            ];
+            for (const v of cases) {
+                const confirmText = (typeof v === 'string' && v.length > 0) ? v : undefined;
+                window.__swalCalls.length = 0;
+                await window.SwalApp.confirm({
+                    title: 'Revoke?',
+                    text: 'sure?',
+                    confirmText: confirmText
+                });
+                calls.push({
+                    input: v,
+                    confirmButtonText: (window.__swalCalls[0] || {}).confirmButtonText
+                });
+            }
+            return calls;
+        });
+        // First 3 cases (undefined/''/null) fall back to SwalApp.confirm's
+        // own default 'Conferma'. Fourth case uses the override.
+        expect(calls[0].confirmButtonText).toBe('Conferma');
+        expect(calls[1].confirmButtonText).toBe('Conferma');
+        expect(calls[2].confirmButtonText).toBe('Conferma');
+        expect(calls[3].confirmButtonText).toBe('Custom Revoke');
+    });
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// BLOCK E — Refactored views (8 tests, login required)
+// ═══════════════════════════════════════════════════════════════════
+//
+// These tests assert the per-page attribute contract — they do NOT
+// click through (avoiding DB-state dependence). Each test:
+//   1. Login as admin (skip on auth failure).
+//   2. Navigate to the target admin page.
+//   3. Locate the form via its `action` URL pattern (DB-state
+//      independent — works on empty installs too because we look for
+//      the markup, not specific records).
+//   4. Assert presence/absence of data-swal-confirm-kind and other
+//      data-swal-* attributes.
+//
+// If the page renders no matching forms (empty DB), the test skips —
+// rather than fail, surface the gap so an operator can seed data.
+
+test.describe('[REFACTORED] per-view attribute assertions', () => {
+
+    test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E credentials not configured (set E2E_ADMIN_EMAIL / E2E_ADMIN_PASS)');
+
+    let context, page;
+    test.beforeAll(async ({ browser }) => {
+        context = await browser.newContext();
+        page = await context.newPage();
+        const ok = await tryLoginAsAdmin(page);
+        if (!ok) {
+            test.skip(true, 'Admin login failed — credentials may be wrong');
+        }
+    });
+
+    test.afterAll(async () => {
+        if (context) await context.close();
+    });
+
+    // E1: admin/utenti — activate-directly form uses kind=action
+    test('E1: admin/utenti activate-directly form has kind="action"', async () => {
+        await page.goto(`${BASE}/admin/utenti`);
+        await page.waitForLoadState('domcontentloaded');
+        const forms = page.locator('form[action*="/activate-directly"]');
+        const count = await forms.count();
+        test.skip(count === 0, 'No pending-activation users on this install — seed a user to run');
+        const kind = await forms.first().getAttribute('data-swal-confirm-kind');
+        expect(kind).toBe('action');
+    });
+
+    // E2: admin/utenti/dettagli — activate-directly form uses kind=action
+    test('E2: admin/utenti/<id> activate-directly form has kind="action"', async () => {
+        // Find a pending user via the index page first.
+        await page.goto(`${BASE}/admin/utenti`);
+        const detailLink = page.locator('a[href*="/admin/utenti/"][href*="/dettagli"], a[href^="/admin/utenti/"]:not([href="/admin/utenti"])').first();
+        const linkCount = await detailLink.count();
+        test.skip(linkCount === 0, 'No user-detail link present — seed a user');
+        const href = await detailLink.getAttribute('href');
+        await page.goto(`${BASE}${href.startsWith('http') ? new URL(href).pathname : href}`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[action*="/activate-directly"]');
+        const count = await form.count();
+        test.skip(count === 0, 'This user is already active — find one with activate-directly form');
+        const kind = await form.first().getAttribute('data-swal-confirm-kind');
+        expect(kind).toBe('action');
+    });
+
+    // E3: admin/languages — set-default form uses kind=action
+    test('E3: admin/languages set-default form has kind="action"', async () => {
+        await page.goto(`${BASE}/admin/languages`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[action*="/set-default"]');
+        const count = await form.count();
+        test.skip(count === 0, 'Only one language installed — no set-default form rendered');
+        const kind = await form.first().getAttribute('data-swal-confirm-kind');
+        expect(kind).toBe('action');
+    });
+
+    // E4: admin/languages — delete form is destructive (no kind=action)
+    test('E4: admin/languages delete form is destructive (no kind=action)', async () => {
+        await page.goto(`${BASE}/admin/languages`);
+        await page.waitForLoadState('domcontentloaded');
+        // Match the delete form: action contains /delete (POST).
+        const form = page.locator('form[action*="/admin/languages/"][action$="/delete"], form[action*="/admin/languages/"][action*="/delete"]').first();
+        const count = await form.count();
+        test.skip(count === 0, 'No deletable language present (only default lang installed)');
+        const kind = await form.getAttribute('data-swal-confirm-kind');
+        const confirmText = await form.getAttribute('data-swal-confirm-button');
+        // Destructive: must NOT opt into kind=action; button text must
+        // include the destructive label.
+        expect(kind).not.toBe('action');
+        expect((confirmText || '').toLowerCase()).toContain('elimin'); // covers Elimina/Eliminate
+    });
+
+    // E5: autori/scheda_autore — delete-author form is wired
+    test('E5: autori/scheda_autore delete-author form carries data-swal-confirm', async () => {
+        await page.goto(`${BASE}/admin/autori`);
+        await page.waitForLoadState('domcontentloaded');
+        const authorLink = page.locator('a[href*="/autori/"]').first();
+        const count = await authorLink.count();
+        test.skip(count === 0, 'No authors seeded — create one to exercise this path');
+        const href = await authorLink.getAttribute('href');
+        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[data-swal-confirm]').first();
+        await expect(form).toBeAttached();
+        const text = await form.getAttribute('data-swal-confirm');
+        expect((text || '').length).toBeGreaterThan(0);
+    });
+
+    // E6: editori/scheda_editore — delete-publisher form is wired
+    test('E6: editori/scheda_editore delete-publisher form carries data-swal-confirm', async () => {
+        await page.goto(`${BASE}/admin/editori`);
+        await page.waitForLoadState('domcontentloaded');
+        const editorLink = page.locator('a[href*="/editori/"]').first();
+        const count = await editorLink.count();
+        test.skip(count === 0, 'No publishers seeded');
+        const href = await editorLink.getAttribute('href');
+        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[data-swal-confirm]').first();
+        await expect(form).toBeAttached();
+    });
+
+    // E7: generi/dettaglio_genere — delete-genre form is wired
+    test('E7: generi/dettaglio_genere delete-genre form carries data-swal-confirm', async () => {
+        await page.goto(`${BASE}/admin/generi`);
+        await page.waitForLoadState('domcontentloaded');
+        const genreLink = page.locator('a[href*="/generi/"]').first();
+        const count = await genreLink.count();
+        test.skip(count === 0, 'No genres seeded');
+        const href = await genreLink.getAttribute('href');
+        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        await page.waitForLoadState('domcontentloaded');
+        const form = page.locator('form[data-swal-confirm]').first();
+        await expect(form).toBeAttached();
+    });
+
+    // E8: collocazione — delete-shelf and delete-position forms wired
+    test('E8: collocazione admin page exposes data-swal-confirm forms for shelf/position deletion', async () => {
+        await page.goto(`${BASE}/admin/collocazione`);
+        await page.waitForLoadState('domcontentloaded');
+        const forms = page.locator('form[data-swal-confirm]');
+        const n = await forms.count();
+        test.skip(n === 0, 'No shelves seeded yet — create at least one shelf to exercise this');
+        // Confirm at least one form has a destructive label.
+        const firstText = await forms.first().getAttribute('data-swal-confirm-button');
+        expect((firstText || '').toLowerCase()).toMatch(/elimin/);
+    });
+});

--- a/tests/sweetalert2-comprehensive.spec.js
+++ b/tests/sweetalert2-comprehensive.spec.js
@@ -537,12 +537,26 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
         expect((confirmText || '').toLowerCase()).toContain('elimin'); // covers Elimina/Eliminate
     });
 
-    // Resolve the first entity that's actually DELETABLE (no books / no
-    // sub-genres) via the admin JSON API, so the scheda renders the
-    // delete-form path rather than the "non eliminabile" placeholder.
-    // Returns null when every row has at least one associated book —
-    // legitimate on a seeded install; tests skip cleanly in that case.
-    async function firstDeletableId(apiPath, hasDepKey) {
+    // Resolve the first entity that's actually DELETABLE via the admin
+    // JSON API, so the scheda renders the delete-form path rather than
+    // the "non eliminabile" placeholder. The view gates the form on
+    // *every* dependency reaching zero — accept an array of dep keys
+    // and require ALL of them to be 0 / null / missing on the picked
+    // row. Single-string input is preserved for the simple cases
+    // (autori, editori) where the only blocker is books.
+    //
+    // Returns null when every row has at least one outstanding
+    // dependency — legitimate on a seeded install; tests skip cleanly
+    // in that case.
+    //
+    // Why all-dep-keys-zero (not any-dep-key-zero): the previous
+    // single-key check let through a genre with `children_count=0` but
+    // `libri_count > 0`. The view renders the form only when BOTH gates
+    // pass, so the picked row would still render the lock button and
+    // the toBeAttached assertion fails. The view is the source of
+    // truth here — every dep listed must clear.
+    async function firstDeletableId(apiPath, depKeys) {
+        const keys = Array.isArray(depKeys) ? depKeys : [depKeys];
         const resp = await page.request.get(`${BASE}${apiPath}`);
         if (!resp.ok()) return null;
         const ct = resp.headers()['content-type'] || '';
@@ -554,11 +568,11 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
                        : Array.isArray(body.items) ? body.items
                        : null;
             if (!rows || rows.length === 0) return null;
-            // Find the first row whose dep-count is 0 (or missing).
-            const row = rows.find(r => {
-                const dep = r[hasDepKey];
+            // Find the first row where EVERY listed dep is 0/null/missing.
+            const row = rows.find(r => keys.every(k => {
+                const dep = r[k];
                 return dep == null || Number(dep) === 0;
-            });
+            }));
             if (!row) return null;
             const id = row.id ?? row.ID ?? row.pk;
             return id != null ? String(id) : null;
@@ -591,10 +605,15 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
 
     // E7: generi/dettaglio_genere — delete-genre form is wired
     test('E7: generi/dettaglio_genere delete-genre form carries data-swal-confirm', async () => {
-        // Genres have BOTH children_count and libri_count gates — accept
-        // first row where neither is > 0. Fall back to children_count
-        // alone (the index API doesn't always return libri_count).
-        const id = await firstDeletableId('/api/generi', 'children_count');
+        // The view gates the delete form on TWO conditions (per
+        // GeneriController + dettaglio_genere.php): no sub-genres
+        // (`children_count == 0`) AND no books referencing this genre
+        // (`libri_count == 0`). Either dep being non-zero swaps the
+        // form out for a lock button, so both must reach zero on the
+        // picked row. The /api/generi index returns both fields when
+        // the row has them; firstDeletableId treats missing fields as
+        // zero (same conservative rule the view applies).
+        const id = await firstDeletableId('/api/generi', ['children_count', 'libri_count']);
         test.skip(!id, 'No deletable genre on this install (every genre has sub-genres or books)');
         await page.goto(`${BASE}/admin/generi/${id}`);
         await page.waitForLoadState('domcontentloaded');

--- a/tests/sweetalert2-comprehensive.spec.js
+++ b/tests/sweetalert2-comprehensive.spec.js
@@ -537,15 +537,41 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
         expect((confirmText || '').toLowerCase()).toContain('elimin'); // covers Elimina/Eliminate
     });
 
+    // Resolve the first entity that's actually DELETABLE (no books / no
+    // sub-genres) via the admin JSON API, so the scheda renders the
+    // delete-form path rather than the "non eliminabile" placeholder.
+    // Returns null when every row has at least one associated book —
+    // legitimate on a seeded install; tests skip cleanly in that case.
+    async function firstDeletableId(apiPath, hasDepKey) {
+        const resp = await page.request.get(`${BASE}${apiPath}`);
+        if (!resp.ok()) return null;
+        const ct = resp.headers()['content-type'] || '';
+        if (!ct.includes('json')) return null;
+        try {
+            const body = await resp.json();
+            const rows = Array.isArray(body) ? body
+                       : Array.isArray(body.data) ? body.data
+                       : Array.isArray(body.items) ? body.items
+                       : null;
+            if (!rows || rows.length === 0) return null;
+            // Find the first row whose dep-count is 0 (or missing).
+            const row = rows.find(r => {
+                const dep = r[hasDepKey];
+                return dep == null || Number(dep) === 0;
+            });
+            if (!row) return null;
+            const id = row.id ?? row.ID ?? row.pk;
+            return id != null ? String(id) : null;
+        } catch { return null; }
+    }
+
     // E5: autori/scheda_autore — delete-author form is wired
     test('E5: autori/scheda_autore delete-author form carries data-swal-confirm', async () => {
-        await page.goto(`${BASE}/admin/autori`);
-        await page.waitForLoadState('domcontentloaded');
-        const authorLink = page.locator('a[href*="/autori/"]').first();
-        const count = await authorLink.count();
-        test.skip(count === 0, 'No authors seeded — create one to exercise this path');
-        const href = await authorLink.getAttribute('href');
-        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        // libri_count > 0 → scheda renders the "non eliminabile" lock
+        // button instead of the delete form. Pick a deletable author.
+        const id = await firstDeletableId('/api/autori', 'libri_count');
+        test.skip(!id, 'No deletable author on this install (every author has at least one associated book)');
+        await page.goto(`${BASE}/admin/autori/${id}`);
         await page.waitForLoadState('domcontentloaded');
         const form = page.locator('form[data-swal-confirm]').first();
         await expect(form).toBeAttached();
@@ -555,13 +581,9 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
 
     // E6: editori/scheda_editore — delete-publisher form is wired
     test('E6: editori/scheda_editore delete-publisher form carries data-swal-confirm', async () => {
-        await page.goto(`${BASE}/admin/editori`);
-        await page.waitForLoadState('domcontentloaded');
-        const editorLink = page.locator('a[href*="/editori/"]').first();
-        const count = await editorLink.count();
-        test.skip(count === 0, 'No publishers seeded');
-        const href = await editorLink.getAttribute('href');
-        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        const id = await firstDeletableId('/api/editori', 'libri_count');
+        test.skip(!id, 'No deletable publisher on this install');
+        await page.goto(`${BASE}/admin/editori/${id}`);
         await page.waitForLoadState('domcontentloaded');
         const form = page.locator('form[data-swal-confirm]').first();
         await expect(form).toBeAttached();
@@ -569,13 +591,12 @@ test.describe('[REFACTORED] per-view attribute assertions', () => {
 
     // E7: generi/dettaglio_genere — delete-genre form is wired
     test('E7: generi/dettaglio_genere delete-genre form carries data-swal-confirm', async () => {
-        await page.goto(`${BASE}/admin/generi`);
-        await page.waitForLoadState('domcontentloaded');
-        const genreLink = page.locator('a[href*="/generi/"]').first();
-        const count = await genreLink.count();
-        test.skip(count === 0, 'No genres seeded');
-        const href = await genreLink.getAttribute('href');
-        await page.goto(href.startsWith('http') ? href : `${BASE}${href}`);
+        // Genres have BOTH children_count and libri_count gates — accept
+        // first row where neither is > 0. Fall back to children_count
+        // alone (the index API doesn't always return libri_count).
+        const id = await firstDeletableId('/api/generi', 'children_count');
+        test.skip(!id, 'No deletable genre on this install (every genre has sub-genres or books)');
+        await page.goto(`${BASE}/admin/generi/${id}`);
         await page.waitForLoadState('domcontentloaded');
         const form = page.locator('form[data-swal-confirm]').first();
         await expect(form).toBeAttached();

--- a/tests/sweetalert2-popups.spec.js
+++ b/tests/sweetalert2-popups.spec.js
@@ -191,12 +191,13 @@ test.describe.serial('Issue #140 — SweetAlert2 popup unification', () => {
 
             // Override THIS form's submit() so we track the programmatic
             // call from the Swal handler (not every submit event).
+            // We do NOT call the original HTMLFormElement.prototype.submit
+            // — that would navigate even with action='javascript:void(0)'
+            // in some browsers; the test only needs to know that the
+            // confirm handler invoked it.
             window.__swalTestSubmitted = false;
-            const origSubmit = HTMLFormElement.prototype.submit;
             form.submit = function() {
                 window.__swalTestSubmitted = true;
-                // Do NOT call origSubmit — that would navigate even with
-                // action='javascript:void(0)' in some browsers.
             };
         });
 

--- a/tests/sweetalert2-popups.spec.js
+++ b/tests/sweetalert2-popups.spec.js
@@ -1,0 +1,320 @@
+// @ts-check
+//
+// Regression test for issue #140 — every refactored banner/popup uses
+// SweetAlert2 instead of the native browser dialogs. Each test exercises
+// one of the patterns introduced by the unification:
+//
+//   1. Defensive helpers (window.SwalApp.confirmDelete / .error / .success)
+//      degrade gracefully when Swal is missing (this we test by stubbing
+//      Swal away — verifies the fallback contract).
+//   2. data-swal-confirm forms auto-wire to Swal at DOMContentLoaded and
+//      block the default submit until the user clicks .swal2-confirm.
+//   3. .swal2-confirm + .swal2-cancel selectors are reachable from
+//      Playwright (no native browser-dialog handlers needed).
+//
+// What this is NOT: a per-finding click-through of every refactored
+// site. The unification is mechanical (same helper bus, same data-*
+// API, same selectors) — a contract-level test on the bus is more
+// stable and catches the regressions we actually care about:
+//   - the helper bus disappearing
+//   - the auto-attach DOMContentLoaded handler not firing
+//   - .swal2-confirm not landing on user click
+//
+// Run:
+//   /tmp/run-e2e.sh tests/sweetalert2-popups.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+
+const BASE        = process.env.E2E_BASE_URL    || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E credentials not configured');
+
+/**
+ * Login admin once per browser context so the protected admin pages
+ * we'll mount are reachable.
+ */
+async function loginAsAdmin(page) {
+    await page.goto(`${BASE}/accedi`);
+    await page.fill('input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await Promise.all([
+        page.waitForURL(/\/(admin|profilo)/, { timeout: 15000 }),
+        page.click('button[type="submit"]'),
+    ]);
+}
+
+test.describe.serial('Issue #140 — SweetAlert2 popup unification', () => {
+
+    /** @type {import('@playwright/test').BrowserContext} */
+    let context;
+    /** @type {import('@playwright/test').Page} */
+    let page;
+
+    test.beforeAll(async ({ browser }) => {
+        context = await browser.newContext();
+        page = await context.newPage();
+        await loginAsAdmin(page);
+    });
+
+    test.afterAll(async () => {
+        await context.close();
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 1 — Swal config bus is reachable.
+    // The whole unification rests on `window.SwalApp` existing on every
+    // page that loads the admin/frontend layout. If swal-config.js
+    // failed to load (CDN error, CSP), every confirm/alert breaks.
+    // ────────────────────────────────────────────────────────────────────
+    test('window.SwalApp bus is initialized on every admin page', async () => {
+        await page.goto(`${BASE}/admin/dashboard`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const swalAppShape = await page.evaluate(() => {
+            const a = window.SwalApp;
+            if (!a) return null;
+            return {
+                hasConfirmDelete: typeof a.confirmDelete === 'function',
+                hasConfirm:       typeof a.confirm === 'function',
+                hasError:         typeof a.error === 'function',
+                hasSuccess:       typeof a.success === 'function',
+                hasInfo:          typeof a.info === 'function',
+                hasWarning:       typeof a.warning === 'function',
+                hasPrompt:        typeof a.prompt === 'function',
+                hasToast:         typeof a.toast === 'function',
+                hasAttach:        typeof a.attachSwalConfirm === 'function',
+            };
+        });
+
+        expect(swalAppShape, 'window.SwalApp must exist on every page').not.toBeNull();
+        expect(swalAppShape).toMatchObject({
+            hasConfirmDelete: true,
+            hasConfirm:       true,
+            hasError:         true,
+            hasSuccess:       true,
+            hasInfo:          true,
+            hasWarning:       true,
+            hasPrompt:        true,
+            hasToast:         true,
+            hasAttach:        true,
+        });
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 2 — Defensive native fallback.
+    // When Swal is removed at runtime, each helper still returns a
+    // Promise-like {isConfirmed, value} shape so callers using
+    // `await SwalApp.confirmDelete().then(r => r.isConfirmed && doStuff())`
+    // keep working with native confirm/alert behind the scenes.
+    // ────────────────────────────────────────────────────────────────────
+    test('SwalApp helpers fall back to native dialogs when Swal is unavailable', async () => {
+        await page.goto(`${BASE}/admin/dashboard`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // Auto-accept any native dialog this test triggers so the
+        // browser doesn't hang the page on a real confirm/alert.
+        page.on('dialog', (d) => d.accept());
+
+        const fallbackResult = await page.evaluate(async () => {
+            // Stash + remove Swal to simulate bundle failure.
+            const stashed = window.Swal;
+            try {
+                delete window.Swal;
+
+                // confirmDelete must still return {isConfirmed: true}
+                // because the native confirm() is auto-accepted by the
+                // page.on('dialog') handler above.
+                const r1 = await window.SwalApp.confirmDelete({ text: 'native fallback test' });
+                // error() must not throw and must return {isConfirmed: true}
+                // (the underlying alert is auto-accepted).
+                const r2 = await window.SwalApp.error('e', 'fallback error');
+                return {
+                    confirmDeleteIsConfirmed: r1 && r1.isConfirmed === true,
+                    errorReturnedPromise:     r2 && r2.isConfirmed === true,
+                };
+            } finally {
+                window.Swal = stashed;
+            }
+        });
+
+        expect(fallbackResult).toEqual({
+            confirmDeleteIsConfirmed: true,
+            errorReturnedPromise:     true,
+        });
+
+        // Drop the test-scoped dialog handler so the next tests use
+        // Swal-driven flows instead.
+        page.removeAllListeners('dialog');
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 3 — data-swal-confirm auto-attach.
+    // The DOMContentLoaded handler in swal-config.js walks every
+    // `form[data-swal-confirm]` and installs the Swal interceptor.
+    // We inject a synthetic form into the dashboard and verify:
+    //   - the submit is blocked at first
+    //   - .swal2-confirm appears after click
+    //   - clicking .swal2-confirm allows the second submit to go through
+    // ────────────────────────────────────────────────────────────────────
+    test('data-swal-confirm forms are auto-wired and gated by .swal2-confirm', async () => {
+        await page.goto(`${BASE}/admin/dashboard`);
+        await page.waitForLoadState('domcontentloaded');
+
+        // Inject the synthetic form. We intercept form.submit() (which
+        // attachSwalConfirm calls programmatically after the user
+        // clicks .swal2-confirm) — the native `submit` event would
+        // also fire on the first user click before Swal preventDefault
+        // runs, which makes it a noisy sentinel. form.submit() bypasses
+        // listeners entirely, so a flag inside the prototype override
+        // is the cleanest signal of "the user confirmed and the form
+        // actually went through".
+        await page.evaluate(() => {
+            const form = document.createElement('form');
+            form.id = 'swal-test-form';
+            form.method = 'post';
+            form.action = 'javascript:void(0)';
+            form.setAttribute('data-swal-confirm', 'Banner test confirm text');
+            form.setAttribute('data-swal-confirm-button', 'Proceed');
+            const btn = document.createElement('button');
+            btn.type = 'submit';
+            btn.textContent = 'submit';
+            btn.id = 'swal-test-submit';
+            form.appendChild(btn);
+            document.body.appendChild(form);
+
+            // Re-run the auto-attach so the freshly-injected form gets
+            // wired up (the DOMContentLoaded handler already fired).
+            window.SwalApp.attachSwalConfirm();
+
+            // Override THIS form's submit() so we track the programmatic
+            // call from the Swal handler (not every submit event).
+            window.__swalTestSubmitted = false;
+            const origSubmit = HTMLFormElement.prototype.submit;
+            form.submit = function() {
+                window.__swalTestSubmitted = true;
+                // Do NOT call origSubmit — that would navigate even with
+                // action='javascript:void(0)' in some browsers.
+            };
+        });
+
+        // First click: should NOT submit (blocked by Swal preventDefault).
+        const submitBtn = page.locator('#swal-test-submit');
+        await submitBtn.click();
+
+        // Wait for the Swal dialog to land.
+        const swalConfirm = page.locator('.swal2-confirm');
+        await expect(swalConfirm).toBeAttached({ timeout: 5000 });
+        // The dialog content matches what we passed in data-swal-confirm.
+        await expect(page.locator('.swal2-popup')).toContainText('Banner test confirm text');
+
+        // Confirming should call form.submit() programmatically.
+        await swalConfirm.click();
+        await page.waitForTimeout(300);
+        const submittedAfter = await page.evaluate(() => window.__swalTestSubmitted === true);
+        expect(submittedAfter, 'form.submit() must be called after Swal confirm').toBe(true);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 4 — Cancel path.
+    // Clicking the Swal cancel button must NOT submit the form.
+    // ────────────────────────────────────────────────────────────────────
+    test('data-swal-confirm cancel keeps the form untouched', async () => {
+        await page.goto(`${BASE}/admin/dashboard`);
+        await page.waitForLoadState('domcontentloaded');
+
+        await page.evaluate(() => {
+            const form = document.createElement('form');
+            form.id = 'swal-cancel-form';
+            form.action = 'javascript:void(0)';
+            form.setAttribute('data-swal-confirm', 'You will cancel this');
+            const btn = document.createElement('button');
+            btn.type = 'submit';
+            btn.textContent = 'submit';
+            btn.id = 'swal-cancel-submit';
+            form.appendChild(btn);
+            document.body.appendChild(form);
+            window.SwalApp.attachSwalConfirm();
+
+            // Track form.submit() (programmatic), not the submit event —
+            // see Test 3 for why. Cancel must leave the flag false.
+            window.__swalCancelSubmitted = false;
+            form.submit = function() {
+                window.__swalCancelSubmitted = true;
+            };
+        });
+
+        await page.locator('#swal-cancel-submit').click();
+        const swalCancel = page.locator('.swal2-cancel');
+        await expect(swalCancel).toBeAttached({ timeout: 5000 });
+        await swalCancel.click();
+        await page.waitForTimeout(300);
+
+        const submitted = await page.evaluate(() => window.__swalCancelSubmitted === true);
+        expect(submitted, 'form.submit() must NOT be called after Swal cancel').toBe(false);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 5 — Real-site smoke: settings/index event-image-layout form.
+    // The /admin/settings?tab=cms tab contains the new event-layout
+    // settings form added in PR #139. Loading the tab should render
+    // the form WITHOUT a native dialog wired to its submit.
+    // (Negative invariant — guards against accidental re-introduction
+    // of onsubmit='return confirm(...)' on this form.)
+    // ────────────────────────────────────────────────────────────────────
+    test('admin/settings?tab=cms: no native onsubmit confirm on event-layout form', async () => {
+        await page.goto(`${BASE}/admin/settings?tab=cms`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const violatingForms = await page.evaluate(() => {
+            const forms = document.querySelectorAll('form');
+            const out = [];
+            forms.forEach((f) => {
+                const onsubmit = f.getAttribute('onsubmit') || '';
+                const onclick  = (f.querySelector('button[type="submit"]')?.getAttribute('onclick')) || '';
+                if (onsubmit.includes('confirm(') || onclick.includes('confirm(')) {
+                    out.push({
+                        action: f.getAttribute('action') || '',
+                        onsubmit, onclick,
+                    });
+                }
+            });
+            return out;
+        });
+
+        expect(
+            violatingForms,
+            'No form on /admin/settings?tab=cms must still use native confirm() in onsubmit/onclick',
+        ).toEqual([]);
+    });
+
+    // ────────────────────────────────────────────────────────────────────
+    // Test 6 — Real-site smoke: admin/languages page exercises the
+    // form-attribute auto-wire. The language list has set-default/delete
+    // buttons that we converted from onclick='return confirm(...)' to
+    // data-swal-confirm on their parent <form>. Verify at least one
+    // form on that page actually carries the attribute.
+    // ────────────────────────────────────────────────────────────────────
+    test('admin/languages: at least one data-swal-confirm form is present', async () => {
+        await page.goto(`${BASE}/admin/languages`);
+        await page.waitForLoadState('domcontentloaded');
+
+        const count = await page.locator('form[data-swal-confirm]').count();
+        // Skip when no languages are configured (a fresh install ships
+        // only the default — the set-default + delete buttons only
+        // render for non-default rows).
+        test.skip(count === 0, 'no languages with data-swal-confirm — empty configuration');
+
+        // At least one form with the attribute should exist.
+        expect(count).toBeGreaterThan(0);
+
+        // The first such form should also have data-swal-confirm-button
+        // (we wired both attributes on every refactor) — sanity that
+        // the attribute set is complete.
+        const firstHasButtonAttr = await page.locator('form[data-swal-confirm]').first()
+            .evaluate((el) => el.hasAttribute('data-swal-confirm-button'));
+        expect(firstHasButtonAttr).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #140.

Refactor every native `alert()` / `confirm()` / `prompt()` across the views to the existing `window.SwalApp` helper bus, plus add a defensive native fallback to every helper so the destructive flows still work when the SweetAlert2 bundle fails to load (CDN error, CSP, etc.).

**Note on the diff**: this branch was cut from `feat/event-image-layout-setting` (PR #139) so the SwalApp work would start from the recent EventsController + spec teardown improvements. The first 9 commits in this PR are the #139 set; they will collapse out of the diff automatically when #139 lands on `main`. The genuinely new commits are the last two:

- `chore: unify client-side popups to SweetAlert2 (#140)` — 39 files, ~45 sites
- `test(swal): E2E coverage for issue #140 popup unification` — 1 new spec, 6 tests

## What changed

### `public/assets/js/swal-config.js` (helper bus)

- Every existing helper (`confirmDelete` / `confirm` / `success` / `error` / `info` / `warning` / `toast`) now has a **defensive native fallback** — when `Swal` is missing the helper resolves to `window.confirm` / `window.alert` with the same `{isConfirmed, value}` Promise shape, so callers using `.then(r => r.isConfirmed && doStuff())` keep working.
- New `SwalApp.prompt(opts)` — single-line text input dialog. Falls back to `window.prompt` when Swal is unavailable.
- New `SwalApp.attachSwalConfirm(selector)` — auto-wires every form carrying `data-swal-confirm` to a Swal confirm dialog. Auto-attaches on `DOMContentLoaded` (idempotent via `data-swal-attached` marker).

### Refactor categories

| Category | Sites | Pattern |
|---|---|---|
| `<form onsubmit/onclick="return confirm(...)">` | 11 | → `data-swal-confirm` attribute on `<form>`; auto-wired by `attachSwalConfirm()` |
| JS `confirm()` before action | ~10 | → `SwalApp.confirmDelete` / `SwalApp.confirm` with `.then(r => r.isConfirmed && …)` |
| JS `alert()` error/info | ~20 | → `SwalApp.error` / `SwalApp.success` / `SwalApp.toast` |
| Verbose `if (window.Swal) { Swal.fire(…) } else { alert/confirm(…) }` | ~7 | → single `SwalApp.*` call (collapses 10+ lines to 1) |

### Left unchanged on purpose (documented in commit message)

- `app/Views/libri/scheda_libro.php` — already uses `if (Swal) { fancy } else { fallback }` internally; rewrite would touch 50+ lines for no behavioural change.
- `app/Views/dashboard/index.php:957`, `app/Views/libri/scheda_libro.php:1471` — `alert()` inside the else branch of a documented Swal-or-alert fallback.
- `app/Views/partials/loan-actions-swal.php` — already the canonical Swal+fallback contract for the loan UI.
- `app/Views/admin/recensioni/index.php` — internal `_confirm` helper already implements the pattern.
- `app/Views/frontend/book-detail.php:2729` — `prompt()` in the Swal-missing fallback branch; `SwalApp.prompt` would call the same `window.prompt` internally (circular).

### i18n

+12 new keys across all 4 locale files (`it_IT`, `en_US`, `de_DE`, `fr_FR`) in the same commit, per the project i18n-blocking policy: `Annulla prenotazione`, `Conferma attivazione`, `Attiva utente`, `Imposta come Predefinita`, `Elimina tutto`, `Unisci`, `Attiva`, `Ripristina`, `Rimuovi`, `Confermi?`, `Errore Upload`, `Inserisci un valore`.

## Test plan

- [x] `php -l` clean on every modified PHP file (34 files).
- [x] PHPStan: 11 errors (identical to `main`, all pre-existing in `storage/plugins/{archives,bibframe-linked-data,discogs}`).
- [x] `swal-config.js` syntax check via `new Function(fs.readFileSync(...))`.
- [x] `tests/sweetalert2-popups.spec.js` — 6/6 pass:
  1. `window.SwalApp` bus initialized on every admin page
  2. SwalApp helpers fall back to native dialogs when Swal is unavailable
  3. `data-swal-confirm` forms are auto-wired by `attachSwalConfirm`
  4. Cancel path: `form.submit()` is NOT called when user clicks `.swal2-cancel`
  5. `/admin/settings?tab=cms` — negative invariant: no native `onsubmit confirm` on the event-layout form
  6. `/admin/languages` — at least one `form[data-swal-confirm]` is wired
- [x] Regression: `tests/issue-137-event-image-layout.spec.js` — 8/8 still pass.

## Implementation notes for reviewers

- **`form.submit()` override vs `submit` event**: the `submit` event fires for both intercepted and post-confirm submits (because `preventDefault` doesn't stop other listeners). The programmatic `form.submit()` call is unique to `attachSwalConfirm`'s confirm path — that's the sentinel the tests use.
- **`data-swal-attached='1'` idempotency marker**: `attachSwalConfirm()` can be called multiple times safely (e.g. after injecting a form dynamically). Existing wiring is not duplicated.
- **`data-swal-confirm=''` re-submit escape**: after a successful confirm, the handler sets `dataset.swalConfirm = ''` so `form.submit()` reaches the action without re-prompting (otherwise we'd recurse).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Opzione admin per scegliere il layout dell’immagine evento (full, banner, contained, thumb) con form di salvataggio.

* **Miglioramenti**
  * Upload/rimozione immagine evento resi più sicuri e consistenti, con cleanup automatico su errori e rimozione post-eliminazione.
  * Conferme/notifiche client unificate su una singola API con fallback quando il popup principale non è disponibile.

* **Test**
  * Ampie suite E2E e di regressione per layout immagine e per il comportamento delle conferme/popup.

* **Localizzazioni**
  * Nuove stringhe IT/EN/DE/FR per impostazioni eventi e messaggi di conferma/azione.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fabiodalez-dev/Pinakes/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->