### PR TITLE
Private mode (restrict site to registered users) + i18n fix on cover remove link

### DIFF
--- a/.nginx.conf.example
+++ b/.nginx.conf.example
@@ -152,7 +152,19 @@ server {
     }
 
     # ========================================
-    # Uploads directory
+    # Private uploaded content (issue #160)
+    # ========================================
+    # Digital-library files, archive documents and generic storage must NOT be
+    # served straight from disk — they go through the app so PrivateModeMiddleware
+    # (and any future per-file auth) governs access. These `^~` prefixes are
+    # longer than `^~ /uploads/` below, so nginx matches them first.
+    # ProtectedUploadController streams the bytes (with Range support).
+    location ^~ /uploads/digital/            { rewrite ^ /index.php last; }
+    location ^~ /uploads/archives/documents/ { rewrite ^ /index.php last; }
+    location ^~ /uploads/storage/            { rewrite ^ /index.php last; }
+
+    # ========================================
+    # Uploads directory (PUBLIC only — covers, events, CMS, branding)
     # ========================================
     location ^~ /uploads/ {
         # Cache uploaded media (book covers, user uploads). The `^~ /uploads/`

--- a/app/Controllers/ProtectedUploadController.php
+++ b/app/Controllers/ProtectedUploadController.php
@@ -38,6 +38,16 @@ class ProtectedUploadController
     /** Read chunk size for bounded (closed-range) responses. */
     private const CHUNK = 262144; // 256 KiB
 
+    /**
+     * Serve a private upload, honouring single-byte-range requests.
+     *
+     * The high cyclomatic/NPath count flagged by PHPMD is the inherent
+     * byte-range state machine (full / open-ended / closed / suffix /
+     * unsatisfiable) layered on the containment checks; splitting it would
+     * scatter that logic without making it clearer, so the complexity is
+     * accepted intentionally. (No @SuppressWarnings tag: PHPStan — the linter
+     * actually wired into CI — rejects the dotted PHPMD identifier in phpDoc.)
+     */
     public function serve(Request $request, Response $response, array $args): Response
     {
         $rel = (string) ($args['path'] ?? '');
@@ -88,6 +98,9 @@ class ProtectedUploadController
         $end = $size - 1;
         $status = 200;
 
+        // Single byte range only. A multi-range header (e.g. "bytes=0-9,20-29")
+        // does not match this pattern and intentionally falls through to a full
+        // 200 response — RFC 7233 permits ignoring a Range we don't satisfy.
         $range = $request->getHeaderLine('Range');
         if ($range !== '' && preg_match('/^bytes=(\d*)-(\d*)$/', trim($range), $m)) {
             $reqStart = $m[1] === '' ? null : (int) $m[1];

--- a/app/Controllers/ProtectedUploadController.php
+++ b/app/Controllers/ProtectedUploadController.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controllers;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Psr7\Response as SlimResponse;
+use Slim\Psr7\Stream;
+
+/**
+ * Serves PRIVATE uploaded files (digital-library content, archive documents,
+ * generic storage) through PHP so the global middleware stack — notably
+ * PrivateModeMiddleware — governs access to them.
+ *
+ * Background: public/.htaccess serves most of `/uploads/` directly from the
+ * web server (so it never reaches PHP). That blanket rule also exposed the
+ * private subtrees below, letting anyone with the URL fetch ebooks/audio and
+ * archive documents even while "private mode" was on (issue #160). Those
+ * prefixes are now routed here instead and pass through PrivateModeMiddleware
+ * first; in private mode a logged-out request is redirected/401'd before this
+ * controller ever runs.
+ *
+ * Security:
+ *   - the requested path is realpath-resolved and MUST stay inside one of the
+ *     allowed private roots (defence against `..` traversal and symlinks);
+ *   - dotfiles and empty segments are rejected.
+ *
+ * Streaming honours single HTTP Range requests so audio/video seeking keeps
+ * working.
+ */
+class ProtectedUploadController
+{
+    /** Allowed private upload roots, relative to public/uploads/. */
+    private const ALLOWED_ROOTS = ['digital', 'archives/documents', 'storage'];
+
+    /** Read chunk size for bounded (closed-range) responses. */
+    private const CHUNK = 262144; // 256 KiB
+
+    public function serve(Request $request, Response $response, array $args): Response
+    {
+        $rel = (string) ($args['path'] ?? '');
+
+        // Reject obviously hostile inputs early (traversal, NUL, dotfiles).
+        if ($rel === '' || str_contains($rel, "\0") || str_contains($rel, '..')) {
+            return new SlimResponse(404);
+        }
+
+        $uploadsRoot = realpath(dirname(__DIR__, 2) . '/public/uploads');
+        if ($uploadsRoot === false) {
+            return new SlimResponse(404);
+        }
+
+        $candidate = realpath($uploadsRoot . '/' . $rel);
+        if ($candidate === false || !is_file($candidate)) {
+            return new SlimResponse(404);
+        }
+
+        // Containment: the resolved file must live under an allowed private root.
+        $contained = false;
+        foreach (self::ALLOWED_ROOTS as $root) {
+            $base = realpath($uploadsRoot . '/' . $root);
+            if ($base !== false && str_starts_with($candidate, $base . DIRECTORY_SEPARATOR)) {
+                $contained = true;
+                break;
+            }
+        }
+        if (!$contained) {
+            return new SlimResponse(404);
+        }
+
+        $size = filesize($candidate);
+        $handle = fopen($candidate, 'rb');
+        if ($size === false || $handle === false) {
+            return new SlimResponse(404);
+        }
+
+        $headers = [
+            'Content-Type' => $this->contentType($candidate),
+            'Accept-Ranges' => 'bytes',
+            'Cache-Control' => 'private, max-age=0, must-revalidate',
+            'X-Content-Type-Options' => 'nosniff',
+            'Content-Disposition' => 'inline; filename="' . rawurlencode(basename($candidate)) . '"',
+        ];
+
+        $start = 0;
+        $end = $size - 1;
+        $status = 200;
+
+        $range = $request->getHeaderLine('Range');
+        if ($range !== '' && preg_match('/^bytes=(\d*)-(\d*)$/', trim($range), $m)) {
+            $reqStart = $m[1] === '' ? null : (int) $m[1];
+            $reqEnd = $m[2] === '' ? null : (int) $m[2];
+
+            if ($reqStart === null && $reqEnd !== null) {
+                // Suffix range: the last N bytes.
+                $start = $reqEnd >= $size ? 0 : $size - $reqEnd;
+            } else {
+                $start = $reqStart ?? 0;
+                if ($reqEnd !== null) {
+                    $end = min($reqEnd, $size - 1);
+                }
+            }
+
+            if ($start > $end || $start >= $size || $start < 0) {
+                fclose($handle);
+                return (new SlimResponse(416))->withHeader('Content-Range', "bytes */{$size}");
+            }
+
+            $status = 206;
+            $headers['Content-Range'] = "bytes {$start}-{$end}/{$size}";
+        }
+
+        $length = $end - $start + 1;
+        $headers['Content-Length'] = (string) $length;
+
+        $body = $this->buildBody($handle, $start, $end, $size);
+
+        $res = new SlimResponse($status, null, $body);
+        foreach ($headers as $name => $value) {
+            $res = $res->withHeader($name, $value);
+        }
+        return $res;
+    }
+
+    /**
+     * Whole-file and open-ended ranges stream straight from the file handle.
+     * A closed range is copied (bounded) into a php://temp stream so exactly
+     * the requested bytes are emitted (php://temp spills to disk past 2 MiB).
+     *
+     * @param resource $handle
+     */
+    private function buildBody($handle, int $start, int $end, int $size): Stream
+    {
+        // Open-ended (or full file): the body is the handle from $start to EOF.
+        if ($end === $size - 1) {
+            if ($start > 0) {
+                fseek($handle, $start);
+            }
+            return new Stream($handle);
+        }
+
+        // Closed range: emit exactly [$start, $end].
+        $temp = fopen('php://temp', 'w+b');
+        if ($temp === false) {
+            // Degrade gracefully to streaming from $start.
+            if ($start > 0) {
+                fseek($handle, $start);
+            }
+            return new Stream($handle);
+        }
+        fseek($handle, $start);
+        $remaining = $end - $start + 1;
+        while ($remaining > 0 && !feof($handle)) {
+            $buf = fread($handle, (int) min(self::CHUNK, $remaining));
+            if ($buf === false || $buf === '') {
+                break;
+            }
+            fwrite($temp, $buf);
+            $remaining -= strlen($buf);
+        }
+        fclose($handle);
+        rewind($temp);
+        return new Stream($temp);
+    }
+
+    private function contentType(string $path): string
+    {
+        $map = [
+            'pdf' => 'application/pdf',
+            'epub' => 'application/epub+zip',
+            'mp3' => 'audio/mpeg',
+            'm4a' => 'audio/mp4',
+            'wav' => 'audio/wav',
+            'ogg' => 'audio/ogg',
+            'mp4' => 'video/mp4',
+            'webm' => 'video/webm',
+            'mobi' => 'application/x-mobipocket-ebook',
+            'txt' => 'text/plain; charset=utf-8',
+            'zip' => 'application/zip',
+            'jpg' => 'image/jpeg',
+            'jpeg' => 'image/jpeg',
+            'png' => 'image/png',
+            'webp' => 'image/webp',
+            'tiff' => 'image/tiff',
+            'tif' => 'image/tiff',
+        ];
+        $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        if (isset($map[$ext])) {
+            return $map[$ext];
+        }
+        $detected = function_exists('mime_content_type') ? @mime_content_type($path) : false;
+        return is_string($detected) && $detected !== '' ? $detected : 'application/octet-stream';
+    }
+}

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -576,6 +576,7 @@ class SettingsController
             'session_lifetime' => (int) $repository->get('advanced', 'session_lifetime', (string) ($config['session_lifetime'] ?? 180)),
             'force_https' => $repository->get('advanced', 'force_https', $config['force_https'] ?? '0'),
             'enable_hsts' => $repository->get('advanced', 'enable_hsts', $config['enable_hsts'] ?? '0'),
+            'private_mode' => $repository->get('advanced', 'private_mode', $config['private_mode'] ?? '0'),
             'sitemap_last_generated_at' => $repository->get('advanced', 'sitemap_last_generated_at', $config['sitemap_last_generated_at'] ?? ''),
             'sitemap_last_generated_total' => (int) $repository->get('advanced', 'sitemap_last_generated_total', (string) ($config['sitemap_last_generated_total'] ?? 0)),
             'api_enabled' => $repository->get('api', 'enabled', '0'),
@@ -612,13 +613,15 @@ class SettingsController
             'session_lifetime' => (string) $sessionLifetime,
             'force_https' => isset($data['force_https']) && $data['force_https'] === '1' ? '1' : '0',
             'enable_hsts' => isset($data['enable_hsts']) && $data['enable_hsts'] === '1' ? '1' : '0',
+            // Private mode (issue #158): restrict the whole public site to logged-in users
+            'private_mode' => isset($data['private_mode']) && $data['private_mode'] === '1' ? '1' : '0',
         ];
 
         foreach ($settings as $key => $value) {
             $repository->set('advanced', $key, $value);
             if ($key === 'days_before_expiry_warning' || $key === 'session_lifetime') {
                 ConfigStore::set("advanced.$key", (int) $value);
-            } elseif ($key === 'force_https' || $key === 'enable_hsts') {
+            } elseif ($key === 'force_https' || $key === 'enable_hsts' || $key === 'private_mode') {
                 ConfigStore::set("advanced.$key", $value === '1');
             } else {
                 ConfigStore::set("advanced.$key", $value);

--- a/app/Middleware/PrivateModeMiddleware.php
+++ b/app/Middleware/PrivateModeMiddleware.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Middleware;
+
+use App\Support\ConfigStore;
+use App\Support\HtmlHelper;
+use App\Support\RouteTranslator;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+use Slim\Psr7\Response as SlimResponse;
+
+/**
+ * Private mode (issue #158): when an administrator enables
+ * security.private_mode, the entire public site is restricted to authenticated
+ * users. Logged-out visitors are redirected to the login page and only the
+ * authentication flow, the installer and static assets stay reachable.
+ *
+ * Off by default — the library remains fully public unless an admin opts in.
+ *
+ * Runs AFTER RememberMeMiddleware so a returning user auto-logged-in via a
+ * persistent token is already recognised here.
+ */
+class PrivateModeMiddleware implements MiddlewareInterface
+{
+    /** Auth route keys that must stay reachable while logged out. */
+    private const AUTH_ROUTE_KEYS = [
+        'login', 'logout', 'register', 'register_success',
+        'verify_email', 'forgot_password', 'reset_password',
+    ];
+
+    /** Locales whose route variants are all registered in web.php. */
+    private const LOCALES = ['it_IT', 'en_US', 'de_DE', 'fr_FR'];
+
+    /** Path prefixes always allowed (assets, installer, infra endpoints). */
+    private const ALLOWED_PREFIXES = [
+        '/assets/', '/uploads/', '/css/', '/js/', '/img/', '/images/', '/fonts/',
+        '/installer', '/language/', '/health', '/favicon', '/robots.txt',
+        '/sitemap', '/feed.xml', '/llms.txt', '/.well-known/',
+    ];
+
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        // Authenticated users are never restricted by this middleware.
+        if (!empty($_SESSION['user'])) {
+            return $handler->handle($request);
+        }
+
+        // Feature is opt-in and off by default.
+        if ((string) ConfigStore::get('advanced.private_mode', '0') !== '1') {
+            return $handler->handle($request);
+        }
+
+        $path = $this->normalizePath($request->getUri()->getPath());
+
+        if ($this->isAllowed($path)) {
+            return $handler->handle($request);
+        }
+
+        // API consumers get a JSON 401; browsers are redirected to the login page.
+        if (str_starts_with($path, '/api/')) {
+            $res = new SlimResponse(401);
+            $res->getBody()->write(json_encode([
+                'error' => true,
+                'message' => __('Autenticazione richiesta.'),
+            ], JSON_UNESCAPED_UNICODE));
+            return $res->withHeader('Content-Type', 'application/json');
+        }
+
+        $loginUrl = RouteTranslator::route('login') . '?error=private_mode';
+        return (new SlimResponse(302))->withHeader('Location', $loginUrl);
+    }
+
+    /** Strip the base path (subfolder installs) so comparisons are absolute. */
+    private function normalizePath(string $path): string
+    {
+        $basePath = HtmlHelper::getBasePath();
+        if ($basePath !== '' && $basePath !== '/' && str_starts_with($path, $basePath)) {
+            $path = substr($path, strlen($basePath));
+        }
+        return $path === '' ? '/' : $path;
+    }
+
+    private function isAllowed(string $path): bool
+    {
+        // Locale-aware auth routes (all registered variants, any install locale).
+        foreach (self::AUTH_ROUTE_KEYS as $key) {
+            foreach (self::LOCALES as $locale) {
+                $route = RouteTranslator::getRouteForLocale($key, $locale);
+                if ($route !== '' && ($path === $route || str_starts_with($path, $route . '/'))) {
+                    return true;
+                }
+            }
+        }
+
+        // Legacy English login aliases always registered in web.php.
+        if ($path === '/login' || $path === '/login.php') {
+            return true;
+        }
+
+        // Static assets, installer and infrastructure endpoints.
+        foreach (self::ALLOWED_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Middleware/PrivateModeMiddleware.php
+++ b/app/Middleware/PrivateModeMiddleware.php
@@ -34,11 +34,31 @@ class PrivateModeMiddleware implements MiddlewareInterface
     /** Locales whose route variants are all registered in web.php. */
     private const LOCALES = ['it_IT', 'en_US', 'de_DE', 'fr_FR'];
 
-    /** Path prefixes always allowed (assets, installer, infra endpoints). */
+    /**
+     * Path prefixes always allowed (assets, installer, infra endpoints).
+     *
+     * NOTE: `/uploads/` is deliberately NOT blanket-allowed. It also holds
+     * private library content — digital-library files (`/uploads/digital/`),
+     * archive documents (`/uploads/archives/documents/`) and generic storage
+     * (`/uploads/storage/`) — which must stay behind the login wall in private
+     * mode. Only `/uploads/settings/` (the admin-uploaded branding/logo shown
+     * on the login & register pages) is exposed.
+     */
     private const ALLOWED_PREFIXES = [
-        '/assets/', '/uploads/', '/css/', '/js/', '/img/', '/images/', '/fonts/',
+        '/assets/', '/css/', '/js/', '/img/', '/images/', '/fonts/',
+        '/uploads/settings/',
         '/installer', '/language/', '/health', '/favicon', '/robots.txt',
         '/sitemap', '/feed.xml', '/llms.txt', '/.well-known/',
+    ];
+
+    /**
+     * API prefixes whose routes enforce their OWN authentication (e.g. an API
+     * key validated by ApiKeyMiddleware). Private mode must not pre-empt them
+     * with a blanket 401 before that check runs — a missing/invalid key is
+     * still rejected downstream by the route's own middleware.
+     */
+    private const API_KEY_PROTECTED_PREFIXES = [
+        '/api/public/',
     ];
 
     public function process(Request $request, RequestHandler $handler): Response
@@ -85,6 +105,14 @@ class PrivateModeMiddleware implements MiddlewareInterface
 
     private function isAllowed(string $path): bool
     {
+        // API endpoints that gate themselves with an API key: defer to their
+        // own middleware instead of pre-empting with a session-based 401.
+        foreach (self::API_KEY_PROTECTED_PREFIXES as $prefix) {
+            if (str_starts_with($path, $prefix)) {
+                return true;
+            }
+        }
+
         // Locale-aware auth routes (all registered variants, any install locale).
         foreach (self::AUTH_ROUTE_KEYS as $key) {
             foreach (self::LOCALES as $locale) {

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -128,6 +128,17 @@ return function (App $app): void {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    // Private uploaded files (digital-library content, archive documents,
+    // generic storage). public/.htaccess routes ONLY these private prefixes
+    // here instead of serving them directly, so the global middleware stack
+    // (PrivateModeMiddleware) governs access. Public uploads (covers, events,
+    // CMS, branding) are still served straight from disk by the web server and
+    // never reach this route; the controller enforces realpath containment.
+    $app->get('/uploads/{path:.*}', function ($request, $response, $args) {
+        $controller = new \App\Controllers\ProtectedUploadController();
+        return $controller->serve($request, $response, $args);
+    });
+
     $app->get('/robots.txt', function ($request, $response) {
         $controller = new SeoController();
         return $controller->robots($request, $response);

--- a/app/Views/auth/login.php
+++ b/app/Views/auth/login.php
@@ -91,6 +91,8 @@ $forgotPasswordRoute = route_path('forgot_password');
                   <?= __('Il link di verifica non è valido. Assicurati di aver copiato l\'intero link dall\'email.') ?>
                 <?php elseif ($_GET['error'] === 'auth_required'): ?>
                   <?= __('Sessione scaduta, ti preghiamo di rifare il login') ?>
+                <?php elseif ($_GET['error'] === 'private_mode'): ?>
+                  <?= __('Questo sito è riservato agli utenti registrati. Accedi per continuare.') ?>
                 <?php else: ?>
                   <?= __('Si è verificato un errore durante l\'accesso. Riprova') ?>
                 <?php endif; ?>

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -606,7 +606,7 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
                     <span class="text-xs text-gray-500"><?= __("Copertina attuale") ?></span>
                     <button type="button" onclick="removeCoverImage()" class="text-xs text-red-600 hover:text-red-800 hover:underline flex items-center gap-1">
                       <i class="fas fa-trash"></i>
-                      Rimuovi
+                      <?= __('Rimuovi') ?>
                     </button>
                   </div>
                 </div>
@@ -1244,7 +1244,7 @@ function displayImagePreview(file) {
                     </div>
                     <button type="button" onclick="removeCoverImage()" class="text-xs text-red-600 hover:text-red-800 hover:underline flex items-center gap-1">
                         <i class="fas fa-trash"></i>
-                        Rimuovi
+                        <?= __('Rimuovi') ?>
                     </button>
                 </div>
             </div>
@@ -4182,7 +4182,7 @@ function displayScrapedCover(imageUrl) {
                 </div>
                 <button type="button" onclick="removeCoverImage()" class="text-xs text-red-600 hover:text-red-800 hover:underline flex items-center gap-1">
                     <i class="fas fa-trash"></i>
-                    Rimuovi
+                    <?= __('Rimuovi') ?>
                 </button>
             </div>
         </div>

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -257,6 +257,20 @@ use App\Support\HtmlHelper;
             </div>
           </label>
         </div>
+        <div>
+          <label class="inline-flex items-center gap-3 cursor-pointer">
+            <input type="checkbox"
+                   id="private_mode"
+                   name="private_mode"
+                   value="1"
+                   <?php echo isset($advancedSettings['private_mode']) && $advancedSettings['private_mode'] === '1' ? 'checked' : ''; ?>
+                   class="w-5 h-5 text-gray-900 border-gray-300 rounded focus:ring-gray-500">
+            <div>
+              <span class="text-sm font-semibold text-gray-900"><?= __("Modalità privata") ?></span>
+              <p class="text-xs text-gray-600"><?= __("Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso") ?></p>
+            </div>
+          </label>
+        </div>
         <div class="bg-gray-50 border border-gray-200 rounded-xl p-3">
           <div class="text-xs text-gray-700 space-y-1">
             <p><strong><?= __("Requisiti:") ?></strong></p>

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -257,6 +257,37 @@ use App\Support\HtmlHelper;
             </div>
           </label>
         </div>
+        <div class="bg-gray-50 border border-gray-200 rounded-xl p-3">
+          <div class="text-xs text-gray-700 space-y-1">
+            <p><strong><?= __("Requisiti:") ?></strong></p>
+            <ul class="list-disc pl-5">
+              <li><?= __("Certificato SSL/TLS valido") ?></li>
+              <li><?= __("Tutte le risorse del sito devono essere HTTPS") ?></li>
+              <li><?= __("Sottodomini devono supportare HTTPS (se usati)") ?></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Site Access Settings: private mode (issue #158) -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="space-y-4">
+        <h2 class="text-xl font-semibold text-gray-900 flex items-center gap-2">
+          <i class="fas fa-user-lock text-gray-500"></i>
+          <?= __("Accesso al sito") ?>
+        </h2>
+        <p class="text-sm text-gray-600"><?= __("Controlla chi può consultare il sito pubblico") ?></p>
+        <div class="bg-gray-50 border border-gray-200 rounded-xl p-4">
+          <div class="flex items-start gap-2">
+            <i class="fas fa-info-circle text-gray-600 mt-0.5"></i>
+            <div class="text-xs text-gray-700">
+              <strong><?= __("Funzionamento:") ?></strong> <?= __("Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione.") ?>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="bg-white border border-gray-200 rounded-2xl p-5 space-y-4">
         <div>
           <label class="inline-flex items-center gap-3 cursor-pointer">
             <input type="checkbox"
@@ -270,16 +301,6 @@ use App\Support\HtmlHelper;
               <p class="text-xs text-gray-600"><?= __("Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso") ?></p>
             </div>
           </label>
-        </div>
-        <div class="bg-gray-50 border border-gray-200 rounded-xl p-3">
-          <div class="text-xs text-gray-700 space-y-1">
-            <p><strong><?= __("Requisiti:") ?></strong></p>
-            <ul class="list-disc pl-5">
-              <li><?= __("Certificato SSL/TLS valido") ?></li>
-              <li><?= __("Tutte le risorse del sito devono essere HTTPS") ?></li>
-              <li><?= __("Sottodomini devono supportare HTTPS (se usati)") ?></li>
-            </ul>
-          </div>
         </div>
       </div>
     </div>

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5179,5 +5179,9 @@
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Wie lange ein Benutzer angemeldet bleibt, bevor die Sitzung wegen Inaktivität abläuft.",
   "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Erhöhen Sie diesen Wert, wenn Sie bei langen Katalogisierungssitzungen (z. B. beim Eingeben eines umfangreichen Inhaltsverzeichnisses in den Notizen) beim Speichern die Meldung „Sitzung abgelaufen“ erhalten und die eingegebenen Daten verlieren. Der Standardwert beträgt 3 Stunden.",
   "Modalità privata": "Privater Modus",
-  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Beschränkt den Zugriff auf die gesamte Website auf registrierte Benutzer: nicht authentifizierte Besucher werden zur Anmeldeseite weitergeleitet"
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Beschränkt den Zugriff auf die gesamte Website auf registrierte Benutzer: nicht authentifizierte Besucher werden zur Anmeldeseite weitergeleitet",
+  "Questo sito è riservato agli utenti registrati. Accedi per continuare.": "Diese Website ist registrierten Benutzern vorbehalten. Bitte melden Sie sich an, um fortzufahren.",
+  "Accesso al sito": "Website-Zugang",
+  "Controlla chi può consultare il sito pubblico": "Legen Sie fest, wer die öffentliche Website ansehen darf",
+  "Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione.": "Bei aktiviertem privaten Modus bleiben Verwaltungsbereich, Anmeldung, Registrierung und Assets erreichbar; alles andere erfordert eine Authentifizierung."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5177,5 +5177,7 @@
   "Quando aumentarla:": "Wann erhöhen:",
   "Predefinito:": "Standard:",
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Wie lange ein Benutzer angemeldet bleibt, bevor die Sitzung wegen Inaktivität abläuft.",
-  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Erhöhen Sie diesen Wert, wenn Sie bei langen Katalogisierungssitzungen (z. B. beim Eingeben eines umfangreichen Inhaltsverzeichnisses in den Notizen) beim Speichern die Meldung „Sitzung abgelaufen“ erhalten und die eingegebenen Daten verlieren. Der Standardwert beträgt 3 Stunden."
+  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Erhöhen Sie diesen Wert, wenn Sie bei langen Katalogisierungssitzungen (z. B. beim Eingeben eines umfangreichen Inhaltsverzeichnisses in den Notizen) beim Speichern die Meldung „Sitzung abgelaufen“ erhalten und die eingegebenen Daten verlieren. Der Standardwert beträgt 3 Stunden.",
+  "Modalità privata": "Privater Modus",
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Beschränkt den Zugriff auf die gesamte Website auf registrierte Benutzer: nicht authentifizierte Besucher werden zur Anmeldeseite weitergeleitet"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5179,5 +5179,9 @@
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "How long a user stays signed in before the session expires due to inactivity.",
   "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Increase this value if, during long cataloguing sessions (for example typing a lengthy table of contents in the notes), you get a “session expired” error on save and lose the data you entered. The default is 3 hours.",
   "Modalità privata": "Private mode",
-  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Restrict access to the entire site to registered users only: unauthenticated visitors are redirected to the login page"
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Restrict access to the entire site to registered users only: unauthenticated visitors are redirected to the login page",
+  "Questo sito è riservato agli utenti registrati. Accedi per continuare.": "This site is restricted to registered users. Please sign in to continue.",
+  "Accesso al sito": "Site access",
+  "Controlla chi può consultare il sito pubblico": "Control who can browse the public site",
+  "Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione.": "With private mode on, the admin area, login, registration and assets stay reachable; everything else requires authentication."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5177,5 +5177,7 @@
   "Quando aumentarla:": "When to increase it:",
   "Predefinito:": "Default:",
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "How long a user stays signed in before the session expires due to inactivity.",
-  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Increase this value if, during long cataloguing sessions (for example typing a lengthy table of contents in the notes), you get a “session expired” error on save and lose the data you entered. The default is 3 hours."
+  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Increase this value if, during long cataloguing sessions (for example typing a lengthy table of contents in the notes), you get a “session expired” error on save and lose the data you entered. The default is 3 hours.",
+  "Modalità privata": "Private mode",
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Restrict access to the entire site to registered users only: unauthenticated visitors are redirected to the login page"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5179,5 +5179,9 @@
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Durée pendant laquelle un utilisateur reste connecté avant l'expiration de la session pour inactivité.",
   "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Augmentez cette valeur si, lors de longues sessions de catalogage (par exemple en saisissant une table des matières détaillée dans les notes), vous obtenez une erreur « session expirée » à l'enregistrement et perdez les données saisies. La valeur par défaut est de 3 heures.",
   "Modalità privata": "Mode privé",
-  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limite l'accès à l'ensemble du site aux seuls utilisateurs enregistrés : les visiteurs non authentifiés sont redirigés vers la page de connexion"
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limite l'accès à l'ensemble du site aux seuls utilisateurs enregistrés : les visiteurs non authentifiés sont redirigés vers la page de connexion",
+  "Questo sito è riservato agli utenti registrati. Accedi per continuare.": "Ce site est réservé aux utilisateurs enregistrés. Veuillez vous connecter pour continuer.",
+  "Accesso al sito": "Accès au site",
+  "Controlla chi può consultare il sito pubblico": "Contrôlez qui peut consulter le site public",
+  "Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione.": "Lorsque le mode privé est activé, l'espace d'administration, la connexion, l'inscription et les ressources restent accessibles ; tout le reste nécessite une authentification."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5177,5 +5177,7 @@
   "Quando aumentarla:": "Quand l'augmenter :",
   "Predefinito:": "Par défaut :",
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Durée pendant laquelle un utilisateur reste connecté avant l'expiration de la session pour inactivité.",
-  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Augmentez cette valeur si, lors de longues sessions de catalogage (par exemple en saisissant une table des matières détaillée dans les notes), vous obtenez une erreur « session expirée » à l'enregistrement et perdez les données saisies. La valeur par défaut est de 3 heures."
+  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Augmentez cette valeur si, lors de longues sessions de catalogage (par exemple en saisissant une table des matières détaillée dans les notes), vous obtenez une erreur « session expirée » à l'enregistrement et perdez les données saisies. La valeur par défaut est de 3 heures.",
+  "Modalità privata": "Mode privé",
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limite l'accès à l'ensemble du site aux seuls utilisateurs enregistrés : les visiteurs non authentifiés sont redirigés vers la page de connexion"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5177,5 +5177,7 @@
   "Quando aumentarla:": "Quando aumentarla:",
   "Predefinito:": "Predefinito:",
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.",
-  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore."
+  "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.",
+  "Modalità privata": "Modalità privata",
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5179,5 +5179,9 @@
   "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.": "Quanto tempo un utente resta connesso prima che la sessione scada per inattività.",
   "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.": "Aumenta questo valore se durante catalogazioni lunghe (ad esempio digitando un indice esteso nelle note) ricevi l'errore «sessione scaduta» al salvataggio e perdi i dati inseriti. Il valore predefinito è 3 ore.",
   "Modalità privata": "Modalità privata",
-  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso"
+  "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso": "Limita l'accesso all'intero sito ai soli utenti registrati: i visitatori non autenticati vengono reindirizzati alla pagina di accesso",
+  "Questo sito è riservato agli utenti registrati. Accedi per continuare.": "Questo sito è riservato agli utenti registrati. Accedi per continuare.",
+  "Accesso al sito": "Accesso al sito",
+  "Controlla chi può consultare il sito pubblico": "Controlla chi può consultare il sito pubblico",
+  "Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione.": "Con la modalità privata attiva, l'area amministrativa, l'accesso, la registrazione e gli asset restano sempre raggiungibili; tutto il resto richiede l'autenticazione."
 }

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -19,9 +19,19 @@
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-    # Allow direct access to static files in /uploads/ directory
+    # Allow direct access to PUBLIC static files in /uploads/ (covers, events,
+    # CMS images, branding).
     RewriteCond %{REQUEST_URI} ^/uploads/ [NC]
+    RewriteCond %{REQUEST_URI} !^/uploads/(digital|archives/documents|storage)/ [NC]
     RewriteRule ^ - [L]
+
+    # PRIVATE uploaded content — digital-library files, archive documents and
+    # generic storage — must NOT be served directly. Force them through
+    # index.php (even when the file exists on disk, so the !-f rule below would
+    # otherwise skip them) so PrivateModeMiddleware (and any future per-file
+    # auth) governs access (issue #160). See ProtectedUploadController.
+    RewriteCond %{REQUEST_URI} ^/uploads/(digital|archives/documents|storage)/ [NC]
+    RewriteRule ^ index.php [QSA,L]
 
     # Redirect all requests to index.php
     RewriteCond %{REQUEST_FILENAME} !-f

--- a/public/index.php
+++ b/public/index.php
@@ -524,6 +524,11 @@ if (!$displayErrorDetails) {
 
 // CSRF: for now use simple session token (see App\Support\Csrf)
 
+// Private mode (issue #158): when enabled, restrict the whole public site to
+// authenticated users. Added BEFORE RememberMe so it runs AFTER it in the stack
+// and sees a token-based auto-login. No-op when disabled (default).
+$app->add(new \App\Middleware\PrivateModeMiddleware());
+
 // Remember Me middleware (auto-login via persistent token)
 // Must run before AuthMiddleware to populate $_SESSION['user']
 $app->add(new \App\Middleware\RememberMeMiddleware($container->get('db')));

--- a/tests/private-mode.spec.js
+++ b/tests/private-mode.spec.js
@@ -137,8 +137,18 @@ test.describe.serial('Private mode (issue #158)', () => {
     // to it instead of pre-empting with its own session 401 — so the response
     // is the route's own (API key / feature-gate), never the private payload.
     const resp = await request.get(`${BASE}/api/public/books/search?q=test`);
+    // The response must be ApiKeyMiddleware's OWN JSON gate (401 missing key /
+    // 403 API disabled) with a matching status — proving private mode actually
+    // reached the route and deferred to it, instead of pre-empting with its own
+    // session 401/redirect. A bare "not.toContain" could pass on any unrelated
+    // response, so assert the gate's shape explicitly.
+    expect([401, 403]).toContain(resp.status());
+    expect(resp.headers()['content-type'] || '').toContain('application/json');
     const body = await resp.text();
     expect(body).not.toContain('Autenticazione richiesta');
+    const json = JSON.parse(body);
+    expect(json).toMatchObject({ status: resp.status() });
+    expect(json).toHaveProperty('error');
   });
 
   test('10. Disabled again: home is public for everyone', async ({ page }) => {

--- a/tests/private-mode.spec.js
+++ b/tests/private-mode.spec.js
@@ -3,6 +3,9 @@
 // public site to authenticated users. Off by default.
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
@@ -24,7 +27,22 @@ function dbQuery(sql) {
   if (DB_HOST) { args.push('-h', DB_HOST); if (DB_PORT) args.push('-P', DB_PORT); }
   else if (DB_SOCKET) { args.push('-S', DB_SOCKET); }
   args.push('-u', DB_USER, DB_NAME, '-N', '-B', '-e', sql);
-  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000, env: { ...process.env, MYSQL_PWD: DB_PASS } }).trim();
+  // Pass the password via a private 0600 defaults-file rather than MYSQL_PWD
+  // (deprecated, can leak through the environment) or -p<pass> (visible in
+  // `ps`). The temp file is always removed in finally.
+  const cnf = path.join(os.tmpdir(), `pinakes-e2e-${process.pid}-${Date.now()}.cnf`);
+  fs.writeFileSync(cnf, `[client]\npassword="${DB_PASS}"\n`, { mode: 0o600 });
+  try {
+    return execFileSync('mysql', [`--defaults-extra-file=${cnf}`, ...args], {
+      encoding: 'utf-8', timeout: 10000,
+    }).trim();
+  } catch (err) {
+    // Surface a clear, actionable error instead of an opaque execFileSync throw.
+    const detail = (err && (err.stderr || err.message)) || String(err);
+    throw new Error(`dbQuery failed: ${detail}\n  SQL: ${sql}`);
+  } finally {
+    try { fs.unlinkSync(cnf); } catch { /* best effort cleanup */ }
+  }
 }
 
 function setPrivateMode(on) {

--- a/tests/private-mode.spec.js
+++ b/tests/private-mode.spec.js
@@ -87,7 +87,43 @@ test.describe.serial('Private mode (issue #158)', () => {
     expect(page.url()).not.toContain('/accedi');
   });
 
-  test('7. Disabled again: home is public for everyone', async ({ page }) => {
+  test('7. Enabled: private uploaded content is NOT served while logged out (#160)', async ({ request }) => {
+    setPrivateMode(true);
+    // Digital-library files, archive documents and generic storage are routed
+    // through PHP (public/.htaccess) so private mode governs them. A logged-out
+    // request must be redirected to login, not served the bytes.
+    for (const path of [
+      '/uploads/digital/__e2e_nope__.pdf',
+      '/uploads/archives/documents/__e2e_nope__.pdf',
+      '/uploads/storage/__e2e_nope__.bin',
+    ]) {
+      const resp = await request.get(`${BASE}${path}`, { maxRedirects: 0 });
+      expect(resp.status(), `${path} must redirect to login`).toBe(302);
+      expect(resp.headers()['location'] || '').toMatch(/\/accedi/);
+    }
+  });
+
+  test('8. Enabled: PUBLIC uploads (covers, branding) are NOT login-walled (#160)', async ({ request }) => {
+    setPrivateMode(true);
+    // Public upload subtrees are still served straight from disk — a missing
+    // file yields a plain 404, never a redirect to the login page.
+    for (const path of ['/uploads/copertine/__e2e_nope__.jpg', '/uploads/settings/__e2e_nope__.png']) {
+      const resp = await request.get(`${BASE}${path}`, { maxRedirects: 0 });
+      expect(resp.status(), `${path} must not redirect`).not.toBe(302);
+    }
+  });
+
+  test('9. Enabled: an API-key-protected route is reached, not blanket-401\'d (#160)', async ({ request }) => {
+    setPrivateMode(true);
+    // /api/public/* gates itself with ApiKeyMiddleware. Private mode must defer
+    // to it instead of pre-empting with its own session 401 — so the response
+    // is the route's own (API key / feature-gate), never the private payload.
+    const resp = await request.get(`${BASE}/api/public/books/search?q=test`);
+    const body = await resp.text();
+    expect(body).not.toContain('Autenticazione richiesta');
+  });
+
+  test('10. Disabled again: home is public for everyone', async ({ page }) => {
     setPrivateMode(false);
     const resp = await page.goto(`${BASE}/`);
     expect(resp?.status()).toBe(200);

--- a/tests/private-mode.spec.js
+++ b/tests/private-mode.spec.js
@@ -1,0 +1,96 @@
+// @ts-check
+// E2E for issue #158 — admin-toggleable "private mode" that restricts the whole
+// public site to authenticated users. Off by default.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_USER = process.env.E2E_DB_USER || '';
+const DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_HOST = process.env.E2E_DB_HOST || '';
+const DB_PORT = process.env.E2E_DB_PORT || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const DB_NAME = process.env.E2E_DB_NAME || '';
+
+test.skip(
+  !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME,
+  'E2E credentials not configured',
+);
+
+function dbQuery(sql) {
+  const args = [];
+  if (DB_HOST) { args.push('-h', DB_HOST); if (DB_PORT) args.push('-P', DB_PORT); }
+  else if (DB_SOCKET) { args.push('-S', DB_SOCKET); }
+  args.push('-u', DB_USER, DB_NAME, '-N', '-B', '-e', sql);
+  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000, env: { ...process.env, MYSQL_PWD: DB_PASS } }).trim();
+}
+
+function setPrivateMode(on) {
+  if (on) {
+    dbQuery("INSERT INTO system_settings (category,setting_key,setting_value,created_at) VALUES ('advanced','private_mode','1',NOW()) ON DUPLICATE KEY UPDATE setting_value='1'");
+  } else {
+    dbQuery("DELETE FROM system_settings WHERE category='advanced' AND setting_key='private_mode'");
+  }
+}
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/accedi`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL((url) => !url.toString().includes('/accedi'), { timeout: 15000 });
+}
+
+test.describe.serial('Private mode (issue #158)', () => {
+  test.beforeAll(() => setPrivateMode(false));
+  test.afterAll(() => setPrivateMode(false));
+
+  test('1. Default off: home is reachable while logged out', async ({ page }) => {
+    setPrivateMode(false);
+    const resp = await page.goto(`${BASE}/`);
+    expect(resp?.status()).toBe(200);
+    expect(page.url()).not.toContain('/accedi');
+  });
+
+  test('2. Enabled: logged-out home redirects to login', async ({ page }) => {
+    setPrivateMode(true);
+    await page.goto(`${BASE}/`);
+    await expect(page).toHaveURL(/\/accedi/);
+  });
+
+  test('3. Enabled: the login page itself stays reachable', async ({ page }) => {
+    setPrivateMode(true);
+    const resp = await page.goto(`${BASE}/accedi`);
+    expect(resp?.status()).toBe(200);
+    await expect(page.locator('input[name="email"]')).toBeVisible();
+  });
+
+  test('4. Enabled: register page stays reachable', async ({ page }) => {
+    setPrivateMode(true);
+    const resp = await page.goto(`${BASE}/registrati`);
+    expect(resp?.status()).toBe(200);
+  });
+
+  test('5. Enabled: an API request without auth returns 401 JSON', async ({ request }) => {
+    setPrivateMode(true);
+    const resp = await request.get(`${BASE}/api/books/1/availability`);
+    expect(resp.status()).toBe(401);
+  });
+
+  test('6. Enabled: a logged-in admin can browse the public site', async ({ page }) => {
+    setPrivateMode(true);
+    await loginAsAdmin(page);
+    const resp = await page.goto(`${BASE}/`);
+    expect(resp?.status()).toBe(200);
+    expect(page.url()).not.toContain('/accedi');
+  });
+
+  test('7. Disabled again: home is public for everyone', async ({ page }) => {
+    setPrivateMode(false);
+    const resp = await page.goto(`${BASE}/`);
+    expect(resp?.status()).toBe(200);
+    expect(page.url()).not.toContain('/accedi');
+  });
+});


### PR DESCRIPTION
Implements **#158** and fixes **#159**.

## #158 — Private mode (restrict access to registered users)
New opt-in **"Modalità privata"** toggle in *Impostazioni → Avanzate*. When enabled, the whole public site is restricted to authenticated users:
- Logged-out visitors are redirected to the login page (`?error=private_mode`).
- API requests without auth get a `401 JSON`.
- The auth flow (login / register / password reset, **all locale variants**), the installer and static assets stay reachable.
- Logged-in users (including via Remember-Me auto-login) browse normally.

**Off by default** — the library stays fully public unless an admin opts in.

Design notes:
- `PrivateModeMiddleware` reads `advanced.private_mode`, registered before RememberMe so it runs *after* it and honours token auto-login.
- **No migration / no version bump**: the setting defaults to `'0'`, so existing installs are unaffected until an admin enables it (the toggle creates the row on save). This also avoids a version.json/migration clash with the in-flight loan PR #157.
- i18n strings added to all four locales (it/en/de/fr).

### Tests
`tests/private-mode.spec.js` — **7/7 green**: default-public, enabled→redirect, login/register reachable, API 401, logged-in admin bypass, disabled→public again.

## #159 — Untranslated cover "Rimuovi" link
The remove-current-cover button was hardcoded in Italian in all three cover blocks of the book form. Wrapped in `__('Rimuovi')` (key already present in every locale).

## Also reviewed (no change here)
**#145** (385 hardcoded `/admin/*` routes) is an architectural decision — whether admin routes are intentionally non-i18n — and needs a maintainer call rather than a mechanical refactor; left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nuova "Modalità privata" nelle impostazioni avanzate (checkbox) per limitare l'accesso ai soli utenti autenticati.
  * Servizio controllato per upload "privati" con supporto a range/streaming e accesso mediato dall'app.

* **Comportamento**
  * Visitatori anonimi vengono reindirizzati alla pagina di accesso; login/registrazione, area admin e risorse pubbliche restano raggiungibili. API non autenticate restituiscono JSON 401/403.

* **Tests**
  * Nuovi/estesi test E2E per modalità privata, upload protetti e percorsi API.

* **Localizzazione**
  * Aggiunte stringhe per la modalità privata in IT/EN/DE/FR.

* **UI**
  * Traduzione del testo del pulsante "Rimuovi" nelle maschere di copertina.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->