### PR TITLE
refactor: address remaining CodeRabbit nitpicks from #167

### DIFF
--- a/app/Controllers/UpdateController.php
+++ b/app/Controllers/UpdateController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace App\Controllers;
 
+use App\Models\SettingsRepository;
 use App\Support\Updater;
 use App\Support\BackupManager;
 use App\Support\Csrf;
@@ -10,6 +11,7 @@ use App\Support\SecureLogger;
 use mysqli;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Psr7\Stream;
 
 class UpdateController
 {
@@ -36,7 +38,7 @@ class UpdateController
         $githubTokenMasked = $updater->getGitHubTokenMasked();
         $hasGithubToken = $updater->hasGitHubToken();
 
-        $backupIncludeFiles = (new \App\Models\SettingsRepository($db))
+        $backupIncludeFiles = (new SettingsRepository($db))
             ->get('backup', 'pre_update_include_files', '0') === '1';
 
         ob_start();
@@ -265,7 +267,7 @@ class UpdateController
         $size = filesize((string) $result['path']);
 
         return $response
-            ->withBody(new \Slim\Psr7\Stream($handle))
+            ->withBody(new Stream($handle))
             ->withHeader('Content-Type', (string) $result['mime'])
             ->withHeader('Content-Disposition', 'attachment; filename="' . $result['filename'] . '"')
             ->withHeader('Content-Length', (string) ($size === false ? 0 : $size));
@@ -340,7 +342,7 @@ class UpdateController
         // exhaust storage just to be rejected. restoreFromUploadedZip keeps the
         // post-move check as a backstop (getSize() can be null/spoofed).
         $earlySize = $upload->getSize();
-        if ($earlySize !== null && $earlySize > \App\Support\BackupManager::MAX_UPLOAD_BYTES) {
+        if ($earlySize !== null && $earlySize > BackupManager::MAX_UPLOAD_BYTES) {
             // 413 here for consistency with restoreFailureStatus(), which maps
             // the same BackupManager message to 413 on the post-move check.
             return $this->jsonResponse($response, ['error' => __('File di backup troppo grande')], 413);
@@ -395,7 +397,7 @@ class UpdateController
         }
 
         $value = (($data['include_files'] ?? '0') === '1') ? '1' : '0';
-        (new \App\Models\SettingsRepository($db))->set('backup', 'pre_update_include_files', $value);
+        (new SettingsRepository($db))->set('backup', 'pre_update_include_files', $value);
 
         return $this->jsonResponse($response, ['success' => true]);
     }

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Models\SettingsRepository;
+use App\Support\BackupManager;
 use App\Support\SecureLogger;
 use mysqli;
 use Exception;
@@ -2059,12 +2061,12 @@ class Updater
             // The complete-backup logic lives in BackupManager. The pre-update
             // backup is DB-only by default; the admin can opt into bundling the
             // uploaded files via the backup.pre_update_include_files setting.
-            $includeFiles = (new \App\Models\SettingsRepository($this->db))
+            $includeFiles = (new SettingsRepository($this->db))
                 ->get('backup', 'pre_update_include_files', '0') === '1';
             $scope = $includeFiles ? 'full' : 'db';
 
             $this->debugLog('INFO', 'Inizio backup', ['scope' => $scope]);
-            $result = (new \App\Support\BackupManager($this->db, $this->rootPath))->createBackup($scope);
+            $result = (new BackupManager($this->db, $this->rootPath))->createBackup($scope);
 
             // Record the history row against the actual backup file path (or the
             // backups dir on failure, where path is null).

--- a/tests/backup-restore.spec.js
+++ b/tests/backup-restore.spec.js
@@ -133,6 +133,11 @@ test.describe('#162 — complete backup + restore', () => {
     const trigCount = () => Number(dbQuery(`SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA=DATABASE()`));
     const trigBefore = trigCount();
     expect(trigBefore).toBeGreaterThan(0);
+    // Precondition: the specific protective trigger must exist before we drop it,
+    // otherwise DROP TRIGGER IF EXISTS is a silent no-op and the post-drop
+    // assertion would fail confusingly instead of testing the restore.
+    const specificTrig = () => Number(dbQuery(`SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA=DATABASE() AND TRIGGER_NAME='trg_check_active_prestito_before_insert'`));
+    expect(specificTrig()).toBe(1);
 
     // Simulate a dirty state: drop the row, the file, and a protective trigger.
     dbQuery(`DELETE FROM libri WHERE titolo='${TAG} libro'`);
@@ -140,7 +145,7 @@ test.describe('#162 — complete backup + restore', () => {
     dbQuery(`DROP TRIGGER IF EXISTS trg_check_active_prestito_before_insert`);
     expect(Number(dbQuery(`SELECT COUNT(*) FROM libri WHERE titolo='${TAG} libro'`))).toBe(0);
     expect(fs.existsSync(markerCover)).toBe(false);
-    expect(trigCount()).toBe(trigBefore - 1);
+    expect(specificTrig()).toBe(0);
 
     // Restore the snapshot.
     const res = await apiPost(page, '/admin/updates/backup/restore', { backup: snapName });
@@ -154,7 +159,7 @@ test.describe('#162 — complete backup + restore', () => {
     expect(fs.existsSync(markerCover)).toBe(true);
     expect(fs.readFileSync(markerCover, 'utf-8')).toBe('MARKER-' + TAG);
     expect(trigCount()).toBe(trigBefore);
-    expect(Number(dbQuery(`SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA=DATABASE() AND TRIGGER_NAME='trg_check_active_prestito_before_insert'`))).toBe(1);
+    expect(specificTrig()).toBe(1);
     const backupsAfter = fs.readdirSync(BACKUP_DIR).filter((f) => f.startsWith('backup_')).length;
     expect(backupsAfter).toBeGreaterThan(backupsBefore);
   });


### PR DESCRIPTION
Cleans up the remaining unresolved CodeRabbit nitpicks from #167:

- **`UpdateController` / `Updater`**: replace inline FQCNs (`App\Models\SettingsRepository`, `Slim\Psr7\Stream`, `App\Support\BackupManager`) with `use` imports, for consistency with the rest of each file. No behaviour change.
- **`backup-restore.spec.js`**: assert the specific protective trigger exists *before* dropping it (precondition) and verify that exact trigger by name afterwards, instead of a fragile total-count delta — a missing trigger now fails at a clear precondition rather than a confusing count mismatch.

The #168 `page.on('request')` listener-leak nitpick was already addressed in main (`page.off` present). Validated: PHPStan L5 + backup-restore E2E 6/6.