### PR TITLE
fix(updater): fail-closed patch error handling + redirect-safe releases fetch

### DIFF
--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -999,7 +999,11 @@ class Updater
             $ch = curl_init($url);
             curl_setopt_array($ch, [
                 CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_FOLLOWLOCATION => true,
+                // Do not follow redirects on this authenticated API call (api.github.com
+                // does not legitimately redirect); a 3xx is rejected as failure below,
+                // matching makeGitHubRequest()'s fail-closed redirect stance.
+                CURLOPT_FOLLOWLOCATION => false,
+                CURLOPT_MAXREDIRS => 0,
                 CURLOPT_TIMEOUT => 30,
                 CURLOPT_CONNECTTIMEOUT => 10,
                 CURLOPT_USERAGENT => 'Pinakes-Updater/1.0',
@@ -1012,7 +1016,7 @@ class Updater
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             curl_close($ch);
 
-            if ($curlResult !== false && $httpCode >= 200 && $httpCode < 400) {
+            if ($curlResult !== false && $httpCode >= 200 && $httpCode < 300) {
                 $response = $curlResult;
             } elseif (in_array($httpCode, [401, 403], true) && $this->githubToken !== '') {
                 // Retry without token on auth failure
@@ -1021,7 +1025,8 @@ class Updater
                 $ch2 = curl_init($url);
                 curl_setopt_array($ch2, [
                     CURLOPT_RETURNTRANSFER => true,
-                    CURLOPT_FOLLOWLOCATION => true,
+                    CURLOPT_FOLLOWLOCATION => false,
+                    CURLOPT_MAXREDIRS => 0,
                     CURLOPT_TIMEOUT => 30,
                     CURLOPT_CONNECTTIMEOUT => 10,
                     CURLOPT_USERAGENT => 'Pinakes-Updater/1.0',
@@ -1032,7 +1037,7 @@ class Updater
                 $retryResult = curl_exec($ch2);
                 $retryCode = curl_getinfo($ch2, CURLINFO_HTTP_CODE);
                 curl_close($ch2);
-                if ($retryResult !== false && $retryCode >= 200 && $retryCode < 400) {
+                if ($retryResult !== false && $retryCode >= 200 && $retryCode < 300) {
                     $response = $retryResult;
                 }
             }
@@ -3982,7 +3987,11 @@ class Updater
             }
 
             if (file_put_contents($tempPatchFile, $patchContent) === false) {
-                $this->debugLog('ERROR', 'Impossibile salvare patch temporanea');
+                // The patch is PRESENT and digest-verified; if we can't even stage
+                // it we must NOT install without it — fail closed (nothing committed
+                // yet, the caller aborts and the user retries).
+                $this->debugLog('ERROR', 'Impossibile salvare pre-update patch temporanea → fail-closed');
+                $result['success'] = false;
                 return $result;
             }
 
@@ -3992,7 +4001,9 @@ class Updater
             @unlink($tempPatchFile);
 
             if (!is_array($patchDefinition)) {
-                $this->debugLog('WARNING', 'Patch definition non valida (non è un array)');
+                // Present, verified patch whose definition is malformed — fail closed.
+                $this->debugLog('ERROR', 'Pre-update patch definition non valida (non è un array) → fail-closed');
+                $result['success'] = false;
                 return $result;
             }
 
@@ -4044,12 +4055,14 @@ class Updater
             ]);
 
         } catch (\Throwable $e) {
-            // Don't fail the entire update if patch fails
+            // A present, digest-verified pre-update patch that errors mid-apply must
+            // NOT let the install proceed half-patched — fail closed (nothing is
+            // committed yet, so the caller aborts and the user retries cleanly).
             $this->debugLog('ERROR', 'Errore durante pre-update-patch', [
                 'exception' => get_class($e),
                 'message' => $e->getMessage()
             ]);
-            // Still return success=true to allow update to continue
+            $result['success'] = false;
             $result['error'] = $e->getMessage();
         }
 
@@ -4352,11 +4365,14 @@ class Updater
             ]);
 
         } catch (\Throwable $e) {
-            // Don't fail if post-install patch fails - update is already done
+            // The core update is already committed, so this is NON-FATAL — but it
+            // must surface as a warning at the caller (success=false → warning
+            // branch), not be hidden as "no patch applied".
             $this->debugLog('ERROR', 'Errore durante post-install-patch', [
                 'exception' => get_class($e),
                 'message' => $e->getMessage()
             ]);
+            $result['success'] = false;
             $result['error'] = $e->getMessage();
         }
 

--- a/tests/updater-hardening.unit.php
+++ b/tests/updater-hardening.unit.php
@@ -223,6 +223,24 @@ $check(preg_match('/statusCode\s*>=\s*300\s*&&\s*\$statusCode\s*<\s*400/s', $src
 // token-retry) must also pin follow_location => 0 so the bearer is never resent.
 $check(substr_count($src, "'follow_location' => 0") >= 3,
     'authenticated file_get_contents fallback paths also disable redirect follow');
+// 14b. fetchReleasesRaw's cURL branch (primary + token-retry) is fail-closed on
+//      redirects too — FOLLOWLOCATION=false on both. (The asset-DOWNLOAD paths keep
+//      FOLLOWLOCATION=true on purpose: they must follow github.com→CDN, and stay
+//      token-safe via isApiUrl()/anonymous headers.)
+$check(substr_count($src, 'CURLOPT_FOLLOWLOCATION => false') >= 2,
+    'fetchReleasesRaw cURL branch disables redirect auto-follow (primary + retry)');
+
+// 15. Patch error handling is fail-closed where nothing is committed yet:
+//     a present, verified pre-update patch that errors mid-apply sets success=false
+//     (the caller aborts) — the old "Still return success=true" fail-open is gone.
+$check(strpos($src, 'Still return success=true to allow update to continue') === false,
+    'pre-update patch no longer fails open on a mid-apply error');
+$check(preg_match('/Errore durante pre-update-patch.*?\$result\[\x27success\x27\]\s*=\s*false/s', $src) === 1,
+    'pre-update patch catch is fail-closed (success=false)');
+// post-install: the core update is already committed, so a runtime error is a
+// non-fatal warning — but it must set success=false so it is not hidden.
+$check(preg_match('/Errore durante post-install-patch.*?\$result\[\x27success\x27\]\s*=\s*false/s', $src) === 1,
+    'post-install patch catch surfaces errors (success=false), not hidden as "no patch"');
 
 // ---------------------------------------------------------------------------
 echo "\n" . ($failed === 0


### PR DESCRIPTION
Follow-up to the PR #172 review. Each finding verified against current code; only still-valid ones fixed.

## Fixed
- **`applyPreUpdatePatch` fail-open → fail-closed.** A present, digest-verified pre-update patch that failed to stage (`file_put_contents`), parsed to a non-array, or threw mid-apply used to return `success=true`, letting the install proceed half/un-patched. Now `success=false` (the caller aborts; nothing committed yet). Consistent with the existing `invalid` handling.
- **`applyPostInstallPatch` catch surfaces errors.** A runtime exception set only `$error` but left `success=true`, hiding it as “no patch applied”. Now `success=false`, so it surfaces through the caller’s **non-fatal warning** branch (core update is already done → stays a warning).
- **`fetchReleasesRaw` cURL branch redirect-safe.** Primary + token-retry contexts now pin `FOLLOWLOCATION=false` / `MAXREDIRS=0` and gate success to 2xx, matching `makeGitHubRequest`. (Token was already protected by `UNRESTRICTED_AUTH=false`; this is defense-in-depth/consistency. Asset-download paths keep `FOLLOWLOCATION=true` on purpose — github.com→CDN.)

## Skipped (with reason)
- Locale digest keys (it/en/de/fr), sidecar guard removal, digest full-hex regex, scrape-hooks `false→null` — **already addressed** in earlier commits.
- create-release.sh “draft-safe STEP 9 / cleanup” — **false positive**: `gh release view <tag>` (CLI) resolves drafts by tag_name (the 0.7.20 release passed those steps as a draft). Only the REST `/releases/tags` endpoint 404s on drafts, which is exactly why STEP 9.5 uses the API list.

## Validation
PHPStan L5 clean · `updater-hardening` unit **37/37** (+4 new fail-closed assertions) · all `tests/*.unit.php` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Note di Rilascio

* **Bug Fixes**
  * Migliorata la robustezza del sistema di aggiornamento con gestione più rigorosa dei codici di risposta della API
  * Rafforzata la gestione degli errori durante il processo di aggiornamento per bloccare operazioni non sicure
  * Garantito il fallimento controllato delle operazioni di patching in caso di problemi

* **Tests**
  * Aggiunti test di sicurezza per verificare il comportamento del sistema di aggiornamento

<!-- end of auto-generated comment: release notes by coderabbit.ai -->