### PR TITLE
feat(installer): activate Mobile API by default on fresh installs

### DIFF
--- a/installer/classes/Installer.php
+++ b/installer/classes/Installer.php
@@ -1490,7 +1490,8 @@ HTACCESS;
             }
         };
 
-        // NOTE: Only the 5 historically-default plugins are auto-activated on fresh install.
+        // NOTE: The 5 historically-default plugins plus mobile-api (active by default
+        // since 0.7.21) are auto-activated on fresh install.
         // Other bundled plugins (BundledPlugins::LIST) are registered later by
         // autoRegisterBundledPlugins() and remain deactivated until admin opt-in.
         // Keeping new plugins opt-in is safer for fresh installs: it avoids surprising
@@ -1508,6 +1509,14 @@ HTACCESS;
         ]);
         $installPlugin('dewey-editor', [
             ['name' => 'app.routes.register', 'callback_method' => 'registerRoutes', 'priority' => 10]
+        ]);
+        // Mobile API: active by default since 0.7.21 so a fresh install ships a
+        // working /api/v1 for the companion Android app out of the box. Its tables
+        // are created by schema.sql (mirrors MobileApiPlugin::ensureSchema). Existing
+        // installs get it shipped + registered but INACTIVE on upgrade — admin opts in.
+        $installPlugin('mobile-api', [
+            ['name' => 'app.routes.register', 'callback_method' => 'registerRoutes', 'priority' => 10],
+            ['name' => 'mobile_api.dispatch_push', 'callback_method' => 'dispatchPush', 'priority' => 20]
         ]);
 
         // Configure Z39 Server with SBN (Servizio Bibliotecario Nazionale) as default

--- a/installer/classes/Installer.php
+++ b/installer/classes/Installer.php
@@ -32,6 +32,13 @@ class Installer {
         'log_modifiche',
         'mensole',
         'migrations',
+        // Mobile API plugin tables — active by default since 0.7.21 (schema.sql),
+        // so the installer's post-import verification must check them too.
+        'mobile_app_tokens',
+        'mobile_availability_watchers',
+        'mobile_push_log',
+        'mobile_push_prefs',
+        'mobile_push_subscriptions',
         'plugin_data',
         'plugin_hooks',
         'plugin_logs',

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -1293,6 +1293,86 @@ CREATE TABLE `consent_log` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 
+--
+-- Mobile API plugin tables (bundled + active by default since 0.7.21).
+-- Mirrors MobileApiPlugin::ensureSchema() (idempotent, single source of truth
+-- on activation/upgrade). Kept here so a fresh install — where the plugin is
+-- auto-activated — has the tables ready. FK_CHECKS is off during this import.
+--
+CREATE TABLE IF NOT EXISTS mobile_app_tokens (
+    id           INT AUTO_INCREMENT PRIMARY KEY,
+    user_id      INT          NOT NULL,
+    token_hash   CHAR(64)     NOT NULL,
+    device_name  VARCHAR(190) NULL,
+    device_id    VARCHAR(190) NULL,
+    platform     VARCHAR(32)  NULL,
+    created_at   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_used_at DATETIME     NULL,
+    revoked_at   DATETIME     NULL,
+    expires_at   DATETIME     NULL,
+    UNIQUE KEY uq_token_hash (token_hash),
+    KEY idx_user       (user_id),
+    KEY idx_user_active (user_id, revoked_at),
+    CONSTRAINT fk_mobile_token_user
+        FOREIGN KEY (user_id) REFERENCES utenti (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS mobile_push_subscriptions (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    user_id         INT          NOT NULL,
+    token_id        INT          NULL,
+    provider        ENUM('unifiedpush','fcm') NOT NULL DEFAULT 'unifiedpush',
+    endpoint        VARCHAR(500) NULL,
+    registration_id VARCHAR(500) NULL,
+    public_key      VARCHAR(255) NULL,
+    auth            VARCHAR(255) NULL,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_ok_at      DATETIME     NULL,
+    failure_count   INT          NOT NULL DEFAULT 0,
+    KEY idx_user     (user_id),
+    KEY idx_token    (token_id),
+    CONSTRAINT fk_mobile_push_user
+        FOREIGN KEY (user_id) REFERENCES utenti (id) ON DELETE CASCADE,
+    CONSTRAINT fk_mobile_push_token
+        FOREIGN KEY (token_id) REFERENCES mobile_app_tokens (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS mobile_push_prefs (
+    user_id           INT       NOT NULL PRIMARY KEY,
+    loan_due          TINYINT(1) NOT NULL DEFAULT 1,
+    loan_overdue      TINYINT(1) NOT NULL DEFAULT 1,
+    reservation_ready TINYINT(1) NOT NULL DEFAULT 1,
+    new_message       TINYINT(1) NOT NULL DEFAULT 1,
+    book_available    TINYINT(1) NOT NULL DEFAULT 1,
+    quiet_start       TIME      NULL,
+    quiet_end         TIME      NULL,
+    CONSTRAINT fk_mobile_prefs_user
+        FOREIGN KEY (user_id) REFERENCES utenti (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS mobile_availability_watchers (
+    id         INT AUTO_INCREMENT PRIMARY KEY,
+    user_id    INT       NOT NULL,
+    libro_id   INT       NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_user_book (user_id, libro_id),
+    KEY idx_libro (libro_id),
+    CONSTRAINT fk_mobile_watch_user
+        FOREIGN KEY (user_id) REFERENCES utenti (id) ON DELETE CASCADE,
+    CONSTRAINT fk_mobile_watch_book
+        FOREIGN KEY (libro_id) REFERENCES libri (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS mobile_push_log (
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id    INT          NOT NULL,
+    event_key  VARCHAR(191) NOT NULL,
+    created_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_user_event (user_id, event_key),
+    KEY idx_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
Makes a **fresh install** ship a working `/api/v1` out of the box (powers the companion Android app):

- **`installer/database/schema.sql`**: add the 5 `mobile_*` tables (mirror `MobileApiPlugin::ensureSchema`, idempotent) so they exist after a fresh schema import.
- **`installer/classes/Installer.php`**: add `mobile-api` to the auto-activated plugin set with its hooks (`app.routes.register`, `mobile_api.dispatch_push`).
- **`updater.md`**: add mobile-api to the bundled-plugin table + bump the verification count 17→18.

**Existing installs (upgrade)** get the plugin shipped + registered but **INACTIVE** — admin opt-in, no behaviour change on upgrade.

Validated end-to-end with a **fresh headed install**: 9/9 installer steps, `mobile-api is_active=1`, 2 hooks registered, 5 `mobile_*` tables created, `/api/v1/health → 200`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Note di Rilascio

* **Nuove Funzionalità**
  * Il plugin Mobile API è ora attivato di default durante l'installazione. Questo abilita il supporto per app mobile con funzionalità come notifiche push, autenticazione tramite token dispositivo e gestione delle preferenze di notifica.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->