### PR TITLE
refactor(backup): drop redundant commit() in PHP restore importer

### DIFF
--- a/app/Support/BackupManager.php
+++ b/app/Support/BackupManager.php
@@ -977,7 +977,13 @@ class BackupManager
                     throw new \RuntimeException(__('Errore durante il ripristino del database') . ': ' . $conn->error);
                 }
             }
-            $conn->commit();
+            // No explicit commit/rollback: autocommit is on (set above) so every
+            // statement is already persisted. A transaction wouldn't help anyway —
+            // the dump is DDL-heavy (DROP/CREATE TABLE implicitly commit in MySQL),
+            // so it can't be made atomic at the connection level. Atomicity is
+            // provided instead by the pre-restore safety backup + the idempotent
+            // dump (DROP ... IF EXISTS), and a mid-import failure is surfaced as a
+            // partial restore by doRestoreZip().
         } finally {
             $conn->close();
             if (is_resource($handle)) {


### PR DESCRIPTION
`importViaPhp()` runs with `autocommit(true)`, so the trailing `$conn->commit()` was a no-op. Removed it and replaced it with a comment documenting why the restore deliberately uses **no transaction**: the dump is DDL-heavy (`DROP`/`CREATE TABLE` implicitly commit in MySQL), so a transaction can't make it atomic. Atomicity is provided instead by the pre-restore **safety backup** + **idempotent dump** (`DROP ... IF EXISTS`) + **partial-restore signaling** in `doRestoreZip()`.

Addresses a CodeRabbit observation from #167. No behaviour change. Validated: PHPStan L5 + backup-restore E2E 6/6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Ottimizzazione della logica di importazione dei backup con miglioramento della chiarezza del codice relativamente alla gestione delle transazioni e della modalità autocommit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->