### PR TITLE
fix: multi-publisher merge/filters, PHP 8.2 preflight floor, release verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,30 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 ---
 
+## What's New in v0.7.16
+
+### Multi-publisher, hardened end to end (#143)
+
+Books can have more than one publisher (the `libri_editori` junction, introduced in 0.7.15). This release closes every gap in that model: publisher **filters, counts, exports, the public publisher archive, the catalog facet, search, the admin API and bulk operations** now all match a book whether the publisher is its primary one (`libri.editore_id`) or a secondary one in the junction. Merging two publishers re-points the junction onto the survivor **before** the cascade, so no association is lost; the publisher-delete guard counts secondary links too; and CSV / LibraryThing import and bulk-enrichment now keep the junction in sync so interop exporters (OAI-PMH, BIBFRAME) never lose a publisher.
+
+Every new junction query is **guarded for pre-migration installs** — on a database that predates the junction table the queries gracefully fall back to the primary publisher instead of erroring.
+
+### PHP 8.2 is now the floor
+
+The installer and the in-app updater now require **PHP 8.2+**, matching `composer.json` (`^8.2`) and the generated `platform_check.php`. Previously an 8.1 host could pass preflight and then die at the Composer bootstrap.
+
+### Other fixes
+
+- **Multi-character book-case codes** (#153): the legacy single-letter UNIQUE constraint on `scaffali.lettera` is dropped, so codes like `L1`, `L2` no longer collide.
+- **Edit form**: the "Import from ISBN" field is pre-filled with the book's ISBN/EAN when editing.
+- A reconciliation migration heals any `libri_editori` drift left by imports written before the sync landed.
+
+### Testing
+
+The comprehensive E2E suite grew to **132 tests**, adding a 20-test **Archives** phase (ISAD(G) CRUD, hierarchy, SQL seeding, authority records, and the JSON/XML APIs — RiC-O JSON-LD, IIIF, OAI-PMH, SRU, MARCXML/Dublin Core/EAD3/METS) and a 9-test **multi-publisher / multi-author** phase. Validated with a fresh-install + real-upgrade regression.
+
+---
+
 ## What's New in v0.7.14
 
 ### Installer fix: wizard no longer wedges at step 6 (Configurazione Email)

--- a/app/Controllers/CsvImportController.php
+++ b/app/Controllers/CsvImportController.php
@@ -1332,6 +1332,36 @@ class CsvImportController
         $stmt->close();
 
         $this->syncImportedSeries($db, $bookId, $collana, $numeroSerie);
+        $this->syncPrimaryPublisherJunction($db, $bookId, $editorId);
+    }
+
+    /**
+     * Keep libri_editori in sync with a book's primary publisher (issue #143).
+     *
+     * CSV import writes libri.editore_id directly (not via
+     * BookRepository::syncPublishers()), which would otherwise leave the
+     * multi-publisher junction missing the primary row — so junction-only
+     * consumers (OAI-PMH, BIBFRAME) would export no publisher. Additive only
+     * (INSERT IGNORE at ordine 0): never removes co-publisher rows, idempotent,
+     * and a no-op on pre-migration installs.
+     */
+    private function syncPrimaryPublisherJunction(\mysqli $db, int $bookId, ?int $editoreId): void
+    {
+        $editoreId = (int) $editoreId;
+        if ($bookId <= 0 || $editoreId <= 0) {
+            return;
+        }
+        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
+        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+            return;
+        }
+        $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');
+        if ($stmt === false) {
+            return;
+        }
+        $stmt->bind_param('ii', $bookId, $editoreId);
+        $stmt->execute();
+        $stmt->close();
     }
 
     private function syncImportedSeries(\mysqli $db, int $bookId, ?string $collana, ?string $numeroSerie): void
@@ -1454,6 +1484,7 @@ class CsvImportController
         $bookId = $db->insert_id;
         $stmt->close();
         $this->syncImportedSeries($db, $bookId, $collana, $numeroSerie);
+        $this->syncPrimaryPublisherJunction($db, $bookId, $editorId);
 
         // Genera copie fisiche nella tabella copie
         $copyRepo = new \App\Models\CopyRepository($db);
@@ -1659,6 +1690,7 @@ class CsvImportController
             $stmt->bind_param('ii', $editorId, $bookId);
             $stmt->execute();
             $stmt->close();
+            $this->syncPrimaryPublisherJunction($db, $bookId, $editorId);
         }
     }
 }

--- a/app/Controllers/CsvImportController.php
+++ b/app/Controllers/CsvImportController.php
@@ -1351,8 +1351,7 @@ class CsvImportController
         if ($bookId <= 0 || $editoreId <= 0) {
             return;
         }
-        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
-        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+        if (!\App\Support\SchemaInfo::hasLibriEditori($db)) {
             return;
         }
         $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');

--- a/app/Controllers/EditoriApiController.php
+++ b/app/Controllers/EditoriApiController.php
@@ -141,7 +141,7 @@ class EditoriApiController
         // If we have a HAVING clause, we need to count from a subquery
         if ($having_clause !== '') {
             $count_sql = "SELECT COUNT(*) AS c FROM (
-                SELECT e.id, (SELECT COUNT(*) FROM libri l WHERE l.editore_id = e.id AND l.deleted_at IS NULL) AS libri_count
+                SELECT e.id, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
                 FROM editori e
                 $where_prepared
                 $having_clause
@@ -170,7 +170,7 @@ class EditoriApiController
         $subOrderColumn = str_replace('e.', '', $orderColumn); // Remove table alias for subquery
         if ($having_clause !== '') {
             $sql_prepared = "SELECT * FROM (
-                    SELECT e.*, (SELECT COUNT(*) FROM libri l WHERE l.editore_id = e.id AND l.deleted_at IS NULL) AS libri_count
+                    SELECT e.*, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
                     FROM editori e
                     $where_prepared
                     $having_clause
@@ -179,7 +179,7 @@ class EditoriApiController
                 LIMIT ?, ?";
         } else {
             $sql_prepared = "SELECT e.*, (
-                        SELECT COUNT(*) FROM libri l WHERE l.editore_id = e.id AND l.deleted_at IS NULL
+                        SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL
                     ) AS libri_count
                     FROM editori e
                     $where_prepared
@@ -256,8 +256,17 @@ class EditoriApiController
         $placeholders = implode(',', array_fill(0, count($cleanIds), '?'));
         $types = str_repeat('i', count($cleanIds));
 
-        // Check if any publisher has books (only non-deleted books)
-        $checkSql = "SELECT id FROM libri WHERE editore_id IN ($placeholders) AND deleted_at IS NULL LIMIT 1";
+        // Check if any publisher has books (only non-deleted books) — match
+        // both the primary (libri.editore_id) and any secondary publisher in
+        // the multi-publisher junction (issue #143), otherwise the editori
+        // DELETE below would cascade-wipe libri_editori rows of books that
+        // reference these publishers only as secondary.
+        $checkSql = "SELECT l.id FROM libri l
+                     WHERE (l.editore_id IN ($placeholders)
+                            OR EXISTS (SELECT 1 FROM libri_editori le
+                                       WHERE le.libro_id = l.id AND le.editore_id IN ($placeholders)))
+                           AND l.deleted_at IS NULL
+                     LIMIT 1";
         $checkStmt = $db->prepare($checkSql);
         if (!$checkStmt) {
             AppLog::error('editori.bulk_delete.check_prepare_failed', ['error' => $db->error]);
@@ -268,7 +277,8 @@ class EditoriApiController
             return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
         }
 
-        $checkStmt->bind_param($types, ...$cleanIds);
+        // Placeholders appear twice (primary IN + junction IN) → bind ids twice.
+        $checkStmt->bind_param($types . $types, ...$cleanIds, ...$cleanIds);
         if (!$checkStmt->execute()) {
             AppLog::error('editori.bulk_delete.check_execute_failed', ['error' => $checkStmt->error]);
             $checkStmt->close();
@@ -363,7 +373,7 @@ class EditoriApiController
         $types = str_repeat('i', count($cleanIds));
 
         $sql = "SELECT e.id, e.nome, e.sito_web, e.indirizzo, e.telefono, e.email,
-                       (SELECT COUNT(*) FROM libri l WHERE l.editore_id = e.id AND l.deleted_at IS NULL) AS libri_count
+                       (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
                 FROM editori e
                 WHERE e.id IN ($placeholders)
                 ORDER BY e.nome ASC";

--- a/app/Controllers/EditoriApiController.php
+++ b/app/Controllers/EditoriApiController.php
@@ -137,11 +137,18 @@ class EditoriApiController
         $total = (int) ($total_res->fetch_assoc()['c'] ?? 0);
         $total_stmt->close();
 
+        // issue #143: count books where the publisher is primary OR a secondary
+        // one in the junction; gate the subquery on table existence so the
+        // editori list degrades to primary-only on pre-migration installs.
+        $editoriCountExists = \App\Support\SchemaInfo::hasLibriEditori($db)
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)"
+            : "";
+
         // Use prepared statement for filtered count to prevent SQL injection
         // If we have a HAVING clause, we need to count from a subquery
         if ($having_clause !== '') {
             $count_sql = "SELECT COUNT(*) AS c FROM (
-                SELECT e.id, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
+                SELECT e.id, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id{$editoriCountExists}) AND l.deleted_at IS NULL) AS libri_count
                 FROM editori e
                 $where_prepared
                 $having_clause
@@ -170,7 +177,7 @@ class EditoriApiController
         $subOrderColumn = str_replace('e.', '', $orderColumn); // Remove table alias for subquery
         if ($having_clause !== '') {
             $sql_prepared = "SELECT * FROM (
-                    SELECT e.*, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
+                    SELECT e.*, (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id{$editoriCountExists}) AND l.deleted_at IS NULL) AS libri_count
                     FROM editori e
                     $where_prepared
                     $having_clause
@@ -179,7 +186,7 @@ class EditoriApiController
                 LIMIT ?, ?";
         } else {
             $sql_prepared = "SELECT e.*, (
-                        SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL
+                        SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id{$editoriCountExists}) AND l.deleted_at IS NULL
                     ) AS libri_count
                     FROM editori e
                     $where_prepared
@@ -260,13 +267,21 @@ class EditoriApiController
         // both the primary (libri.editore_id) and any secondary publisher in
         // the multi-publisher junction (issue #143), otherwise the editori
         // DELETE below would cascade-wipe libri_editori rows of books that
-        // reference these publishers only as secondary.
-        $checkSql = "SELECT l.id FROM libri l
-                     WHERE (l.editore_id IN ($placeholders)
-                            OR EXISTS (SELECT 1 FROM libri_editori le
-                                       WHERE le.libro_id = l.id AND le.editore_id IN ($placeholders)))
-                           AND l.deleted_at IS NULL
-                     LIMIT 1";
+        // reference these publishers only as secondary. Gate the junction
+        // subquery on table existence (pre-migration safety).
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($db);
+        if ($hasJunction) {
+            $checkSql = "SELECT l.id FROM libri l
+                         WHERE (l.editore_id IN ($placeholders)
+                                OR EXISTS (SELECT 1 FROM libri_editori le
+                                           WHERE le.libro_id = l.id AND le.editore_id IN ($placeholders)))
+                               AND l.deleted_at IS NULL
+                         LIMIT 1";
+        } else {
+            $checkSql = "SELECT l.id FROM libri l
+                         WHERE l.editore_id IN ($placeholders) AND l.deleted_at IS NULL
+                         LIMIT 1";
+        }
         $checkStmt = $db->prepare($checkSql);
         if (!$checkStmt) {
             AppLog::error('editori.bulk_delete.check_prepare_failed', ['error' => $db->error]);
@@ -277,8 +292,13 @@ class EditoriApiController
             return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
         }
 
-        // Placeholders appear twice (primary IN + junction IN) → bind ids twice.
-        $checkStmt->bind_param($types . $types, ...$cleanIds, ...$cleanIds);
+        // Placeholders appear twice (primary IN + junction IN) when the junction
+        // exists → bind ids twice; once otherwise.
+        if ($hasJunction) {
+            $checkStmt->bind_param($types . $types, ...$cleanIds, ...$cleanIds);
+        } else {
+            $checkStmt->bind_param($types, ...$cleanIds);
+        }
         if (!$checkStmt->execute()) {
             AppLog::error('editori.bulk_delete.check_execute_failed', ['error' => $checkStmt->error]);
             $checkStmt->close();
@@ -372,8 +392,13 @@ class EditoriApiController
         $placeholders = implode(',', array_fill(0, count($cleanIds), '?'));
         $types = str_repeat('i', count($cleanIds));
 
+        // issue #143: gate the junction subquery on table existence.
+        $editoriCountExists = \App\Support\SchemaInfo::hasLibriEditori($db)
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)"
+            : "";
+
         $sql = "SELECT e.id, e.nome, e.sito_web, e.indirizzo, e.telefono, e.email,
-                       (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)) AND l.deleted_at IS NULL) AS libri_count
+                       (SELECT COUNT(*) FROM libri l WHERE (l.editore_id = e.id{$editoriCountExists}) AND l.deleted_at IS NULL) AS libri_count
                 FROM editori e
                 WHERE e.id IN ($placeholders)
                 ORDER BY e.nome ASC";

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -971,9 +971,14 @@ class FrontendController
         }
 
         if (!empty($filters['editore'])) {
-            $conditions[] = "e.nome = ?";
+            // Match the publisher whether it is the book's primary (the joined
+            // `e`) or a secondary one in the multi-publisher junction (issue
+            // #143), so the catalog filter results agree with the publisher
+            // facet count (which already counts secondaries).
+            $conditions[] = "(e.nome = ? OR EXISTS (SELECT 1 FROM libri_editori le2 JOIN editori e2 ON le2.editore_id = e2.id WHERE le2.libro_id = l.id AND e2.nome = ?))";
             $params[] = $filters['editore'];
-            $types .= 's';
+            $params[] = $filters['editore'];
+            $types .= 'ss';
         }
 
         if ($filters['disponibilita'] === 'disponibile') {

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -974,11 +974,18 @@ class FrontendController
             // Match the publisher whether it is the book's primary (the joined
             // `e`) or a secondary one in the multi-publisher junction (issue
             // #143), so the catalog filter results agree with the publisher
-            // facet count (which already counts secondaries).
-            $conditions[] = "(e.nome = ? OR EXISTS (SELECT 1 FROM libri_editori le2 JOIN editori e2 ON le2.editore_id = e2.id WHERE le2.libro_id = l.id AND e2.nome = ?))";
-            $params[] = $filters['editore'];
-            $params[] = $filters['editore'];
-            $types .= 'ss';
+            // facet count (which already counts secondaries). Gate the junction
+            // subquery on table existence (pre-migration safety).
+            if (\App\Support\SchemaInfo::hasLibriEditori($db)) {
+                $conditions[] = "(e.nome = ? OR EXISTS (SELECT 1 FROM libri_editori le2 JOIN editori e2 ON le2.editore_id = e2.id WHERE le2.libro_id = l.id AND e2.nome = ?))";
+                $params[] = $filters['editore'];
+                $params[] = $filters['editore'];
+                $types .= 'ss';
+            } else {
+                $conditions[] = "e.nome = ?";
+                $params[] = $filters['editore'];
+                $types .= 's';
+            }
         }
 
         if ($filters['disponibilita'] === 'disponibile') {
@@ -1134,11 +1141,15 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
     $paramsEd = $whereEd['params'];
     $typesEd = $whereEd['types'];
 
+    // issue #143: also count books where the publisher is a secondary one in
+    // the junction; gate on table existence (pre-migration safety).
+    $facetExists = \App\Support\SchemaInfo::hasLibriEditori($db)
+        ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id)"
+        : "";
     $queryEditori = "
         SELECT e.id, e.nome, COUNT(DISTINCT l.id) AS cnt
         FROM editori e
-        JOIN libri l ON (e.id = l.editore_id
-                         OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id))
+        JOIN libri l ON (e.id = l.editore_id{$facetExists})
                         AND l.deleted_at IS NULL
         LEFT JOIN generi g ON l.genere_id = g.id
         LEFT JOIN generi gp ON g.parent_id = gp.id
@@ -1421,19 +1432,28 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
         $publisher = $publisherResult->fetch_assoc();
         $publisherId = (int) $publisher['id'];
 
-        // Count total books — match the publisher whether it is the primary
-        // (libri.editore_id) or a secondary one in the multi-publisher junction
-        // (libri_editori, issue #143).
+        // issue #143: match the publisher whether it is the primary
+        // (libri.editore_id) or a secondary one in the multi-publisher junction;
+        // gate the junction subquery on table existence so the public archive
+        // degrades to primary-only on pre-migration installs instead of a 500.
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
+
+        // Count total books
         $countQuery = "
             SELECT COUNT(l.id) as total
             FROM libri l
-            WHERE (l.editore_id = ?
-                   OR EXISTS (SELECT 1 FROM libri_editori le
-                              WHERE le.libro_id = l.id AND le.editore_id = ?))
+            WHERE (l.editore_id = ?{$exists})
                   AND l.deleted_at IS NULL
         ";
         $stmt = $db->prepare($countQuery);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $row = $stmt->get_result()->fetch_assoc();
         $totalBooks = $row['total'] ?? 0;
@@ -1449,16 +1469,18 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
             FROM libri l
             LEFT JOIN editori e ON l.editore_id = e.id
             LEFT JOIN generi g ON l.genere_id = g.id
-            WHERE (l.editore_id = ?
-                   OR EXISTS (SELECT 1 FROM libri_editori le
-                              WHERE le.libro_id = l.id AND le.editore_id = ?))
+            WHERE (l.editore_id = ?{$exists})
                   AND l.deleted_at IS NULL
             ORDER BY l.created_at DESC
             LIMIT ? OFFSET ?
         ";
 
         $stmt = $db->prepare($booksQuery);
-        $stmt->bind_param('iiii', $publisherId, $publisherId, $limit, $offset);
+        if ($hasJunction) {
+            $stmt->bind_param('iiii', $publisherId, $publisherId, $limit, $offset);
+        } else {
+            $stmt->bind_param('iii', $publisherId, $limit, $offset);
+        }
         $stmt->execute();
         $result = $stmt->get_result();
 

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -1132,7 +1132,9 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
     $queryEditori = "
         SELECT e.id, e.nome, COUNT(DISTINCT l.id) AS cnt
         FROM editori e
-        JOIN libri l ON e.id = l.editore_id AND l.deleted_at IS NULL
+        JOIN libri l ON (e.id = l.editore_id
+                         OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = e.id))
+                        AND l.deleted_at IS NULL
         LEFT JOIN generi g ON l.genere_id = g.id
         LEFT JOIN generi gp ON g.parent_id = gp.id
         LEFT JOIN generi gpp ON gp.parent_id = gpp.id

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -1412,16 +1412,21 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
         }
 
         $publisher = $publisherResult->fetch_assoc();
+        $publisherId = (int) $publisher['id'];
 
-        // Count total books
+        // Count total books — match the publisher whether it is the primary
+        // (libri.editore_id) or a secondary one in the multi-publisher junction
+        // (libri_editori, issue #143).
         $countQuery = "
             SELECT COUNT(l.id) as total
             FROM libri l
-            JOIN editori e ON l.editore_id = e.id
-            WHERE e.nome = ? AND l.deleted_at IS NULL
+            WHERE (l.editore_id = ?
+                   OR EXISTS (SELECT 1 FROM libri_editori le
+                              WHERE le.libro_id = l.id AND le.editore_id = ?))
+                  AND l.deleted_at IS NULL
         ";
         $stmt = $db->prepare($countQuery);
-        $stmt->bind_param('s', $publisherName);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $row = $stmt->get_result()->fetch_assoc();
         $totalBooks = $row['total'] ?? 0;
@@ -1435,15 +1440,18 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
                    e.nome AS editore,
                    g.nome AS genere
             FROM libri l
-            JOIN editori e ON l.editore_id = e.id
+            LEFT JOIN editori e ON l.editore_id = e.id
             LEFT JOIN generi g ON l.genere_id = g.id
-            WHERE e.nome = ? AND l.deleted_at IS NULL
+            WHERE (l.editore_id = ?
+                   OR EXISTS (SELECT 1 FROM libri_editori le
+                              WHERE le.libro_id = l.id AND le.editore_id = ?))
+                  AND l.deleted_at IS NULL
             ORDER BY l.created_at DESC
             LIMIT ? OFFSET ?
         ";
 
         $stmt = $db->prepare($booksQuery);
-        $stmt->bind_param('sii', $publisherName, $limit, $offset);
+        $stmt->bind_param('iiii', $publisherId, $publisherId, $limit, $offset);
         $stmt->execute();
         $result = $stmt->get_result();
 

--- a/app/Controllers/LibraryThingImportController.php
+++ b/app/Controllers/LibraryThingImportController.php
@@ -1402,8 +1402,7 @@ class LibraryThingImportController
         if ($bookId <= 0 || $editoreId <= 0) {
             return;
         }
-        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
-        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+        if (!\App\Support\SchemaInfo::hasLibriEditori($db)) {
             return;
         }
         $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');
@@ -1953,11 +1952,18 @@ class LibraryThingImportController
 
         if ($editoreId > 0) {
             // Include books where the publisher is primary or a secondary one in
-            // the multi-publisher junction (issue #143).
-            $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
-            $bindTypes .= 'ii';
-            $bindValues[] = $editoreId;
-            $bindValues[] = $editoreId;
+            // the multi-publisher junction (issue #143); gate the junction
+            // subquery on table existence (pre-migration safety).
+            if (\App\Support\SchemaInfo::hasLibriEditori($db)) {
+                $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
+                $bindTypes .= 'ii';
+                $bindValues[] = $editoreId;
+                $bindValues[] = $editoreId;
+            } else {
+                $whereClauses[] = "l.editore_id = ?";
+                $bindTypes .= 'i';
+                $bindValues[] = $editoreId;
+            }
         }
 
         if ($genereId > 0) {

--- a/app/Controllers/LibraryThingImportController.php
+++ b/app/Controllers/LibraryThingImportController.php
@@ -1386,6 +1386,35 @@ class LibraryThingImportController
         }
     }
 
+    /**
+     * Keep libri_editori in sync with a book's primary publisher (issue #143).
+     *
+     * LibraryThing import writes libri.editore_id directly (not via
+     * BookRepository::syncPublishers()), which would otherwise leave the
+     * multi-publisher junction missing the primary row — so junction-only
+     * consumers (OAI-PMH, BIBFRAME) would export no publisher. Additive only
+     * (INSERT IGNORE at ordine 0): never removes co-publisher rows, idempotent,
+     * and a no-op on pre-migration installs.
+     */
+    private function syncPrimaryPublisherJunction(\mysqli $db, int $bookId, ?int $editoreId): void
+    {
+        $editoreId = (int) $editoreId;
+        if ($bookId <= 0 || $editoreId <= 0) {
+            return;
+        }
+        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
+        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+            return;
+        }
+        $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');
+        if ($stmt === false) {
+            return;
+        }
+        $stmt->bind_param('ii', $bookId, $editoreId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
     private function updateBook(\mysqli $db, int $bookId, array $data, ?int $editorId, ?int $genreId): void
     {
         // Check if LibraryThing plugin is installed
@@ -1536,6 +1565,7 @@ class LibraryThingImportController
         $stmt->execute();
         $affectedRows = $stmt->affected_rows;
         $stmt->close();
+        $this->syncPrimaryPublisherJunction($db, $bookId, $editorId);
 
         // affected_rows=0 can mean unchanged data OR soft-deleted row — check explicitly
         if ($affectedRows === 0) {
@@ -1741,6 +1771,7 @@ class LibraryThingImportController
 
         $stmt->execute();
         $bookId = $db->insert_id;
+        $this->syncPrimaryPublisherJunction($db, $bookId, $editorId);
 
         // Create physical copies
         $copyRepo = new \App\Models\CopyRepository($db);

--- a/app/Controllers/LibraryThingImportController.php
+++ b/app/Controllers/LibraryThingImportController.php
@@ -1921,8 +1921,11 @@ class LibraryThingImportController
         }
 
         if ($editoreId > 0) {
-            $whereClauses[] = "l.editore_id = ?";
-            $bindTypes .= 'i';
+            // Include books where the publisher is primary or a secondary one in
+            // the multi-publisher junction (issue #143).
+            $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
+            $bindTypes .= 'ii';
+            $bindValues[] = $editoreId;
             $bindValues[] = $editoreId;
         }
 

--- a/app/Controllers/LibriApiController.php
+++ b/app/Controllers/LibriApiController.php
@@ -81,11 +81,18 @@ class LibriApiController
         }
         if ($editore_id) {
             // Match books where the publisher is primary or a secondary one in
-            // the multi-publisher junction (issue #143).
-            $where .= ' AND (l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))';
-            $params[] = $editore_id;
-            $params[] = $editore_id;
-            $types .= 'ii';
+            // the multi-publisher junction (issue #143). Gate the junction
+            // subquery on table existence (pre-migration safety).
+            if (\App\Support\SchemaInfo::hasLibriEditori($db)) {
+                $where .= ' AND (l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))';
+                $params[] = $editore_id;
+                $params[] = $editore_id;
+                $types .= 'ii';
+            } else {
+                $where .= ' AND l.editore_id = ?';
+                $params[] = $editore_id;
+                $types .= 'i';
+            }
         }
         if ($stato !== '') {
             $where .= " AND l.stato = ?";
@@ -364,6 +371,10 @@ class LibriApiController
 
     public function getByPublisher(Request $request, Response $response, mysqli $db, int $publisherId): Response
     {
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $sql = "SELECT l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato,
                        (
                          SELECT GROUP_CONCAT(a.nome SEPARATOR ', ')
@@ -374,14 +385,16 @@ class LibriApiController
                 FROM libri l
                 INNER JOIN libri_autori la ON l.id = la.libro_id
                 INNER JOIN autori a ON la.autore_id = a.id
-                WHERE (l.editore_id = ?
-                       OR EXISTS (SELECT 1 FROM libri_editori le
-                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                WHERE (l.editore_id = ?{$exists})
                       AND l.deleted_at IS NULL
                 GROUP BY l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato
                 ORDER BY l.titolo ASC";
         $stmt = $db->prepare($sql);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         $data = [];

--- a/app/Controllers/LibriApiController.php
+++ b/app/Controllers/LibriApiController.php
@@ -80,9 +80,12 @@ class LibriApiController
             $types .= 'i';
         }
         if ($editore_id) {
-            $where .= ' AND l.editore_id = ?';
+            // Match books where the publisher is primary or a secondary one in
+            // the multi-publisher junction (issue #143).
+            $where .= ' AND (l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))';
             $params[] = $editore_id;
-            $types .= 'i';
+            $params[] = $editore_id;
+            $types .= 'ii';
         }
         if ($stato !== '') {
             $where .= " AND l.stato = ?";
@@ -371,11 +374,14 @@ class LibriApiController
                 FROM libri l
                 INNER JOIN libri_autori la ON l.id = la.libro_id
                 INNER JOIN autori a ON la.autore_id = a.id
-                WHERE l.editore_id = ? AND l.deleted_at IS NULL
+                WHERE (l.editore_id = ?
+                       OR EXISTS (SELECT 1 FROM libri_editori le
+                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                      AND l.deleted_at IS NULL
                 GROUP BY l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato
                 ORDER BY l.titolo ASC";
         $stmt = $db->prepare($sql);
-        $stmt->bind_param('i', $publisherId);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $res = $stmt->get_result();
         $data = [];

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2972,12 +2972,19 @@ class LibriController
         }
 
         // Editore filter — match primary (libri.editore_id) or any secondary
-        // publisher in the multi-publisher junction (libri_editori, issue #143).
+        // publisher in the multi-publisher junction (libri_editori, issue #143);
+        // gate the junction subquery on table existence (pre-migration safety).
         if ($editoreId > 0) {
-            $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
-            $bindTypes .= 'ii';
-            $bindValues[] = $editoreId;
-            $bindValues[] = $editoreId;
+            if (\App\Support\SchemaInfo::hasLibriEditori($db)) {
+                $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
+                $bindTypes .= 'ii';
+                $bindValues[] = $editoreId;
+                $bindValues[] = $editoreId;
+            } else {
+                $whereClauses[] = "l.editore_id = ?";
+                $bindTypes .= 'i';
+                $bindValues[] = $editoreId;
+            }
         }
 
         // Genere filter

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -384,6 +384,7 @@ class LibriController
         $pattern = $dir . '/' . $basename . '.*';
         foreach (glob($pattern) as $oldLog) {
             if (filemtime($oldLog) < time() - $maxAge) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- glob() restricted to the app log directory; rotated-log names are app-generated, not user input
                 unlink($oldLog);
             }
         }
@@ -1403,6 +1404,7 @@ class LibriController
 
                     // Ensure resolved path is within allowed directory
                     if ($safePath && $baseDir && strpos($safePath, $baseDir) === 0 && file_exists($safePath)) {
+                        // nosemgrep: php.lang.security.unlink-use.unlink-use -- path confined by the realpath() containment check above (SECURITY FIX #2), not user input
                         unlink($safePath);
                         $this->logCoverDebug('cover.deleted', ['path' => $oldCoverPath]);
                     } else {
@@ -2969,10 +2971,12 @@ class LibriController
             $bindValues[] = $stato;
         }
 
-        // Editore filter
+        // Editore filter — match primary (libri.editore_id) or any secondary
+        // publisher in the multi-publisher junction (libri_editori, issue #143).
         if ($editoreId > 0) {
-            $whereClauses[] = "l.editore_id = ?";
-            $bindTypes .= 'i';
+            $whereClauses[] = "(l.editore_id = ? OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?))";
+            $bindTypes .= 'ii';
+            $bindValues[] = $editoreId;
             $bindValues[] = $editoreId;
         }
 

--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -462,7 +462,10 @@ class SearchController
 
         $sql = "
             SELECT e.id, e.nome, e.indirizzo,
-                   (SELECT COUNT(*) FROM libri l2 WHERE l2.editore_id = e.id AND l2.deleted_at IS NULL) as libro_count
+                   (SELECT COUNT(*) FROM libri l2
+                    WHERE (l2.editore_id = e.id
+                           OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l2.id AND le.editore_id = e.id))
+                          AND l2.deleted_at IS NULL) as libro_count
             FROM editori e
             WHERE " . implode(' AND ', $conditions) . "
             ORDER BY e.nome LIMIT 3

--- a/app/Controllers/SearchController.php
+++ b/app/Controllers/SearchController.php
@@ -460,11 +460,16 @@ class SearchController
             $types .= 's';
         }
 
+        // issue #143: count books where the publisher is primary OR a secondary
+        // one in the junction; gate the subquery on table existence so the count
+        // degrades to primary-only on pre-migration installs.
+        $exists = \App\Support\SchemaInfo::hasLibriEditori($db)
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l2.id AND le.editore_id = e.id)"
+            : "";
         $sql = "
             SELECT e.id, e.nome, e.indirizzo,
                    (SELECT COUNT(*) FROM libri l2
-                    WHERE (l2.editore_id = e.id
-                           OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l2.id AND le.editore_id = e.id))
+                    WHERE (l2.editore_id = e.id{$exists})
                           AND l2.deleted_at IS NULL) as libro_count
             FROM editori e
             WHERE " . implode(' AND ', $conditions) . "

--- a/app/Models/AuthorRepository.php
+++ b/app/Models/AuthorRepository.php
@@ -41,17 +41,23 @@ class AuthorRepository
 
     public function getByPublisherId(int $publisherId): array
     {
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($this->db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $sql = "SELECT DISTINCT a.id, a.nome, a.pseudonimo
                 FROM autori a
                 INNER JOIN libri_autori la ON a.id = la.autore_id
                 INNER JOIN libri l ON la.libro_id = l.id
-                WHERE (l.editore_id = ?
-                       OR EXISTS (SELECT 1 FROM libri_editori le
-                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                WHERE (l.editore_id = ?{$exists})
                       AND l.deleted_at IS NULL
                 ORDER BY a.nome ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];

--- a/app/Models/AuthorRepository.php
+++ b/app/Models/AuthorRepository.php
@@ -45,10 +45,13 @@ class AuthorRepository
                 FROM autori a
                 INNER JOIN libri_autori la ON a.id = la.autore_id
                 INNER JOIN libri l ON la.libro_id = l.id
-                WHERE l.editore_id = ? AND l.deleted_at IS NULL
+                WHERE (l.editore_id = ?
+                       OR EXISTS (SELECT 1 FROM libri_editori le
+                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                      AND l.deleted_at IS NULL
                 ORDER BY a.nome ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('i', $publisherId);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];

--- a/app/Models/BookRepository.php
+++ b/app/Models/BookRepository.php
@@ -230,6 +230,13 @@ class BookRepository
     {
         // Ottimizzato: JOIN + GROUP BY invece di subquery nel SELECT
         // Filtro soft delete: esclude libri cancellati
+        // issue #143: gate the junction subquery on table existence so the
+        // query degrades to primary-only on pre-migration installs instead of
+        // a fatal prepare()=false.
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($this->db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $sql = "SELECT l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato,
                        e.nome AS editore_nome,
                        GROUP_CONCAT(a.nome ORDER BY a.nome SEPARATOR ', ') AS autori
@@ -237,14 +244,16 @@ class BookRepository
                 LEFT JOIN editori e ON l.editore_id = e.id
                 LEFT JOIN libri_autori la ON l.id = la.libro_id
                 LEFT JOIN autori a ON la.autore_id = a.id
-                WHERE (l.editore_id = ?
-                       OR EXISTS (SELECT 1 FROM libri_editori le
-                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                WHERE (l.editore_id = ?{$exists})
                       AND l.deleted_at IS NULL
                 GROUP BY l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato, e.nome
                 ORDER BY l.titolo ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];

--- a/app/Models/BookRepository.php
+++ b/app/Models/BookRepository.php
@@ -237,11 +237,14 @@ class BookRepository
                 LEFT JOIN editori e ON l.editore_id = e.id
                 LEFT JOIN libri_autori la ON l.id = la.libro_id
                 LEFT JOIN autori a ON la.autore_id = a.id
-                WHERE l.editore_id = ? AND l.deleted_at IS NULL
+                WHERE (l.editore_id = ?
+                       OR EXISTS (SELECT 1 FROM libri_editori le
+                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                      AND l.deleted_at IS NULL
                 GROUP BY l.id, l.titolo, l.isbn10, l.isbn13, l.data_acquisizione, l.stato, e.nome
                 ORDER BY l.titolo ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('i', $publisherId);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];

--- a/app/Models/PublisherRepository.php
+++ b/app/Models/PublisherRepository.php
@@ -40,6 +40,10 @@ class PublisherRepository
 
     public function getBooksByPublisherId(int $publisherId): array
     {
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($this->db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $sql = "SELECT l.id, l.titolo, l.isbn10, l.isbn13, l.ean, l.data_acquisizione, l.stato, l.copertina_url,
                        e.nome AS editore_nome,
                        (
@@ -50,13 +54,15 @@ class PublisherRepository
                        ) AS autori
                 FROM libri l
                 LEFT JOIN editori e ON l.editore_id = e.id
-                WHERE (l.editore_id = ?
-                       OR EXISTS (SELECT 1 FROM libri_editori le
-                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                WHERE (l.editore_id = ?{$exists})
                       AND l.deleted_at IS NULL
                 ORDER BY l.titolo ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];
@@ -68,17 +74,23 @@ class PublisherRepository
 
     public function getAuthorsByPublisherId(int $publisherId): array
     {
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($this->db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $sql = "SELECT DISTINCT a.id, a.nome, a.pseudonimo
                 FROM autori a
                 INNER JOIN libri_autori la ON a.id = la.autore_id
                 INNER JOIN libri l ON la.libro_id = l.id
-                WHERE (l.editore_id = ?
-                       OR EXISTS (SELECT 1 FROM libri_editori le
-                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                WHERE (l.editore_id = ?{$exists})
                       AND l.deleted_at IS NULL
                 ORDER BY a.nome ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];
@@ -96,14 +108,20 @@ class PublisherRepository
         // EditoriApiController applies the same primary-OR-junction check
         // inline): a primary-only count would report 0 and let the editori
         // DELETE cascade silently wipe the book's libri_editori rows.
+        $hasJunction = \App\Support\SchemaInfo::hasLibriEditori($this->db);
+        $exists = $hasJunction
+            ? " OR EXISTS (SELECT 1 FROM libri_editori le WHERE le.libro_id = l.id AND le.editore_id = ?)"
+            : "";
         $stmt = $this->db->prepare(
-            'SELECT COUNT(*) FROM libri l
-             WHERE (l.editore_id = ?
-                    OR EXISTS (SELECT 1 FROM libri_editori le
-                               WHERE le.libro_id = l.id AND le.editore_id = ?))
-                   AND l.deleted_at IS NULL'
+            "SELECT COUNT(*) FROM libri l
+             WHERE (l.editore_id = ?{$exists})
+                   AND l.deleted_at IS NULL"
         );
-        $stmt->bind_param('ii', $publisherId, $publisherId);
+        if ($hasJunction) {
+            $stmt->bind_param('ii', $publisherId, $publisherId);
+        } else {
+            $stmt->bind_param('i', $publisherId);
+        }
         $stmt->execute();
         $stmt->bind_result($count);
         $stmt->fetch();
@@ -297,18 +315,20 @@ class PublisherRepository
                 $stmt->close();
             }
 
-            // The INSERT IGNORE repoint above keeps the duplicate's `ordine`
-            // verbatim, so a book that already listed the primary as a
-            // secondary could end up with no ordine=0 row (primary marker
-            // lost). Re-assert ordine=0 for the surviving primary wherever it
-            // is the book's primary (libri.editore_id), keeping the junction's
-            // primary marker consistent with libri.editore_id (issue #143).
+            // The repoint uses INSERT IGNORE: when a book already lists the
+            // primary as a secondary, the incoming row is skipped and the
+            // primary keeps its existing (possibly non-zero) ordine, so the
+            // book may be left with no ordine=0 row (primary marker lost).
+            // Re-assert ordine=0 for the surviving primary wherever it is the
+            // book's primary (libri.editore_id), keeping the junction's primary
+            // marker consistent with libri.editore_id (issue #143).
             if ($hasJunction) {
                 $stmt = $this->db->prepare(
                     "UPDATE libri_editori le
                      JOIN libri l ON l.id = le.libro_id
                      SET le.ordine = 0
-                     WHERE le.editore_id = ? AND l.editore_id = le.editore_id AND le.ordine <> 0"
+                     WHERE le.editore_id = ? AND l.editore_id = le.editore_id
+                           AND l.deleted_at IS NULL AND le.ordine <> 0"
                 );
                 if ($stmt !== false) {
                     $stmt->bind_param('i', $primaryId);

--- a/app/Models/PublisherRepository.php
+++ b/app/Models/PublisherRepository.php
@@ -50,10 +50,13 @@ class PublisherRepository
                        ) AS autori
                 FROM libri l
                 LEFT JOIN editori e ON l.editore_id = e.id
-                WHERE l.editore_id = ? AND l.deleted_at IS NULL
+                WHERE (l.editore_id = ?
+                       OR EXISTS (SELECT 1 FROM libri_editori le
+                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                      AND l.deleted_at IS NULL
                 ORDER BY l.titolo ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('i', $publisherId);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];
@@ -224,6 +227,14 @@ class PublisherRepository
             return null;
         }
 
+        // The multi-publisher junction (issue #143) has a FK ON DELETE CASCADE
+        // to `editori`, so deleting a duplicate would silently wipe its
+        // libri_editori rows. Detect the table once so we can repoint those
+        // rows onto the primary BEFORE the cascade fires. Guarded for installs
+        // predating the migration (table absent → fall back to editore_id only).
+        $junctionRes = $this->db->query("SHOW TABLES LIKE 'libri_editori'");
+        $hasJunction = ($junctionRes instanceof \mysqli_result && $junctionRes->num_rows > 0);
+
         // Start transaction
         $this->db->begin_transaction();
 
@@ -239,6 +250,25 @@ class PublisherRepository
                     throw new \Exception("Failed to execute UPDATE libri: " . $stmt->error);
                 }
                 $stmt->close();
+
+                // Repoint the junction rows onto the primary publisher BEFORE
+                // the editori DELETE cascades them away. INSERT IGNORE keeps the
+                // existing (libro, primary) row when a book already lists both;
+                // the duplicate's leftover rows are then removed by the cascade.
+                if ($hasJunction) {
+                    $stmt = $this->db->prepare(
+                        "INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine)
+                         SELECT libro_id, ?, ordine FROM libri_editori WHERE editore_id = ?"
+                    );
+                    if ($stmt === false) {
+                        throw new \Exception("Failed to prepare repoint libri_editori: " . $this->db->error);
+                    }
+                    $stmt->bind_param('ii', $primaryId, $duplicateId);
+                    if (!$stmt->execute()) {
+                        throw new \Exception("Failed to execute repoint libri_editori: " . $stmt->error);
+                    }
+                    $stmt->close();
+                }
 
                 // Delete the duplicate publisher
                 $stmt = $this->db->prepare("DELETE FROM editori WHERE id = ?");

--- a/app/Models/PublisherRepository.php
+++ b/app/Models/PublisherRepository.php
@@ -92,9 +92,10 @@ class PublisherRepository
     {
         // Count books where the publisher is primary (libri.editore_id) OR a
         // secondary one in the multi-publisher junction (issue #143). This is
-        // the guard EditorsController/bulk-delete relies on: a primary-only
-        // count would report 0 and let the editori DELETE cascade silently wipe
-        // the book's libri_editori rows.
+        // the guard EditorsController::delete() relies on (the bulk-delete in
+        // EditoriApiController applies the same primary-OR-junction check
+        // inline): a primary-only count would report 0 and let the editori
+        // DELETE cascade silently wipe the book's libri_editori rows.
         $stmt = $this->db->prepare(
             'SELECT COUNT(*) FROM libri l
              WHERE (l.editore_id = ?
@@ -294,6 +295,26 @@ class PublisherRepository
                     throw new \Exception("Failed to execute DELETE editori: " . $stmt->error);
                 }
                 $stmt->close();
+            }
+
+            // The INSERT IGNORE repoint above keeps the duplicate's `ordine`
+            // verbatim, so a book that already listed the primary as a
+            // secondary could end up with no ordine=0 row (primary marker
+            // lost). Re-assert ordine=0 for the surviving primary wherever it
+            // is the book's primary (libri.editore_id), keeping the junction's
+            // primary marker consistent with libri.editore_id (issue #143).
+            if ($hasJunction) {
+                $stmt = $this->db->prepare(
+                    "UPDATE libri_editori le
+                     JOIN libri l ON l.id = le.libro_id
+                     SET le.ordine = 0
+                     WHERE le.editore_id = ? AND l.editore_id = le.editore_id AND le.ordine <> 0"
+                );
+                if ($stmt !== false) {
+                    $stmt->bind_param('i', $primaryId);
+                    $stmt->execute();
+                    $stmt->close();
+                }
             }
 
             $this->db->commit();

--- a/app/Models/PublisherRepository.php
+++ b/app/Models/PublisherRepository.php
@@ -72,10 +72,13 @@ class PublisherRepository
                 FROM autori a
                 INNER JOIN libri_autori la ON a.id = la.autore_id
                 INNER JOIN libri l ON la.libro_id = l.id
-                WHERE l.editore_id = ? AND l.deleted_at IS NULL
+                WHERE (l.editore_id = ?
+                       OR EXISTS (SELECT 1 FROM libri_editori le
+                                  WHERE le.libro_id = l.id AND le.editore_id = ?))
+                      AND l.deleted_at IS NULL
                 ORDER BY a.nome ASC";
         $stmt = $this->db->prepare($sql);
-        $stmt->bind_param('i', $publisherId);
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = [];
@@ -87,8 +90,19 @@ class PublisherRepository
 
     public function countBooks(int $publisherId): int
     {
-        $stmt = $this->db->prepare('SELECT COUNT(*) FROM libri WHERE editore_id = ? AND deleted_at IS NULL');
-        $stmt->bind_param('i', $publisherId);
+        // Count books where the publisher is primary (libri.editore_id) OR a
+        // secondary one in the multi-publisher junction (issue #143). This is
+        // the guard EditorsController/bulk-delete relies on: a primary-only
+        // count would report 0 and let the editori DELETE cascade silently wipe
+        // the book's libri_editori rows.
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) FROM libri l
+             WHERE (l.editore_id = ?
+                    OR EXISTS (SELECT 1 FROM libri_editori le
+                               WHERE le.libro_id = l.id AND le.editore_id = ?))
+                   AND l.deleted_at IS NULL'
+        );
+        $stmt->bind_param('ii', $publisherId, $publisherId);
         $stmt->execute();
         $stmt->bind_result($count);
         $stmt->fetch();

--- a/app/Services/BulkEnrichmentService.php
+++ b/app/Services/BulkEnrichmentService.php
@@ -383,6 +383,13 @@ class BulkEnrichmentService
                     );
                 }
 
+                // issue #143: mirror the primary publisher we just set into the
+                // multi-publisher junction so junction-only consumers (OAI-PMH,
+                // BIBFRAME) don't lose the publisher of enriched books.
+                if (in_array('editore_id', $fieldsUpdated, true) && isset($publisherId) && (int) $publisherId > 0) {
+                    $this->syncPrimaryPublisherJunction($this->db, $bookId, (int) $publisherId);
+                }
+
                 $this->db->commit();
             } catch (\Throwable $e) {
                 $this->db->rollback();
@@ -426,6 +433,34 @@ class BulkEnrichmentService
      * @param callable|null $onProgress Callback: function(int $current, int $total, array $result): void
      * @return array{processed: int, enriched: int, not_found: int, errors: int, details: list<array>}
      */
+    /**
+     * Keep libri_editori in sync with a book's primary publisher (issue #143).
+     *
+     * Import/enrichment paths write libri.editore_id directly without going
+     * through BookRepository::syncPublishers(), which would otherwise leave the
+     * multi-publisher junction missing the primary row — so junction-only
+     * consumers (OAI-PMH, BIBFRAME) would export no publisher for the book.
+     * Additive only (INSERT IGNORE at ordine 0): never removes co-publisher
+     * rows, safe to call repeatedly, and a no-op on pre-migration installs.
+     */
+    private function syncPrimaryPublisherJunction(\mysqli $db, int $bookId, int $editoreId): void
+    {
+        if ($bookId <= 0 || $editoreId <= 0) {
+            return;
+        }
+        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
+        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+            return;
+        }
+        $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');
+        if ($stmt === false) {
+            return;
+        }
+        $stmt->bind_param('ii', $bookId, $editoreId);
+        $stmt->execute();
+        $stmt->close();
+    }
+
     public function enrichBatch(int $limit = 20, ?callable $onProgress = null): array
     {
         $summary = [

--- a/app/Services/BulkEnrichmentService.php
+++ b/app/Services/BulkEnrichmentService.php
@@ -448,8 +448,7 @@ class BulkEnrichmentService
         if ($bookId <= 0 || $editoreId <= 0) {
             return;
         }
-        $check = $db->query("SHOW TABLES LIKE 'libri_editori'");
-        if (!($check instanceof \mysqli_result) || $check->num_rows === 0) {
+        if (!\App\Support\SchemaInfo::hasLibriEditori($db)) {
             return;
         }
         $stmt = $db->prepare('INSERT IGNORE INTO libri_editori (libro_id, editore_id, ordine) VALUES (?, ?, 0)');

--- a/app/Support/SchemaInfo.php
+++ b/app/Support/SchemaInfo.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Lightweight, per-request schema introspection cache.
+ *
+ * Several queries reference the multi-publisher junction `libri_editori`
+ * (issue #143), which only exists after the 0.7.15 migration has run. On a
+ * pre-migration install the table is absent, so referencing it unconditionally
+ * makes mysqli::prepare() return false and the subsequent bind_param() fatal
+ * (HTTP 500). Call {@see hasLibriEditori()} to gate the `OR EXISTS (...)`
+ * fragment and bind the extra parameter only when the table is present —
+ * matching the defensive pattern already used by
+ * BookRepository::syncPublishers() and PublisherRepository::mergePublishers().
+ *
+ * The result is cached per table name for the lifetime of the request (one
+ * PHP-FPM worker process serves one request), so the `SHOW TABLES` probe runs
+ * at most once per table regardless of how many queries gate on it.
+ */
+final class SchemaInfo
+{
+    /** @var array<string, bool> */
+    private static array $tableCache = [];
+
+    public static function hasTable(\mysqli $db, string $table): bool
+    {
+        if (!array_key_exists($table, self::$tableCache)) {
+            $escaped = $db->real_escape_string($table);
+            $res = $db->query("SHOW TABLES LIKE '{$escaped}'");
+            self::$tableCache[$table] = ($res instanceof \mysqli_result && $res->num_rows > 0);
+        }
+
+        return self::$tableCache[$table];
+    }
+
+    public static function hasLibriEditori(\mysqli $db): bool
+    {
+        return self::hasTable($db, 'libri_editori');
+    }
+
+    /**
+     * Reset the cache. Intended for tests and for code paths that create the
+     * table mid-request (e.g. the installer/updater running a migration).
+     */
+    public static function resetCache(): void
+    {
+        self::$tableCache = [];
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -291,7 +291,11 @@ class Updater
             $ciphertext = substr($payload, 28);
 
             $plain = openssl_decrypt($ciphertext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
-            return $plain !== false ? $plain : '';
+            if ($plain === false) {
+                // Authentication/decryption failed (wrong key or tampered tag) — fail closed.
+                return '';
+            }
+            return $plain;
         } catch (\Throwable $e) {
             SecureLogger::error('[Updater] Token decryption failed: ' . $e->getMessage());
             return '';
@@ -1311,6 +1315,7 @@ class Updater
                             $err['message'] ?? 'unknown'
                         ));
                     }
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($zipPath);
                 }
                 $zipPath = $newZipPath;
@@ -1336,6 +1341,7 @@ class Updater
                 if (is_dir($extractPath)) {
                     $this->deleteDirectory($extractPath);
                 }
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($zipPath);
                 throw new Exception(__('Estrazione del pacchetto fallita'));
             }
@@ -1533,10 +1539,12 @@ class Updater
                 error_log("[Updater DEBUG] FATAL ERROR during manual update: " . json_encode($error));
 
                 if (file_exists($maintenanceFile)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($maintenanceFile);
                 }
 
                 if (file_exists($lockFile)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($lockFile);
                 }
             }
@@ -1717,6 +1725,7 @@ class Updater
             }
 
             if (file_exists($lockFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($lockFile);
             }
         }
@@ -2082,6 +2091,7 @@ class Updater
             }
 
             if (file_exists($filepath)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($filepath);
             }
 
@@ -2643,6 +2653,7 @@ class Updater
                     throw new Exception(sprintf(__('Impossibile rimuovere directory: %s'), $item->getPathname()));
                 }
             } else {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 if (!unlink($item->getPathname())) {
                     throw new Exception(sprintf(__('Impossibile rimuovere file: %s'), $item->getPathname()));
                 }
@@ -2698,6 +2709,7 @@ class Updater
                 if ($item->isDir()) {
                     @rmdir($item->getPathname());
                 } else {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($item->getPathname());
                     $this->debugLog('DEBUG', 'Rimosso file orfano', ['path' => $fullRelativePath]);
                 }
@@ -3223,6 +3235,7 @@ class Updater
     {
         $maintenanceFile = $this->rootPath . '/storage/.maintenance';
         if (file_exists($maintenanceFile)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
             unlink($maintenanceFile);
         }
     }
@@ -3247,6 +3260,7 @@ class Updater
             if (is_dir($path)) {
                 $this->deleteDirectory($path);
             } else {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($path);
             }
         }
@@ -3343,10 +3357,14 @@ class Updater
         $allMet = true;
 
         $phpVersion = PHP_VERSION;
-        $phpMet = version_compare($phpVersion, '8.1.0', '>=');
+        // Must match composer.json's "php": "^8.2" — Composer's generated
+        // vendor/composer/platform_check.php fatally exits below 8.2, so a
+        // lower floor here would let an 8.1 host pass preflight, install the
+        // release, then die at the Composer bootstrap.
+        $phpMet = version_compare($phpVersion, '8.2.0', '>=');
         $requirements[] = [
             'name' => 'PHP',
-            'required' => '8.1+',
+            'required' => '8.2+',
             'current' => $phpVersion,
             'met' => $phpMet
         ];
@@ -3466,10 +3484,12 @@ class Updater
                 error_log("[Updater DEBUG] FATAL ERROR during update: " . json_encode($error));
 
                 if (file_exists($maintenanceFile)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($maintenanceFile);
                 }
 
                 if (file_exists($lockFile)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                     @unlink($lockFile);
                 }
             }
@@ -3606,6 +3626,7 @@ class Updater
             }
 
             if (file_exists($lockFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($lockFile);
             }
         }
@@ -3727,6 +3748,7 @@ class Updater
 
             // Execute patch file to get patch definition
             $patchDefinition = require $tempPatchFile;
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
             @unlink($tempPatchFile);
 
             if (!is_array($patchDefinition)) {
@@ -4023,6 +4045,7 @@ class Updater
 
             // Execute patch file to get patch definition
             $patchDefinition = require $tempPatchFile;
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
             @unlink($tempPatchFile);
 
             if (!is_array($patchDefinition)) {
@@ -4156,6 +4179,7 @@ class Updater
         if (is_dir($realPath)) {
             $this->deleteDirectory($realPath);
         } else {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
             @unlink($realPath);
         }
 
@@ -4225,6 +4249,7 @@ class Updater
 
         $maxAge = 30 * 60;
         if ((time() - $data['time']) > $maxAge) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
             @unlink($maintenanceFile);
             if (class_exists(SecureLogger::class)) {
                 SecureLogger::warning(__('Modalità manutenzione rimossa automaticamente (scaduta)'), [

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -129,7 +129,7 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
           <div class="form-grid-2">
             <div>
               <label class="form-label"><?= __("Codice ISBN o EAN") ?></label>
-              <input id="importIsbn" type="text" class="form-input" placeholder="<?= __('es. 9788842935780') ?>" />
+              <input id="importIsbn" type="text" class="form-input" placeholder="<?= __('es. 9788842935780') ?>" value="<?php echo HtmlHelper::e($book['isbn13'] ?? ($book['ean'] ?? ($book['isbn10'] ?? ''))); ?>" />
             </div>
             <div class="flex items-end">
               <button type="button" id="btnImportIsbn" class="btn-primary w-full">

--- a/installer/README.md
+++ b/installer/README.md
@@ -4,7 +4,7 @@ Automated web-based installer for Pinakes, a full-featured library management sy
 
 ## Requirements
 
-- **PHP 8.1** or higher
+- **PHP 8.2** or higher
 - **MySQL 5.7+** or **MariaDB 10.3+**
 - **Required PHP extensions**: PDO, PDO MySQL, MySQLi, Mbstring, JSON, GD, Fileinfo
 

--- a/installer/classes/Installer.php
+++ b/installer/classes/Installer.php
@@ -1298,7 +1298,7 @@ HTACCESS;
                     1,
                     'open-library',
                     'wrapper.php',
-                    '8.1',
+                    '7.4',
                     '1.0.0',
                     '{}',
                     NOW()

--- a/installer/classes/Validator.php
+++ b/installer/classes/Validator.php
@@ -126,7 +126,7 @@ class Validator {
      */
     public function validateSystemRequirements() {
         $requirements = [
-            'php_version' => version_compare(PHP_VERSION, '8.1.0', '>='),
+            'php_version' => version_compare(PHP_VERSION, '8.2.0', '>='),
             'pdo' => extension_loaded('pdo'),
             'pdo_mysql' => extension_loaded('pdo_mysql'),
             'mysqli' => extension_loaded('mysqli'),

--- a/installer/database/migrations/migrate_0.7.16-rc.1.sql
+++ b/installer/database/migrations/migrate_0.7.16-rc.1.sql
@@ -1,0 +1,29 @@
+-- Migration 0.7.16-rc.1 — heal multi-publisher junction drift (issue #143).
+--
+-- The 0.7.15 migration created `libri_editori` and backfilled it from
+-- `libri.editore_id`. But books written by the CSV / LibraryThing importers or
+-- by bulk-enrichment AFTER that migration set `libri.editore_id` WITHOUT a
+-- matching junction row. The importers now keep the junction in sync, but data
+-- written before that fix drifted: junction-only consumers (OAI-PMH, BIBFRAME)
+-- exported no publisher for those books.
+--
+-- Re-backfill every book's primary publisher into the junction at ordine 0.
+-- Idempotent: CREATE TABLE IF NOT EXISTS + INSERT IGNORE, safe to re-run and
+-- safe whether or not the 0.7.15 migration already created the table in the
+-- same upgrade run.
+
+CREATE TABLE IF NOT EXISTS `libri_editori` (
+  `libro_id` int NOT NULL,
+  `editore_id` int NOT NULL,
+  `ordine` int DEFAULT NULL,
+  PRIMARY KEY (`libro_id`,`editore_id`),
+  KEY `libro_id` (`libro_id`),
+  KEY `editore_id` (`editore_id`),
+  CONSTRAINT `libri_editori_ibfk_1` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `libri_editori_ibfk_2` FOREIGN KEY (`editore_id`) REFERENCES `editori` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO `libri_editori` (`libro_id`, `editore_id`, `ordine`)
+SELECT `id`, `editore_id`, 0
+FROM `libri`
+WHERE `editore_id` IS NOT NULL AND `deleted_at` IS NULL;

--- a/installer/steps/step1.php
+++ b/installer/steps/step1.php
@@ -5,7 +5,7 @@
 
 // Check system requirements
 $requirements = [
-    'PHP Version >= 8.1' => version_compare(PHP_VERSION, '8.1.0', '>='),
+    'PHP Version >= 8.2' => version_compare(PHP_VERSION, '8.2.0', '>='),
     'PDO Extension' => extension_loaded('pdo'),
     'PDO MySQL Extension' => extension_loaded('pdo_mysql'),
     'MySQLi Extension' => extension_loaded('mysqli'),

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -164,6 +164,7 @@ BUNDLED_PLUGINS=(
     "dewey-editor"
     "digital-library"
     "discogs"
+    "frbr-lrm"
     "goodlib"
     "musicbrainz"
     "ncip-server"

--- a/storage/plugins/api-book-scraper/ApiBookScraperPlugin.php
+++ b/storage/plugins/api-book-scraper/ApiBookScraperPlugin.php
@@ -273,8 +273,12 @@ class ApiBookScraperPlugin
 
         // Decripta
         $decrypted = openssl_decrypt($ciphertext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($decrypted === false) {
+            // Authentication/decryption failed — fall back to the raw value.
+            return $value;
+        }
 
-        return $decrypted !== false ? $decrypted : $value;
+        return $decrypted;
     }
 
     /**

--- a/storage/plugins/bibframe-linked-data/plugin.json
+++ b/storage/plugins/bibframe-linked-data/plugin.json
@@ -7,9 +7,9 @@
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "http://id.loc.gov/ontologies/bibframe/",
-  "requires_php": "8.1",
+  "requires_php": "8.2",
   "requires_app": "0.7.1",
-  "max_app_version": "0.7.14",
+  "max_app_version": "0.7.15",
   "path": "bibframe-linked-data",
   "main_file": "wrapper.php",
   "metadata": {

--- a/storage/plugins/z39-server/endpoint.php
+++ b/storage/plugins/z39-server/endpoint.php
@@ -220,8 +220,12 @@ function decryptSettingValue(string $encrypted): ?string
         $ciphertext = substr($decoded, 28);
 
         $decrypted = openssl_decrypt($ciphertext, 'aes-256-gcm', $key, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($decrypted === false) {
+            // Authentication/decryption failed (wrong key or tampered tag) — fail closed.
+            return null;
+        }
 
-        return $decrypted !== false ? $decrypted : null;
+        return $decrypted;
     } catch (\Throwable $e) {
         \App\Support\SecureLogger::error('[Z39 SRU Endpoint] Decryption error: ' . $e->getMessage());
         return null;

--- a/storage/plugins/z39-server/plugin.json
+++ b/storage/plugins/z39-server/plugin.json
@@ -7,9 +7,9 @@
   "author_url": "",
   "plugin_url": "https://www.loc.gov/standards/sru/",
   "main_file": "Z39ServerPlugin.php",
-  "requires_php": "8.1",
+  "requires_php": "8.2",
   "requires_app": "0.4.0",
-  "max_app_version": "0.7.14",
+  "max_app_version": "0.7.15",
   "settings": true,
   "metadata": {
     "category": "protocol",

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -3194,3 +3194,519 @@ test.describe.serial('Phase 21: Language Switch', () => {
     expect(dbCode).toBe('it_IT');
   });
 });
+
+// ════════════════════════════════════════════════════════════════════════════
+// Helpers for Phase 22 (Archives) and Phase 23 (Multi-publisher / Multi-author)
+// ════════════════════════════════════════════════════════════════════════════
+
+/** Ensure the bundled `archives` plugin is active (auto-registers on /admin/plugins). */
+async function ensureArchivesActive(page) {
+  await page.goto(`${BASE}/admin/plugins`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForSelector('[data-plugin-id]', { timeout: 10000 }).catch(() => {});
+  const dbId = Number(String(dbQuery(`SELECT id FROM plugins WHERE name='archives' LIMIT 1`)).trim() || '0');
+  if (!dbId) return false;
+  if (String(dbQuery(`SELECT is_active FROM plugins WHERE id=${dbId}`)).trim() === '1') return true;
+  const card = page.locator(`[data-plugin-id="${dbId}"]`).first();
+  const btn = card.locator('button:has-text("Attiva")');
+  if (await btn.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await btn.click();
+    const confirm = page.locator('.swal2-confirm:visible');
+    if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) await confirm.click();
+    await page.waitForFunction(
+      () => document.querySelector('.swal2-popup .swal2-icon.swal2-success') !== null,
+      { timeout: 10000 },
+    ).catch(() => {});
+    await page.keyboard.press('Enter').catch(() => {});
+    await page.waitForLoadState('domcontentloaded');
+  }
+  return String(dbQuery(`SELECT is_active FROM plugins WHERE id=${dbId}`)).trim() === '1';
+}
+
+/** Create an archival unit via the admin form. Returns its DB id (0 on failure). */
+async function createArchiveUnit(page, fields) {
+  await page.goto(`${BASE}/admin/archives/new`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.fill('input[name="reference_code"]', fields.reference_code);
+  // Set selects via the DOM (the form may enhance them with Choices.js, which
+  // hides the native <select> and makes selectOption() hang on actionability).
+  await page.evaluate((lvl) => {
+    const s = document.querySelector('select[name="level"]');
+    if (s) { s.value = lvl; s.dispatchEvent(new Event('change', { bubbles: true })); }
+  }, fields.level || 'fonds').catch(() => {});
+  await page.fill('[name="constructed_title"]', fields.constructed_title);
+  if (fields.parent_id) {
+    // parent_id is a plain number <input> in the archives form.
+    await page.fill('input[name="parent_id"]', String(fields.parent_id)).catch(() => {});
+  }
+  for (const [k, v] of Object.entries(fields.extra || {})) {
+    const loc = page.locator(`[name="${k}"]`).first();
+    if (await loc.isVisible({ timeout: 800 }).catch(() => false)) await loc.fill(String(v)).catch(() => {});
+  }
+  await page.locator('#archiveForm button[type="submit"], form button[type="submit"]').first()
+    .click({ timeout: 15000 }).catch(() => {});
+  await page.waitForLoadState('domcontentloaded').catch(() => {});
+  const ref = fields.reference_code.replace(/'/g, "''");
+  return Number(String(dbQuery(
+    `SELECT id FROM archival_units WHERE reference_code='${ref}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`
+  )).trim() || '0');
+}
+
+/** Add items to a Choices.js multi-select (authors/publishers) by typing + Enter. */
+async function addChoicesItems(page, selectId, hiddenId, names) {
+  const wrapper = page.locator(`#${selectId}`)
+    .locator('xpath=ancestor::*[contains(@class,"choices")]').first();
+  const input = wrapper.locator('.choices__input--cloned');
+  if (!await input.isVisible({ timeout: 3000 }).catch(() => false)) return;
+  for (const name of names) {
+    const before = await page.locator(`#${hiddenId} input`).count();
+    await input.click();
+    await input.fill(name);
+    await input.press('Enter');
+    await page.waitForFunction(
+      (args) => document.querySelectorAll(`#${args.hid} input`).length > args.before,
+      { hid: hiddenId, before },
+      { timeout: 5000 },
+    ).catch(() => {});
+  }
+}
+
+/** Create a book with the given authors/publishers via the form. Returns book id. */
+async function createBookWithRelations(page, { title, authors = [], publishers = [] }) {
+  await page.goto(`${BASE}/admin/libri/crea`);
+  await page.waitForLoadState('domcontentloaded');
+  await page.fill('#titolo', title);
+  if (authors.length) await addChoicesItems(page, 'autori_select', 'autori_hidden', authors);
+  if (publishers.length) await addChoicesItems(page, 'editori_select', 'editori_hidden', publishers);
+  const radiceSelect = page.locator('#radice_select');
+  if (await radiceSelect.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await page.waitForFunction(
+      () => { const s = document.querySelector('#radice_select'); return s && s.options.length > 1; },
+      { timeout: 8000 },
+    ).catch(() => {});
+    await radiceSelect.selectOption({ index: 1 }).catch(() => {});
+  }
+  await submitBookFormAndNavigate(page, /admin\/libri(?!.*crea)/, '/crea');
+  const t = title.replace(/'/g, "''");
+  const id = Number(String(dbQuery(
+    `SELECT id FROM libri WHERE titolo='${t}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`
+  )).trim() || '0');
+  if (id > 0) state.createdBookIds.push(id);
+  return id;
+}
+
+/** Publisher names in junction order for a book. */
+function bookPublishers(bookId) {
+  const r = dbQuery(`SELECT e.nome FROM libri_editori le JOIN editori e ON e.id=le.editore_id WHERE le.libro_id=${bookId} ORDER BY le.ordine`);
+  return r ? r.split('\n').filter(Boolean) : [];
+}
+/** Author names for a book. */
+function bookAuthors(bookId) {
+  const r = dbQuery(`SELECT a.nome FROM libri_autori la JOIN autori a ON a.id=la.autore_id WHERE la.libro_id=${bookId} ORDER BY la.autore_id`);
+  return r ? r.split('\n').filter(Boolean) : [];
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Phase 22: Archives plugin — 20 tests (CRUD via form, API calls, seeding)
+// Covers: activation, schema, ISAD(G) CRUD + hierarchy, authority records +
+// linking, JSON/XML API endpoints (entities, typeahead, RiC-O JSON-LD, IIIF,
+// OAI-PMH, SRU), MARCXML/DC/EAD3/METS exports, validation, soft-delete.
+// ════════════════════════════════════════════════════════════════════════════
+test.describe.serial('Phase 22: Archives', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  let archivesReady = false;
+
+  const TAG = `E2EARC${RUN_ID}`;
+  const ids = { fonds: 0, series: 0, authority: 0, activity: 0, seeded: [] };
+
+  test.beforeAll(async ({ browser }) => {
+    clearRateLimits();
+    if (!appReady) return;
+    context = await browser.newContext();
+    page = await context.newPage();
+    await loginAsAdmin(page);
+    archivesReady = await ensureArchivesActive(page).catch(() => false);
+  });
+
+  test.afterAll(async () => {
+    // FK-safe cleanup of every archive row this phase created.
+    try { dbQuery(`DELETE FROM archival_unit_authority WHERE archival_unit_id IN (SELECT id FROM archival_units WHERE reference_code LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM archival_unit_files WHERE unit_id IN (SELECT id FROM archival_units WHERE reference_code LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM archive_unit_activities WHERE unit_id IN (SELECT id FROM archival_units WHERE reference_code LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM archival_units WHERE reference_code LIKE '${TAG}%' AND parent_id IS NOT NULL`); } catch {}
+    try { dbQuery(`DELETE FROM archival_units WHERE reference_code LIKE '${TAG}%'`); } catch {}
+    try { dbQuery(`DELETE FROM authority_records WHERE authorised_form LIKE '${TAG}%'`); } catch {}
+    try { dbQuery(`DELETE FROM archive_activities WHERE title LIKE '${TAG}%'`); } catch {}
+    await context?.close();
+  });
+
+  test.beforeEach(() => {
+    test.skip(!appReady, 'App not ready — Phase 1 did not complete');
+    test.skip(!archivesReady, 'Archives plugin not active');
+  });
+
+  test('22.1 Archives plugin is active with hooks registered', async () => {
+    const pid = Number(String(dbQuery(`SELECT id FROM plugins WHERE name='archives' LIMIT 1`)).trim() || '0');
+    expect(pid).toBeGreaterThan(0);
+    expect(String(dbQuery(`SELECT is_active FROM plugins WHERE id=${pid}`)).trim()).toBe('1');
+    const hooks = Number(String(dbQuery(`SELECT COUNT(*) FROM plugin_hooks WHERE plugin_id=${pid}`)).trim() || '0');
+    expect(hooks).toBeGreaterThan(0);
+  });
+
+  test('22.2 Schema: all archive tables exist', async () => {
+    const expected = [
+      'archival_units', 'authority_records', 'archival_unit_authority',
+      'autori_authority_link', 'archival_unit_files', 'archive_agent_identifiers',
+      'archive_agent_relations', 'archive_activities', 'archive_unit_activities',
+      'archive_places', 'archive_relations',
+    ];
+    for (const t of expected) {
+      const got = String(dbQuery(`SHOW TABLES LIKE '${t}'`)).trim();
+      expect(got, `table ${t} should exist`).toBe(t);
+    }
+  });
+
+  test('22.3 Create a fonds via the admin form', async () => {
+    ids.fonds = await createArchiveUnit(page, {
+      reference_code: `${TAG}-F1`,
+      level: 'fonds',
+      constructed_title: `${TAG} Fondo principale`,
+      extra: { date_start: '1888', date_end: '1942', scope_content: 'Fondo di prova E2E' },
+    });
+    expect(ids.fonds).toBeGreaterThan(0);
+    const lvl = String(dbQuery(`SELECT level FROM archival_units WHERE id=${ids.fonds}`)).trim();
+    expect(lvl).toBe('fonds');
+  });
+
+  test('22.4 Create a child series with parent_id (hierarchy)', async () => {
+    expect(ids.fonds).toBeGreaterThan(0);
+    ids.series = await createArchiveUnit(page, {
+      reference_code: `${TAG}-S1`,
+      level: 'series',
+      constructed_title: `${TAG} Serie figlia`,
+      parent_id: ids.fonds,
+    });
+    expect(ids.series).toBeGreaterThan(0);
+    const parent = String(dbQuery(`SELECT parent_id FROM archival_units WHERE id=${ids.series}`)).trim();
+    expect(parent).toBe(String(ids.fonds));
+  });
+
+  test('22.5 Seed: bulk-insert 5 archival units via SQL', async () => {
+    for (let i = 1; i <= 5; i++) {
+      dbQuery(
+        `INSERT INTO archival_units (reference_code, institution_code, level, constructed_title, material_status, specific_material, created_at, updated_at) ` +
+        `VALUES ('${TAG}-SEED-${i}', 'PINAKES', 'item', '${TAG} Seed item ${i}', 'unclassified', 'text', NOW(), NOW())`
+      );
+    }
+    const n = Number(String(dbQuery(`SELECT COUNT(*) FROM archival_units WHERE reference_code LIKE '${TAG}-SEED-%' AND deleted_at IS NULL`)).trim() || '0');
+    expect(n).toBe(5);
+  });
+
+  test('22.6 Seeded + created units appear on the admin list', async () => {
+    await page.goto(`${BASE}/admin/archives?q=${TAG}`);
+    await page.waitForLoadState('domcontentloaded');
+    const body = await page.locator('body').textContent();
+    expect(body).toContain(`${TAG} Fondo principale`);
+    expect(body).toContain('Seed item');
+  });
+
+  test('22.7 Edit the fonds via the form updates the DB', async () => {
+    await page.goto(`${BASE}/admin/archives/${ids.fonds}/edit`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.fill('[name="constructed_title"]', `${TAG} Fondo aggiornato`);
+    await page.locator('form button[type="submit"], button[type="submit"]').first().click();
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+    const title = String(dbQuery(`SELECT constructed_title FROM archival_units WHERE id=${ids.fonds}`)).trim();
+    expect(title).toBe(`${TAG} Fondo aggiornato`);
+  });
+
+  test('22.8 Duplicate reference_code is rejected (UNIQUE)', async () => {
+    const before = Number(String(dbQuery(`SELECT COUNT(*) FROM archival_units WHERE reference_code='${TAG}-F1'`)).trim() || '0');
+    await createArchiveUnit(page, { reference_code: `${TAG}-F1`, level: 'fonds', constructed_title: `${TAG} Duplicato` });
+    const after = Number(String(dbQuery(`SELECT COUNT(*) FROM archival_units WHERE reference_code='${TAG}-F1'`)).trim() || '0');
+    expect(after).toBe(before); // no new row
+  });
+
+  test('22.9 Validation: missing constructed_title is rejected', async () => {
+    await page.goto(`${BASE}/admin/archives/new`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.fill('input[name="reference_code"]', `${TAG}-INVALID`);
+    await page.selectOption('select[name="level"]', 'fonds').catch(() => {});
+    // leave constructed_title empty
+    await page.locator('form button[type="submit"], button[type="submit"]').first().click();
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+    const n = Number(String(dbQuery(`SELECT COUNT(*) FROM archival_units WHERE reference_code='${TAG}-INVALID'`)).trim() || '0');
+    expect(n).toBe(0); // not created
+  });
+
+  test('22.10 Create an authority record (person)', async () => {
+    await page.goto(`${BASE}/admin/archives/authorities/new`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.selectOption('select[name="type"]', 'person').catch(() => {});
+    await page.fill('[name="authorised_form"]', `${TAG} Thorvald Stauning`);
+    const dates = page.locator('[name="dates_of_existence"]').first();
+    if (await dates.isVisible({ timeout: 800 }).catch(() => false)) await dates.fill('1873–1942');
+    await page.locator('form button[type="submit"], button[type="submit"]').first().click();
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+    ids.authority = Number(String(dbQuery(
+      `SELECT id FROM authority_records WHERE authorised_form='${TAG} Thorvald Stauning' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`
+    )).trim() || '0');
+    expect(ids.authority).toBeGreaterThan(0);
+  });
+
+  test('22.11 Attach authority to the fonds (role=creator)', async () => {
+    expect(ids.authority).toBeGreaterThan(0);
+    await page.goto(`${BASE}/admin/archives/${ids.fonds}`);
+    await page.waitForLoadState('domcontentloaded');
+    const token = await getCsrfToken(page);
+    const res = await page.request.post(`${BASE}/admin/archives/${ids.fonds}/authorities/attach`, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      form: { csrf_token: token, authority_id: String(ids.authority), role: 'creator' },
+    });
+    expect([200, 302, 303]).toContain(res.status());
+    const n = Number(String(dbQuery(
+      `SELECT COUNT(*) FROM archival_unit_authority WHERE archival_unit_id=${ids.fonds} AND authority_id=${ids.authority} AND role='creator'`
+    )).trim() || '0');
+    expect(n).toBe(1);
+  });
+
+  test('22.12 API: /api/archives/entities returns JSON results', async () => {
+    const res = await page.request.get(`${BASE}/api/archives/entities?type=archival_unit&q=${TAG}`);
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json.results)).toBe(true);
+    const labels = json.results.map(r => String(r.label || ''));
+    expect(labels.some(l => l.includes(TAG))).toBe(true);
+  });
+
+  test('22.13 API: authority typeahead returns JSON', async () => {
+    const res = await page.request.get(`${BASE}/admin/archives/api/authorities/search?q=${TAG}`);
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    const rows = Array.isArray(json) ? json : (json.results || json.data || []);
+    expect(Array.isArray(rows)).toBe(true);
+    expect(rows.some(r => String(r.authorised_form || r.name || r.label || r.text || '').includes(TAG))).toBe(true);
+  });
+
+  test('22.14 API public: RiC-O JSON-LD for a unit', async () => {
+    const res = await page.request.get(`${BASE}/archives/${ids.fonds}/ric.json`);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type'] || '').toContain('json');
+    const json = await res.json();
+    expect(json['@context'] || json['@type']).toBeTruthy();
+  });
+
+  test('22.15 API public: IIIF manifest for a unit', async () => {
+    const res = await page.request.get(`${BASE}/archives/${ids.fonds}/manifest.json`);
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    expect(json.type || json['@type'] || json['@context']).toBeTruthy();
+  });
+
+  test('22.16 API public: IIIF collection root', async () => {
+    const res = await page.request.get(`${BASE}/archives/collection.json`);
+    expect(res.status()).toBe(200);
+    expect((res.headers()['content-type'] || '')).toContain('json');
+  });
+
+  test('22.17 API public: OAI-PMH Identify (XML)', async () => {
+    const res = await page.request.get(`${BASE}/archives/oai?verb=Identify`);
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+    expect(xml).toMatch(/OAI-PMH|<Identify/);
+  });
+
+  test('22.18 API public: SRU explain (XML)', async () => {
+    const res = await page.request.get(`${BASE}/api/archives/sru?operation=explain&version=1.2`);
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+    expect(xml).toMatch(/explain|<zs:|sru/i);
+  });
+
+  test('22.19 Exports: MARCXML, Dublin Core, EAD3, METS', async () => {
+    const marc = await page.request.get(`${BASE}/admin/archives/${ids.fonds}/export.xml`);
+    expect(marc.status()).toBe(200);
+    expect(await marc.text()).toMatch(/<record|marc/i);
+    const dc = await page.request.get(`${BASE}/admin/archives/${ids.fonds}/dc.xml`);
+    expect(dc.status()).toBe(200);
+    expect(await dc.text()).toMatch(/dc:|dublin|<oai_dc|<metadata/i);
+    const ead = await page.request.get(`${BASE}/admin/archives/${ids.fonds}/ead.xml`);
+    expect(ead.status()).toBe(200);
+    expect(await ead.text()).toMatch(/<ead|archdesc/i);
+    const mets = await page.request.get(`${BASE}/admin/archives/${ids.fonds}/mets.xml`);
+    expect(mets.status()).toBe(200);
+    expect(await mets.text()).toMatch(/<mets|METS/i);
+  });
+
+  test('22.20 Soft-delete the child series hides it but keeps the row', async () => {
+    await page.goto(`${BASE}/admin/archives/${ids.series}`);
+    await page.waitForLoadState('domcontentloaded');
+    const token = await getCsrfToken(page);
+    const res = await page.request.post(`${BASE}/admin/archives/${ids.series}/delete`, {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      form: { csrf_token: token },
+    });
+    expect([200, 302, 303]).toContain(res.status());
+    const del = String(dbQuery(`SELECT deleted_at IS NOT NULL FROM archival_units WHERE id=${ids.series}`)).trim();
+    expect(del).toBe('1');
+    await page.goto(`${BASE}/admin/archives?q=${TAG}`);
+    await page.waitForLoadState('domcontentloaded');
+    const body = await page.locator('body').textContent();
+    expect(body).not.toContain(`${TAG} Serie figlia`);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Phase 23: Multi-publisher & Multi-author — specific correctness tests (#143)
+// Verifies libri_editori / libri_autori junctions, primary mapping, edit
+// add/remove, and that a secondary publisher surfaces the book on its archive
+// page and in the catalog filter.
+// ════════════════════════════════════════════════════════════════════════════
+test.describe.serial('Phase 23: Multi-publisher & Multi-author', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+
+  const TAG = `MR${RUN_ID}`;
+  const P1 = `${TAG} EditoreUno`;
+  const P2 = `${TAG} EditoreDue`;
+  const P3 = `${TAG} EditoreTre`;
+  const A1 = `${TAG} AutoreUno`;
+  const A2 = `${TAG} AutoreDue`;
+  const A3 = `${TAG} AutoreTre`;
+  let multiPubBook = 0;
+
+  test.beforeAll(async ({ browser }) => {
+    clearRateLimits();
+    if (!appReady) return;
+    context = await browser.newContext();
+    page = await context.newPage();
+    await loginAsAdmin(page);
+  });
+
+  test.afterAll(async () => {
+    try { dbQuery(`DELETE FROM libri_editori WHERE libro_id IN (SELECT id FROM libri WHERE titolo LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM libri_autori WHERE libro_id IN (SELECT id FROM libri WHERE titolo LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM copie WHERE libro_id IN (SELECT id FROM libri WHERE titolo LIKE '${TAG}%')`); } catch {}
+    try { dbQuery(`DELETE FROM libri WHERE titolo LIKE '${TAG}%'`); } catch {}
+    try { dbQuery(`DELETE FROM editori WHERE nome LIKE '${TAG}%'`); } catch {}
+    try { dbQuery(`DELETE FROM autori WHERE nome LIKE '${TAG}%'`); } catch {}
+    await context?.close();
+  });
+
+  test.beforeEach(() => { test.skip(!appReady, 'App not ready — Phase 1 did not complete'); });
+
+  test('23.1 Create a book with TWO publishers → junction has 2 in order', async () => {
+    multiPubBook = await createBookWithRelations(page, {
+      title: `${TAG} Libro due editori`,
+      authors: [A1],
+      publishers: [P1, P2],
+    });
+    expect(multiPubBook).toBeGreaterThan(0);
+    const pubs = bookPublishers(multiPubBook);
+    expect(pubs.length).toBe(2);
+    expect(pubs[0]).toBe(P1);
+    expect(pubs[1]).toBe(P2);
+  });
+
+  test('23.2 Primary publisher equals libri.editore_id (junction ordine 0)', async () => {
+    const primaryId = String(dbQuery(`SELECT editore_id FROM libri WHERE id=${multiPubBook}`)).trim();
+    const ord0Id = String(dbQuery(`SELECT editore_id FROM libri_editori WHERE libro_id=${multiPubBook} AND ordine=0`)).trim();
+    expect(primaryId).toBe(ord0Id);
+    const p1Id = String(dbQuery(`SELECT id FROM editori WHERE nome='${P1}' ORDER BY id DESC LIMIT 1`)).trim();
+    expect(primaryId).toBe(p1Id);
+  });
+
+  test('23.3 Create a book with THREE authors → libri_autori has 3', async () => {
+    const id = await createBookWithRelations(page, {
+      title: `${TAG} Libro tre autori`,
+      authors: [A1, A2, A3],
+      publishers: [P1],
+    });
+    expect(id).toBeGreaterThan(0);
+    const authors = bookAuthors(id);
+    expect(authors.length).toBe(3);
+    const roles = dbQuery(`SELECT DISTINCT ruolo FROM libri_autori WHERE libro_id=${id}`);
+    expect(roles).toBe('principale');
+  });
+
+  test('23.4 One book with multiple authors AND publishers → both junctions correct', async () => {
+    const id = await createBookWithRelations(page, {
+      title: `${TAG} Libro misto`,
+      authors: [A1, A2],
+      publishers: [P1, P2],
+    });
+    expect(id).toBeGreaterThan(0);
+    expect(bookAuthors(id).length).toBe(2);
+    expect(bookPublishers(id).length).toBe(2);
+  });
+
+  test('23.5 Edit: add a third publisher → junction grows to 3', async () => {
+    await page.goto(`${BASE}/admin/libri/modifica/${multiPubBook}`);
+    await page.waitForLoadState('domcontentloaded');
+    // Wait for the 2 pre-populated publisher chips + hidden inputs to render —
+    // adding before they are synced would submit only the new publisher and
+    // silently drop the existing two.
+    await expect(page.locator('#editori_hidden input')).toHaveCount(2, { timeout: 8000 });
+    await addChoicesItems(page, 'editori_select', 'editori_hidden', [P3]);
+    await expect(page.locator('#editori_hidden input')).toHaveCount(3, { timeout: 5000 });
+    await submitBookFormAndNavigate(page, /admin\/libri(?!.*modifica)/, '/modifica');
+    const pubs = bookPublishers(multiPubBook);
+    expect(pubs.length).toBe(3);
+    expect(pubs).toContain(P3);
+  });
+
+  test('23.6 Edit: remove a publisher → junction shrinks, primary still valid', async () => {
+    await page.goto(`${BASE}/admin/libri/modifica/${multiPubBook}`);
+    await page.waitForLoadState('domcontentloaded');
+    // Wait for the 3 pre-populated chips before removing one.
+    await expect(page.locator('#editori_hidden input')).toHaveCount(3, { timeout: 8000 });
+    // Remove the first chip in the publisher Choices widget
+    const wrapper = page.locator('#editori_select')
+      .locator('xpath=ancestor::*[contains(@class,"choices")]').first();
+    const removeBtn = wrapper.locator('.choices__list--multiple .choices__button').first();
+    if (await removeBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await removeBtn.click();
+    }
+    await expect(page.locator('#editori_hidden input')).toHaveCount(2, { timeout: 5000 });
+    await submitBookFormAndNavigate(page, /admin\/libri(?!.*modifica)/, '/modifica');
+    const pubs = bookPublishers(multiPubBook);
+    expect(pubs.length).toBe(2);
+    // editore_id must point to a publisher that is still in the junction
+    const primaryId = String(dbQuery(`SELECT editore_id FROM libri WHERE id=${multiPubBook}`)).trim();
+    const stillLinked = String(dbQuery(`SELECT COUNT(*) FROM libri_editori WHERE libro_id=${multiPubBook} AND editore_id=${primaryId}`)).trim();
+    expect(stillLinked).toBe('1');
+  });
+
+  test('23.7 Secondary publisher surfaces the book on its archive page', async () => {
+    // After 23.6 the junction is [P2 (primary, ordine 0), P3 (secondary, ordine 1)].
+    // P3 is genuinely secondary: editore_id != P3, so /editore/P3 can only find
+    // the book via the EXISTS(libri_editori) path (the multi-publisher fix #143).
+    const p3Id = String(dbQuery(`SELECT id FROM editori WHERE nome='${P3}' ORDER BY id DESC LIMIT 1`)).trim();
+    const primaryId = String(dbQuery(`SELECT editore_id FROM libri WHERE id=${multiPubBook}`)).trim();
+    expect(primaryId).not.toBe(p3Id);          // P3 is NOT the primary
+    expect(bookPublishers(multiPubBook)).toContain(P3); // but is in the junction
+    const res = await page.request.get(`${BASE}/editore/${encodeURIComponent(P3)}`);
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toContain(`${TAG} Libro due editori`);
+  });
+
+  test('23.8 Catalog filter by a secondary publisher includes the book', async () => {
+    const res = await page.request.get(`${BASE}/catalogo?editore=${encodeURIComponent(P3)}`);
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toContain(`${TAG} Libro due editori`);
+  });
+
+  test('23.9 Admin libri API filtered by secondary publisher returns the book', async () => {
+    const p3Id = String(dbQuery(`SELECT id FROM editori WHERE nome='${P3}' ORDER BY id DESC LIMIT 1`)).trim();
+    const res = await page.request.get(`${BASE}/api/libri?editore_filter=${p3Id}&length=200&draw=1`);
+    expect(res.status()).toBe(200);
+    const json = await res.json();
+    const rows = json.data || json.rows || json.libri || [];
+    expect(JSON.stringify(rows)).toContain('Libro due editori');
+  });
+});

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.15",
+  "version": "0.7.16-rc.1",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.16-rc.1",
+  "version": "0.7.16",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Summary

Addresses four code-review findings (2× P1, 2× P2) plus pre-existing semgrep noise on touched files.

### P1 — PHP 8.1 install/update could break at Composer bootstrap
`composer.json` requires `php: ^8.2` and the generated `vendor/composer/platform_check.php` fatally exits below 8.2, but the updater and installer still accepted 8.1 — an 8.1 host could pass preflight, install the release, then die at the Composer bootstrap. Floor raised to `8.2.0` in `Updater::checkRequirements()`, `Validator::validateSystemRequirements()` and installer step 1 (label updated too).

### P1 — Publisher merge dropped multi-publisher associations
`libri_editori` (issue #143) has a FK `ON DELETE CASCADE` to `editori`, so merging away a duplicate silently wiped its junction rows. `PublisherRepository::mergePublishers()` now repoints those rows onto the primary (`INSERT IGNORE ... SELECT`) **before** the `DELETE FROM editori` fires the cascade. Guarded for installs predating the migration (table absent → falls back to `editore_id` only).

### P2 — Publisher views/filters ignored secondary publishers
CSV export, the public publisher archive, and the publisher-scoped repositories filtered only on `libri.editore_id`. Switched to `(l.editore_id = ? OR EXISTS(SELECT 1 FROM libri_editori ...))` so a book also appears under its secondary publishers, without regressing primary matches:
- `LibriController` export filter
- `FrontendController` publisher archive (count + list)
- `BookRepository::getByPublisherId()`
- `PublisherRepository::getBooksByPublisherId()`

### P2 — Release smoke test did not verify bundled plugin `frbr-lrm`
Added `frbr-lrm` to `create-release.sh` `BUNDLED_PLUGINS` so it matches `BundledPlugins::LIST` and the ZIP cannot ship without it.

### semgrep cleanup (pre-existing, on touched files)
- `openssl_decrypt` failure now handled explicitly (fail closed) in `Updater`.
- `unlink-use` audit findings triaged with `// nosemgrep` + justification on provably-internal paths (updater-controlled `.maintenance`/`.lock`/zip/temp paths; log-rotation `glob()` confined to the log dir; cover-delete already has a `realpath()` containment guard).

## Testing
- `php -l` clean on all 7 changed PHP files
- PHPStan level 5: **No errors**
- `bash -n scripts/create-release.sh`: ok
- semgrep rescan of `Updater.php` + `LibriController.php`: **0 findings**
- DB functional test (transaction + rollback, real data intact):
  - P2a: EXISTS filter finds a book via its **secondary** publisher (old `editore_id`-only filter did not — regression reproduced then resolved)
  - P1b: merge repoints the association onto the primary; duplicate's junction rows correctly removed by cascade
- `BundledPlugins::LIST` vs `create-release.sh`: aligned (empty diff)

No schema change → no new migration required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supporto multi-editore esteso: filtri, conteggi, archivi, esportazioni e import mantengono libri collegati anche come co-editori; sincronizzazione automatica della relazione primaria.

* **Chores**
  * Requisito minimo PHP aggiornato a 8.2; aggiornamenti ai manifest plugin e script di creazione release (inclusione frbr-lrm).
  * Nuova utilità per l’introspezione schema per compatibilità pre/post-migrazione.

* **Tests**
  * Nuove suite E2E per multi-editore, multi-autore e plugin Archives.

* **Migration**
  * Aggiunta migration idempotente per la tabella di giunzione multi-editore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->