### PR TITLE
fix(loans): canonical loan/reservation state model — fix 10 state bugs

### DIFF
--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -80,7 +80,8 @@ class CopyController
         $libroId = (int) $copy['libro_id'];
         $statoCorrente = $copy['stato'];
 
-        // Verifica se la copia è in prestito attivo
+        // Prestito "in carico" su questa copia (in_corso/in_ritardo): usato per la
+        // chiusura automatica quando la copia torna 'disponibile'.
         $stmt = $db->prepare("
             SELECT id
             FROM prestiti
@@ -88,8 +89,24 @@ class CopyController
         ");
         $stmt->bind_param('i', $copyId);
         $stmt->execute();
-        $result = $stmt->get_result();
-        $prestito = $result->fetch_assoc();
+        $prestito = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        // La copia è "trattenuta" da QUALSIASI impegno HOLDING — prestito attivo
+        // (prenotato/da_ritirare/in_corso/in_ritardo) o pendente-con-copia? Blocca il
+        // passaggio a stati non prestabili senza prima liberarla (I10/BUG7a/D12):
+        // anche un ritiro in attesa o una prenotazione futura trattengono la copia.
+        $stmt = $db->prepare("
+            SELECT 1
+            FROM prestiti
+            WHERE copia_id = ?
+              AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                    OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
+            LIMIT 1
+        ");
+        $stmt->bind_param('i', $copyId);
+        $stmt->execute();
+        $copyHeld = (bool) $stmt->get_result()->fetch_row();
         $stmt->close();
 
         // GESTIONE CAMBIO STATO -> "PRESTATO"
@@ -100,26 +117,57 @@ class CopyController
         }
 
         // GESTIONE CAMBIO STATO DA "PRESTATO" A "DISPONIBILE"
-        // Se c'è un prestito attivo e si vuole rendere disponibile, chiudi il prestito
+        // Se c'è un prestito in carico e si vuole rendere disponibile, chiudilo.
         if ($prestito && $statoCorrente === 'prestato' && $stato === 'disponibile') {
-            $prestitoId = (int) $prestito['id'];
-
             $db->begin_transaction();
             try {
-                // Chiudi il prestito
-                $stmt = $db->prepare("
+                // Ri-leggi e BLOCCA il prestito da chiudere dentro la transazione.
+                $sel = $db->prepare("
+                    SELECT id, stato, data_scadenza
+                    FROM prestiti
+                    WHERE copia_id = ? AND attivo = 1 AND stato IN ('in_corso','in_ritardo','da_ritirare')
+                    ORDER BY data_prestito DESC
+                    LIMIT 1
+                    FOR UPDATE
+                ");
+                $sel->bind_param('i', $copyId);
+                $sel->execute();
+                $loanRow = $sel->get_result()->fetch_assoc();
+                $sel->close();
+                if (!$loanRow) {
+                    $db->rollback();
+                    $_SESSION['error_message'] = __('Il prestito associato non è più chiudibile. Ricarica la pagina.');
+                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                }
+                $prestitoId = (int) $loanRow['id'];
+                // Ritardo calcolato in PHP dalla riga bloccata: nell'UPDATE single-table
+                // non si può riferire il vecchio `stato` dopo averlo riassegnato.
+                $scadenza = (string) ($loanRow['data_scadenza'] ?? '');
+                $wasLate = ($loanRow['stato'] === 'in_ritardo')
+                    || ($scadenza !== '' && $scadenza < date('Y-m-d'));
+                $lateFlag = $wasLate ? 1 : 0;
+
+                // Chiudi come 'restituito' (MAI 'completato', I8); marca il ritardo (BUG5).
+                $upd = $db->prepare("
                     UPDATE prestiti
-                    SET stato = 'completato',
+                    SET stato = 'restituito',
+                        restituito_in_ritardo = ?,
                         attivo = 0,
                         data_restituzione = CURDATE(),
                         updated_at = NOW()
-                    WHERE id = ?
+                    WHERE id = ? AND attivo = 1
                 ");
-                $stmt->bind_param('i', $prestitoId);
-                $stmt->execute();
-                $stmt->close();
+                $upd->bind_param('ii', $lateFlag, $prestitoId);
+                $upd->execute();
+                $affected = $upd->affected_rows;
+                $upd->close();
+                if ($affected !== 1) {
+                    $db->rollback();
+                    $_SESSION['error_message'] = __('Il prestito associato non è più chiudibile. Ricarica la pagina.');
+                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                }
 
-                // Aggiorna la copia nello stesso transaction
+                // Aggiorna la copia nella stessa transazione
                 $stmt = $db->prepare("UPDATE copie SET stato = ?, note = ?, updated_at = NOW() WHERE id = ?");
                 $stmt->bind_param('ssi', $stato, $note, $copyId);
                 $stmt->execute();
@@ -134,9 +182,10 @@ class CopyController
             $_SESSION['success_message'] = __('Prestito chiuso automaticamente. La copia è ora disponibile.');
         } else {
             // GESTIONE ALTRI STATI
-            // Blocca modifiche se c'è un prestito attivo (eccetto cambio a disponibile già gestito)
-            if ($prestito) {
-                $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente in prestito. Prima termina il prestito o imposta lo stato su "Disponibile" per chiuderlo automaticamente.');
+            // Blocca modifiche se la copia è trattenuta da un impegno HOLDING
+            // (eccetto il cambio a disponibile già gestito sopra).
+            if ($copyHeld) {
+                $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su "Disponibile".');
                 return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
             }
 
@@ -200,11 +249,14 @@ class CopyController
         $libroId = (int) $copy['libro_id'];
         $stato = $copy['stato'];
 
-        // Verifica se la copia è in prestito attivo
+        // Verifica se la copia è trattenuta da QUALSIASI impegno HOLDING (prestito
+        // attivo o pendente-con-copia, incluse prenotazioni future e ritiri in attesa).
         $stmt = $db->prepare("
             SELECT COUNT(*) as count
             FROM prestiti
-            WHERE copia_id = ? AND attivo = 1 AND stato IN ('in_corso', 'in_ritardo')
+            WHERE copia_id = ?
+              AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                    OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
         ");
         $stmt->bind_param('i', $copyId);
         $stmt->execute();
@@ -213,7 +265,7 @@ class CopyController
         $stmt->close();
 
         if ($hasPrestito) {
-            $_SESSION['error_message'] = __('Impossibile eliminare una copia attualmente in prestito.');
+            $_SESSION['error_message'] = __('Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.');
             return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
         }
 

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -210,7 +210,7 @@ class CopyController
                 // Layer 2: promote queued waitlist reservations for this book (loop
                 // until none convert). Both queues on every release path (D5/BUG10).
                 $reservationManager = new \App\Controllers\ReservationManager($db);
-                while ($reservationManager->processBookAvailability($libroId)) {
+                for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
                     // keep promoting while freed capacity converts the next queued reservation
                 }
             }

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -206,7 +206,13 @@ class CopyController
             }
             // Case 9: Copy became available -> Assign to waiting reservation
             elseif ($stato === 'disponibile') {
-                $reassignmentService->reassignOnReturn($copyId); // reassignOnReturn handles picking a waiting reservation
+                $reassignmentService->reassignOnReturn($copyId); // Layer 1: copy-less prenotato holds
+                // Layer 2: promote queued waitlist reservations for this book (loop
+                // until none convert). Both queues on every release path (D5/BUG10).
+                $reservationManager = new \App\Controllers\ReservationManager($db);
+                while ($reservationManager->processBookAvailability($libroId)) {
+                    // keep promoting while freed capacity converts the next queued reservation
+                }
             }
         } catch (\Throwable $e) {
             SecureLogger::error(__('Errore gestione cambio stato copia'), [

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -182,18 +182,50 @@ class CopyController
             $_SESSION['success_message'] = __('Prestito chiuso automaticamente. La copia è ora disponibile.');
         } else {
             // GESTIONE ALTRI STATI
-            // Blocca modifiche se la copia è trattenuta da un impegno HOLDING
-            // (eccetto il cambio a disponibile già gestito sopra).
+            // Fast-path: blocca subito se è già evidentemente trattenuta (HOLDING).
             if ($copyHeld) {
                 $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su "Disponibile".');
                 return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
             }
 
-            // Aggiorna la copia
-            $stmt = $db->prepare("UPDATE copie SET stato = ?, note = ?, updated_at = NOW() WHERE id = ?");
-            $stmt->bind_param('ssi', $stato, $note, $copyId);
-            $stmt->execute();
-            $stmt->close();
+            // L'aggiornamento avviene sotto lock del libro (ordine di lock canonico,
+            // come store/approveLoan) con ri-verifica HOLDING atomica: così una
+            // creazione prestito/prenotazione concorrente non può inserirsi tra il
+            // check e l'UPDATE lasciando la copia non-prestabile ma ancora impegnata.
+            $db->begin_transaction();
+            try {
+                $lockBook = $db->prepare("SELECT id FROM libri WHERE id = ? FOR UPDATE");
+                $lockBook->bind_param('i', $libroId);
+                $lockBook->execute();
+                $lockBook->close();
+
+                $recheck = $db->prepare("
+                    SELECT 1 FROM prestiti
+                    WHERE copia_id = ?
+                      AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                            OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
+                    LIMIT 1
+                ");
+                $recheck->bind_param('i', $copyId);
+                $recheck->execute();
+                $heldNow = (bool) $recheck->get_result()->fetch_row();
+                $recheck->close();
+                if ($heldNow) {
+                    $db->rollback();
+                    $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su "Disponibile".');
+                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                }
+
+                $stmt = $db->prepare("UPDATE copie SET stato = ?, note = ?, updated_at = NOW() WHERE id = ?");
+                $stmt->bind_param('ssi', $stato, $note, $copyId);
+                $stmt->execute();
+                $stmt->close();
+
+                $db->commit();
+            } catch (\Throwable $e) {
+                $db->rollback();
+                throw $e;
+            }
         }
 
         // Case 2 & 9: Handle Copy Status Changes

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -194,10 +194,18 @@ class CopyController
             // check e l'UPDATE lasciando la copia non-prestabile ma ancora impegnata.
             $db->begin_transaction();
             try {
-                $lockBook = $db->prepare("SELECT id FROM libri WHERE id = ? FOR UPDATE");
+                // Lock + soft-delete guard: su un libro rimosso dal catalogo NON si
+                // committa stato operativo sulle copie (fail-closed, AND deleted_at IS NULL).
+                $lockBook = $db->prepare("SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE");
                 $lockBook->bind_param('i', $libroId);
                 $lockBook->execute();
+                $bookLocked = (bool) $lockBook->get_result()->fetch_row();
                 $lockBook->close();
+                if (!$bookLocked) {
+                    $db->rollback();
+                    $_SESSION['error_message'] = __('Libro non trovato o non più disponibile.');
+                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                }
 
                 $recheck = $db->prepare("
                     SELECT 1 FROM prestiti

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -776,13 +776,20 @@ class LoanApprovalController
                 $copyCheckStmt->close();
 
                 $invalidStates = ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'];
-                if ($copyResult && !in_array($copyResult['stato'], $invalidStates)) {
-                    $copyRepo = new \App\Models\CopyRepository($db);
-                    $copyRepo->updateStatus($copiaId, 'prestato');
-                } elseif ($copyResult) {
-                    // Log anomaly: loan confirmed but copy in invalid state - requires manual review
-                    \App\Support\SecureLogger::warning("[confirmPickup] Loan {$loanId} confirmed but copy {$copiaId} is in state '{$copyResult['stato']}' - requires manual review");
+                if (!$copyResult || in_array($copyResult['stato'], $invalidStates, true)) {
+                    // Fail closed: roll back the just-applied 'in_corso' update instead
+                    // of committing a loan over a missing/non-lendable copy (BUG7c/D12).
+                    $db->rollback();
+                    $copyState = $copyResult ? (string) $copyResult['stato'] : 'inesistente';
+                    \App\Support\SecureLogger::error("[confirmPickup] Loan {$loanId} aborted: copy {$copiaId} non-lendable ('{$copyState}')");
+                    $response->getBody()->write(json_encode([
+                        'success' => false,
+                        'message' => __('La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.')
+                    ]));
+                    return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
                 }
+                $copyRepo = new \App\Models\CopyRepository($db);
+                $copyRepo->updateStatus($copiaId, 'prestato');
             }
 
             // Recalculate book availability (inside transaction)

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -914,7 +914,7 @@ class LoanApprovalController
             // queued reservations. Loop until none convert. Both queues (D5/BUG10).
             $reservationManager = new \App\Controllers\ReservationManager($db);
             $reservationManager->setExternalTransaction(true);
-            while ($reservationManager->processBookAvailability($libroId)) {
+            for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
                 // keep promoting while freed capacity converts the next queued reservation
             }
 
@@ -1053,7 +1053,7 @@ class LoanApprovalController
             // promote several. Both queues on every release path (D5/BUG10).
             $reservationManager = new \App\Controllers\ReservationManager($db);
             $reservationManager->setExternalTransaction(true);
-            while ($reservationManager->processBookAvailability($libroId)) {
+            for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
                 // keep promoting while freed capacity converts the next queued reservation
             }
 

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -910,6 +910,14 @@ class LoanApprovalController
                 }
             }
 
+            // Promote the waitlist (Layer 2): a cancelled pickup frees capacity for
+            // queued reservations. Loop until none convert. Both queues (D5/BUG10).
+            $reservationManager = new \App\Controllers\ReservationManager($db);
+            $reservationManager->setExternalTransaction(true);
+            while ($reservationManager->processBookAvailability($libroId)) {
+                // keep promoting while freed capacity converts the next queued reservation
+            }
+
             // Recalculate book availability (inside transaction)
             $integrity = new DataIntegrity($db);
             if (!$integrity->recalculateBookAvailability($libroId, true)) {
@@ -920,6 +928,7 @@ class LoanApprovalController
 
             // Send deferred reservation notifications AFTER commit (outside transaction)
             $reassignmentService->flushDeferredNotifications();
+            $reservationManager->flushDeferredNotifications();
 
             // Send notification to user about cancelled pickup (outside transaction)
             try {
@@ -1039,7 +1048,16 @@ class LoanApprovalController
                 $reassignmentService->reassignOnReturn($copiaId);
             }
 
-            // Recalculate availability AFTER reassignment
+            // Promote the waitlist (Layer 2): a freed unit may convert one or more
+            // queued reservations. Loop until none convert — multi-copy frees can
+            // promote several. Both queues on every release path (D5/BUG10).
+            $reservationManager = new \App\Controllers\ReservationManager($db);
+            $reservationManager->setExternalTransaction(true);
+            while ($reservationManager->processBookAvailability($libroId)) {
+                // keep promoting while freed capacity converts the next queued reservation
+            }
+
+            // Recalculate availability AFTER reassignment + promotion
             $integrity = new DataIntegrity($db);
             if (!$integrity->recalculateBookAvailability($libroId, true)) {
                 throw new \RuntimeException('Failed to recalculate book availability');
@@ -1051,6 +1069,7 @@ class LoanApprovalController
             if ($reassignmentService) {
                 $reassignmentService->flushDeferredNotifications();
             }
+            $reservationManager->flushDeferredNotifications();
 
             // Notify wishlist users AFTER commit, only if book has available copies
             try {

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -967,7 +967,7 @@ class LoanApprovalController
             $db->begin_transaction();
 
             $stmt = $db->prepare("
-                SELECT libro_id, copia_id, stato
+                SELECT libro_id, copia_id, stato, data_scadenza
                 FROM prestiti
                 WHERE id = ? AND attivo = 1 AND stato IN ('in_corso','in_ritardo')
                 FOR UPDATE
@@ -990,10 +990,15 @@ class LoanApprovalController
             $libroId = (int) $loan['libro_id'];
             $copiaId = $loan['copia_id'] ? (int) $loan['copia_id'] : null;
             $dataRestituzione = date('Y-m-d');
+            // Returned-late flag: a return past the due date is restituito + flag (I4/BUG5).
+            // This is the primary quick-return path — without it late returns keep the
+            // flag at 0 and Stats/Recensioni undercount late returners.
+            $scadenza = (string) ($loan['data_scadenza'] ?? '');
+            $ritardo = ($scadenza !== '' && $scadenza < $dataRestituzione) ? 1 : 0;
 
             // Close the loan
-            $stmt = $db->prepare("UPDATE prestiti SET stato = 'restituito', data_restituzione = ?, attivo = 0 WHERE id = ?");
-            $stmt->bind_param('si', $dataRestituzione, $loanId);
+            $stmt = $db->prepare("UPDATE prestiti SET stato = 'restituito', restituito_in_ritardo = ?, data_restituzione = ?, attivo = 0 WHERE id = ? AND attivo = 1");
+            $stmt->bind_param('isi', $ritardo, $dataRestituzione, $loanId);
             $stmt->execute();
             $stmt->close();
 

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -611,14 +611,14 @@ class PrestitiController
         // CSRF validated by CsrfMiddleware
         $repo = new \App\Models\LoanRepository($db);
         $processedBy = $_SESSION['user']['id'] ?? null;
-        // Whitelist esplicita dei campi modificabili per prevenire mass assignment
-        // Note: data_restituzione e attivo sono gestiti dal form "Registra Restituzione" dedicato
-        $allowedFields = ['libro_id', 'utente_id', 'data_prestito', 'data_scadenza'];
+        // Whitelist esplicita dei campi modificabili per prevenire mass assignment.
+        // libro_id è SOLO display (cambiarlo scollegherebbe la copia dal libro → I7);
+        // data_restituzione/attivo/stato sono gestiti dal form "Registra Restituzione".
+        $allowedFields = ['utente_id', 'data_prestito', 'data_scadenza'];
         $updateData = [];
         foreach ($allowedFields as $field) {
             if (isset($data[$field])) {
                 switch ($field) {
-                    case 'libro_id':
                     case 'utente_id':
                         $updateData[$field] = (int) $data[$field];
                         break;
@@ -631,7 +631,30 @@ class PrestitiController
         }
         $updateData['processed_by'] = $processedBy;
 
-        $repo->update($id, $updateData);
+        // Rifiuta la modifica di un prestito CHIUSO: editarlo non deve riattivarlo
+        // (I1/I2 — BUG1). Un prestito è chiuso se attivo=0 o data_restituzione valorizzata.
+        $check = $db->prepare('SELECT attivo, data_restituzione FROM prestiti WHERE id=?');
+        $check->bind_param('i', $id);
+        $check->execute();
+        $current = $check->get_result()->fetch_assoc();
+        $check->close();
+        if (!$current) {
+            return $response->withHeader('Location', url('/admin/loans'))->withStatus(302);
+        }
+        if ((int) $current['attivo'] === 0 || $current['data_restituzione'] !== null) {
+            return $response->withHeader('Location', url('/admin/loans') . '?error=loan_closed')->withStatus(302);
+        }
+
+        try {
+            $ok = $repo->update($id, $updateData);
+        } catch (\mysqli_sql_exception $e) {
+            // A trigger SIGNAL (e.g. I7) surfaces here under STRICT mode — never a 500.
+            \App\Support\SecureLogger::error('Loan update failed: ' . $e->getMessage());
+            return $response->withHeader('Location', url('/admin/loans') . '?error=loan_update_failed')->withStatus(302);
+        }
+        if (!$ok) {
+            return $response->withHeader('Location', url('/admin/loans') . '?error=loan_update_failed')->withStatus(302);
+        }
         return $response->withHeader('Location', url('/admin/loans'))->withStatus(302);
     }
     public function close(Request $request, Response $response, mysqli $db, int $id): Response
@@ -693,7 +716,9 @@ class PrestitiController
         $note = trim((string) ($data['note'] ?? '')) ?: null;
         $redirectTo = $this->sanitizeRedirect($data['redirect_to'] ?? null);
 
-        $allowed_status = ['restituito', 'in_ritardo', 'perso', 'danneggiato'];
+        // 'in_ritardo' NON è più un esito di restituzione: un rientro tardivo è
+        // 'restituito' + restituito_in_ritardo=1 (I4). Gli unici esiti sono questi.
+        $allowed_status = ['restituito', 'perso', 'danneggiato'];
         if (!in_array($nuovo_stato, $allowed_status)) {
             return $response->withHeader('Location', url('/admin/loans/returned/' . $id) . '?error=invalid_status')->withStatus(302);
         }
@@ -703,8 +728,15 @@ class PrestitiController
         // Avvia transazione
         $db->begin_transaction();
         try {
-            // Recupera libro_id e copia_id dal prestito
-            $stmt = $db->prepare("SELECT libro_id, copia_id FROM prestiti WHERE id = ?");
+            // Recupera e BLOCCA il prestito: solo un prestito ancora aperto
+            // (attivo=1, in_corso/in_ritardo) è restituibile (BUG4/D10 — niente
+            // doppia elaborazione, niente TypeError su copia_id nullo).
+            $stmt = $db->prepare("
+                SELECT libro_id, copia_id, stato, data_scadenza
+                FROM prestiti
+                WHERE id = ? AND attivo = 1 AND stato IN ('in_corso','in_ritardo')
+                FOR UPDATE
+            ");
             $stmt->bind_param("i", $id);
             $stmt->execute();
             $result = $stmt->get_result();
@@ -713,32 +745,42 @@ class PrestitiController
 
             if (!$loan) {
                 $db->rollback();
-                return $response->withHeader('Location', url('/admin/loans') . '?error=loan_not_found')->withStatus(302);
+                return $response->withHeader('Location', url('/admin/loans/returned/' . $id) . '?error=not_returnable')->withStatus(302);
             }
 
             $libro_id = $loan['libro_id'];
             $copia_id = $loan['copia_id'];
 
-            // Aggiorna il prestito
-            $stmt = $db->prepare("UPDATE prestiti SET stato = ?, data_restituzione = ?, note = ?, attivo = 0 WHERE id = ?");
-            $stmt->bind_param("sssi", $nuovo_stato, $data_restituzione, $note, $id);
-            $stmt->execute();
-            $stmt->close();
+            // Ritardo: un rientro oltre la scadenza è 'restituito' + flag (I4/BUG5).
+            // Confronto lessicografico Y-m-d sicuro. Significativo solo per 'restituito'.
+            $scadenza = (string) ($loan['data_scadenza'] ?? '');
+            $ritardo = ($nuovo_stato === 'restituito' && $scadenza !== '' && $scadenza < $data_restituzione) ? 1 : 0;
 
-            // Mappa stato prestito → stato copia
-            // Nota: questo è il form di RESTITUZIONE, quindi il libro torna sempre
-            // 'in_ritardo' qui significa "restituito in ritardo", non "ancora in prestito"
+            // Aggiorna il prestito (state-guard sull'attivo per evitare doppie restituzioni)
+            $stmt = $db->prepare("UPDATE prestiti SET stato = ?, data_restituzione = ?, note = ?, attivo = 0, restituito_in_ritardo = ? WHERE id = ? AND attivo = 1");
+            $stmt->bind_param("sssii", $nuovo_stato, $data_restituzione, $note, $ritardo, $id);
+            $stmt->execute();
+            $loanAffected = $stmt->affected_rows;
+            $stmt->close();
+            if ($loanAffected < 1) {
+                // Un'altra richiesta ha già chiuso questo prestito tra la SELECT e l'UPDATE.
+                throw new \RuntimeException('Prestito non più restituibile (race).');
+            }
+
+            // Mappa stato prestito → stato copia (form di RESTITUZIONE).
             $copia_stato = match ($nuovo_stato) {
                 'restituito' => 'disponibile',
-                'in_ritardo' => 'disponibile',  // Restituito in ritardo = disponibile
                 'perso' => 'perso',
                 'danneggiato' => 'danneggiato',
                 default => 'disponibile'
             };
 
-            // Aggiorna lo stato della copia
-            $copyRepo = new \App\Models\CopyRepository($db);
-            $copyRepo->updateStatus($copia_id, $copia_stato);
+            // Aggiorna lo stato della copia — solo se il prestito porta una copia
+            // (updateStatus ha firma int non-nullable: un copia_id nullo darebbe TypeError).
+            if ($copia_id !== null) {
+                $copyRepo = new \App\Models\CopyRepository($db);
+                $copyRepo->updateStatus((int) $copia_id, $copia_stato);
+            }
 
             $integrity = new DataIntegrity($db);
 
@@ -754,9 +796,11 @@ class PrestitiController
                 // transazione e deve propagare al catch esterno per il rollback
                 // dell'intera restituzione, evitando il commit di uno stato parziale
                 // (CRITICAL #157). Il servizio rilancia in transazione esterna.
-                $reassignmentService = new \App\Services\ReservationReassignmentService($db);
-                $reassignmentService->setExternalTransaction(true);
-                $reassignmentService->reassignOnReturn($copia_id);
+                if ($copia_id !== null) {
+                    $reassignmentService = new \App\Services\ReservationReassignmentService($db);
+                    $reassignmentService->setExternalTransaction(true);
+                    $reassignmentService->reassignOnReturn((int) $copia_id);
+                }
 
                 // Processa prenotazioni attive per questo libro (Future/Scheduled reservations)
                 $reservationManager = new \App\Controllers\ReservationManager($db);
@@ -806,7 +850,7 @@ class PrestitiController
 
             // Conferma di restituzione all'utente (GAP-1) — solo per restituzioni
             // effettive, non per copie segnate perse/danneggiate.
-            if (in_array($nuovo_stato, ['restituito', 'in_ritardo'], true)) {
+            if ($nuovo_stato === 'restituito') {
                 try {
                     (new NotificationService($db))->sendLoanReturnedNotification($id);
                 } catch (\Throwable $e) {

--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -178,7 +178,7 @@ class ReservationManager
                 $startDate = $nextReservation['data_inizio_richiesta'];
                 $endDate = $nextReservation['data_fine_richiesta'];
 
-                if ($this->isDateRangeAvailable($bookId, $startDate, $endDate)) {
+                if ($this->isDateRangeAvailable($bookId, $startDate, $endDate, (int) $nextReservation['id'])) {
                     // Create the loan - check return value to handle race conditions
                     // Note: createLoanFromReservation() handles its own transaction internally
                     // when called standalone, but here we're already in a transaction
@@ -195,6 +195,14 @@ class ReservationManager
                     $stmt->bind_param('i', $nextReservation['id']);
                     $stmt->execute();
                     $stmt->close();
+
+                    // BUG9/D4 double-subtraction fix: createLoanFromReservation() already
+                    // recalc'd availability, but the source reservation was still 'attiva'
+                    // then — so the new pendente+copy loan AND the waitlist slot were both
+                    // counted. Recalc again now that the reservation is 'completata', so the
+                    // commitment is counted exactly once.
+                    $integrity = new \App\Support\DataIntegrity($this->db);
+                    $integrity->recalculateBookAvailability($bookId, true);
 
                     // Update queue positions for remaining reservations.
                     // Pass the completed reservation's position: the converted
@@ -253,59 +261,25 @@ class ReservationManager
      * @param string|null $endDate End date (Y-m-d format)
      * @return bool True if at least one copy is available
      */
-    private function isDateRangeAvailable($bookId, $startDate, $endDate)
+    private function isDateRangeAvailable($bookId, $startDate, $endDate, ?int $excludeReservationId = null)
     {
         if (!$startDate || !$endDate) {
             return false;
         }
 
-        // Multi-copy aware: count only loanable copies.
-        $totalStmt = $this->db->prepare("
-            SELECT COUNT(*) as total FROM copie
-            WHERE libro_id = ? AND stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')
-        ");
-        $totalStmt->bind_param('i', $bookId);
-        $totalStmt->execute();
-        $totalCopies = (int) ($totalStmt->get_result()->fetch_assoc()['total'] ?? 0);
-        $totalStmt->close();
-
-        if ($totalCopies === 0) {
-            return false;
-        }
-
-        // Count overlapping loans (approved states only)
-        // Overlap check: existing_start <= our_end AND existing_end >= our_start
-        // Note: We only count LOANS here, not reservations, because:
-        // - This method is only used by processBookAvailability() to convert reservations to loans
-        // - Reservations are in a queue system - they wait their turn, they don't block each other
-        // - When converting reservation #1, other reservations shouldn't prevent the conversion
-        // Note: 'da_ritirare' counts as occupied even if copy is physically available
-        // CANONICAL "copy is occupied" predicate (#157, model A-refined):
-        //   (attivo = 1 AND stato IN active-states)
-        //   OR (stato = 'pendente' AND copia_id IS NOT NULL)
-        // A reservation-conversion pending (attivo=0) carries a copia_id and
-        // holds that copy until the admin confirms pickup, so it must count;
-        // a bare 'pendente' request with no copy assigned (origine='richiesta')
-        // does NOT yet hold a copy and must NOT reduce availability. The same
-        // predicate is mirrored in store/approveLoan/createReservation and the
-        // DB triggers so every entry point agrees.
-        $stmt = $this->db->prepare("
-            SELECT COUNT(*) as conflicts
-            FROM prestiti
-            WHERE libro_id = ?
-            AND data_prestito <= ? AND data_scadenza >= ?
-            AND (
-                (attivo = 1 AND stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato'))
-                OR (stato = 'pendente' AND copia_id IS NOT NULL)
-            )
-        ");
-        $stmt->bind_param('iss', $bookId, $endDate, $startDate);
-        $stmt->execute();
-        $loanConflicts = (int) ($stmt->get_result()->fetch_assoc()['conflicts'] ?? 0);
-        $stmt->close();
-
-        // Multi-copy: available if there's at least one free slot
-        return $loanConflicts < $totalCopies;
+        // Canonical capacity gate (CapacityService): OCC counts HOLDING loans AND
+        // active reservations — the waitlist occupies one capacity unit for its
+        // promised period. This is the promotion gate, so it excludes the
+        // reservation being promoted (it would otherwise block its own conversion).
+        // Same predicate as the admin creation gate and the overbooked auditor —
+        // one source of truth, no drift.
+        $capacity = new \App\Services\CapacityService($this->db);
+        return $capacity->hasFreeCapacity(
+            (int) $bookId,
+            (string) $startDate,
+            (string) $endDate,
+            excludeReservationId: $excludeReservationId
+        );
     }
 
     /**
@@ -611,52 +585,22 @@ class ReservationManager
             }
         }
 
-        // Count active loans that overlap with the requested period (approved states only)
-        // Overlap condition: existing_start <= our_end AND existing_end >= our_start
-        // Note: We don't exclude user's own loans here - if they have a loan, they have the book.
-        // Unless we want to allow them to borrow ANOTHER copy? Usually no.
-        // Note: 'da_ritirare' counts as occupied even if copy is physically available
-        $stmt = $this->db->prepare("
-            SELECT COUNT(*) as active_loans
-            FROM prestiti
-            WHERE libro_id = ?
-            AND attivo = 1
-            AND stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato')
-            AND data_prestito <= ? AND data_scadenza >= ?
-        ");
-        $stmt->bind_param('iss', $bookId, $endDate, $startDate);
-        $stmt->execute();
-        $activeLoans = (int) ($stmt->get_result()->fetch_assoc()['active_loans'] ?? 0);
-        $stmt->close();
+        // Canonical OCC (CapacityService): per-day peak of HOLDING loans + active
+        // reservations over the requested period, using the canonical 3-step
+        // coalesce chain and the full HOLDING predicate (incl. the pendente+copy
+        // holder). excludeUserId drops the requesting user's own commitments so
+        // they are not blocked by themselves. Replaces the previous naive
+        // loans+reservations sum and the 2-step coalesce.
+        $capacity = new \App\Services\CapacityService($this->db);
+        $occupied = $capacity->occupiedCount(
+            (int) $bookId,
+            (string) $startDate,
+            (string) $endDate,
+            excludeUserId: $excludeUserId
+        );
 
-        // Count active reservations that overlap with the requested period
-        // Use COALESCE for safety, though data_inizio/fine_richiesta are always set
-        $sql = "
-            SELECT COUNT(*) as active_reservations
-            FROM prenotazioni
-            WHERE libro_id = ? AND stato = 'attiva'
-            AND COALESCE(data_inizio_richiesta, data_scadenza_prenotazione) <= ?
-            AND COALESCE(data_fine_richiesta, data_scadenza_prenotazione) >= ?
-        ";
-
-        $params = [$bookId, $endDate, $startDate];
-        $types = 'iss';
-
-        if ($excludeUserId !== null) {
-            $sql .= " AND utente_id != ?";
-            $params[] = $excludeUserId;
-            $types .= 'i';
-        }
-
-        $stmt = $this->db->prepare($sql);
-        $stmt->bind_param($types, ...$params);
-        $stmt->execute();
-        $activeReservations = (int) ($stmt->get_result()->fetch_assoc()['active_reservations'] ?? 0);
-        $stmt->close();
-
-        // Multi-copy: available if total occupied < total copies
-        $totalOccupied = $activeLoans + $activeReservations;
-        return $totalOccupied < $totalCopies;
+        // Multi-copy: available if peak occupancy is below the (possibly legacy) capacity.
+        return $occupied < $totalCopies;
     }
 
     /**

--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -174,9 +174,18 @@ class ReservationManager
             $stmt->close();
 
             if ($nextReservation) {
-                // Check if the desired date range is available
+                // Check if the desired date range is available. Resolve the canonical
+                // R_END once: a legacy prenotazione may have data_fine_richiesta NULL but
+                // data_scadenza_prenotazione set — passing the raw NULL would make
+                // isDateRangeAvailable() return false and the row would never promote.
                 $startDate = $nextReservation['data_inizio_richiesta'];
-                $endDate = $nextReservation['data_fine_richiesta'];
+                $endDate = $nextReservation['data_fine_richiesta']
+                    ?: (!empty($nextReservation['data_scadenza_prenotazione'])
+                        ? substr((string) $nextReservation['data_scadenza_prenotazione'], 0, 10)
+                        : $startDate);
+                // Feed the resolved end to createLoanFromReservation() too (it reads
+                // $reservation['data_fine_richiesta'] for the loan period).
+                $nextReservation['data_fine_richiesta'] = $endDate;
 
                 if ($this->isDateRangeAvailable($bookId, $startDate, $endDate, (int) $nextReservation['id'])) {
                     // Create the loan - check return value to handle race conditions

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -224,6 +224,17 @@ class ReservationsAdminController
                 $dupLoanStmt->close();
             }
 
+            // Capacity gate on edit (the decision): only an 'attiva' reservation
+            // occupies. Reject a change that would push the period over capacity,
+            // excluding this reservation itself (and the user) from the count.
+            if ($stato === 'attiva') {
+                $capacity = new \App\Services\CapacityService($db);
+                if (!$capacity->hasFreeCapacity($libroId, $dataInizioRichiesta, $dataFineRichiesta, excludeReservationId: $id, excludeUserId: $utenteId)) {
+                    $db->rollback();
+                    return $response->withHeader('Location', url('/admin/reservations/edit/' . $id) . '?error=capacity_full')->withStatus(302);
+                }
+            }
+
             $stmt = $db->prepare("UPDATE prenotazioni SET stato=?, data_prenotazione=?, data_scadenza_prenotazione=?, data_inizio_richiesta=?, data_fine_richiesta=? WHERE id=?");
             $stmt->bind_param('sssssi', $stato, $startDt, $endDt, $dataInizioRichiesta, $dataFineRichiesta, $id);
             if (!$stmt->execute()) {
@@ -404,6 +415,16 @@ class ReservationsAdminController
                 return $response->withHeader('Location', url('/admin/reservations/create') . '?error=duplicate')->withStatus(302);
             }
             $dupLoanStmt->close();
+
+            // Capacity gate (the decision): a waitlist reservation occupies one
+            // capacity unit for its promised period, so reject it when the book is
+            // already at capacity for that window (counting other commitments).
+            // Same CapacityService predicate as the promotion gate and the auditor.
+            $capacity = new \App\Services\CapacityService($db);
+            if (!$capacity->hasFreeCapacity($libroId, $dataInizioRichiesta, $dataFineRichiesta, excludeUserId: $utenteId)) {
+                $db->rollback();
+                return $response->withHeader('Location', url('/admin/reservations/create') . '?error=capacity_full')->withStatus(302);
+            }
 
             $stmt = $db->prepare("SELECT COALESCE(MAX(queue_position), 0) + 1 as position FROM prenotazioni WHERE libro_id = ? AND stato = 'attiva'");
             $stmt->bind_param('i', $libroId);

--- a/app/Controllers/ReservationsController.php
+++ b/app/Controllers/ReservationsController.php
@@ -215,6 +215,16 @@ class ReservationsController
         ];
     }
 
+    /**
+     * Create a user loan REQUEST (D19 — name kept for route stability).
+     *
+     * Despite the name, this writes a BARE `prestiti` row with stato='pendente'
+     * and origine='richiesta' and NO copia_id. Per the canonical occupancy model
+     * this *unbounded* request does NOT occupy capacity — only a period-bearing
+     * `prenotazioni` waitlist row (stato='attiva') occupies its promised period.
+     * It correctly runs a per-day capacity pre-check + a post-lock recheck before
+     * inserting. Do not confuse it with the waitlist (`prenotazioni`).
+     */
     public function createReservation($request, $response, $args)
     {
         $bookId = (int) $args['id'];

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -183,7 +183,7 @@ class UserActionsController
             // queued reservations. Loop until none convert. Both queues (D5/BUG10).
             $reservationManager = new \App\Controllers\ReservationManager($db);
             $reservationManager->setExternalTransaction(true);
-            while ($reservationManager->processBookAvailability((int) $loan['libro_id'])) {
+            for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability((int) $loan['libro_id']); $promoGuard++) {
                 // keep promoting while freed capacity converts the next queued reservation
             }
 

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -179,6 +179,14 @@ class UserActionsController
                 $reassignmentService->reassignOnReturn($copiaId);
             }
 
+            // Promote the waitlist (Layer 2): a cancellation frees capacity for
+            // queued reservations. Loop until none convert. Both queues (D5/BUG10).
+            $reservationManager = new \App\Controllers\ReservationManager($db);
+            $reservationManager->setExternalTransaction(true);
+            while ($reservationManager->processBookAvailability((int) $loan['libro_id'])) {
+                // keep promoting while freed capacity converts the next queued reservation
+            }
+
             // Recalculate book availability (insideTransaction: true — TXN-002:
             // siamo dentro la transazione aperta in questo metodo, evita il
             // commit implicito di una begin_transaction() annidata)
@@ -194,6 +202,11 @@ class UserActionsController
                 } catch (\Throwable $e) {
                     SecureLogger::warning('Failed to flush deferred notifications after loan cancellation', ['error' => $e->getMessage()]);
                 }
+            }
+            try {
+                $reservationManager->flushDeferredNotifications();
+            } catch (\Throwable $e) {
+                SecureLogger::warning('Failed to flush reservation notifications after loan cancellation', ['error' => $e->getMessage()]);
             }
 
             return $response->withHeader('Location', RouteTranslator::route('reservations') . '?canceled=1')->withStatus(302);

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -221,7 +221,7 @@ class LoanRepository
             // (a multi-copy free can promote several). Both queues (D5/BUG10).
             $reservationManager = new ReservationManager($this->db);
             $reservationManager->setExternalTransaction(true); // TXN-003: siamo già in transazione
-            while ($reservationManager->processBookAvailability($bookId)) {
+            for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($bookId); $promoGuard++) {
                 // keep promoting while freed capacity converts the next queued reservation
             }
 
@@ -232,19 +232,21 @@ class LoanRepository
             throw $e;
         }
 
-        // P2: invia le notifiche reservation_book_available accodate durante la
-        // transazione esterna (eseguito solo sul percorso di successo, post-commit).
-        try {
-            $reservationManager->flushDeferredNotifications();
-        } catch (\Throwable $e) {
-            SecureLogger::warning('LoanRepository::close flush notifications warning', ['error' => $e->getMessage()]);
-        }
+        // P2: invia le notifiche accodate durante la transazione esterna (solo sul
+        // percorso di successo, post-commit). Ordine: prima il reassignment (Layer 1,
+        // copia assegnata a una prenotazione copy-less), poi la promozione waitlist
+        // (Layer 2) — stesso ordine temporale in cui sono avvenuti.
         if ($reassignmentService !== null) {
             try {
                 $reassignmentService->flushDeferredNotifications();
             } catch (\Throwable $e) {
                 SecureLogger::warning('LoanRepository::close reassign flush warning', ['error' => $e->getMessage()]);
             }
+        }
+        try {
+            $reservationManager->flushDeferredNotifications();
+        } catch (\Throwable $e) {
+            SecureLogger::warning('LoanRepository::close flush notifications warning', ['error' => $e->getMessage()]);
         }
 
         // validateAndUpdateLoan has its own transaction, call it after main transaction completes

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -161,7 +161,7 @@ class LoanRepository
             // e ricalcolato il libro sbagliato. In quel caso (rarissimo: il
             // libro di un prestito non viene riassegnato) abortiamo invece di
             // operare su dati incoerenti.
-            $stmt = $this->db->prepare('SELECT libro_id FROM prestiti WHERE id=? FOR UPDATE');
+            $stmt = $this->db->prepare('SELECT libro_id, copia_id, data_scadenza FROM prestiti WHERE id=? FOR UPDATE');
             $stmt->bind_param('i', $id);
             $stmt->execute();
             $lockedRow = $stmt->get_result()->fetch_assoc();
@@ -174,11 +174,14 @@ class LoanRepository
                 $this->db->rollback();
                 return false;
             }
+            $closedCopiaId = $lockedRow['copia_id'] !== null ? (int) $lockedRow['copia_id'] : null;
 
-            // Chiude il prestito
+            // Chiude il prestito (restituito + flag ritardo se oltre scadenza, I4/BUG5)
             $today = gmdate('Y-m-d');
-            $stmt = $this->db->prepare('UPDATE prestiti SET attivo=0, data_restituzione=?, stato="restituito" WHERE id=?');
-            $stmt->bind_param('si', $today, $id);
+            $scadenza = (string) ($lockedRow['data_scadenza'] ?? '');
+            $ritardo = ($scadenza !== '' && $scadenza < $today) ? 1 : 0;
+            $stmt = $this->db->prepare('UPDATE prestiti SET attivo=0, data_restituzione=?, stato="restituito", restituito_in_ritardo=? WHERE id=?');
+            $stmt->bind_param('sii', $today, $ritardo, $id);
             if (!$stmt->execute()) {
                 throw new \RuntimeException('Impossibile aggiornare lo stato del prestito.');
             }
@@ -205,12 +208,21 @@ class LoanRepository
                 throw new \RuntimeException(__('Impossibile ricalcolare la disponibilità del libro.'));
             }
 
+            // Layer 1: reassign any copy-less 'prenotato' hold to the freed copy
+            // (the inverse-gap fix — close() previously promoted only the waitlist).
+            $reassignmentService = null;
+            if ($closedCopiaId !== null) {
+                $reassignmentService = new \App\Services\ReservationReassignmentService($this->db);
+                $reassignmentService->setExternalTransaction(true);
+                $reassignmentService->reassignOnReturn($closedCopiaId);
+            }
+
+            // Layer 2: promote queued waitlist reservations. Loop until none convert
+            // (a multi-copy free can promote several). Both queues (D5/BUG10).
             $reservationManager = new ReservationManager($this->db);
             $reservationManager->setExternalTransaction(true); // TXN-003: siamo già in transazione
-            // Note: processBookAvailability returning false typically indicates no pending
-            // reservation or a race condition - acceptable to continue, just log for observability
-            if (!$reservationManager->processBookAvailability($bookId)) {
-                SecureLogger::debug("LoanRepository::close - No reservation processed for book ID: {$bookId}");
+            while ($reservationManager->processBookAvailability($bookId)) {
+                // keep promoting while freed capacity converts the next queued reservation
             }
 
             $this->db->commit();
@@ -226,6 +238,13 @@ class LoanRepository
             $reservationManager->flushDeferredNotifications();
         } catch (\Throwable $e) {
             SecureLogger::warning('LoanRepository::close flush notifications warning', ['error' => $e->getMessage()]);
+        }
+        if ($reassignmentService !== null) {
+            try {
+                $reassignmentService->flushDeferredNotifications();
+            } catch (\Throwable $e) {
+                SecureLogger::warning('LoanRepository::close reassign flush warning', ['error' => $e->getMessage()]);
+            }
         }
 
         // validateAndUpdateLoan has its own transaction, call it after main transaction completes

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -74,16 +74,24 @@ class LoanRepository
         );
     }
 
+    /**
+     * Edit ONLY the user-editable fields of a loan. It deliberately never writes
+     * the lifecycle columns (attivo / stato / data_restituzione / restituito_in_ritardo)
+     * nor libro_id / copia_id — editing a loan must not resurrect a returned one
+     * (BUG1/I1) nor decouple the copy from its book (BUG2/I7). Lifecycle changes
+     * go through the dedicated return/approve/cancel paths, never through here.
+     *
+     * @param array<string,mixed> $data
+     */
     public function update(int $id, array $data): bool
     {
-        $sql = "UPDATE prestiti SET libro_id=?, utente_id=?, data_prestito=?, data_scadenza=?, data_restituzione=?, processed_by=?, attivo=? WHERE id=?";
+        $sql = "UPDATE prestiti SET utente_id=?, data_prestito=?, data_scadenza=?, processed_by=? WHERE id=?";
         $stmt = $this->db->prepare($sql);
+        $utente_id = (int) ($data['utente_id'] ?? 0);
         $data_prestito = $data['data_prestito'] ?? date('Y-m-d');
         $data_scadenza = $data['data_scadenza'] ?? date('Y-m-d', strtotime('+14 days'));
-        $data_restituzione = $data['data_restituzione'] ?? null;
         $processed_by = $data['processed_by'] ?? null;
-        $attivo = (int)($data['attivo'] ?? 1);
-        $stmt->bind_param('iisssiii', $data['libro_id'], $data['utente_id'], $data_prestito, $data_scadenza, $data_restituzione, $processed_by, $attivo, $id);
+        $stmt->bind_param('issii', $utente_id, $data_prestito, $data_scadenza, $processed_by, $id);
         return $stmt->execute();
     }
 

--- a/app/Services/CapacityService.php
+++ b/app/Services/CapacityService.php
@@ -1,0 +1,234 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Services;
+
+use mysqli;
+
+/**
+ * CapacityService — the single authority for book-level capacity (issue
+ * fix/loan-state-bugs). Every reader that asks "is this book free for a period?"
+ * routes through here so the occupancy predicate cannot drift across controllers.
+ *
+ * ── CANONICAL OCCUPANCY RULE (two enforcement layers, never mixed) ────────────
+ *
+ * HOLDING set (per-copy, Layer 1 — what occupies a *specific* copy):
+ *     HOLDING(p) :=
+ *         ( p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo') )
+ *      OR ( p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL )
+ * Enforced by DB triggers + per-copy allocators. The waitlist (prenotazioni)
+ * never participates here — it has no copia_id.
+ *
+ * OCC (book-level capacity, Layer 2 — how many simultaneous commitments):
+ *     OCC(b,[s,e]) := per-day MAX over [s,e] of (
+ *           COUNT(HOLDING loans of b overlapping the day)
+ *         + COUNT(active prenotazioni of b overlapping the day) )
+ *     where the reservation interval end is
+ *       R_END(r) := COALESCE(r.data_fine_richiesta, DATE(r.data_scadenza_prenotazione), r.data_inizio_richiesta)
+ * Inclusive overlap: start_a <= end_b AND end_a >= start_b.
+ *
+ * Free capacity for [s,e] iff OCC(b,[s,e]) < copie_totali(b) for EVERY day in [s,e].
+ * copie_totali(b) = COUNT of copie rows whose stato is lendable
+ *                   (NOT IN perso, danneggiato, manutenzione, in_restauro, in_trasferimento).
+ *
+ * THE DECISION: a prenotazioni row (stato='attiva') with period
+ * [data_inizio_richiesta, R_END] occupies exactly one capacity unit for that
+ * period, counted in OCC up to copie_totali. It is *soft* (gates capacity,
+ * blocks new commitments) but does not pin a physical copy. The bare prestiti
+ * request (stato='pendente', copia_id IS NULL) is unbounded and does NOT occupy.
+ */
+final class CapacityService
+{
+    public function __construct(private mysqli $db) {}
+
+    /** Lendable physical copies of a book (the capacity ceiling). */
+    public function totalCopies(int $libroId): int
+    {
+        $stmt = $this->db->prepare(
+            "SELECT COUNT(*) FROM copie
+             WHERE libro_id = ?
+               AND stato NOT IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento')"
+        );
+        $stmt->bind_param('i', $libroId);
+        $stmt->execute();
+        $stmt->bind_result($n);
+        $stmt->fetch();
+        $stmt->close();
+        return (int) $n;
+    }
+
+    /**
+     * OCC(b,[s,e]) — the peak simultaneous occupancy over the inclusive interval
+     * [$start,$end], counting HOLDING loans + active reservations. Excludes the
+     * row/user being decided (so a gate can ignore the very commitment it is about
+     * to create or move).
+     *
+     * @param string $start Y-m-d inclusive
+     * @param string $end   Y-m-d inclusive
+     */
+    public function occupiedCount(
+        int $libroId,
+        string $start,
+        string $end,
+        ?int $excludePrestitoId = null,
+        ?int $excludeReservationId = null,
+        ?int $excludeUserId = null
+    ): int {
+        $intervals = array_merge(
+            $this->holdingLoanIntervals($libroId, $start, $end, $excludePrestitoId, $excludeUserId),
+            $this->activeReservationIntervals($libroId, $start, $end, $excludeReservationId, $excludeUserId)
+        );
+        return $this->sweepPeak($intervals);
+    }
+
+    /** True iff OCC(b,[s,e]) < totalCopies(b) for every day in [s,e]. */
+    public function hasFreeCapacity(
+        int $libroId,
+        string $start,
+        string $end,
+        ?int $excludePrestitoId = null,
+        ?int $excludeReservationId = null,
+        ?int $excludeUserId = null
+    ): bool {
+        $total = $this->totalCopies($libroId);
+        if ($total <= 0) {
+            return false;
+        }
+        $occ = $this->occupiedCount($libroId, $start, $end, $excludePrestitoId, $excludeReservationId, $excludeUserId);
+        return $occ < $total;
+    }
+
+    /**
+     * HOLDING loan intervals overlapping [$start,$end], clamped to the window.
+     * @return list<array{0:string,1:string}>
+     */
+    private function holdingLoanIntervals(int $libroId, string $start, string $end, ?int $excludePrestitoId, ?int $excludeUserId): array
+    {
+        $sql = "SELECT GREATEST(p.data_prestito, ?) AS s, LEAST(p.data_scadenza, ?) AS e
+                FROM prestiti p
+                WHERE p.libro_id = ?
+                  AND p.data_prestito <= ? AND p.data_scadenza >= ?
+                  AND ( (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                        OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )";
+        $types = 'ssiss';
+        $params = [$start, $end, $libroId, $end, $start];
+        if ($excludePrestitoId !== null) {
+            $sql .= ' AND p.id <> ?';
+            $types .= 'i';
+            $params[] = $excludePrestitoId;
+        }
+        if ($excludeUserId !== null) {
+            $sql .= ' AND p.utente_id <> ?';
+            $types .= 'i';
+            $params[] = $excludeUserId;
+        }
+        return $this->fetchIntervals($sql, $types, $params);
+    }
+
+    /**
+     * Active reservation intervals overlapping [$start,$end], clamped to the window.
+     * @return list<array{0:string,1:string}>
+     */
+    private function activeReservationIntervals(int $libroId, string $start, string $end, ?int $excludeReservationId, ?int $excludeUserId): array
+    {
+        // Canonical 3-step coalesce chain for the reservation end (no 2-step variants).
+        $rEnd = 'COALESCE(r.data_fine_richiesta, DATE(r.data_scadenza_prenotazione), r.data_inizio_richiesta)';
+        $sql = "SELECT GREATEST(r.data_inizio_richiesta, ?) AS s, LEAST($rEnd, ?) AS e
+                FROM prenotazioni r
+                WHERE r.libro_id = ?
+                  AND r.stato = 'attiva'
+                  AND r.data_inizio_richiesta IS NOT NULL
+                  AND r.data_inizio_richiesta <= ?
+                  AND $rEnd >= ?";
+        $types = 'ssiss';
+        $params = [$start, $end, $libroId, $end, $start];
+        if ($excludeReservationId !== null) {
+            $sql .= ' AND r.id <> ?';
+            $types .= 'i';
+            $params[] = $excludeReservationId;
+        }
+        if ($excludeUserId !== null) {
+            $sql .= ' AND r.utente_id <> ?';
+            $types .= 'i';
+            $params[] = $excludeUserId;
+        }
+        return $this->fetchIntervals($sql, $types, $params);
+    }
+
+    /**
+     * @param string $types
+     * @param list<int|string> $params
+     * @return list<array{0:string,1:string}>
+     */
+    private function fetchIntervals(string $sql, string $types, array $params): array
+    {
+        $stmt = $this->db->prepare($sql);
+        $refs = [$types];
+        foreach ($params as $k => $v) {
+            $refs[] = &$params[$k];
+        }
+        call_user_func_array([$stmt, 'bind_param'], $refs);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $out = [];
+        while ($row = $res->fetch_assoc()) {
+            $s = (string) $row['s'];
+            $e = (string) $row['e'];
+            if ($s !== '' && $e !== '' && $s <= $e) {
+                $out[] = [$s, $e];
+            }
+        }
+        $stmt->close();
+        return $out;
+    }
+
+    /**
+     * Sweep-line peak: the maximum number of intervals overlapping on any single
+     * day. Inclusive bounds → the end event fires on (end + 1 day). Returns 0 for
+     * an empty set.
+     *
+     * @param list<array{0:string,1:string}> $intervals each [startYmd, endYmd]
+     */
+    private function sweepPeak(array $intervals): int
+    {
+        if ($intervals === []) {
+            return 0;
+        }
+        /** @var list<array{0:string,1:int}> $events */
+        $events = [];
+        foreach ($intervals as [$s, $e]) {
+            $events[] = [$s, 1];
+            $events[] = [$this->nextDay($e), -1];
+        }
+        // Sort by day. At the same coordinate, process the end event (-1) BEFORE
+        // the start event (+1): with half-open [start, end+1) intervals, an
+        // interval ending and another starting on the same day do NOT overlap
+        // (adjacent ranges [1..10] and [11..20] peak at 1, not 2).
+        usort($events, static function (array $a, array $b): int {
+            if ($a[0] === $b[0]) {
+                return $a[1] <=> $b[1]; // -1 (end) before +1 (start)
+            }
+            return $a[0] <=> $b[0];
+        });
+        $running = 0;
+        $peak = 0;
+        foreach ($events as [, $delta]) {
+            $running += $delta;
+            if ($running > $peak) {
+                $peak = $running;
+            }
+        }
+        return $peak;
+    }
+
+    /** Y-m-d of the day after $ymd (string math via DateTime, no TZ ambiguity). */
+    private function nextDay(string $ymd): string
+    {
+        $dt = \DateTime::createFromFormat('Y-m-d', $ymd);
+        if ($dt === false) {
+            return $ymd;
+        }
+        $dt->modify('+1 day');
+        return $dt->format('Y-m-d');
+    }
+}

--- a/app/Services/CapacityService.php
+++ b/app/Services/CapacityService.php
@@ -41,20 +41,41 @@ final class CapacityService
 {
     public function __construct(private mysqli $db) {}
 
-    /** Lendable physical copies of a book (the capacity ceiling). */
+    /**
+     * Lendable physical copies of a book (the capacity ceiling). If the book has
+     * per-copy rows, count the lendable ones; otherwise fall back to the legacy
+     * libri.copie_totali (NULL → 1, explicit 0 → 0), matching
+     * ReservationsController::getBookTotalCopies and the overbooked auditor so a
+     * legacy book without copie rows is not spuriously blocked by every gate.
+     */
     public function totalCopies(int $libroId): int
     {
-        $stmt = $this->db->prepare(
-            "SELECT COUNT(*) FROM copie
-             WHERE libro_id = ?
-               AND stato NOT IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento')"
-        );
+        $stmt = $this->db->prepare("SELECT COUNT(*) AS total FROM copie WHERE libro_id = ?");
         $stmt->bind_param('i', $libroId);
         $stmt->execute();
-        $stmt->bind_result($n);
-        $stmt->fetch();
+        $copyRows = (int) ($stmt->get_result()->fetch_assoc()['total'] ?? 0);
         $stmt->close();
-        return (int) $n;
+
+        if ($copyRows > 0) {
+            $stmt = $this->db->prepare(
+                "SELECT COUNT(*) AS total FROM copie
+                 WHERE libro_id = ?
+                   AND stato NOT IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento')"
+            );
+            $stmt->bind_param('i', $libroId);
+            $stmt->execute();
+            $lendable = (int) ($stmt->get_result()->fetch_assoc()['total'] ?? 0);
+            $stmt->close();
+            return $lendable;
+        }
+
+        // No per-copy rows: legacy fallback to libri.copie_totali (NULL → 1, 0 → 0).
+        $stmt = $this->db->prepare("SELECT IFNULL(copie_totali, 1) AS total FROM libri WHERE id = ? AND deleted_at IS NULL");
+        $stmt->bind_param('i', $libroId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $row !== null ? (int) $row['total'] : 0;
     }
 
     /**

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -132,14 +132,19 @@ class ReservationReassignmentService
     {
         // 1. Trova prenotazioni che sono "bloccate" (assegnate a copie non disponibili o senza copia)
         // Ordina per data creazione (FIFO)
+        // Solo righe GENUINAMENTE bloccate: senza copia, oppure con una copia in
+        // stato NON prestabile. NON 'c.stato != disponibile' — una copia 'prenotato'
+        // o 'prestato' per un periodo NON sovrapposto è legittimamente assegnata e
+        // non va strappata (BUG6/D11).
         $stmt = $this->db->prepare("
-            SELECT p.id, p.copia_id, p.utente_id
+            SELECT p.id, p.copia_id, p.utente_id, p.data_prestito, p.data_scadenza
             FROM prestiti p
             LEFT JOIN copie c ON p.copia_id = c.id
             WHERE p.libro_id = ?
             AND p.stato = 'prenotato'
-            AND (p.copia_id IS NULL OR c.stato != 'disponibile')
             AND p.attivo = 1
+            AND ( p.copia_id IS NULL
+                  OR c.stato IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento') )
             ORDER BY p.created_at ASC
             LIMIT 1
         ");
@@ -164,6 +169,28 @@ class ReservationReassignmentService
             $stmt->close();
 
             if (!$copyStatus || $copyStatus['stato'] !== 'disponibile') {
+                $this->rollbackIfOwned($ownTransaction);
+                return;
+            }
+
+            // Non riassegnare se la copia target ha un impegno HOLDING sovrapposto
+            // al periodo della prenotazione: eviterebbe un SIGNAL del trigger di
+            // overlap che avvelenerebbe la transazione (BUG6/D11). Overlap inclusivo.
+            $ovl = $this->db->prepare("
+                SELECT 1 FROM prestiti
+                WHERE copia_id = ? AND id <> ?
+                AND data_prestito <= ? AND data_scadenza >= ?
+                AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                      OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
+                LIMIT 1
+            ");
+            $ovl->bind_param('iiss', $newCopiaId, $reservation['id'], $reservation['data_scadenza'], $reservation['data_prestito']);
+            $ovl->execute();
+            $hasOverlap = (bool) $ovl->get_result()->fetch_row();
+            $ovl->close();
+            if ($hasOverlap) {
+                // La nuova copia non è libera per l'intero periodo: lascia la
+                // prenotazione bloccata, verrà riassegnata da un'altra copia/ritorno.
                 $this->rollbackIfOwned($ownTransaction);
                 return;
             }

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -141,7 +141,7 @@ class ReservationReassignmentService
             FROM prestiti p
             LEFT JOIN copie c ON p.copia_id = c.id
             WHERE p.libro_id = ?
-            AND p.stato = 'prenotato'
+            AND p.stato IN ('prenotato', 'da_ritirare')
             AND p.attivo = 1
             AND ( p.copia_id IS NULL
                   OR c.stato IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento') )

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -252,12 +252,14 @@ class ReservationReassignmentService
      */
     public function reassignOnCopyLost(int $copiaId): void
     {
-        // Trova se c'era una prenotazione attiva su questa copia
+        // Trova un impegno HOLDING "futuro" su questa copia da riassegnare. Include
+        // 'da_ritirare' (ritiro in attesa) oltre a 'prenotato' (BUG7b/D12): perdere
+        // la copia di un ritiro in attesa deve riassegnarlo, non lasciarlo bloccato.
         $stmt = $this->db->prepare("
-            SELECT id, libro_id, utente_id
+            SELECT id, libro_id, utente_id, data_prestito, data_scadenza
             FROM prestiti
             WHERE copia_id = ?
-            AND stato = 'prenotato'
+            AND stato IN ('prenotato', 'da_ritirare')
             AND attivo = 1
             LIMIT 1
         ");
@@ -272,6 +274,8 @@ class ReservationReassignmentService
 
         $libroId = (int) $reservation['libro_id'];
         $reservationId = (int) $reservation['id'];
+        $resStart = (string) $reservation['data_prestito'];
+        $resEnd = (string) $reservation['data_scadenza'];
         $excludedCopies = [$copiaId]; // Copie da escludere dalla ricerca
         $maxRetries = 5; // Limite tentativi per evitare loop infiniti
 
@@ -299,6 +303,27 @@ class ReservationReassignmentService
                 if (!$copyStatus || $copyStatus['stato'] !== 'disponibile') {
                     $this->rollbackIfOwned($ownTransaction);
                     // Aggiungi questa copia alle escluse e riprova
+                    $excludedCopies[] = $nextCopyId;
+                    continue;
+                }
+
+                // Non riassegnare a una copia con un impegno HOLDING sovrapposto al
+                // periodo della prenotazione: eviterebbe un SIGNAL del trigger di
+                // overlap (BUG7b/D12). Overlap inclusivo.
+                $ovl = $this->db->prepare("
+                    SELECT 1 FROM prestiti
+                    WHERE copia_id = ? AND id <> ?
+                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                          OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
+                    LIMIT 1
+                ");
+                $ovl->bind_param('iiss', $nextCopyId, $reservationId, $resEnd, $resStart);
+                $ovl->execute();
+                $hasOverlap = (bool) $ovl->get_result()->fetch_row();
+                $ovl->close();
+                if ($hasOverlap) {
+                    $this->rollbackIfOwned($ownTransaction);
                     $excludedCopies[] = $nextCopyId;
                     continue;
                 }

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -40,8 +40,9 @@ class DataIntegrity {
                     ) THEN 'prestato'
                     WHEN EXISTS (
                         SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id AND p.attivo = 1
-                        AND p.stato IN ('prenotato', 'da_ritirare')
+                        WHERE p.copia_id = c.id
+                        AND ( (p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare'))
+                              OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )
                     ) THEN 'prenotato'
                     ELSE 'disponibile'
                 END
@@ -63,10 +64,12 @@ class DataIntegrity {
                         SELECT COUNT(*)
                         FROM copie c
                         LEFT JOIN prestiti p ON c.id = p.copia_id
-                            AND p.attivo = 1
                             AND (
-                                p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
-                                OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE())
+                                ( p.attivo = 1 AND (
+                                    p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
+                                    OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE() AND p.data_scadenza >= CURDATE())
+                                ) )
+                                OR ( p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL )
                             )
                         WHERE c.libro_id = l.id
                         AND c.stato IN ('disponibile', 'prenotato')
@@ -94,10 +97,12 @@ class DataIntegrity {
                             SELECT COUNT(*)
                             FROM copie c
                             LEFT JOIN prestiti p ON c.id = p.copia_id
-                                AND p.attivo = 1
                                 AND (
-                                    p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
-                                    OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE())
+                                    ( p.attivo = 1 AND (
+                                        p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
+                                        OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE() AND p.data_scadenza >= CURDATE())
+                                    ) )
+                                    OR ( p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL )
                                 )
                             WHERE c.libro_id = l.id
                             AND c.stato IN ('disponibile', 'prenotato')
@@ -174,8 +179,9 @@ class DataIntegrity {
                     ) THEN 'prestato'
                     WHEN EXISTS (
                         SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id AND p.attivo = 1
-                        AND p.stato IN ('prenotato', 'da_ritirare')
+                        WHERE p.copia_id = c.id
+                        AND ( (p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare'))
+                              OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )
                     ) THEN 'prenotato'
                     ELSE 'disponibile'
                 END
@@ -283,8 +289,9 @@ class DataIntegrity {
                     ) THEN 'prestato'
                     WHEN EXISTS (
                         SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id AND p.attivo = 1
-                        AND p.stato IN ('prenotato', 'da_ritirare')
+                        WHERE p.copia_id = c.id
+                        AND ( (p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare'))
+                              OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )
                     ) THEN 'prenotato'
                     ELSE 'disponibile'
                 END
@@ -308,10 +315,12 @@ class DataIntegrity {
                         SELECT COUNT(*)
                         FROM copie c
                         LEFT JOIN prestiti p ON c.id = p.copia_id
-                            AND p.attivo = 1
                             AND (
-                                p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
-                                OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE())
+                                ( p.attivo = 1 AND (
+                                    p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
+                                    OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE() AND p.data_scadenza >= CURDATE())
+                                ) )
+                                OR ( p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL )
                             )
                         WHERE c.libro_id = ?
                         AND c.stato IN ('disponibile', 'prenotato')
@@ -339,10 +348,12 @@ class DataIntegrity {
                             SELECT COUNT(*)
                             FROM copie c
                             LEFT JOIN prestiti p ON c.id = p.copia_id
-                                AND p.attivo = 1
                                 AND (
-                                    p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
-                                    OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE())
+                                    ( p.attivo = 1 AND (
+                                        p.stato IN ('in_corso', 'in_ritardo', 'da_ritirare')
+                                        OR (p.stato = 'prenotato' AND p.data_prestito <= CURDATE() AND p.data_scadenza >= CURDATE())
+                                    ) )
+                                    OR ( p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL )
                                 )
                             WHERE c.libro_id = ?
                             AND c.stato IN ('disponibile', 'prenotato')
@@ -706,13 +717,12 @@ class DataIntegrity {
         }
         $stmt->close();
 
-        // Occupancy = the #157 canonical copy-holding set only: active loans plus
-        // reservation-conversion pendings that already hold a copy
-        // (attivo=0, stato='pendente', copia_id IS NOT NULL). Waitlist
-        // reservations (prenotazioni, stato='attiva') are intentionally a QUEUE
-        // that may exceed copy count and do NOT hold a copy until converted, so
-        // counting them as full-interval occupancy produced false-positive
-        // overbooked periods for popular low-copy books — they are excluded here.
+        // Occupancy = the canonical OCC: HOLDING loans (active loans + the
+        // pendente-with-copy conversion holder) PLUS active waitlist reservations.
+        // Per the canonical model, a prenotazioni row (stato='attiva') occupies one
+        // capacity unit for its promised period [data_inizio_richiesta, R_END], so
+        // the auditor MUST count it — otherwise it would bless an over-capacity
+        // waitlist that the creation/promotion gates already reject.
         $eventsByBook = [];
         $stmt = $this->db->prepare("
             SELECT libro_id, 'prestito' AS source_type, id AS source_id,
@@ -744,6 +754,38 @@ class DataIntegrity {
                 $end = $start;
             }
 
+            $endExclusive = (new \DateTimeImmutable($end))->modify('+1 day')->format('Y-m-d');
+            $eventsByBook[$bookId][$start] = ($eventsByBook[$bookId][$start] ?? 0) + 1;
+            $eventsByBook[$bookId][$endExclusive] = ($eventsByBook[$bookId][$endExclusive] ?? 0) - 1;
+        }
+        $stmt->close();
+
+        // Active waitlist reservations occupy their promised period too (the
+        // decision): add them as occupancy events with the canonical 3-step
+        // coalesce chain for the interval end, same endExclusive conversion.
+        $stmt = $this->db->prepare("
+            SELECT libro_id,
+                   DATE(data_inizio_richiesta) AS start_date,
+                   DATE(COALESCE(data_fine_richiesta, DATE(data_scadenza_prenotazione), data_inizio_richiesta)) AS end_date
+            FROM prenotazioni
+            WHERE stato = 'attiva'
+              AND data_inizio_richiesta IS NOT NULL
+        ");
+        $stmt->execute();
+        $resResult = $stmt->get_result();
+        while ($row = $resResult->fetch_assoc()) {
+            $bookId = (int) $row['libro_id'];
+            if (!isset($capacityByBook[$bookId])) {
+                continue;
+            }
+            $start = substr((string) $row['start_date'], 0, 10);
+            $end = substr((string) ($row['end_date'] ?? ''), 0, 10);
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $start)) {
+                continue;
+            }
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $end) || $end < $start) {
+                $end = $start;
+            }
             $endExclusive = (new \DateTimeImmutable($end))->modify('+1 day')->format('Y-m-d');
             $eventsByBook[$bookId][$start] = ($eventsByBook[$bookId][$start] ?? 0) + 1;
             $eventsByBook[$bookId][$endExclusive] = ($eventsByBook[$bookId][$endExclusive] ?? 0) - 1;

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -624,8 +624,9 @@ class DataIntegrity {
             WHERE c.stato IN ('prenotato', 'prestato')
             AND NOT EXISTS (
                 SELECT 1 FROM prestiti p
-                WHERE p.copia_id = c.id AND p.attivo = 1
-                AND p.stato IN ('in_corso', 'in_ritardo', 'prenotato', 'da_ritirare')
+                WHERE p.copia_id = c.id
+                AND ( (p.attivo = 1 AND p.stato IN ('in_corso', 'in_ritardo', 'prenotato', 'da_ritirare'))
+                      OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )
             )
         ");
         $stmt->execute();

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -84,6 +84,23 @@ class MaintenanceService
             'errors' => []
         ];
 
+        // Expire FIRST (BUG8/D13 ordering): cull dead-period reservations and
+        // unclaimed pickups before activating scheduled loans, so a reservation
+        // whose window has already passed is never promoted to 'da_ritirare'.
+        try {
+            $results['expired_reservations'] = $this->checkExpiredReservations();
+        } catch (\Throwable $e) {
+            $results['errors'][] = 'checkExpiredReservations: ' . $e->getMessage();
+            SecureLogger::error(__('MaintenanceService errore prenotazioni scadute'), ['error' => $e->getMessage()]);
+        }
+
+        try {
+            $results['expired_pickups'] = $this->checkExpiredPickups();
+        } catch (\Throwable $e) {
+            $results['errors'][] = 'checkExpiredPickups: ' . $e->getMessage();
+            SecureLogger::error(__('MaintenanceService errore ritiri scaduti'), ['error' => $e->getMessage()]);
+        }
+
         try {
             $results['scheduled_loans_activated'] = $this->activateScheduledLoans();
         } catch (\Throwable $e) {
@@ -104,22 +121,6 @@ class MaintenanceService
         } catch (\Throwable $e) {
             $results['errors'][] = 'processScheduledReservations: ' . $e->getMessage();
             SecureLogger::error(__('MaintenanceService errore conversione prenotazioni'), ['error' => $e->getMessage()]);
-        }
-
-        // Check expired reservations (Case 4 from reservation plan)
-        try {
-            $results['expired_reservations'] = $this->checkExpiredReservations();
-        } catch (\Throwable $e) {
-            $results['errors'][] = 'checkExpiredReservations: ' . $e->getMessage();
-            SecureLogger::error(__('MaintenanceService errore prenotazioni scadute'), ['error' => $e->getMessage()]);
-        }
-
-        // Check expired pickups (da_ritirare with pickup_deadline passed)
-        try {
-            $results['expired_pickups'] = $this->checkExpiredPickups();
-        } catch (\Throwable $e) {
-            $results['errors'][] = 'checkExpiredPickups: ' . $e->getMessage();
-            SecureLogger::error(__('MaintenanceService errore ritiri scaduti'), ['error' => $e->getMessage()]);
         }
 
         try {
@@ -221,11 +222,14 @@ class MaintenanceService
      */
     public function activateScheduledLoans(): int
     {
-        // Find all scheduled loans that should be activated
+        // Find all scheduled loans that should be activated. data_scadenza >= today
+        // guard (BUG8/D13): never promote a reservation whose whole window is already
+        // past into 'da_ritirare' — its expiry cron culls it instead.
         $stmt = $this->db->prepare("
             SELECT id, copia_id, libro_id FROM prestiti
             WHERE stato = 'prenotato'
             AND data_prestito <= CURDATE()
+            AND data_scadenza >= CURDATE()
             AND attivo = 1
         ");
 
@@ -258,7 +262,7 @@ class MaintenanceService
                 $updateStmt = $this->db->prepare("
                     UPDATE prestiti
                     SET stato = 'da_ritirare', pickup_deadline = ?
-                    WHERE id = ? AND stato = 'prenotato'
+                    WHERE id = ? AND stato = 'prenotato' AND data_scadenza >= CURDATE()
                 ");
                 $updateStmt->bind_param('si', $pickupDeadline, $loan['id']);
                 $updateStmt->execute();
@@ -468,18 +472,25 @@ class MaintenanceService
                 // Build note suffix safely with bound parameter
                 $noteSuffix = "\n[System] " . __('Scaduta il') . ' ' . date('d/m/Y');
 
-                // Mark as expired
+                // Mark as expired. Re-assert stato='prenotato' + check affected_rows
+                // (D14): a concurrent confirmPickup/activateScheduledLoans may have
+                // advanced this row between the SELECT and here — don't stomp it.
                 $updateStmt = $this->db->prepare("
                     UPDATE prestiti
                     SET stato = 'scaduto',
                         attivo = 0,
                         updated_at = NOW(),
                         note = CONCAT(COALESCE(note, ''), ?)
-                    WHERE id = ?
+                    WHERE id = ? AND stato = 'prenotato' AND attivo = 1
                 ");
                 $updateStmt->bind_param('si', $noteSuffix, $id);
                 $updateStmt->execute();
+                $expiredAffected = $updateStmt->affected_rows;
                 $updateStmt->close();
+                if ($expiredAffected === 0) {
+                    $this->db->rollback();
+                    continue;
+                }
 
                 // If a copy was assigned, make it available (if currently 'prenotato')
                 if ($copiaId) {
@@ -502,6 +513,14 @@ class MaintenanceService
                     }
                 }
 
+                // Layer 2: promote queued waitlist reservations freed by this expiry
+                // (loop until none convert). Both queues on every release path (D5/BUG10).
+                $reservationManager = new \App\Controllers\ReservationManager($this->db);
+                $reservationManager->setExternalTransaction(true);
+                while ($reservationManager->processBookAvailability($libroId)) {
+                    // keep promoting while freed capacity converts the next queued reservation
+                }
+
                 // Recalculate book availability (inside transaction)
                 $integrity->recalculateBookAvailability($libroId, true);
 
@@ -514,6 +533,7 @@ class MaintenanceService
                 // transazione già committata).
                 try {
                     $reassignmentService->flushDeferredNotifications();
+                    $reservationManager->flushDeferredNotifications();
                 } catch (\Throwable $flushErr) {
                     \App\Support\SecureLogger::warning('Flush notifiche differite fallito', ['error' => $flushErr->getMessage()]);
                 }
@@ -647,6 +667,14 @@ class MaintenanceService
                     $reassignmentService->reassignOnReturn($copiaId);
                 }
 
+                // Layer 2: promote queued waitlist reservations freed by this expired
+                // pickup (loop until none convert). Both queues (D5/BUG10).
+                $reservationManager = new \App\Controllers\ReservationManager($this->db);
+                $reservationManager->setExternalTransaction(true);
+                while ($reservationManager->processBookAvailability($libroId)) {
+                    // keep promoting while freed capacity converts the next queued reservation
+                }
+
                 // Recalculate book availability (inside transaction)
                 $integrity->recalculateBookAvailability($libroId, true);
 
@@ -659,6 +687,7 @@ class MaintenanceService
                 // transazione già committata).
                 try {
                     $reassignmentService->flushDeferredNotifications();
+                    $reservationManager->flushDeferredNotifications();
                 } catch (\Throwable $flushErr) {
                     \App\Support\SecureLogger::warning('Flush notifiche differite fallito', ['error' => $flushErr->getMessage()]);
                 }

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -517,7 +517,7 @@ class MaintenanceService
                 // (loop until none convert). Both queues on every release path (D5/BUG10).
                 $reservationManager = new \App\Controllers\ReservationManager($this->db);
                 $reservationManager->setExternalTransaction(true);
-                while ($reservationManager->processBookAvailability($libroId)) {
+                for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
                     // keep promoting while freed capacity converts the next queued reservation
                 }
 
@@ -671,7 +671,7 @@ class MaintenanceService
                 // pickup (loop until none convert). Both queues (D5/BUG10).
                 $reservationManager = new \App\Controllers\ReservationManager($this->db);
                 $reservationManager->setExternalTransaction(true);
-                while ($reservationManager->processBookAvailability($libroId)) {
+                for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
                     // keep promoting while freed capacity converts the next queued reservation
                 }
 

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -2067,6 +2067,11 @@ class Updater
                 'executed' => $migrationResult['executed']
             ]);
 
+            // Some migrations (e.g. 0.7.20 loan-state cleanup) change occupancy by
+            // rewriting prestiti rows directly; re-derive copie.stato and the
+            // libri.copie_disponibili/stato display caches so they stay consistent.
+            $this->recalculateAfterMigrations();
+
             // Fix file permissions
             $this->debugLog('INFO', 'Fix permessi file');
             $this->fixPermissions();
@@ -2850,6 +2855,25 @@ class Updater
      * missing TRIGGER privilege only logs a warning; the same overlap rules are
      * enforced at the application layer.
      */
+    /**
+     * Re-derive availability caches after migrations that rewrite prestiti rows
+     * (e.g. the 0.7.20 loan-state cleanup flips attivo/stato directly, which a
+     * bare UPDATE cannot reflect into copie.stato / libri.copie_disponibili).
+     * Idempotent and non-fatal — a recalc failure must not abort the upgrade.
+     */
+    private function recalculateAfterMigrations(): void
+    {
+        try {
+            $integrity = new \App\Support\DataIntegrity($this->db);
+            $integrity->recalculateAllBookAvailability();
+            $this->debugLog('INFO', 'Recalcolo disponibilità post-migrazione completato');
+        } catch (\Throwable $e) {
+            $this->debugLog('WARNING', 'Recalcolo disponibilità post-migrazione non riuscito (non fatale)', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
     private function reapplyTriggers(): void
     {
         $triggersFile = $this->rootPath . '/installer/database/triggers.sql';

--- a/app/Views/prenotazioni/crea_prenotazione.php
+++ b/app/Views/prenotazioni/crea_prenotazione.php
@@ -71,6 +71,18 @@
                     </div>
                 </div>
             </div>
+        <?php elseif ($error === 'capacity_full'): ?>
+            <div class="mb-8 p-6 bg-red-50 border border-red-200 text-red-700 rounded-xl shadow-sm" role="alert">
+                <div class="flex items-center">
+                    <div class="w-8 h-8 bg-red-100 rounded-full flex items-center justify-center mr-4">
+                        <i class="fas fa-exclamation-triangle text-red-600"></i>
+                    </div>
+                    <div>
+                        <h3 class="font-semibold"><?= __("Nessuna disponibilità nel periodo") ?></h3>
+                        <p class="text-sm mt-1"><?= __("Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.") ?></p>
+                    </div>
+                </div>
+            </div>
         <?php endif; ?>
 
         <!-- Form -->

--- a/app/Views/prestiti/modifica_prestito.php
+++ b/app/Views/prestiti/modifica_prestito.php
@@ -36,7 +36,7 @@ $csrf = Csrf::ensureToken();
     <form method="post" action="<?= htmlspecialchars(url('/admin/loans/update/' . (int)($prestito['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
         <input type="hidden" name="utente_id" value="<?= (int)($prestito['utente_id'] ?? 0); ?>">
-        <input type="hidden" name="libro_id" value="<?= (int)($prestito['libro_id'] ?? 0); ?>">
+        <?php /* libro_id è display-only: NON inviato — cambiarlo scollegherebbe la copia dal libro (I7). */ ?>
 
         <div class="grid gap-5 md:grid-cols-2">
             <div class="rounded-lg border border-gray-200 bg-gray-50 p-5">

--- a/app/Views/prestiti/restituito_prestito.php
+++ b/app/Views/prestiti/restituito_prestito.php
@@ -142,9 +142,10 @@ $csrfToken = Csrf::ensureToken();
                         class="rounded-lg border-2 border-gray-300 bg-white px-4 py-3 text-gray-900 font-medium focus:border-gray-900 focus:outline-none"
                     >
                         <?php
+                        // Il ritardo NON è una scelta: è derivato automaticamente dalla
+                        // scadenza (restituito + restituito_in_ritardo=1 se oltre termine, I4).
                         $options = [
-                            'restituito'   => __('Restituito regolarmente'),
-                            'in_ritardo'   => __('Restituito in ritardo'),
+                            'restituito'   => __('Restituito'),
                             'perso'        => __('Perso'),
                             'danneggiato'  => __('Danneggiato'),
                         ];

--- a/installer/database/migrations/migrate_0.7.20.sql
+++ b/installer/database/migrations/migrate_0.7.20.sql
@@ -1,0 +1,72 @@
+-- Migration 0.7.20 — loan/reservation state-model unification (fix/loan-state-bugs)
+--
+-- Wires the dead `restituito_in_ritardo` column (added to schema.sql) and cleans
+-- up historical rows that violate the canonical state invariants:
+--   I1  CLOSED  ⇒ attivo=0
+--   I4  in_ritardo ⇒ attivo=1 ALWAYS (a returned-late loan is restituito + flag, never in_ritardo)
+--   I8  stato='completato' is forbidden (success = restituito)
+--
+-- NOTE: the loan-integrity triggers (incl. the new I7 copy/book guard) are NOT
+-- shipped here — the updater re-applies installer/database/triggers.sql with its
+-- DELIMITER-aware splitter after migrations (Updater::reapplyTriggers), so
+-- upgraded installs pick up the trigger change automatically.
+--
+-- Every statement is idempotent / re-runnable.
+
+-- ─── 1A. restituito_in_ritardo column (fresh installs already have it via
+--         schema.sql; upgraded installs do not). information_schema-guarded so
+--         it is portable across MySQL 8 (no ADD COLUMN IF NOT EXISTS) and MariaDB.
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prestiti' AND COLUMN_NAME = 'restituito_in_ritardo');
+SET @sql = IF(@col_exists = 0,
+    "ALTER TABLE `prestiti` ADD COLUMN `restituito_in_ritardo` tinyint(1) NOT NULL DEFAULT 0 AFTER `data_restituzione`",
+    "SELECT 1");
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- ─── 1B. Backfill the returned-late flag from historical returns.
+UPDATE `prestiti`
+   SET `restituito_in_ritardo` = 1
+ WHERE `stato` = 'restituito'
+   AND `data_restituzione` IS NOT NULL
+   AND `data_scadenza` IS NOT NULL
+   AND `data_restituzione` > `data_scadenza`
+   AND `restituito_in_ritardo` = 0;
+
+-- ─── 1C. Normalize the legacy "returned late" overload: rows closed as
+--         stato='in_ritardo' with attivo=0 become restituito + flag (I4).
+UPDATE `prestiti`
+   SET `restituito_in_ritardo` = 1,
+       `stato` = 'restituito'
+ WHERE `attivo` = 0
+   AND `stato` = 'in_ritardo';
+
+-- ─── 1D. Normalize any invalid stato (e.g. 'completato' written by the old
+--         CopyController bug, or '' coerced on non-strict installs) for closed rows (I8).
+UPDATE `prestiti`
+   SET `stato` = 'restituito',
+       `data_restituzione` = COALESCE(`data_restituzione`, CURDATE())
+ WHERE `attivo` = 0
+   AND `stato` NOT IN ('pendente','prenotato','da_ritirare','in_corso','restituito',
+                       'in_ritardo','perso','danneggiato','annullato','scaduto');
+
+-- ─── 1E. Resurrected returns: closed loans wrongly left attivo=1 (I1 / BUG1).
+--         Discriminator: data_restituzione present but attivo still 1.
+UPDATE `prestiti`
+   SET `attivo` = 0,
+       `stato`  = CASE WHEN `stato` IN ('restituito','perso','danneggiato','annullato','scaduto')
+                       THEN `stato` ELSE 'restituito' END
+ WHERE `data_restituzione` IS NOT NULL
+   AND `attivo` = 1;
+
+-- ─── 1F. Dead-period holds stuck 'prenotato' whose whole window is already past
+--         (BUG8): mark scaduto + inactive so they stop occupying capacity.
+UPDATE `prestiti`
+   SET `stato` = 'scaduto',
+       `attivo` = 0
+ WHERE `attivo` = 1
+   AND `stato` = 'prenotato'
+   AND `data_scadenza` < CURDATE();
+
+-- NOTE: steps 1E/1F change occupancy. The updater runs a full availability
+-- recalc after migrations (Updater::recalculateAfterMigrations) so copie.stato
+-- and libri.copie_disponibili/stato are re-derived for every affected book.

--- a/installer/database/migrations/migrate_0.7.20.sql
+++ b/installer/database/migrations/migrate_0.7.20.sql
@@ -1,21 +1,59 @@
--- Migration 0.7.20 — loan/reservation state-model unification (fix/loan-state-bugs)
+-- Migration 0.7.20 — consolidated release migration
+--
+-- This single file carries ALL schema/data changes shipped in 0.7.20, from two
+-- independent work streams that both target this release:
+--   A) Issue #163 — author photo + relevant source/website links (autori columns)
+--   B) fix/loan-state-bugs — loan/reservation state-model unification
+--
+-- One file per release version is mandatory: the updater runs a migration iff its
+-- version is > the installed version AND <= the target version, so every 0.7.20
+-- change must live here (CLAUDE.md rule 6). Every statement is idempotent.
+--
+-- NOTE (section B): the loan-integrity triggers (incl. the I7 copy/book guard) are
+-- NOT shipped here — the updater re-applies installer/database/triggers.sql with
+-- its DELIMITER-aware splitter after migrations (Updater::reapplyTriggers), so
+-- upgraded installs pick up the trigger change automatically.
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- SECTION A — Issue #163: author photo + relevant source/website links
+-- ═══════════════════════════════════════════════════════════════════════
+--
+-- Adds two nullable columns to `autori`:
+--   foto         — author photo: an uploaded file path (/uploads/autori/...) OR
+--                  an external image URL.
+--   collegamenti — JSON array of relevant sources/websites, each entry
+--                  { "etichetta": "<label>", "url": "<https url>" }.
+-- Idempotent: each ALTER is guarded by an information_schema check.
+
+-- ─── autori.foto ─────────────────────────────────────────────────────
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'autori' AND COLUMN_NAME = 'foto');
+SET @sql = IF(@col_exists = 0,
+    "ALTER TABLE `autori` ADD COLUMN `foto` VARCHAR(500) NULL AFTER `sito_web`",
+    "SELECT 1");
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- ─── autori.collegamenti ─────────────────────────────────────────────
+SET @col_exists = (SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'autori' AND COLUMN_NAME = 'collegamenti');
+SET @sql = IF(@col_exists = 0,
+    "ALTER TABLE `autori` ADD COLUMN `collegamenti` JSON NULL AFTER `foto`",
+    "SELECT 1");
+PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- SECTION B — fix/loan-state-bugs: loan/reservation state-model unification
+-- ═══════════════════════════════════════════════════════════════════════
 --
 -- Wires the dead `restituito_in_ritardo` column (added to schema.sql) and cleans
 -- up historical rows that violate the canonical state invariants:
 --   I1  CLOSED  ⇒ attivo=0
 --   I4  in_ritardo ⇒ attivo=1 ALWAYS (a returned-late loan is restituito + flag, never in_ritardo)
 --   I8  stato='completato' is forbidden (success = restituito)
---
--- NOTE: the loan-integrity triggers (incl. the new I7 copy/book guard) are NOT
--- shipped here — the updater re-applies installer/database/triggers.sql with its
--- DELIMITER-aware splitter after migrations (Updater::reapplyTriggers), so
--- upgraded installs pick up the trigger change automatically.
---
--- Every statement is idempotent / re-runnable.
 
--- ─── 1A. restituito_in_ritardo column (fresh installs already have it via
---         schema.sql; upgraded installs do not). information_schema-guarded so
---         it is portable across MySQL 8 (no ADD COLUMN IF NOT EXISTS) and MariaDB.
+-- ─── B1A. restituito_in_ritardo column (fresh installs already have it via
+--          schema.sql; upgraded installs do not). information_schema-guarded so
+--          it is portable across MySQL 8 (no ADD COLUMN IF NOT EXISTS) and MariaDB.
 SET @col_exists = (SELECT COUNT(*) FROM information_schema.COLUMNS
     WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'prestiti' AND COLUMN_NAME = 'restituito_in_ritardo');
 SET @sql = IF(@col_exists = 0,
@@ -23,7 +61,7 @@ SET @sql = IF(@col_exists = 0,
     "SELECT 1");
 PREPARE _s FROM @sql; EXECUTE _s; DEALLOCATE PREPARE _s;
 
--- ─── 1B. Backfill the returned-late flag from historical returns.
+-- ─── B1B. Backfill the returned-late flag from historical returns.
 UPDATE `prestiti`
    SET `restituito_in_ritardo` = 1
  WHERE `stato` = 'restituito'
@@ -32,16 +70,16 @@ UPDATE `prestiti`
    AND `data_restituzione` > `data_scadenza`
    AND `restituito_in_ritardo` = 0;
 
--- ─── 1C. Normalize the legacy "returned late" overload: rows closed as
---         stato='in_ritardo' with attivo=0 become restituito + flag (I4).
+-- ─── B1C. Normalize the legacy "returned late" overload: rows closed as
+--          stato='in_ritardo' with attivo=0 become restituito + flag (I4).
 UPDATE `prestiti`
    SET `restituito_in_ritardo` = 1,
        `stato` = 'restituito'
  WHERE `attivo` = 0
    AND `stato` = 'in_ritardo';
 
--- ─── 1D. Normalize any invalid stato (e.g. 'completato' written by the old
---         CopyController bug, or '' coerced on non-strict installs) for closed rows (I8).
+-- ─── B1D. Normalize any invalid stato (e.g. 'completato' written by the old
+--          CopyController bug, or '' coerced on non-strict installs) for closed rows (I8).
 UPDATE `prestiti`
    SET `stato` = 'restituito',
        `data_restituzione` = COALESCE(`data_restituzione`, CURDATE())
@@ -49,8 +87,8 @@ UPDATE `prestiti`
    AND `stato` NOT IN ('pendente','prenotato','da_ritirare','in_corso','restituito',
                        'in_ritardo','perso','danneggiato','annullato','scaduto');
 
--- ─── 1E. Resurrected returns: closed loans wrongly left attivo=1 (I1 / BUG1).
---         Discriminator: data_restituzione present but attivo still 1.
+-- ─── B1E. Resurrected returns: closed loans wrongly left attivo=1 (I1 / BUG1).
+--          Discriminator: data_restituzione present but attivo still 1.
 UPDATE `prestiti`
    SET `attivo` = 0,
        `stato`  = CASE WHEN `stato` IN ('restituito','perso','danneggiato','annullato','scaduto')
@@ -58,8 +96,8 @@ UPDATE `prestiti`
  WHERE `data_restituzione` IS NOT NULL
    AND `attivo` = 1;
 
--- ─── 1F. Dead-period holds stuck 'prenotato' whose whole window is already past
---         (BUG8): mark scaduto + inactive so they stop occupying capacity.
+-- ─── B1F. Dead-period holds stuck 'prenotato' whose whole window is already past
+--          (BUG8): mark scaduto + inactive so they stop occupying capacity.
 UPDATE `prestiti`
    SET `stato` = 'scaduto',
        `attivo` = 0
@@ -67,6 +105,6 @@ UPDATE `prestiti`
    AND `stato` = 'prenotato'
    AND `data_scadenza` < CURDATE();
 
--- NOTE: steps 1E/1F change occupancy. The updater runs a full availability
--- recalc after migrations (Updater::recalculateAfterMigrations) so copie.stato
--- and libri.copie_disponibili/stato are re-derived for every affected book.
+-- NOTE (section B): steps B1E/B1F change occupancy. The updater runs a full
+-- availability recalc after migrations (Updater::recalculateAfterMigrations) so
+-- copie.stato and libri.copie_disponibili/stato are re-derived for every book.

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -817,6 +817,7 @@ CREATE TABLE `prestiti` (
   `data_scadenza` date NOT NULL,
   `pickup_deadline` date DEFAULT NULL,
   `data_restituzione` date DEFAULT NULL,
+  `restituito_in_ritardo` tinyint(1) NOT NULL DEFAULT '0',
   `stato` enum('pendente','prenotato','da_ritirare','in_corso','restituito','in_ritardo','perso','danneggiato','annullato','scaduto') COLLATE utf8mb4_unicode_ci DEFAULT 'pendente',
   `origine` enum('richiesta','prenotazione','diretto','ncip') COLLATE utf8mb4_unicode_ci DEFAULT 'richiesta',
   `ncip_request_id` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/installer/database/triggers.sql
+++ b/installer/database/triggers.sql
@@ -10,6 +10,14 @@ CREATE TRIGGER `trg_check_active_prestito_before_insert`
 BEFORE INSERT ON `prestiti`
 FOR EACH ROW
 BEGIN
+    -- I7: la copia di un prestito deve appartenere al libro del prestito stesso
+    -- (vale anche per righe chiuse: previene il decoupling libro_id/copia_id, #fix/loan-state-bugs BUG2).
+    IF NEW.copia_id IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM copie WHERE id = NEW.copia_id AND libro_id = NEW.libro_id) THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'La copia non appartiene al libro del prestito.';
+    END IF;
+
     -- #157 model A-refined: a copy is "held" by an active loan OR by a
     -- reservation-conversion 'pendente' that already carries a copia_id.
     IF (NEW.copia_id IS NOT NULL AND (NEW.attivo = 1 OR NEW.stato = 'pendente')) THEN
@@ -52,6 +60,14 @@ CREATE TRIGGER `trg_check_active_prestito_before_update`
 BEFORE UPDATE ON `prestiti`
 FOR EACH ROW
 BEGIN
+    -- I7: la copia di un prestito deve appartenere al libro del prestito stesso
+    -- (vale anche per righe chiuse: previene il decoupling libro_id/copia_id, #fix/loan-state-bugs BUG2).
+    IF NEW.copia_id IS NOT NULL
+       AND NOT EXISTS (SELECT 1 FROM copie WHERE id = NEW.copia_id AND libro_id = NEW.libro_id) THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'La copia non appartiene al libro del prestito.';
+    END IF;
+
     -- Solo se si sta assegnando/cambiando una copia a un prestito attivo
     -- #157 model A-refined: a copy is "held" by an active loan OR by a
     -- reservation-conversion 'pendente' that already carries a copia_id.

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5278,5 +5278,6 @@
   "Ripristino in corso. Riprova tra qualche minuto.": "Wiederherstellung läuft. Bitte versuchen Sie es in einigen Minuten erneut.",
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup zu groß für PHP-Import: Installieren Sie den mysql-Client oder erhöhen Sie memory_limit",
   "Nessuna disponibilità nel periodo": "Keine Verfügbarkeit im Zeitraum",
-  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Alle Exemplare sind im gewünschten Zeitraum bereits vergeben (Ausleihen oder Vormerkungen). Wählen Sie einen anderen Zeitraum."
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Alle Exemplare sind im gewünschten Zeitraum bereits vergeben (Ausleihen oder Vormerkungen). Wählen Sie einen anderen Zeitraum.",
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "Das zugewiesene Exemplar ist nicht ausleihbar. Weisen Sie das Exemplar neu zu oder brechen Sie die Abholung ab."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5276,5 +5276,7 @@
   "Archivio di backup non valido: dimensione decompressa eccessiva": "Ungültiges Backup-Archiv: entpackte Größe zu groß",
   "Un ripristino o aggiornamento è già in corso. Riprova tra poco.": "Eine Wiederherstellung oder ein Update läuft bereits. Bitte versuchen Sie es in Kürze erneut.",
   "Ripristino in corso. Riprova tra qualche minuto.": "Wiederherstellung läuft. Bitte versuchen Sie es in einigen Minuten erneut.",
-  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup zu groß für PHP-Import: Installieren Sie den mysql-Client oder erhöhen Sie memory_limit"
+  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup zu groß für PHP-Import: Installieren Sie den mysql-Client oder erhöhen Sie memory_limit",
+  "Nessuna disponibilità nel periodo": "Keine Verfügbarkeit im Zeitraum",
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Alle Exemplare sind im gewünschten Zeitraum bereits vergeben (Ausleihen oder Vormerkungen). Wählen Sie einen anderen Zeitraum."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5279,5 +5279,8 @@
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup zu groß für PHP-Import: Installieren Sie den mysql-Client oder erhöhen Sie memory_limit",
   "Nessuna disponibilità nel periodo": "Keine Verfügbarkeit im Zeitraum",
   "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Alle Exemplare sind im gewünschten Zeitraum bereits vergeben (Ausleihen oder Vormerkungen). Wählen Sie einen anderen Zeitraum.",
-  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "Das zugewiesene Exemplar ist nicht ausleihbar. Weisen Sie das Exemplar neu zu oder brechen Sie die Abholung ab."
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "Das zugewiesene Exemplar ist nicht ausleihbar. Weisen Sie das Exemplar neu zu oder brechen Sie die Abholung ab.",
+  "Il prestito associato non è più chiudibile. Ricarica la pagina.": "Die zugehörige Ausleihe kann nicht mehr geschlossen werden. Laden Sie die Seite neu.",
+  "Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.": "Ein Exemplar, das aktuell durch eine Ausleihe oder Vormerkung gebunden ist, kann nicht gelöscht werden.",
+  "Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su \"Disponibile\".": "Ein Exemplar, das aktuell durch eine Ausleihe oder Vormerkung gebunden ist, kann nicht geändert werden. Geben Sie es zuerst frei (Ausleihe schließen oder stornieren) oder setzen Sie es auf \"Verfügbar\"."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5276,5 +5276,7 @@
   "Archivio di backup non valido: dimensione decompressa eccessiva": "Invalid backup archive: uncompressed size too large",
   "Un ripristino o aggiornamento è già in corso. Riprova tra poco.": "A restore or update is already in progress. Please try again shortly.",
   "Ripristino in corso. Riprova tra qualche minuto.": "Restore in progress. Please try again in a few minutes.",
-  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup too large for PHP import: install the mysql client or increase memory_limit"
+  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup too large for PHP import: install the mysql client or increase memory_limit",
+  "Nessuna disponibilità nel periodo": "No availability for this period",
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "All copies are already committed (loans or reservations) for the requested period. Choose another period."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5278,5 +5278,6 @@
   "Ripristino in corso. Riprova tra qualche minuto.": "Restore in progress. Please try again in a few minutes.",
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup too large for PHP import: install the mysql client or increase memory_limit",
   "Nessuna disponibilità nel periodo": "No availability for this period",
-  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "All copies are already committed (loans or reservations) for the requested period. Choose another period."
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "All copies are already committed (loans or reservations) for the requested period. Choose another period.",
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "The assigned copy is not lendable. Reassign the copy or cancel the pickup."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5279,5 +5279,8 @@
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup too large for PHP import: install the mysql client or increase memory_limit",
   "Nessuna disponibilità nel periodo": "No availability for this period",
   "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "All copies are already committed (loans or reservations) for the requested period. Choose another period.",
-  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "The assigned copy is not lendable. Reassign the copy or cancel the pickup."
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "The assigned copy is not lendable. Reassign the copy or cancel the pickup.",
+  "Il prestito associato non è più chiudibile. Ricarica la pagina.": "The associated loan can no longer be closed. Reload the page.",
+  "Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.": "Cannot delete a copy currently committed to a loan or reservation.",
+  "Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su \"Disponibile\".": "Cannot modify a copy currently committed to a loan or reservation. First release it (close or cancel the loan) or set it to \"Available\"."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5279,5 +5279,8 @@
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Sauvegarde trop volumineuse pour l'import PHP : installez le client mysql ou augmentez memory_limit",
   "Nessuna disponibilità nel periodo": "Aucune disponibilité pour cette période",
   "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tous les exemplaires sont déjà engagés (prêts ou réservations) pour la période demandée. Choisissez une autre période.",
-  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "L'exemplaire attribué n'est pas empruntable. Réattribuez l'exemplaire ou annulez le retrait."
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "L'exemplaire attribué n'est pas empruntable. Réattribuez l'exemplaire ou annulez le retrait.",
+  "Il prestito associato non è più chiudibile. Ricarica la pagina.": "Le prêt associé ne peut plus être clôturé. Rechargez la page.",
+  "Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.": "Impossible de supprimer un exemplaire actuellement engagé dans un prêt ou une réservation.",
+  "Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su \"Disponibile\".": "Impossible de modifier un exemplaire actuellement engagé dans un prêt ou une réservation. Libérez-le d'abord (clôturez ou annulez le prêt) ou définissez-le sur « Disponible »."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5278,5 +5278,6 @@
   "Ripristino in corso. Riprova tra qualche minuto.": "Restauration en cours. Réessayez dans quelques minutes.",
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Sauvegarde trop volumineuse pour l'import PHP : installez le client mysql ou augmentez memory_limit",
   "Nessuna disponibilità nel periodo": "Aucune disponibilité pour cette période",
-  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tous les exemplaires sont déjà engagés (prêts ou réservations) pour la période demandée. Choisissez une autre période."
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tous les exemplaires sont déjà engagés (prêts ou réservations) pour la période demandée. Choisissez une autre période.",
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "L'exemplaire attribué n'est pas empruntable. Réattribuez l'exemplaire ou annulez le retrait."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5276,5 +5276,7 @@
   "Archivio di backup non valido: dimensione decompressa eccessiva": "Archive de sauvegarde non valide : taille décompressée excessive",
   "Un ripristino o aggiornamento è già in corso. Riprova tra poco.": "Une restauration ou une mise à jour est déjà en cours. Réessayez dans un instant.",
   "Ripristino in corso. Riprova tra qualche minuto.": "Restauration en cours. Réessayez dans quelques minutes.",
-  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Sauvegarde trop volumineuse pour l'import PHP : installez le client mysql ou augmentez memory_limit"
+  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Sauvegarde trop volumineuse pour l'import PHP : installez le client mysql ou augmentez memory_limit",
+  "Nessuna disponibilità nel periodo": "Aucune disponibilité pour cette période",
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tous les exemplaires sont déjà engagés (prêts ou réservations) pour la période demandée. Choisissez une autre période."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5278,5 +5278,6 @@
   "Ripristino in corso. Riprova tra qualche minuto.": "Ripristino in corso. Riprova tra qualche minuto.",
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit",
   "Nessuna disponibilità nel periodo": "Nessuna disponibilità nel periodo",
-  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo."
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.",
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5279,5 +5279,8 @@
   "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit",
   "Nessuna disponibilità nel periodo": "Nessuna disponibilità nel periodo",
   "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.",
-  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro."
+  "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.": "La copia assegnata non è prestabile. Riassegna la copia o annulla il ritiro.",
+  "Il prestito associato non è più chiudibile. Ricarica la pagina.": "Il prestito associato non è più chiudibile. Ricarica la pagina.",
+  "Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.": "Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.",
+  "Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su \"Disponibile\".": "Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su \"Disponibile\"."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5276,5 +5276,7 @@
   "Archivio di backup non valido: dimensione decompressa eccessiva": "Archivio di backup non valido: dimensione decompressa eccessiva",
   "Un ripristino o aggiornamento è già in corso. Riprova tra poco.": "Un ripristino o aggiornamento è già in corso. Riprova tra poco.",
   "Ripristino in corso. Riprova tra qualche minuto.": "Ripristino in corso. Riprova tra qualche minuto.",
-  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit"
+  "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit": "Backup troppo grande per l'importazione PHP: installa il client mysql o aumenta memory_limit",
+  "Nessuna disponibilità nel periodo": "Nessuna disponibilità nel periodo",
+  "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo.": "Tutte le copie sono già impegnate (prestiti o prenotazioni) per il periodo richiesto. Scegli un altro periodo."
 }

--- a/tests/loan-state-model.spec.js
+++ b/tests/loan-state-model.spec.js
@@ -16,7 +16,7 @@ const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
 const DB_USER = process.env.E2E_DB_USER || '', DB_PASS = process.env.E2E_DB_PASS || '';
 const DB_SOCKET = process.env.E2E_DB_SOCKET || '', DB_HOST = process.env.E2E_DB_HOST || '';
 const DB_PORT = process.env.E2E_DB_PORT || '', DB_NAME = process.env.E2E_DB_NAME || '';
-test.skip(!ADMIN_EMAIL || !DB_USER || !DB_NAME, 'creds not configured');
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME, 'creds not configured');
 
 function dbQuery(sql){
   const args=[]; if(DB_HOST){args.push('-h',DB_HOST); if(DB_PORT)args.push('-P',DB_PORT);} else if(DB_SOCKET){args.push('-S',DB_SOCKET);}
@@ -25,7 +25,11 @@ function dbQuery(sql){
   try{ return execFileSync('mysql',[`--defaults-extra-file=${cnf}`,...args],{encoding:'utf-8',timeout:10000}).trim(); } finally { try{fs.unlinkSync(cnf);}catch{} }
 }
 const q1 = (sql) => dbQuery(sql).split('\n')[0].trim();
-const addDays = (n) => { const d = new Date(); d.setDate(d.getDate()+n); return d.toISOString().slice(0,10); };
+const addDays = (n) => {
+  const d = new Date(); d.setDate(d.getDate()+n);
+  // Local Y-m-d (not toISOString/UTC) so dates don't slip ±1 near local midnight.
+  return d.getFullYear() + '-' + String(d.getMonth()+1).padStart(2,'0') + '-' + String(d.getDate()).padStart(2,'0');
+};
 
 test.describe('canonical loan/reservation state model', () => {
   /** @type {import('@playwright/test').Page} */

--- a/tests/loan-state-model.spec.js
+++ b/tests/loan-state-model.spec.js
@@ -1,0 +1,181 @@
+// @ts-check
+// Canonical loan/reservation state-model verification (fix/loan-state-bugs).
+// Asserts the NEW behaviours not covered by loan-reservation.spec.js:
+//   BUG1  — editing a returned loan must NOT reactivate it (I1)
+//   BUG5  — a late return sets restituito_in_ritardo=1, never stato='in_ritardo'+attivo=0
+//   BUG10 — the waitlist occupies its promised period: an overlapping admin
+//           reservation on a full book is rejected; a disjoint one succeeds
+//   Invariant sweep — the canonical invariants hold across the whole DB
+const { test, expect } = require('@playwright/test');
+test.describe.configure({ mode: 'serial' });
+const { execFileSync } = require('child_process');
+const fs = require('fs'); const os = require('os'); const path = require('path');
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_USER = process.env.E2E_DB_USER || '', DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '', DB_HOST = process.env.E2E_DB_HOST || '';
+const DB_PORT = process.env.E2E_DB_PORT || '', DB_NAME = process.env.E2E_DB_NAME || '';
+test.skip(!ADMIN_EMAIL || !DB_USER || !DB_NAME, 'creds not configured');
+
+function dbQuery(sql){
+  const args=[]; if(DB_HOST){args.push('-h',DB_HOST); if(DB_PORT)args.push('-P',DB_PORT);} else if(DB_SOCKET){args.push('-S',DB_SOCKET);}
+  args.push('-u',DB_USER,DB_NAME,'-N','-B','-e',sql);
+  const cnf=path.join(os.tmpdir(),`pk-lsm-${process.pid}.cnf`); fs.writeFileSync(cnf,`[client]\npassword="${DB_PASS}"\n`,{mode:0o600});
+  try{ return execFileSync('mysql',[`--defaults-extra-file=${cnf}`,...args],{encoding:'utf-8',timeout:10000}).trim(); } finally { try{fs.unlinkSync(cnf);}catch{} }
+}
+const q1 = (sql) => dbQuery(sql).split('\n')[0].trim();
+const esc = (s) => String(s).replace(/'/g, "''");
+const addDays = (n) => { const d = new Date(); d.setDate(d.getDate()+n); return d.toISOString().slice(0,10); };
+
+test.describe('canonical loan/reservation state model', () => {
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  let bookId = 0, copyId = 0, userA = 0, userB = 0;
+  const tag = `LSM${Date.now()}`;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    await page.goto(`${BASE}/accedi`);
+    await page.fill('input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.locator('button[type="submit"]').click();
+    await page.waitForURL((u) => !u.toString().includes('/accedi'), { timeout: 15000 });
+
+    // 1-copy book + two borrowers, created directly for a deterministic fixture.
+    dbQuery(`INSERT INTO libri (titolo, created_at, updated_at) VALUES ('${tag} Book', NOW(), NOW())`);
+    bookId = parseInt(q1(`SELECT id FROM libri WHERE titolo='${tag} Book' ORDER BY id DESC LIMIT 1`), 10);
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at, updated_at) VALUES (${bookId}, '${tag}-INV1', 'disponibile', NOW(), NOW())`);
+    copyId = parseInt(q1(`SELECT id FROM copie WHERE libro_id=${bookId} ORDER BY id DESC LIMIT 1`), 10);
+    for (const s of ['A', 'B']) {
+      const em = `${tag.toLowerCase()}_${s}@test.local`;
+      dbQuery(`INSERT INTO utenti (nome, cognome, email, password, codice_tessera, tipo_utente, created_at, updated_at) VALUES ('${tag}${s}', 'Test', '${em}', 'x', '${tag}${s}', 'standard', NOW(), NOW())`);
+      const id = parseInt(q1(`SELECT id FROM utenti WHERE email='${em}' LIMIT 1`), 10);
+      if (s === 'A') userA = id; else userB = id;
+    }
+    dbQuery(`UPDATE libri SET copie_totali=1, copie_disponibili=1 WHERE id=${bookId}`);
+    expect(bookId).toBeGreaterThan(0); expect(copyId).toBeGreaterThan(0);
+    expect(userA).toBeGreaterThan(0); expect(userB).toBeGreaterThan(0);
+  });
+
+  test.afterAll(async () => {
+    if (bookId) {
+      try { dbQuery(`DELETE FROM prestiti WHERE libro_id=${bookId}`); } catch {}
+      try { dbQuery(`DELETE FROM prenotazioni WHERE libro_id=${bookId}`); } catch {}
+      try { dbQuery(`DELETE FROM copie WHERE libro_id=${bookId}`); } catch {}
+      try { dbQuery(`DELETE FROM libri WHERE id=${bookId}`); } catch {}
+    }
+    if (userA) try { dbQuery(`DELETE FROM utenti WHERE id IN (${userA}, ${userB})`); } catch {}
+    await page?.close();
+  });
+
+  async function csrfFrom(urlPath) {
+    return await page.evaluate(async (p) => {
+      const r = await fetch(p, { credentials: 'same-origin' });
+      const html = await r.text();
+      const m = html.match(/name="csrf_token"\s+value="([^"]+)"/);
+      return m ? m[1] : '';
+    }, urlPath);
+  }
+  async function postForm(urlPath, fields) {
+    // Follow the redirect (manual mode yields an unreadable opaque-redirect with
+    // status 0) and report the final URL, which carries the ?error=... code.
+    return await page.evaluate(async ({ p, f }) => {
+      const r = await fetch(p, {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(f).toString(), redirect: 'follow',
+      });
+      return { status: r.status, url: r.url };
+    }, { p: urlPath, f: fields });
+  }
+  async function postJson(urlPath, obj, csrf) {
+    return await page.evaluate(async ({ p, o, c }) => {
+      const r = await fetch(p, {
+        method: 'POST', credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': c },
+        body: JSON.stringify(o), redirect: 'follow',
+      });
+      let body = {}; try { body = await r.json(); } catch {}
+      return { status: r.status, body };
+    }, { p: urlPath, o: obj, c: csrf });
+  }
+
+  test('BUG1 — editing a returned loan does not reactivate it', async () => {
+    // A returned loan: attivo=0, restituito, data_restituzione set, copy of the book.
+    dbQuery(`INSERT INTO prestiti (libro_id, utente_id, copia_id, data_prestito, data_scadenza, data_restituzione, stato, attivo, created_at)
+             VALUES (${bookId}, ${userA}, ${copyId}, '${addDays(-20)}', '${addDays(-6)}', '${addDays(-6)}', 'restituito', 0, NOW())`);
+    const loanId = parseInt(q1(`SELECT id FROM prestiti WHERE libro_id=${bookId} AND stato='restituito' ORDER BY id DESC LIMIT 1`), 10);
+    // CSRF token is session-global; fetch from a page that always renders a form
+    // (the loan edit page 404s for a closed loan, yielding no token).
+    const csrf = await csrfFrom('/admin/reservations/create');
+    const res = await postForm(`/admin/loans/update/${loanId}`, {
+      csrf_token: csrf, utente_id: String(userA), data_prestito: addDays(-3), data_scadenza: addDays(11),
+    });
+    // Rejected as a closed loan; the row stays closed.
+    expect(res.url).toContain('error=loan_closed');
+    const row = dbQuery(`SELECT attivo, IFNULL(data_restituzione,''), stato FROM prestiti WHERE id=${loanId}`).split('\t');
+    expect(row[0]).toBe('0');           // still inactive
+    expect(row[1]).not.toBe('');        // data_restituzione preserved
+    expect(row[2]).toBe('restituito');  // still returned
+    dbQuery(`DELETE FROM prestiti WHERE id=${loanId}`);
+  });
+
+  test('BUG5 — a late return sets restituito_in_ritardo=1', async () => {
+    dbQuery(`UPDATE copie SET stato='prestato' WHERE id=${copyId}`);
+    dbQuery(`INSERT INTO prestiti (libro_id, utente_id, copia_id, data_prestito, data_scadenza, stato, attivo, created_at)
+             VALUES (${bookId}, ${userA}, ${copyId}, '${addDays(-30)}', '${addDays(-3)}', 'in_corso', 1, NOW())`);
+    const loanId = parseInt(q1(`SELECT id FROM prestiti WHERE libro_id=${bookId} AND stato='in_corso' ORDER BY id DESC LIMIT 1`), 10);
+    const csrf = await csrfFrom('/admin/reservations/create');
+    const res = await postJson('/admin/loans/return', { loan_id: loanId }, csrf);
+    expect(res.status).toBe(200);
+    const row = dbQuery(`SELECT stato, attivo, restituito_in_ritardo FROM prestiti WHERE id=${loanId}`).split('\t');
+    expect(row[0]).toBe('restituito');
+    expect(row[1]).toBe('0');
+    expect(row[2]).toBe('1'); // flagged late, NOT left as stato='in_ritardo'
+    dbQuery(`DELETE FROM prestiti WHERE id=${loanId}`);
+    dbQuery(`UPDATE copie SET stato='disponibile' WHERE id=${copyId}`);
+  });
+
+  test('BUG10 — the waitlist occupies its period: overlapping admin reservation rejected, disjoint allowed', async () => {
+    const startA = addDays(5), endA = addDays(10);
+    const csrf1 = await csrfFrom('/admin/reservations/create');
+    const r1 = await postForm('/admin/reservations/create', {
+      csrf_token: csrf1, libro_id: String(bookId), utente_id: String(userA),
+      data_prenotazione: startA, data_scadenza: endA,
+      data_inizio_richiesta: startA, data_fine_richiesta: endA,
+    });
+    const resCount = parseInt(q1(`SELECT COUNT(*) FROM prenotazioni WHERE libro_id=${bookId} AND utente_id=${userA} AND stato='attiva'`), 10);
+    expect(resCount).toBe(1); // first reservation created
+
+    // user B, overlapping window → must be rejected (book has only 1 copy, fully occupied for the period)
+    const csrf2 = await csrfFrom('/admin/reservations/create');
+    const r2 = await postForm('/admin/reservations/create', {
+      csrf_token: csrf2, libro_id: String(bookId), utente_id: String(userB),
+      data_prenotazione: addDays(6), data_scadenza: addDays(9),
+      data_inizio_richiesta: addDays(6), data_fine_richiesta: addDays(9),
+    });
+    expect(r2.url).toContain('error=capacity_full');
+    const overlapCount = parseInt(q1(`SELECT COUNT(*) FROM prenotazioni WHERE libro_id=${bookId} AND utente_id=${userB} AND stato='attiva'`), 10);
+    expect(overlapCount).toBe(0); // overlapping reservation NOT created
+
+    // user B, disjoint window → allowed
+    const csrf3 = await csrfFrom('/admin/reservations/create');
+    const r3 = await postForm('/admin/reservations/create', {
+      csrf_token: csrf3, libro_id: String(bookId), utente_id: String(userB),
+      data_prenotazione: addDays(40), data_scadenza: addDays(45),
+      data_inizio_richiesta: addDays(40), data_fine_richiesta: addDays(45),
+    });
+    const disjointCount = parseInt(q1(`SELECT COUNT(*) FROM prenotazioni WHERE libro_id=${bookId} AND utente_id=${userB} AND stato='attiva'`), 10);
+    expect(disjointCount).toBe(1); // disjoint reservation created
+    dbQuery(`DELETE FROM prenotazioni WHERE libro_id=${bookId}`);
+  });
+
+  test('Invariant sweep — canonical invariants hold across the whole DB', async () => {
+    expect(q1(`SELECT COUNT(*) FROM prestiti WHERE stato='completato'`)).toBe('0');                                   // I8
+    expect(q1(`SELECT COUNT(*) FROM prestiti WHERE attivo=0 AND stato='in_ritardo'`)).toBe('0');                       // I4
+    expect(q1(`SELECT COUNT(*) FROM prestiti WHERE attivo=1 AND data_restituzione IS NOT NULL`)).toBe('0');            // I1 / BUG1
+    expect(q1(`SELECT COUNT(*) FROM prestiti WHERE stato IN ('restituito','perso','danneggiato','annullato','scaduto') AND attivo=1`)).toBe('0'); // I1
+    expect(q1(`SELECT COUNT(*) FROM prestiti p WHERE p.copia_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM copie c WHERE c.id=p.copia_id AND c.libro_id=p.libro_id)`)).toBe('0'); // I7
+  });
+});

--- a/tests/loan-state-model.spec.js
+++ b/tests/loan-state-model.spec.js
@@ -25,7 +25,6 @@ function dbQuery(sql){
   try{ return execFileSync('mysql',[`--defaults-extra-file=${cnf}`,...args],{encoding:'utf-8',timeout:10000}).trim(); } finally { try{fs.unlinkSync(cnf);}catch{} }
 }
 const q1 = (sql) => dbQuery(sql).split('\n')[0].trim();
-const esc = (s) => String(s).replace(/'/g, "''");
 const addDays = (n) => { const d = new Date(); d.setDate(d.getDate()+n); return d.toISOString().slice(0,10); };
 
 test.describe('canonical loan/reservation state model', () => {
@@ -140,7 +139,7 @@ test.describe('canonical loan/reservation state model', () => {
   test('BUG10 — the waitlist occupies its period: overlapping admin reservation rejected, disjoint allowed', async () => {
     const startA = addDays(5), endA = addDays(10);
     const csrf1 = await csrfFrom('/admin/reservations/create');
-    const r1 = await postForm('/admin/reservations/create', {
+    await postForm('/admin/reservations/create', {
       csrf_token: csrf1, libro_id: String(bookId), utente_id: String(userA),
       data_prenotazione: startA, data_scadenza: endA,
       data_inizio_richiesta: startA, data_fine_richiesta: endA,
@@ -161,7 +160,7 @@ test.describe('canonical loan/reservation state model', () => {
 
     // user B, disjoint window → allowed
     const csrf3 = await csrfFrom('/admin/reservations/create');
-    const r3 = await postForm('/admin/reservations/create', {
+    await postForm('/admin/reservations/create', {
       csrf_token: csrf3, libro_id: String(bookId), utente_id: String(userB),
       data_prenotazione: addDays(40), data_scadenza: addDays(45),
       data_inizio_richiesta: addDays(40), data_fine_richiesta: addDays(45),

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Sintesi

Unifica il modello di stato di prestiti/prenotazioni attorno a un'unica regola canonica di occupazione e corregge i 10 bug di stato segnalati. Decisione centrale: **una prenotazione in lista d'attesa (`prenotazioni`, `stato='attiva'`) occupa una unità di capacità per il suo periodo promesso `[data_inizio_richiesta, R_END]`**, conteggiata fino a `copie_totali`. Una richiesta nuda (`prestiti pendente`, senza copia) resta non vincolante e non occupa.

## Modello canonico (due livelli, mai mischiati)

- **Layer 1 — per-copia (HOLDING)**: `(attivo=1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')) OR (attivo=0 AND stato='pendente' AND copia_id IS NOT NULL)`. Enforced dai trigger DB e dagli allocatori per-copia.
- **Layer 2 — capacità libro (OCC)**: prestiti HOLDING + prenotazioni attive, picco giornaliero su `[s,e]`, libero sse `OCC < copie_totali`. Unico predicato in `CapacityService`, riusato da gate di promozione, gate admin e auditor.

## Bug risolti

| Bug | Fix |
|-----|-----|
| 1 | Modificare un prestito restituito non lo riattiva più (`LoanRepository::update` tocca solo i campi editabili; controller rifiuta i prestiti chiusi) |
| 2 | `libro_id` non più modificabile (no decoupling copia/libro); trigger I7 a livello DB |
| 3 | `CopyController` chiude come `restituito` (mai l'invalido `completato`), con lock + flag ritardo |
| 4 | `processReturn` con lock + state-guard + null-safe `copia_id` |
| 5 | Rientro tardivo → `restituito` + `restituito_in_ritardo=1` (mai `in_ritardo`+`attivo=0`); flag su tutti i path di rientro |
| 6 | `reassignOnNewCopy` non strappa più prenotazioni correttamente parcheggiate; check overlap sulla copia target |
| 7 | `reassignOnCopyLost` gestisce `da_ritirare` + ricerca copia consapevole del periodo; `confirmPickup` fail-closed su copia non prestabile |
| 8 | `activateScheduledLoans` non attiva periodi morti; `runAll` espira prima di attivare |
| 9 | Recalc conta il holder `pendente+copia`; fix doppia sottrazione alla conversione |
| 10 | **La waitlist occupa il periodo**: gate promozione/admin + auditor via `CapacityService`; promozione di entrambe le code su ogni path di rilascio |

## Fondazione e hardening

- Nuovo `app/Services/CapacityService.php` (unica autorità OCC, sweep-line per-day peak)
- Trigger I7 (la copia deve appartenere al libro del prestito) — ri-applicato su upgrade da `Updater::reapplyTriggers`
- `migrate_0.7.20.sql` consolidata (sezione A colonne autori #163 + sezione B cleanup stato prestiti), idempotente
- Recalc disponibilità post-migrazione (`Updater::recalculateAfterMigrations`)
- Hardening cron (D13/D14): guard `data_scadenza >= oggi`, riordino expiry/activate, `affected_rows` su expiry concorrenti
- `version.json → 0.7.20` (migration ≤ release version)

## Verifica

- **PHPStan L5** pulito su tutti i file modificati
- **E2E**: `loan-reservation.spec.js` 21/21 (zero regressioni) + nuovo `loan-state-model.spec.js` 4/4 (BUG1 / BUG5 / BUG10-decisione / invariant sweep su tutto il DB)
- Migration verificata idempotente sul DB di sviluppo; trigger I7 attivi
- i18n: ogni nuova stringa user-facing tradotta in tutti e 4 i locale (it/en/de/fr)

## Coordinamento release

`migrate_0.7.20.sql` è **identica** anche su `feature/163` (#170): i due branch condividono la stessa migration 0.7.20, quindi il merge è pulito in qualsiasi ordine. Tagliare la release 0.7.20 solo dopo che **entrambi** i branch sono in `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aggiunto controllo di capacità disponibile durante la creazione e modifica di prenotazioni con messaggi di errore specifici.
  * Migliorato l'algoritmo di promozione automatica della lista d'attesa per le prenotazioni.

* **Bug Fixes**
  * Corretti gli stati dei prestiti al momento della restituzione con tracciamento automatico dei ritardi.
  * Risolti problemi di race condition nelle operazioni di aggiornamento copie e prestiti.
  * Migliorata la validazione per evitare operazioni inconsistenti su prestiti chiusi.

* **Documentation & Localization**
  * Aggiunte nuove traduzioni per messaggi di errore di capacità.
  * Aggiornate viste e form per fornire feedback utente migliorato.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->