### PR TITLE
fix(mobile-api): address CodeRabbit review findings (PR #177)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -26,7 +26,7 @@ Findings from the multi-lens review on PR #177, fixed:
 - **mysqli correctness:** `$stmt->affected_rows` (not connection-level) at 4 sites incl. the push `claim()` and token revoke; `get_result()` null-checked before `->num_rows` at 2 sites.
 - **Docs + a11y:** stale docblocks corrected; settings-view flash banners get `role`/`aria-live`, the Revoke button a per-device `aria-label`, and the actions column an sr-only label.
 
-Known/deferred (low, noted on the PR): `new_message` is a wired-but-unfired push trigger (no producer yet); `X-Forwarded-Proto` is trusted unconditionally (conventional behind a proxy); `HttpClient` IP-pin is curl-only.
+Known/deferred (low, noted on the PR): `new_message` is a wired-but-unfired push trigger (no producer yet); `X-Forwarded-Proto` is honoured only when the TCP peer is in `TRUSTED_PROXIES` (otherwise the real scheme is used, so the header can't be spoofed); `HttpClient` IP-pin is curl-only.
 
 ## Complete (implemented + tested)
 

--- a/storage/plugins/mobile-api/src/Controllers/HealthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/HealthController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\MobileApi\Controllers;
 
+use App\Plugins\MobileApi\Support\ProxyTrust;
 use App\Plugins\MobileApi\Support\ResponseEnvelope;
 use App\Support\ConfigStore;
 use App\Support\SecureLogger;
@@ -122,9 +123,14 @@ final class HealthController
 
     private function isHttps(ServerRequestInterface $request): bool
     {
-        $forwarded = $request->getHeaderLine('X-Forwarded-Proto');
-        if ($forwarded !== '') {
-            return strtolower(trim(explode(',', $forwarded)[0])) === 'https';
+        // Only honour X-Forwarded-Proto when the request actually comes from a
+        // configured trusted proxy (TRUSTED_PROXIES); otherwise a client could
+        // spoof the header and have us advertise https=true over cleartext.
+        if (ProxyTrust::isTrustedProxy($request)) {
+            $forwarded = $request->getHeaderLine('X-Forwarded-Proto');
+            if ($forwarded !== '') {
+                return strtolower(trim(explode(',', $forwarded)[0])) === 'https';
+            }
         }
         if (strtolower($request->getUri()->getScheme()) === 'https') {
             return true;

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -71,7 +71,7 @@ final class OpenApiController
                     . 'Every response uses the `{data, meta, error}` envelope. '
                     . 'Authenticated endpoints require `Authorization: Bearer <token>` obtained via POST /auth/login.',
                 'version'     => $version,
-                'contact'     => ['name' => 'Pinakes', 'url' => 'https://github.com/fabiodalez-dev/biblioteca'],
+                'contact'     => ['name' => 'Pinakes', 'url' => 'https://github.com/fabiodalez-dev/Pinakes'],
                 'license'     => ['name' => 'AGPL-3.0', 'url' => 'https://www.gnu.org/licenses/agpl-3.0.html'],
             ],
             'servers' => [
@@ -454,7 +454,30 @@ final class OpenApiController
                         ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer'], 'description' => 'Book ID'],
                     ],
                     'responses' => [
-                        '200' => ['description' => 'Availability calendar data.'],
+                        '200' => [
+                            'description' => 'Availability calendar data.',
+                            'content'     => ['application/json' => ['schema' => [
+                                'allOf'      => [['$ref' => '#/components/schemas/Envelope']],
+                                'properties' => ['data' => [
+                                    'type'       => 'object',
+                                    'properties' => [
+                                        'total_copies'       => ['type' => 'integer'],
+                                        'earliest_available' => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                                        'unavailable_dates'  => ['type' => 'array', 'items' => ['type' => 'string', 'format' => 'date']],
+                                        'days'               => ['type' => 'array', 'items' => [
+                                            'type'       => 'object',
+                                            'properties' => [
+                                                'date'      => ['type' => 'string', 'format' => 'date'],
+                                                'available' => ['type' => 'integer'],
+                                                'loaned'    => ['type' => 'integer'],
+                                                'reserved'  => ['type' => 'integer'],
+                                                'state'     => ['type' => 'string', 'enum' => ['free', 'borrowed', 'reserved']],
+                                            ],
+                                        ]],
+                                    ],
+                                ]],
+                            ]]],
+                        ],
                         '401' => ['$ref' => '#/components/responses/Unauthorized'],
                         '404' => ['$ref' => '#/components/responses/NotFound'],
                         '500' => ['$ref' => '#/components/responses/InternalError'],
@@ -1131,6 +1154,10 @@ final class OpenApiController
                         'notifications' => ['type' => 'boolean'],
                         'push'          => ['type' => 'boolean'],
                     ],
+                ],
+                'catalogue_mode'       => [
+                    'type'        => 'boolean',
+                    'description' => 'True when the instance is in catalogue-only mode (loans, reservations and wishlist disabled).',
                 ],
                 'app_access_enabled'   => ['type' => 'boolean'],
                 'registration_enabled' => ['type' => 'boolean'],

--- a/storage/plugins/mobile-api/src/Controllers/PushController.php
+++ b/storage/plugins/mobile-api/src/Controllers/PushController.php
@@ -79,6 +79,11 @@ final class PushController
         $auth     = $this->clip($auth, 255);
 
         try {
+            // DELETE+INSERT must be atomic: if the INSERT failed after a
+            // successful DELETE the device would lose its subscription with no
+            // replacement. A transaction keeps the prior row on any failure.
+            $this->db->begin_transaction();
+
             // Idempotent per device: replace any prior subscription for this token
             // (a device re-registers when its endpoint rotates). Scoped by user_id
             // AND token_id so a user can never touch another user's subscription.
@@ -99,6 +104,7 @@ final class PushController
                  VALUES (?, ?, ?, ?, ?, ?, ?, NOW(), 0)'
             );
             if ($ins === false) {
+                $this->db->rollback();
                 return ResponseEnvelope::error($response, 'internal_error', __('Operazione non disponibile.'), 500);
             }
             $endpointParam = $endpoint !== '' ? $endpoint : null;
@@ -110,6 +116,8 @@ final class PushController
             $subId = (int) $ins->insert_id;
             $ins->close();
 
+            $this->db->commit();
+
             // Ensure a prefs row exists (defaults) so GET /me/push/prefs is stable.
             $this->ensurePrefsRow($userId);
 
@@ -120,6 +128,11 @@ final class PushController
                 201
             );
         } catch (\Throwable $e) {
+            try {
+                $this->db->rollback();
+            } catch (\Throwable $ignored) {
+                // already rolled back / no active transaction
+            }
             SecureLogger::error('[MobileApi] push subscribe failed: ' . $e->getMessage());
             return ResponseEnvelope::error($response, 'internal_error', __('Operazione non disponibile.'), 500);
         }

--- a/storage/plugins/mobile-api/src/Controllers/SwaggerUiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/SwaggerUiController.php
@@ -121,7 +121,9 @@ final class SwaggerUiController
         layout: 'BaseLayout',
         persistAuthorization: true,
         requestInterceptor: function (request) {
-          // Strip Cookies from cross-origin requests (CORS hardening).
+          // Avoid sending cookies/session on "Try it out" calls: the API is
+          // bearer-token only, so cookies would just leak the web session.
+          request.credentials = 'omit';
           return request;
         }
       });
@@ -146,10 +148,9 @@ HTML;
         $localBundle = $this->docRoot() . '/assets/swagger-ui/swagger-ui-bundle.js';
 
         if (is_file($localBundle)) {
-            // Local copy available — use it.
-            $basePath = defined('BASE_PATH') ? (string) BASE_PATH : '';
-
-            return rtrim($siteBaseUrl, '/') . rtrim($basePath, '/') . '/assets/swagger-ui';
+            // Local copy available — use it. $siteBaseUrl already includes
+            // BASE_PATH (from baseUrl()), so do not append it again.
+            return rtrim($siteBaseUrl, '/') . '/assets/swagger-ui';
         }
 
         // Fallback: jsDelivr CDN (pinned version).

--- a/storage/plugins/mobile-api/src/Push/PushDispatcher.php
+++ b/storage/plugins/mobile-api/src/Push/PushDispatcher.php
@@ -129,7 +129,11 @@ final class PushDispatcher
                 (int) $r['libro_id'],
                 ['loan_id' => (int) $r['id'], 'due_at' => (string) $r['data_scadenza']]
             );
-            $this->deliver($userId, $payload, $counters);
+            $outcome = $this->deliver($userId, $payload, $counters);
+            if ($outcome['sent'] === 0 && $outcome['failed'] > 0) {
+                // Transient failure only: free the claim so the next sweep retries.
+                $this->releaseClaim($userId, $key);
+            }
         }
 
         return $events;
@@ -169,7 +173,10 @@ final class PushDispatcher
                 (int) $r['libro_id'],
                 ['loan_id' => (int) $r['id'], 'due_at' => (string) $r['data_scadenza']]
             );
-            $this->deliver($userId, $payload, $counters);
+            $outcome = $this->deliver($userId, $payload, $counters);
+            if ($outcome['sent'] === 0 && $outcome['failed'] > 0) {
+                $this->releaseClaim($userId, $key);
+            }
         }
 
         return $events;
@@ -209,7 +216,10 @@ final class PushDispatcher
                 (int) $r['libro_id'],
                 ['loan_id' => (int) $r['id']]
             );
-            $this->deliver($userId, $payload, $counters);
+            $outcome = $this->deliver($userId, $payload, $counters);
+            if ($outcome['sent'] === 0 && $outcome['failed'] > 0) {
+                $this->releaseClaim($userId, $key);
+            }
         }
 
         return $events;
@@ -266,13 +276,16 @@ final class PushDispatcher
                 (int) $r['libro_id'],
                 ['book_id' => (int) $r['libro_id']]
             );
-            $sent = $this->deliver($userId, $payload, $counters);
-            if ($sent <= 0) {
-                // Nothing was delivered (no active subscription / NullProvider):
-                // keep the watcher so GET /me/notifications keeps surfacing the
-                // availability. The claim above is already consumed, so no further
-                // push fires for this watcher — the feed is the durable fallback,
-                // consistent with the other event types.
+            $outcome = $this->deliver($userId, $payload, $counters);
+            if ($outcome['sent'] <= 0) {
+                // Nothing was delivered: keep the watcher so GET /me/notifications
+                // keeps surfacing the availability (the durable fallback). On a
+                // transient provider/network failure also release the claim so the
+                // push retries on the next sweep, matching the FAILED contract; a
+                // pure no-subscription / NullProvider skip leaves the claim in place.
+                if ($outcome['failed'] > 0) {
+                    $this->releaseClaim($userId, 'book_available:' . $watcherId);
+                }
                 continue;
             }
 
@@ -307,23 +320,28 @@ final class PushDispatcher
     /**
      * Deliver one event to all of a user's active subscriptions. Pref + quiet-hours
      * gating is the caller's responsibility (shouldNotify, before the dedup claim).
-     * Returns the number of subscriptions the push was accepted by — callers use a
-     * zero return to decide whether a one-shot trigger (book_available watcher) may
-     * be cleared. The in-app feed (GET /me/notifications) reflects the same state,
-     * so a NullProvider / no-subscription path still leaves the user able to see the
-     * notification by polling.
+     * Returns ['sent' => N, 'failed' => M]: N is the number of subscriptions that
+     * accepted the push, M the number that failed *transiently* (provider/network
+     * down — not a permanent 404/410 prune nor an unconfigured NullProvider skip).
+     * Callers use a zero `sent` to decide whether a one-shot trigger
+     * (book_available watcher) may be cleared, and a transient `failed` to release
+     * the dedup claim so the event retries on the next sweep. The in-app feed
+     * (GET /me/notifications) reflects the same state, so a NullProvider /
+     * no-subscription path still leaves the user able to see the notification.
      *
      * @param array{loan_due:int,loan_overdue:int,reservation_ready:int,book_available:int,sent:int,skipped:int} $counters
+     * @return array{sent:int,failed:int}
      */
-    private function deliver(int $userId, PushPayload $payload, array &$counters): int
+    private function deliver(int $userId, PushPayload $payload, array &$counters): array
     {
         $subs = $this->subscriptionsFor($userId);
         if ($subs === []) {
             $counters['skipped']++;
-            return 0;
+            return ['sent' => 0, 'failed' => 0];
         }
 
-        $sent = 0;
+        $sent   = 0;
+        $failed = 0;
         foreach ($subs as $sub) {
             try {
                 $result = $this->provider->send($sub, $payload);
@@ -348,12 +366,15 @@ final class PushDispatcher
                 // cron passes (failure_count >= 10 excludes the subscription).
                 $counters['skipped']++;
             } else {
+                // Transient failure (provider/network). Bump the per-device counter
+                // and report it so the caller can release the dedup claim for a retry.
                 $counters['skipped']++;
+                $failed++;
                 $this->bumpSubscriptionFailure($subId, $userId);
             }
         }
 
-        return $sent;
+        return ['sent' => $sent, 'failed' => $failed];
     }
 
     // ─── Preferences & quiet hours ────────────────────────────────────────────
@@ -520,6 +541,25 @@ final class PushDispatcher
         $stmt->close();
 
         return $claimed;
+    }
+
+    /**
+     * Release a previously-acquired claim so the event can be re-attempted on the
+     * next sweep. Used only when delivery failed transiently (provider/network
+     * down) and nothing was sent — honouring the PushResult::FAILED "retry next
+     * sweep" contract instead of permanently consuming the dedup on a blip.
+     */
+    private function releaseClaim(int $userId, string $eventKey): void
+    {
+        $stmt = $this->db->prepare(
+            'DELETE FROM mobile_push_log WHERE user_id = ? AND event_key = ?'
+        );
+        if ($stmt === false) {
+            return;
+        }
+        $stmt->bind_param('is', $userId, $eventKey);
+        $stmt->execute();
+        $stmt->close();
     }
 
     private function dueSoonDays(): int

--- a/storage/plugins/mobile-api/src/Push/PushPayload.php
+++ b/storage/plugins/mobile-api/src/Push/PushPayload.php
@@ -59,7 +59,14 @@ final class PushPayload
     public function toJson(): string
     {
         $json = json_encode($this->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            // Never ship an empty `{}` as if it were the real notification: that
+            // could be counted as a successful (2xx) delivery while silently
+            // dropping the payload. Surface the failure so the provider's
+            // try/catch returns PushResult::failed() and the dedup is released.
+            throw new \RuntimeException('PushPayload JSON encode failed: ' . json_last_error_msg());
+        }
 
-        return $json === false ? '{}' : $json;
+        return $json;
     }
 }

--- a/storage/plugins/mobile-api/src/Support/HttpsEnforceMiddleware.php
+++ b/storage/plugins/mobile-api/src/Support/HttpsEnforceMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\MobileApi\Support;
 
+use App\Plugins\MobileApi\Support\ProxyTrust;
 use App\Plugins\MobileApi\Support\ResponseEnvelope;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -43,15 +44,21 @@ final class HttpsEnforceMiddleware implements MiddlewareInterface
 
     private function isSecure(Request $request): bool
     {
-        $forwarded = $request->getHeaderLine('X-Forwarded-Proto');
-        if ($forwarded !== '') {
-            // May be a comma-separated list when chained proxies are involved.
-            $first = strtolower(trim(explode(',', $forwarded)[0]));
-            if ($first === 'https') {
-                return true;
-            }
-            if ($first === 'http') {
-                return false;
+        // Only honour X-Forwarded-Proto from a configured trusted proxy
+        // (TRUSTED_PROXIES). Otherwise a remote client could send plain HTTP with
+        // `X-Forwarded-Proto: https` and bypass HTTPS enforcement entirely,
+        // leaking the bearer token over cleartext.
+        if (ProxyTrust::isTrustedProxy($request)) {
+            $forwarded = $request->getHeaderLine('X-Forwarded-Proto');
+            if ($forwarded !== '') {
+                // May be a comma-separated list when chained proxies are involved.
+                $first = strtolower(trim(explode(',', $forwarded)[0]));
+                if ($first === 'https') {
+                    return true;
+                }
+                if ($first === 'http') {
+                    return false;
+                }
             }
         }
 

--- a/storage/plugins/mobile-api/src/Support/ProxyTrust.php
+++ b/storage/plugins/mobile-api/src/Support/ProxyTrust.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins\MobileApi\Support;
+
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Trusted-proxy gate for forwarded headers.
+ *
+ * Mirrors core's TRUSTED_PROXIES convention (see App\Support\HtmlHelper):
+ * forwarded headers like X-Forwarded-Proto are only honoured when the genuine
+ * TCP peer (REMOTE_ADDR) is one of the configured proxies. An empty/unset
+ * TRUSTED_PROXIES (the default) means no proxy is trusted, so a client cannot
+ * spoof X-Forwarded-Proto: https to make a cleartext request look secure.
+ *
+ * Supports exact IPv4/IPv6 and CIDR ranges for both families.
+ */
+final class ProxyTrust
+{
+    /**
+     * Whether the request's TCP peer is in the configured TRUSTED_PROXIES list.
+     */
+    public static function isTrustedProxy(Request $request): bool
+    {
+        $trustedRaw = $_ENV['TRUSTED_PROXIES'] ?? getenv('TRUSTED_PROXIES');
+        $trustedEnv = is_string($trustedRaw) ? trim($trustedRaw) : '';
+        if ($trustedEnv === '') {
+            return false;
+        }
+
+        $server     = $request->getServerParams();
+        $remoteAddr = trim((string) ($server['REMOTE_ADDR'] ?? ''));
+        if ($remoteAddr === '') {
+            return false;
+        }
+
+        $remoteIp = inet_pton($remoteAddr);
+        if ($remoteIp === false) {
+            return false;
+        }
+
+        $entries = array_map('trim', explode(',', $trustedEnv));
+        foreach ($entries as $entry) {
+            if ($entry === '') {
+                continue;
+            }
+
+            if (strpos($entry, '/') !== false) {
+                [$network, $prefixLen] = explode('/', $entry, 2);
+                if (!is_numeric($prefixLen)) {
+                    continue;
+                }
+                $prefixLen = (int) $prefixLen;
+                $networkIp = inet_pton($network);
+                if ($networkIp === false) {
+                    continue;
+                }
+                $networkLen = strlen($networkIp);
+                if ($networkLen !== strlen($remoteIp)) {
+                    continue; // mixed family — cannot match
+                }
+                $maxPrefix = $networkLen * 8;
+                if ($prefixLen < 0 || $prefixLen > $maxPrefix) {
+                    continue;
+                }
+                $mask          = '';
+                $fullBytes     = intdiv($prefixLen, 8);
+                $remainderBits = $prefixLen % 8;
+                if ($fullBytes > 0) {
+                    $mask .= str_repeat("\xFF", $fullBytes);
+                }
+                if ($remainderBits > 0) {
+                    $mask .= chr((0xFF << (8 - $remainderBits)) & 0xFF);
+                }
+                if (strlen($mask) < $networkLen) {
+                    $mask .= str_repeat("\x00", $networkLen - strlen($mask));
+                }
+                if (($remoteIp & $mask) === ($networkIp & $mask)) {
+                    return true;
+                }
+                continue;
+            }
+
+            $entryIp = inet_pton($entry);
+            if ($entryIp !== false && $remoteIp === $entryIp) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/mobile-api-behaviors.spec.js
+++ b/tests/mobile-api-behaviors.spec.js
@@ -81,9 +81,12 @@ function plusDays(n) { const d = new Date(); d.setDate(d.getDate() + n); return 
 
 // ─── Borrower fixture ────────────────────────────────────────────────────────
 
-const USER_EMAIL = 'behaviors_test_user@pinakes.test';
+// Unique per run so the fixture never collides with — or destroys — a
+// pre-existing real account on a shared (non-ephemeral) database.
+const RUN_ID     = `${Date.now()}_${process.pid}`;
+const USER_EMAIL = `behaviors_${RUN_ID}@pinakes.test`;
 const USER_PASS  = 'Behav1234Test!';
-const USER_CARD  = 'BEHAVTEST0001';
+const USER_CARD  = `BEHAV${String(process.pid).padStart(6, '0')}`.slice(0, 20);
 
 // ─── Shared context ──────────────────────────────────────────────────────────
 
@@ -169,6 +172,7 @@ test.beforeAll(async ({ request }) => {
             INSERT INTO utenti (nome, cognome, email, password, codice_tessera, tipo_utente, stato, email_verificata, created_at)
             VALUES ('Behav','Test',${sqlStr(USER_EMAIL)},${sqlStr(realHash)},${sqlStr(USER_CARD)},'standard','attivo',1,NOW())`);
         uid = dbInt(`SELECT id FROM utenti WHERE email = ${sqlStr(USER_EMAIL)} LIMIT 1`);
+        ctx.createdUser = true;
     } else {
         dbExec(`UPDATE utenti SET password = ${sqlStr(realHash)}, stato = 'attivo', email_verificata = 1, codice_tessera = ${sqlStr(USER_CARD)} WHERE id = ${uid}`);
     }
@@ -196,13 +200,19 @@ test.afterAll(async () => {
         try { dbExec(`DELETE FROM mobile_app_tokens WHERE user_id = ${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM mobile_availability_watchers WHERE user_id = ${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM wishlist WHERE utente_id = ${ctx.userId}`); } catch {}
-        try { dbExec(`DELETE FROM utenti WHERE id = ${ctx.userId}`); } catch {}
+        // Only delete the account if THIS run created it — never an account that
+        // already existed (the unique per-run email makes a collision unlikely,
+        // but stay defensive).
+        if (ctx.createdUser) {
+            try { dbExec(`DELETE FROM utenti WHERE id = ${ctx.userId}`); } catch {}
+        }
     }
     if (ctx.adminId) {
         // Only the tokens this suite created for the admin; leave any others.
         try { dbExec(`DELETE FROM mobile_app_tokens WHERE user_id = ${ctx.adminId} AND device_id = 'behav-admin'`); } catch {}
-        // Any stray reservations created against the admin during reservation tests.
-        try { dbExec(`DELETE FROM prenotazioni WHERE utente_id = ${ctx.adminId} AND created_at >= (NOW() - INTERVAL 1 HOUR) AND stato = 'attiva'`); } catch {}
+        // (No admin reservations are seeded by this suite — all admin fixtures are
+        // loans, each cleaned by its own id — so we avoid a broad time-window
+        // DELETE on prenotazioni that could remove unrelated real reservations.)
     }
     // Always restore catalogue mode off.
     try { dbExec("UPDATE system_settings SET setting_value = '0' WHERE category = 'system' AND setting_key = 'catalogue_mode'"); } catch {}

--- a/tests/mobile-api-idempotency.spec.js
+++ b/tests/mobile-api-idempotency.spec.js
@@ -76,12 +76,22 @@ async function ensurePluginReady(page) {
             const base = window.location.origin + (window.BASE_PATH || '');
             const csrf = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
             if (document.querySelector(`[data-plugin-id="${pid}"].active`)) {
-                await fetch(`${base}/admin/plugins/${pid}/deactivate`, { method: 'POST', headers: { 'X-CSRF-Token': csrf } });
+                const d = await fetch(`${base}/admin/plugins/${pid}/deactivate`, { method: 'POST', headers: { 'X-CSRF-Token': csrf } });
+                if (!d.ok) throw new Error(`plugin deactivate failed: HTTP ${d.status}`);
             }
-            await fetch(`${base}/admin/plugins/${pid}/activate`, { method: 'POST', headers: { 'X-CSRF-Token': csrf } });
+            const a = await fetch(`${base}/admin/plugins/${pid}/activate`, { method: 'POST', headers: { 'X-CSRF-Token': csrf } });
+            if (!a.ok) throw new Error(`plugin activate failed: HTTP ${a.status}`);
         }, pid);
     }
     dbExec("INSERT INTO system_settings (category, setting_key, setting_value) VALUES ('mobile_api','enabled','1') ON DUPLICATE KEY UPDATE setting_value='1'");
+
+    // Fail fast with a clear diagnostic if activation did not actually persist
+    // (CSRF/session/hook issues otherwise surface as confusing 404s later).
+    const activeNow = dbScalar(`SELECT is_active FROM plugins WHERE id=${pid}`) === '1';
+    const hooksNow  = parseInt(dbScalar(`SELECT COUNT(*) FROM plugin_hooks WHERE plugin_id=${pid} AND is_active=1`) || '0', 10);
+    if (!activeNow || hooksNow === 0) {
+        throw new Error('mobile-api plugin activation did not persist (active/hooks check failed)');
+    }
 }
 
 // ─── Request helpers ─────────────────────────────────────────────────────────
@@ -100,8 +110,12 @@ async function call(request, method, fullPath, { token, body, extraHeaders } = {
 
 // ─── Test user A (a borrower) ────────────────────────────────────────────────
 
-const USER_EMAIL = 'idem_test_user@pinakes.test';
+// Unique per run so the fixture never mutates or deletes a pre-existing real
+// account on a shared (non-ephemeral) database.
+const RUN_ID     = `${Date.now()}_${process.pid}`;
+const USER_EMAIL = `idem_${RUN_ID}@pinakes.test`;
 const USER_PASS  = 'Idem1234Test!';
+const USER_CARD  = `IDEM${String(process.pid).padStart(6, '0')}`.slice(0, 20);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // THE MANIFEST — one row per exposed /api/v1 endpoint. `kind` selects the
@@ -255,8 +269,9 @@ test.describe('Mobile API — two calls per endpoint (idempotency + ETag/304)', 
         let uid = parseInt(dbScalar(`SELECT id FROM utenti WHERE email='${USER_EMAIL}' LIMIT 1`) || '0', 10);
         if (uid === 0) {
             dbExec(`INSERT INTO utenti (nome, cognome, email, password, tipo_utente, stato, email_verificata, codice_tessera, created_at)
-                    VALUES ('Idem','Test','${USER_EMAIL}','x','standard','attivo',1,'IDEMTEST0001',NOW())`);
+                    VALUES ('Idem','Test','${USER_EMAIL}','x','standard','attivo',1,'${USER_CARD}',NOW())`);
             uid = parseInt(dbScalar(`SELECT id FROM utenti WHERE email='${USER_EMAIL}' LIMIT 1`) || '0', 10);
+            ctx.createdUser = true;
         }
         // Set the password to USER_PASS using PHP password_hash so /auth/login matches.
         const realHash = execFileSync('php', ['-r', `echo password_hash(${JSON.stringify(USER_PASS)}, PASSWORD_DEFAULT);`], { encoding: 'utf-8' }).trim();
@@ -306,7 +321,10 @@ test.describe('Mobile API — two calls per endpoint (idempotency + ETag/304)', 
         try { dbExec(`DELETE FROM mobile_push_subscriptions WHERE user_id=${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM wishlist WHERE utente_id=${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM prenotazioni WHERE utente_id=${ctx.userId}`); } catch {}
-        try { dbExec(`DELETE FROM utenti WHERE id=${ctx.userId}`); } catch {}
+        // Only delete the account if THIS run created it.
+        if (ctx.createdUser) {
+            try { dbExec(`DELETE FROM utenti WHERE id=${ctx.userId}`); } catch {}
+        }
         await page?.close();
     });
 

--- a/tests/mobile-api.spec.js
+++ b/tests/mobile-api.spec.js
@@ -143,7 +143,8 @@ async function ensureMobileApiPlugin(browser) {
         tableExists('mobile_app_tokens') &&
         tableExists('mobile_push_subscriptions') &&
         tableExists('mobile_push_prefs') &&
-        tableExists('mobile_availability_watchers');
+        tableExists('mobile_availability_watchers') &&
+        tableExists('mobile_push_log');
 
     if (!plugin.active || plugin.hooks === 0 || !hasSchema()) {
         const ctx  = await browser.newContext();
@@ -596,7 +597,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
         const firstTitle = dbQuery(
             "SELECT titolo FROM libri WHERE deleted_at IS NULL ORDER BY id LIMIT 1"
         );
-        if (!firstTitle) return; // no books in DB — skip gracefully
+        test.skip(!firstTitle, 'no books in DB');
 
         const word = firstTitle.split(' ')[0];
         const res  = await apiGet(request, `/catalog/search?q=${encodeURIComponent(word)}`, tokenA);
@@ -629,7 +630,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
             "JOIN libri l ON l.id = la.libro_id AND l.deleted_at IS NULL " +
             "LIMIT 1"
         );
-        if (!authorName) return;
+        test.skip(!authorName, 'no authors in DB');
         const res  = await apiGet(request, `/catalog/search?author=${encodeURIComponent(authorName)}`, tokenA);
         const body = await envelope(res, 200);
         expect(Array.isArray(body.data)).toBe(true);
@@ -640,7 +641,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
         const pubName = dbQuery(
             "SELECT ed.nome FROM editori ed JOIN libri l ON l.editore_id = ed.id AND l.deleted_at IS NULL LIMIT 1"
         );
-        if (!pubName) return;
+        test.skip(!pubName, 'no publishers in DB');
         const res  = await apiGet(request, `/catalog/search?publisher=${encodeURIComponent(pubName)}`, tokenA);
         const body = await envelope(res, 200);
         expect(Array.isArray(body.data)).toBe(true);
@@ -651,7 +652,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
         const genreId = dbQuery(
             "SELECT g.id FROM generi g JOIN libri l ON l.genere_id = g.id AND l.deleted_at IS NULL LIMIT 1"
         );
-        if (!genreId || parseInt(genreId, 10) === 0) return;
+        test.skip(!genreId || parseInt(genreId, 10) === 0, 'no genres in DB');
         const res  = await apiGet(request, `/catalog/search?genre=${genreId}`, tokenA);
         const body = await envelope(res, 200);
         expect(Array.isArray(body.data)).toBe(true);


### PR DESCRIPTION
Applies the CodeRabbit findings from #177. Branched from `feature/mobile-api`, so merging this folds the fixes back into that PR's branch.

## Security
- **X-Forwarded-Proto spoofing** — new `ProxyTrust` helper (mirrors core's `TRUSTED_PROXIES` convention) is used in both `HealthController` (advisory `https` flag) and `HttpsEnforceMiddleware` (HTTPS enforcement). The forwarded scheme is honoured only when the TCP peer is a configured trusted proxy; otherwise the real scheme is used, so a client can't spoof `https`. The middleware fix is broader than the flagged finding because it shares the same root cause and is more critical (it gated actual enforcement).
- **Swagger `requestInterceptor`** now actually sets `credentials: 'omit'` (the comment claimed cookie-stripping but did nothing).

## Correctness
- **`PushController::subscribe`** — the idempotent DELETE+INSERT is wrapped in a transaction (rollback on failure) so a failed INSERT can't drop a device's subscription with no replacement.
- **`PushPayload::toJson`** — throws on `json_encode` failure instead of returning `{}` (which could be counted as a successful 2xx delivery, silently losing the payload). The provider's existing `\Throwable` catch turns it into `PushResult::FAILED`.
- **`PushDispatcher`** — `deliver()` now distinguishes transient failures and releases the dedup claim when nothing was sent, so the event retries on the next sweep (matches the `FAILED` "retry next sweep" contract). Partial success keeps the claim to avoid duplicate pushes.
- **`SwaggerUiController`** — stop appending `BASE_PATH` twice to the asset URL (`baseUrl()` already includes it); fixes 404s on sub-path deployments.

## Docs / OpenAPI
- Add `catalogue_mode` to the `HealthPayload` schema; document the availability endpoint's `200` body with the **actual** day fields (`date/available/loaned/reserved/state`, not the suggested `free/total`).
- Fix the stale contact URL (`biblioteca` → `Pinakes`).

## Tests
- `hasSchema()` also checks `mobile_push_log` (5th table).
- Silent early-returns → `test.skip()` so missing-data cases are visible.
- Borrower fixtures are unique per run and only delete accounts this run created; dropped the broad time-window admin-reservation sweep (the suite seeds only admin loans, each cleaned by id).
- `ensurePluginReady` checks activate/deactivate HTTP status and verifies the plugin actually activated (active + hooks) before proceeding.

## Validation
- `php -l` clean on all changed PHP files; `node --check` clean on all changed specs. PHPStan was not available in the run environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016WQhreDTpEsnckREDHc4tC)_