### PR TITLE
fix(covers): trust Internet Archive + any public CDN on redirect (#173)

### DIFF
--- a/app/Controllers/CoverController.php
+++ b/app/Controllers/CoverController.php
@@ -299,8 +299,14 @@ class CoverController
         }
 
         $host = strtolower($parts['host']);
-        if (!in_array($host, self::ALLOWED_DOMAINS, true)) {
-            throw new \RuntimeException('Dominio non autorizzato per il download');
+
+        // Issue #173: the exact-host allow-list kept blocking legitimate covers whose
+        // CDN host is dynamic (covers.openlibrary.org 302s to archive.org /
+        // iaNNNNNN.us.archive.org). We trust any public HTTPS host here; the real SSRF
+        // boundary is assertPublicDns() below, which rejects private/reserved IPs (and
+        // is re-checked on every redirect hop by downloadCover()).
+        if ($host === '') {
+            throw new \RuntimeException('URL malformato');
         }
 
         $this->assertPublicDns($host);
@@ -441,41 +447,9 @@ class CoverController
         }
     }
 
-    private const ALLOWED_DOMAINS = [
-        // Google Books
-        'images.google.com',
-        'books.google.com',
-        'books.google.it',
-        'books.google.co.uk',
-
-        // OpenLibrary
-        'covers.openlibrary.org',
-
-        // Italian bookstores
-        'www.libreriauniversitaria.it',
-        'img.libreriauniversitaria.it',
-        'img2.libreriauniversitaria.it',
-        'img3.libreriauniversitaria.it',
-        'www.ibs.it',
-        'images.ibs.it',
-        'www.lafeltrinelli.it',
-        'www.ubiklibri.it',
-        'ubiklibri.it',
-        'cdn.mondadoristore.it',
-
-        // Amazon CDN
-        'images-na.ssl-images-amazon.com',
-        'images-eu.ssl-images-amazon.com',
-        'm.media-amazon.com',
-        'images-amazon.com',
-
-        // Goodreads
-        'd.gr-assets.com',
-        'i.gr-assets.com',
-        's.gr-assets.com',
-
-        // Other bookstores
-        'prodimage.images-bn.com',
-        'cdn-images.bookshop.org'
-    ];
+    // NOTE (issue #173): the previous exact-host ALLOWED_DOMAINS list was removed.
+    // It blocked legitimate covers whose CDN host is dynamic (covers.openlibrary.org
+    // 302s to archive.org / iaNNNNNN.us.archive.org). Cover fetches now accept any
+    // public HTTPS host; SSRF is bounded by assertPublicDns() (private/reserved IPs
+    // rejected) and re-checked on every redirect hop in downloadCover().
 }

--- a/app/Controllers/CoverController.php
+++ b/app/Controllers/CoverController.php
@@ -285,7 +285,9 @@ class CoverController
     }
 
     /**
-     * Ensure the URL uses HTTPS, belongs to the whitelist and resolves to public IPs.
+     * Ensure the URL uses HTTPS and resolves to public IPs only. The host allow-list
+     * was removed (issue #173); the boundary is assertPublicDns() + per-hop IP pinning
+     * in downloadCover(), which is what actually prevents reaching internal services.
      */
     private function assertUrlAllowed(string $url): string
     {
@@ -325,11 +327,22 @@ class CoverController
         for ($redirects = 0; $redirects <= 3; $redirects++) {
             $this->assertUrlAllowed($currentUrl);
 
+            // Pin the connection to the validated public IP: assertPublicDns() resolves
+            // and validates, but cURL would re-resolve on connect — a DNS rebind in
+            // between could reach a different (internal) address. CURLOPT_RESOLVE stops
+            // that by forcing cURL to use the exact IP we just checked, per hop.
+            $pinHost = strtolower((string) (parse_url($currentUrl, PHP_URL_HOST) ?? ''));
+            $pinIp = \App\Support\SsrfGuard::resolvePinnedIp($pinHost);
+            if ($pinIp === null) {
+                throw new \RuntimeException('Host non risolvibile a un IP pubblico');
+            }
+
             $ch = curl_init($currentUrl);
             curl_setopt_array($ch, [
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_HEADER => true,
                 CURLOPT_FOLLOWLOCATION => false,
+                CURLOPT_RESOLVE => ["$pinHost:443:$pinIp", "$pinHost:80:$pinIp"],
                 CURLOPT_TIMEOUT => 20,
                 CURLOPT_CONNECTTIMEOUT => 10,
                 CURLOPT_SSL_VERIFYPEER => true,
@@ -434,14 +447,14 @@ class CoverController
         }
 
         foreach ($ips as $ip) {
-            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            if (!\App\Support\SsrfGuard::isPublicIp($ip)) {
                 throw new \RuntimeException('IP privato non consentito');
             }
         }
 
         foreach ($aaaaRecords as $record) {
             $ipv6 = $record['ipv6'] ?? null;
-            if ($ipv6 && filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            if ($ipv6 && !\App\Support\SsrfGuard::isPublicIp((string) $ipv6)) {
                 throw new \RuntimeException('IP privato non consentito');
             }
         }

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -51,11 +51,11 @@ class LibriController
      * private/reserved-IP check, the image-content validation and the size cap below.
      */
     private const COVER_ALLOWED_SUFFIXES = [
-        '.archive.org', '.us.archive.org',
+        '.archive.org',
         '.openlibrary.org',
         '.googleusercontent.com', '.ggpht.com', '.gstatic.com', '.googleapis.com', '.google.com',
         '.ssl-images-amazon.com', '.media-amazon.com', '.images-amazon.com', '.amazonaws.com',
-        '.cloudfront.net', '.akamaized.net', '.akamaihd.net', '.fastly.net', '.cloudflare.net',
+        '.cloudfront.net', '.akamaized.net', '.akamaihd.net', '.fastly.net', '.cloudflare.com',
         '.cloudinary.com', '.imgix.net', '.wikimedia.org',
         '.gr-assets.com', '.images-bn.com', '.bookshop.org',
         '.libreriauniversitaria.it', '.mondadoristore.it', '.lafeltrinelli.it', '.ibs.it', '.ubiklibri.it',
@@ -184,133 +184,18 @@ class LibriController
         }
 
         try {
-            // First, check file size via HEAD request to avoid downloading huge files
-            $ch = curl_init($url);
-            curl_setopt_array($ch, [
-                CURLOPT_NOBODY => true,
-                CURLOPT_FOLLOWLOCATION => true,
-                CURLOPT_MAXREDIRS => 3,
-                CURLOPT_TIMEOUT => 10,
-                CURLOPT_CONNECTTIMEOUT => 5,
-                CURLOPT_SSL_VERIFYPEER => true,
-                CURLOPT_SSL_VERIFYHOST => 2,
-                CURLOPT_USERAGENT => 'BibliotecaCoverBot/1.0',
-            ]);
-            if (defined('CURLOPT_PROTOCOLS_STR')) {
-                curl_setopt($ch, CURLOPT_PROTOCOLS_STR, 'https,http');
-                curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS_STR, 'https,http');
-            } else {
-                curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
-                curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
+            // SSRF-safe fetch: redirects are followed MANUALLY, each hop's host is
+            // resolved to a validated PUBLIC IP and pinned via CURLOPT_RESOLVE, with a
+            // size cap and image validation (App\Support\SsrfGuard). This is what lets
+            // the cover allow-list stay wide (issue #173) without an SSRF: a wide host
+            // can still never make the server reach an internal/reserved IP, on any hop.
+            $fetched = \App\Support\SsrfGuard::fetchImage($url, self::MAX_COVER_SIZE);
+            if ($fetched === null) {
+                \App\Support\SecureLogger::warning('Cover not saved locally: SSRF-safe fetch blocked or failed', ['url' => $url]);
+                return $url; // keep the original URL when we cannot safely localise it
             }
-            curl_exec($ch);
-            $effectiveUrl = (string) curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-            $effectiveHost = strtolower((string) (parse_url($effectiveUrl, PHP_URL_HOST) ?? ''));
-            $primaryIp = (string) curl_getinfo($ch, CURLINFO_PRIMARY_IP);
-            $contentLength = (int) curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
-            curl_close($ch);
+            [$imageData, $mimeType] = $fetched;
 
-            // Redirect target: a cover origin may legitimately 302 to any public CDN
-            // (e.g. covers.openlibrary.org → archive.org / *.us.archive.org, issue
-            // #173). We do NOT gate the redirect host on the allow-list anymore — the
-            // SSRF boundary is the private/reserved-IP check below, which is what
-            // actually stops the server reaching internal services.
-            if ($effectiveHost === '') {
-                \App\Support\SecureLogger::warning('Cover download blocked: empty redirect host', [
-                    'url' => $url,
-                    'effective_url' => $effectiveUrl,
-                ]);
-                return $url;
-            }
-
-            // SSRF protection: block private/reserved IP ranges after redirect resolution
-            if ($primaryIp !== '' && filter_var($primaryIp, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
-                \App\Support\SecureLogger::warning('Cover download blocked: private IP after redirect', [
-                    'url' => $url,
-                    'resolved_ip' => $primaryIp
-                ]);
-                return $url;
-            }
-
-            // Check size limit before downloading (if Content-Length is provided)
-            if ($contentLength > self::MAX_COVER_SIZE) {
-                \App\Support\SecureLogger::warning('Cover too large (HEAD check)', [
-                    'url' => $url,
-                    'size' => $contentLength,
-                    'max' => self::MAX_COVER_SIZE
-                ]);
-                return $url;
-            }
-
-            // Download the image
-            $ch = curl_init($url);
-            curl_setopt_array($ch, [
-                CURLOPT_RETURNTRANSFER => true,
-                CURLOPT_FOLLOWLOCATION => true,
-                CURLOPT_MAXREDIRS => 3,
-                CURLOPT_TIMEOUT => 20,
-                CURLOPT_CONNECTTIMEOUT => 10,
-                CURLOPT_SSL_VERIFYPEER => true,
-                CURLOPT_SSL_VERIFYHOST => 2,
-                CURLOPT_USERAGENT => 'BibliotecaCoverBot/1.0',
-            ]);
-            if (defined('CURLOPT_PROTOCOLS_STR')) {
-                curl_setopt($ch, CURLOPT_PROTOCOLS_STR, 'https,http');
-                curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS_STR, 'https,http');
-            } else {
-                curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
-                curl_setopt($ch, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
-            }
-
-            $imageData = curl_exec($ch);
-            $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            $effectiveUrl = (string) curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
-            $effectiveHost = strtolower((string) (parse_url($effectiveUrl, PHP_URL_HOST) ?? ''));
-            $primaryIp = (string) curl_getinfo($ch, CURLINFO_PRIMARY_IP);
-            curl_close($ch);
-
-            // Redirect target: any public host is allowed (see HEAD branch above,
-            // issue #173). The private/reserved-IP check below is the SSRF boundary.
-            if ($effectiveHost === '') {
-                \App\Support\SecureLogger::warning('Cover GET blocked: empty redirect host', [
-                    'url' => $url,
-                    'effective_url' => $effectiveUrl,
-                ]);
-                return $url;
-            }
-
-            // SSRF protection: block private/reserved IP ranges after redirect resolution
-            if ($primaryIp !== '' && filter_var($primaryIp, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
-                \App\Support\SecureLogger::warning('Cover GET blocked: private IP after redirect', [
-                    'url' => $url,
-                    'resolved_ip' => $primaryIp
-                ]);
-                return $url;
-            }
-
-            if ($imageData === false || $httpCode !== 200 || \strlen($imageData) < 100) {
-                \App\Support\SecureLogger::warning('Cover download failed', ['url' => $url, 'http_code' => $httpCode]);
-                return $url; // Return original URL on download failure
-            }
-
-            // Verify size after download (in case Content-Length was not provided or wrong)
-            if (\strlen($imageData) > self::MAX_COVER_SIZE) {
-                \App\Support\SecureLogger::warning('Cover too large (POST check)', [
-                    'url' => $url,
-                    'size' => \strlen($imageData),
-                    'max' => self::MAX_COVER_SIZE
-                ]);
-                return $url;
-            }
-
-            // Validate image
-            $imageInfo = @getimagesizefromstring($imageData);
-            if ($imageInfo === false) {
-                \App\Support\SecureLogger::warning('Invalid image data', ['url' => $url]);
-                return $url;
-            }
-
-            $mimeType = $imageInfo['mime'];
             $extension = match ($mimeType) {
                 'image/jpeg', 'image/jpg' => 'jpg',
                 'image/png' => 'png',

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -39,7 +39,48 @@ class LibriController
         // Ubik Libri
         'www.ubiklibri.it',
         'ubiklibri.it',
+        // Internet Archive — covers.openlibrary.org 302-redirects here (issue #173)
+        'archive.org',
     ];
+
+    /**
+     * Wide suffix allow-list for cover hosts (issue #173). Exact-host matching kept
+     * blocking legitimate sources whose CDN host is dynamic — most notably
+     * covers.openlibrary.org, which 302s to archive.org / iaNNNNNN.us.archive.org.
+     * These suffixes cover the major book-cover CDNs. SSRF is still bounded by the
+     * private/reserved-IP check, the image-content validation and the size cap below.
+     */
+    private const COVER_ALLOWED_SUFFIXES = [
+        '.archive.org', '.us.archive.org',
+        '.openlibrary.org',
+        '.googleusercontent.com', '.ggpht.com', '.gstatic.com', '.googleapis.com', '.google.com',
+        '.ssl-images-amazon.com', '.media-amazon.com', '.images-amazon.com', '.amazonaws.com',
+        '.cloudfront.net', '.akamaized.net', '.akamaihd.net', '.fastly.net', '.cloudflare.net',
+        '.cloudinary.com', '.imgix.net', '.wikimedia.org',
+        '.gr-assets.com', '.images-bn.com', '.bookshop.org',
+        '.libreriauniversitaria.it', '.mondadoristore.it', '.lafeltrinelli.it', '.ibs.it', '.ubiklibri.it',
+    ];
+
+    /**
+     * Whether a host may be fetched as a cover source: exact match in
+     * COVER_ALLOWED_DOMAINS, or ends with one of the wide COVER_ALLOWED_SUFFIXES.
+     */
+    private static function coverHostAllowed(string $host): bool
+    {
+        if ($host === '') {
+            return false;
+        }
+        $host = strtolower($host);
+        if (\in_array($host, self::COVER_ALLOWED_DOMAINS, true)) {
+            return true;
+        }
+        foreach (self::COVER_ALLOWED_SUFFIXES as $suffix) {
+            if (str_ends_with($host, $suffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
     /**
      * Maximum file size for cover downloads (5MB)
@@ -135,8 +176,9 @@ class LibriController
         $parsedUrl = parse_url($url);
         $host = strtolower($parsedUrl['host'] ?? '');
 
-        // Use centralized whitelist
-        if (!\in_array($host, self::COVER_ALLOWED_DOMAINS, true)) {
+        // Initial host: wide cover allow-list (exact + suffix). The real SSRF
+        // boundary is the public-IP check after each request, not this list.
+        if (!self::coverHostAllowed($host)) {
             \App\Support\SecureLogger::warning('Cover download from non-whitelisted domain', ['url' => $url, 'host' => $host]);
             return $url; // Return original URL if domain not allowed
         }
@@ -168,12 +210,15 @@ class LibriController
             $contentLength = (int) curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
             curl_close($ch);
 
-            // SSRF protection: block redirects to non-whitelisted hosts
-            if ($effectiveHost === '' || !\in_array($effectiveHost, self::COVER_ALLOWED_DOMAINS, true)) {
-                \App\Support\SecureLogger::warning('Cover download blocked: redirected to non-whitelisted host', [
+            // Redirect target: a cover origin may legitimately 302 to any public CDN
+            // (e.g. covers.openlibrary.org → archive.org / *.us.archive.org, issue
+            // #173). We do NOT gate the redirect host on the allow-list anymore — the
+            // SSRF boundary is the private/reserved-IP check below, which is what
+            // actually stops the server reaching internal services.
+            if ($effectiveHost === '') {
+                \App\Support\SecureLogger::warning('Cover download blocked: empty redirect host', [
                     'url' => $url,
                     'effective_url' => $effectiveUrl,
-                    'effective_host' => $effectiveHost,
                 ]);
                 return $url;
             }
@@ -224,12 +269,12 @@ class LibriController
             $primaryIp = (string) curl_getinfo($ch, CURLINFO_PRIMARY_IP);
             curl_close($ch);
 
-            // SSRF protection: block redirects to non-whitelisted hosts
-            if ($effectiveHost === '' || !\in_array($effectiveHost, self::COVER_ALLOWED_DOMAINS, true)) {
-                \App\Support\SecureLogger::warning('Cover GET blocked: redirected to non-whitelisted host', [
+            // Redirect target: any public host is allowed (see HEAD branch above,
+            // issue #173). The private/reserved-IP check below is the SSRF boundary.
+            if ($effectiveHost === '') {
+                \App\Support\SecureLogger::warning('Cover GET blocked: empty redirect host', [
                     'url' => $url,
                     'effective_url' => $effectiveUrl,
-                    'effective_host' => $effectiveHost,
                 ]);
                 return $url;
             }
@@ -2393,7 +2438,7 @@ class LibriController
             return false;
         }
 
-        return \in_array($host, self::COVER_ALLOWED_DOMAINS, true);
+        return self::coverHostAllowed(strtolower($host));
     }
 
     /**

--- a/app/Support/SsrfGuard.php
+++ b/app/Support/SsrfGuard.php
@@ -1,0 +1,165 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * SSRF-safe remote image fetcher (issue #173 hardening).
+ *
+ * The cover allow-list is intentionally WIDE (any public host) — so the real
+ * boundary is the IP layer, and it must be airtight:
+ *   - every redirect hop is followed MANUALLY (CURLOPT_FOLLOWLOCATION is off) so
+ *     each target host can be validated before the request is issued;
+ *   - the host is resolved and ALL of its A/AAAA records must be public — if any
+ *     resolves to a private/reserved/NAT64/IPv4-mapped address the fetch aborts;
+ *   - the connection is PINNED to the validated IP via CURLOPT_RESOLVE, so a DNS
+ *     rebind between the check and the connect cannot reach a different address.
+ */
+final class SsrfGuard
+{
+    /**
+     * True only for a genuinely public IP. Beyond the standard private/reserved
+     * filter this also rejects IPv4-mapped IPv6 (::ffff:a.b.c.d) and NAT64
+     * (64:ff9b::/96) which embed an IPv4 address the base filter does not re-check
+     * (e.g. 64:ff9b::a00:1 == 10.0.0.1, ::ffff:127.0.0.1 == loopback).
+     */
+    public static function isPublicIp(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return false;
+        }
+
+        $packed = @inet_pton($ip);
+        if ($packed !== false && strlen($packed) === 16) {
+            // IPv4-mapped ::ffff:0:0/96
+            if (str_starts_with($packed, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff")) {
+                $embedded = inet_ntop(substr($packed, 12));
+                return $embedded !== false && self::isPublicIp($embedded);
+            }
+            // NAT64 64:ff9b::/96 (well-known prefix)
+            if (str_starts_with($packed, "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00")) {
+                $embedded = inet_ntop(substr($packed, 12));
+                return $embedded !== false && self::isPublicIp($embedded);
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve a host to a single validated public IP for pinning. Returns null if
+     * the host does not resolve, or if ANY resolved address is non-public (strict:
+     * one private record poisons the whole host, defeating round-robin rebind).
+     * IPv4 is preferred for the pin; an IP literal is validated directly.
+     */
+    public static function resolvePinnedIp(string $host): ?string
+    {
+        $host = strtolower($host);
+
+        // Already a literal IP.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return self::isPublicIp($host) ? $host : null;
+        }
+
+        $v4 = @gethostbynamel($host) ?: [];
+        $v6 = [];
+        $aaaa = @dns_get_record($host, DNS_AAAA) ?: [];
+        foreach ($aaaa as $rec) {
+            if (!empty($rec['ipv6'])) {
+                $v6[] = (string) $rec['ipv6'];
+            }
+        }
+
+        $all = array_merge($v4, $v6);
+        if ($all === []) {
+            return null; // unresolvable
+        }
+        foreach ($all as $ip) {
+            if (!self::isPublicIp($ip)) {
+                return null; // one private record blocks the whole host
+            }
+        }
+
+        return $v4[0] ?? $v6[0] ?? null;
+    }
+
+    /**
+     * Fetch a remote image with manual, per-hop-validated, IP-pinned redirects.
+     *
+     * @return array{0:string,1:string}|null [rawBytes, mimeType] on success, null on
+     *         any failure (non-public host, non-image, too large, redirect loop, …).
+     */
+    public static function fetchImage(string $url, int $maxBytes, int $maxHops = 4): ?array
+    {
+        if (!extension_loaded('curl')) {
+            return null;
+        }
+
+        $current = $url;
+        for ($hop = 0; $hop <= $maxHops; $hop++) {
+            $parts = parse_url($current);
+            $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+            $host   = strtolower((string) ($parts['host'] ?? ''));
+            if (!in_array($scheme, ['http', 'https'], true) || $host === '') {
+                return null;
+            }
+
+            $pin = self::resolvePinnedIp($host);
+            if ($pin === null) {
+                SecureLogger::warning('SSRF guard: cover host did not resolve to a public IP', ['host' => $host]);
+                return null;
+            }
+
+            $ch = curl_init($current);
+            curl_setopt_array($ch, [
+                CURLOPT_RETURNTRANSFER  => true,
+                CURLOPT_FOLLOWLOCATION  => false,      // follow manually, validate each hop
+                CURLOPT_TIMEOUT         => 20,
+                CURLOPT_CONNECTTIMEOUT  => 10,
+                CURLOPT_SSL_VERIFYPEER  => true,
+                CURLOPT_SSL_VERIFYHOST  => 2,
+                CURLOPT_USERAGENT       => 'PinakesCoverBot/1.0',
+                // Pin BOTH default ports to the validated IP so cURL never re-resolves.
+                CURLOPT_RESOLVE         => ["$host:443:$pin", "$host:80:$pin"],
+            ]);
+            if (defined('CURLOPT_PROTOCOLS_STR')) {
+                curl_setopt($ch, CURLOPT_PROTOCOLS_STR, 'https,http');
+            } else {
+                curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS | CURLPROTO_HTTP);
+            }
+
+            $body = curl_exec($ch);
+            $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            $redirectUrl = (string) curl_getinfo($ch, CURLINFO_REDIRECT_URL);
+            curl_close($ch);
+
+            if ($body === false) {
+                return null;
+            }
+
+            if ($code >= 300 && $code < 400) {
+                if ($redirectUrl === '') {
+                    return null;
+                }
+                $current = $redirectUrl; // absolute; re-validated at the top of the loop
+                continue;
+            }
+
+            if ($code !== 200) {
+                return null;
+            }
+            $len = strlen($body);
+            if ($len < 100 || $len > $maxBytes) {
+                return null;
+            }
+            $info = @getimagesizefromstring($body);
+            if ($info === false || empty($info['mime'])) {
+                return null;
+            }
+
+            return [$body, (string) $info['mime']];
+        }
+
+        return null; // too many redirects
+    }
+}


### PR DESCRIPTION
Fixes #173 — book cover editing/fetch not saving.

## Root cause
OpenLibrary serves cover images via a **302 redirect** from `covers.openlibrary.org` to the **Internet Archive** (`archive.org` / `iaNNNNNN.us.archive.org`). The SSRF hardening added in `2f18cf2e` gated **redirect targets** on a fixed exact-host allow-list that did not include the Internet Archive, so the download was blocked the instant it followed the redirect. The image *previewed* in the form (the `proxy-image` plugin fetched it for display) but was **dropped on save** — exactly the reported behaviour, plus the `Cover download blocked: redirected to non-whitelisted host` / `Dominio non autorizzato` log lines.

## Fix
- **`LibriController`**: widen the cover allow-list (exact + a generous suffix list incl. `archive.org` and the major cover CDNs) for the **initial** host, and **stop gating the redirect target** on the list — a cover origin may legitimately 302 to any public host. The real SSRF boundary — the **private/reserved-IP check** — stays on every hop.
- **`CoverController`**: drop the exact-host allow-list in `assertUrlAllowed`; any public HTTPS host is accepted, still bounded by `assertPublicDns()` (re-checked on each redirect hop).

The exact-host whitelist was redundant defense-in-depth; the IP check is what actually stops the server reaching internal services, and it is unchanged.

## Verified
The exact case from #173 (EAN `9782205081718`, cover id `13126303`) now follows `covers.openlibrary.org → ia601909.us.archive.org` and downloads a valid **380×500 JPEG**, saved as a local file. `coverHostAllowed()` ALLOWs openlibrary/archive/`ia*.us.archive.org`, DENYs `169.254.169.254` and `evil.com`. PHPStan L5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rafforzata la sicurezza nel download di copertine da sorgenti esterne mediante un sistema di validazione degli host migliorato.
  * Implementati controlli aggiuntivi durante il recupero di immagini per garantire l'accesso esclusivo a indirizzi pubblici autorizzati.
  * Migliorata la gestione dei reindirizzamenti durante il download di risorse remote.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->