### PR TITLE
fix(installer): clear message when re-installing over an existing admin email

### DIFF
--- a/installer/classes/Installer.php
+++ b/installer/classes/Installer.php
@@ -853,6 +853,17 @@ class Installer {
                 'codice_tessera' => $codiceTessera
             ];
         } catch (PDOException $e) {
+            // A duplicate email means an admin with this address already exists —
+            // e.g. re-running the installer against a database that survived while
+            // the .installed marker was lost (failed-install retry, DB restore
+            // without the marker, or a docroot/marker mishap). Surface a clear,
+            // actionable message instead of a raw SQL error.
+            if ($e->getCode() === '23000' || stripos($e->getMessage(), 'Duplicate entry') !== false) {
+                throw new \RuntimeException(sprintf(
+                    __("Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email."),
+                    $email
+                ), 0, $e);
+            }
             throw $e;
         }
     }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -1,4 +1,5 @@
 {
+  "Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email.": "Ein Benutzer mit der E-Mail-Adresse %s existiert bereits. Wenn Sie auf einer bestehenden Datenbank neu installieren, melden Sie sich mit den vorhandenen Zugangsdaten an oder verwenden Sie eine andere E-Mail-Adresse.",
   " libri": " Bücher",
   "\"%s\" prestato a %s è in ritardo di %d giorni": "\"%s\" ausgeliehen an %s ist %d Tage überfällig",
   "$1": "$1",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1,4 +1,5 @@
 {
+  "Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email.": "A user with the email %s already exists. If you are reinstalling over an existing database, log in with the existing credentials or use a different email.",
   " libri": " books",
   "\"%s\" prestato a %s è in ritardo di %d giorni": "\"%s\" loaned to %s is %d days overdue",
   "$1": "$1",

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -1,4 +1,5 @@
 {
+  "Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email.": "Un utilisateur avec l'e-mail %s existe déjà. Si vous réinstallez sur une base de données existante, connectez-vous avec les identifiants existants ou utilisez une autre adresse e-mail.",
   " libri": " livres",
   "\"%s\" prestato a %s è in ritardo di %d giorni": "\"%s\" emprunté par %s est en retard de %d jours",
   "$1": "$1",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -1,4 +1,5 @@
 {
+  "Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email.": "Esiste già un utente con l'email %s. Se stai reinstallando su un database esistente, accedi con le credenziali esistenti oppure usa un'altra email.",
   " libri": " libri",
   "\"%s\" prestato a %s è in ritardo di %d giorni": "\"%s\" prestato a %s è in ritardo di %d giorni",
   "$1": "$1",


### PR DESCRIPTION
While building the Docker image (headless install), an adversarial review surfaced that the installer's `createAdminUser()` re-throws the **raw PDOException** when `utenti.email` already exists.

**When it bites (main app):** re-running the installer against a database that survived while the `.installed` marker was lost — a failed-install retry, a DB restore without the marker, or a docroot/marker mishap. The wizard then shows a raw SQL error instead of something actionable. (In Docker this is the *normal* recreate lifecycle, handled separately in the pinakes-docker image; this PR hardens the upstream installer too.)

**Fix:** catch the duplicate-key (`SQLSTATE 23000` / `Duplicate entry`) and throw a clear, localized message ("A user with the email %s already exists…"). New i18n key added to all four locales (it/en/fr/de) in the same commit. No change to the happy path.

PHPStan L5 clean.