### PR TITLE
feat(mobile-api): Android contract coherence (plugin settings, loan, availability, OpenAPI)

### DIFF
--- a/app/Controllers/PluginController.php
+++ b/app/Controllers/PluginController.php
@@ -40,8 +40,35 @@ class PluginController
 
         $plugins = $this->pluginManager->getAllPlugins();
         $pluginSettings = [];
+        // Which plugins expose a settings page (so the list can show a generic
+        // "Impostazioni" button for ANY such plugin, not just a hardcoded few —
+        // otherwise e.g. the Mobile API gate is unreachable from the UI).
+        $pluginHasSettings = [];
         foreach ($plugins as $plugin) {
             $settings = $this->pluginManager->getSettings((int) $plugin['id']);
+
+            // Settings-page detection: only meaningful for active plugins (the
+            // instance must be loaded). Mirror the settings-route guard.
+            $hasSettingsPage = false;
+            if (!empty($plugin['is_active'])) {
+                try {
+                    $instance = $this->pluginManager->getPluginInstance((int) $plugin['id']);
+                    if ($instance !== null
+                        && is_callable([$instance, 'hasSettingsPage'])
+                        && $instance->hasSettingsPage()
+                        && is_callable([$instance, 'getSettingsViewPath'])
+                    ) {
+                        // Mirror settingsPage()'s guard exactly: a declared view
+                        // path that doesn't exist on disk must NOT surface a button
+                        // (the click would 404).
+                        $viewPath = $instance->getSettingsViewPath();
+                        $hasSettingsPage = is_string($viewPath) && is_file($viewPath);
+                    }
+                } catch (\Throwable $e) {
+                    $hasSettingsPage = false;
+                }
+            }
+            $pluginHasSettings[$plugin['id']] = $hasSettingsPage;
 
             // Handle Google Books API key
             if (array_key_exists('google_books_api_key', $settings)) {
@@ -298,6 +325,16 @@ class PluginController
                 'message' => __('Plugin non trovato.')
             ]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        }
+
+        // Self-rendering settings pages (e.g. Mobile API) post flat form fields and
+        // handle their OWN POST inside the view — CSRF, persistence via the plugin's
+        // saveSettings(), success message, re-render. The legacy AJAX handlers below
+        // require a nested `settings` payload; when it's absent, this is such a
+        // self-handling form, so render the settings page (which runs that logic)
+        // instead of falling through to "questo plugin non supporta impostazioni".
+        if (!is_array($body) || !array_key_exists('settings', $body)) {
+            return $this->settingsPage($request, $response, $args);
         }
 
         error_log('[PluginController] Plugin name: ' . $plugin['name']);

--- a/app/Views/admin/plugins.php
+++ b/app/Views/admin/plugins.php
@@ -5,6 +5,8 @@ use App\Support\Csrf;
 
 $pageTitle = __('Gestione Plugin');
 $pluginSettings = $pluginSettings ?? [];
+/** @var array<int,bool> $pluginHasSettings */
+$pluginHasSettings = $pluginHasSettings ?? [];
 ?>
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -296,7 +298,15 @@ $pluginSettings = $pluginSettings ?? [];
                                         <?= __("Configura Fonti") ?>
                                     </button>
                                 <?php endif; ?>
-                                <?php if ($plugin['name'] === 'discogs'): ?>
+                                <?php
+                                // Generic settings button: shown for ANY active plugin that exposes
+                                // a settings page and isn't already handled by a custom button above
+                                // (open-library / api-book-scraper / goodlib use their own modals).
+                                // Without this, plugins like Mobile API have a working settings page
+                                // (/admin/plugins/{id}/settings) that is unreachable from the UI.
+                                $hasCustomSettingsButton = $isOpenLibrary || $isApiBookScraper || $isGoodLib;
+                                ?>
+                                <?php if (!$hasCustomSettingsButton && !empty($pluginHasSettings[$plugin['id']])): ?>
                                     <a href="<?= htmlspecialchars(url('/admin/plugins') . '/' . (int) $plugin['id'] . '/settings', ENT_QUOTES, 'UTF-8') ?>"
                                         class="px-4 py-2 bg-indigo-100 text-indigo-700 rounded-lg hover:bg-indigo-200 transition-all duration-200 text-sm font-medium inline-flex items-center">
                                         <i class="fas fa-cog mr-1"></i>

--- a/storage/plugins/mobile-api/src/Controllers/ActionsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ActionsController.php
@@ -210,9 +210,13 @@ final class ActionsController
 
             // Decide loan vs reservation using the SAME availability gate the web
             // uses (ReservationManager), so the two surfaces agree. Immediate loan
-            // only when the user asked for "now" (no date) and a copy is free.
+            // when the user asked for "now" — either no date, OR today's date with
+            // a copy free. The app's "Request loan" on an available title sends
+            // today (its date picker pre-selects the first free day = today), so
+            // without the today case that flow wrongly became a reservation
+            // instead of a pending loan. A FUTURE date is always a reservation.
             $immediate = false;
-            if ($desired === '') {
+            if ($desired === '' || $desired === date('Y-m-d')) {
                 $manager   = new \App\Controllers\ReservationManager($this->db);
                 $immediate = $manager->isBookAvailableForImmediateLoan($bookId, null, null, $userId);
             }
@@ -635,7 +639,7 @@ final class ActionsController
         $nome     = trim((string) ($body['nome'] ?? ($user['nome'] ?? '')));
         $cognome  = trim((string) ($body['cognome'] ?? ($user['cognome'] ?? '')));
         $email    = trim((string) ($body['email'] ?? ($user['email'] ?? '')));
-        $messaggio = trim((string) ($body['messaggio'] ?? $body['message'] ?? ''));
+        $messaggio = trim((string) ($body['messaggio'] ?? $body['message'] ?? $body['body'] ?? ''));
 
         if ($nome === '' || $cognome === '' || $email === '' || $messaggio === '') {
             return ResponseEnvelope::error($response, 'required_fields', __('Compila tutti i campi obbligatori.'), 422);

--- a/storage/plugins/mobile-api/src/Controllers/CatalogController.php
+++ b/storage/plugins/mobile-api/src/Controllers/CatalogController.php
@@ -496,12 +496,39 @@ final class CatalogController
                 'total_copies'       => (int) ($avail['total_copies'] ?? 0),
                 'earliest_available' => $avail['earliest_available'] ?? null,
                 'unavailable_dates'  => array_values((array) ($avail['unavailable_dates'] ?? [])),
-                'days'               => array_values((array) ($avail['days'] ?? [])),
+                'days'               => $this->normalizeMobileAvailabilityDays(
+                    array_values((array) ($avail['days'] ?? [])),
+                    (int) ($avail['total_copies'] ?? 0)
+                ),
             ], []);
         } catch (\Throwable $e) {
             SecureLogger::error('[MobileApi] book availability failed: ' . $e->getMessage());
             return ResponseEnvelope::error($response, 'internal_error', __('Disponibilità non disponibile.'), 500);
         }
+    }
+
+    /**
+     * Convert the website availability labels (borrowed/reserved) into the
+     * app calendar contract: free, partial, full.
+     *
+     * @param list<array<string, mixed>> $days
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeMobileAvailabilityDays(array $days, int $totalCopies): array
+    {
+        foreach ($days as &$day) {
+            $available = (int) ($day['available'] ?? 0);
+            if ($available <= 0 || $totalCopies <= 0) {
+                $day['state'] = 'full';
+            } elseif ($available < $totalCopies) {
+                $day['state'] = 'partial';
+            } else {
+                $day['state'] = 'free';
+            }
+        }
+        unset($day);
+
+        return $days;
     }
 
     private function fetchBookCore(int $bookId): ?array

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -471,7 +471,7 @@ final class OpenApiController
                                                 'available' => ['type' => 'integer'],
                                                 'loaned'    => ['type' => 'integer'],
                                                 'reserved'  => ['type' => 'integer'],
-                                                'state'     => ['type' => 'string', 'enum' => ['free', 'borrowed', 'reserved']],
+                                                'state'     => ['type' => 'string', 'enum' => ['free', 'partial', 'full']],
                                             ],
                                         ]],
                                     ],
@@ -828,12 +828,16 @@ final class OpenApiController
     {
         return [
             'type'       => 'object',
-            'required'   => ['nome', 'cognome', 'email', 'password'],
+            'required'   => ['nome', 'cognome', 'email', 'telefono', 'indirizzo', 'password', 'password_confirm', 'privacy_acceptance'],
             'properties' => [
-                'nome'     => ['type' => 'string', 'maxLength' => 100],
-                'cognome'  => ['type' => 'string', 'maxLength' => 100],
-                'email'    => ['type' => 'string', 'format' => 'email'],
-                'password' => ['type' => 'string', 'minLength' => 8],
+                'nome'               => ['type' => 'string', 'maxLength' => 100],
+                'cognome'            => ['type' => 'string', 'maxLength' => 100],
+                'email'              => ['type' => 'string', 'format' => 'email', 'maxLength' => 255],
+                'telefono'           => ['type' => 'string'],
+                'indirizzo'          => ['type' => 'string'],
+                'password'           => ['type' => 'string', 'minLength' => 8, 'maxLength' => 72],
+                'password_confirm'   => ['type' => 'string', 'minLength' => 8, 'maxLength' => 72],
+                'privacy_acceptance' => ['type' => 'boolean'],
             ],
         ];
     }
@@ -872,16 +876,20 @@ final class OpenApiController
         return [
             'type'       => 'object',
             'properties' => [
-                'id'            => ['type' => 'integer'],
-                'titolo'        => ['type' => 'string'],
-                'sottotitolo'   => ['type' => 'string', 'nullable' => true],
-                'autori'        => ['type' => 'array', 'items' => ['type' => 'string']],
-                'editore'       => ['type' => 'string', 'nullable' => true],
-                'anno'          => ['type' => 'integer', 'nullable' => true],
-                'copertina_url' => ['type' => 'string', 'format' => 'uri', 'nullable' => true, 'description' => 'Absolute URL.'],
-                'disponibile'   => ['type' => 'boolean', 'description' => 'True if at least one copy is currently loanable.'],
-                'genere'        => ['type' => 'string', 'nullable' => true],
-                'lingua'        => ['type' => 'string', 'nullable' => true],
+                'id'               => ['type' => 'integer'],
+                'title'            => ['type' => 'string'],
+                'subtitle'         => ['type' => 'string', 'nullable' => true],
+                'author'           => ['type' => 'string', 'nullable' => true],
+                'publisher'        => ['type' => 'string', 'nullable' => true],
+                'genre'            => ['type' => 'string', 'nullable' => true],
+                'year'             => ['type' => 'integer', 'nullable' => true],
+                'language'         => ['type' => 'string', 'nullable' => true],
+                'media_type'       => ['type' => 'string', 'nullable' => true],
+                'isbn13'           => ['type' => 'string', 'nullable' => true],
+                'cover_url'        => ['type' => 'string', 'format' => 'uri', 'nullable' => true, 'description' => 'Absolute URL.'],
+                'copies_total'     => ['type' => 'integer'],
+                'copies_available' => ['type' => 'integer'],
+                'loanable_now'     => ['type' => 'boolean', 'description' => 'True if at least one copy is currently loanable.'],
             ],
         ];
     }
@@ -893,16 +901,47 @@ final class OpenApiController
             'allOf' => [['$ref' => '#/components/schemas/BookSummary']],
             'type'  => 'object',
             'properties' => [
-                'isbn10'          => ['type' => 'string', 'nullable' => true],
-                'isbn13'          => ['type' => 'string', 'nullable' => true],
-                'ean'             => ['type' => 'string', 'nullable' => true],
-                'descrizione'     => ['type' => 'string', 'nullable' => true],
-                'numero_pagine'   => ['type' => 'integer', 'nullable' => true],
-                'condizione'      => ['type' => 'string', 'nullable' => true],
-                'collocazione'    => ['type' => 'string', 'nullable' => true, 'description' => 'Shelf / location label.'],
-                'copie_totali'    => ['type' => 'integer', 'description' => 'Total physical copies.'],
-                'copie_disponibili' => ['type' => 'integer', 'description' => 'Copies currently loanable.'],
-                'personal_history'  => ['$ref' => '#/components/schemas/PersonalHistory'],
+                'isbn10'           => ['type' => 'string', 'nullable' => true],
+                'ean'              => ['type' => 'string', 'nullable' => true],
+                'pages'            => ['type' => 'integer', 'nullable' => true],
+                'description'      => ['type' => 'string', 'nullable' => true],
+                'format'           => ['type' => 'string', 'nullable' => true],
+                'series'           => ['type' => 'string', 'nullable' => true],
+                'condition'        => ['type' => 'string', 'nullable' => true],
+                'audio_url'        => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'has_audio'        => ['type' => 'boolean'],
+                'ebook_url'        => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'ebook_format'     => ['type' => 'string', 'nullable' => true],
+                'has_ebook'        => ['type' => 'boolean'],
+                'genre'            => ['type' => 'object', 'nullable' => true, 'properties' => [
+                    'id'          => ['type' => 'integer', 'nullable' => true],
+                    'name'        => ['type' => 'string', 'nullable' => true],
+                    'parent'      => ['type' => 'string', 'nullable' => true],
+                    'grandparent' => ['type' => 'string', 'nullable' => true],
+                    'subgenre'    => ['type' => 'string', 'nullable' => true],
+                ]],
+                'publishers'       => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => [
+                    'id'   => ['type' => 'integer'],
+                    'name' => ['type' => 'string'],
+                ]]],
+                'authors'          => ['type' => 'array', 'items' => ['type' => 'object', 'properties' => [
+                    'id'   => ['type' => 'integer'],
+                    'name' => ['type' => 'string'],
+                    'role' => ['type' => 'string', 'nullable' => true],
+                ]]],
+                'availability'     => ['type' => 'object', 'properties' => [
+                    'copies_total'     => ['type' => 'integer'],
+                    'copies_available' => ['type' => 'integer'],
+                    'loanable_now'     => ['type' => 'boolean'],
+                    'state'            => ['type' => 'string', 'enum' => ['available', 'on_loan', 'reserved', 'unavailable']],
+                ]],
+                'location'         => ['type' => 'object', 'nullable' => true, 'properties' => [
+                    'label'         => ['type' => 'string', 'nullable' => true],
+                    'shelf_id'      => ['type' => 'integer', 'nullable' => true],
+                    'shelf_unit_id' => ['type' => 'integer', 'nullable' => true],
+                    'position'      => ['type' => 'integer', 'nullable' => true],
+                ]],
+                'personal_history' => ['$ref' => '#/components/schemas/PersonalHistory'],
             ],
         ];
     }
@@ -918,6 +957,7 @@ final class OpenApiController
                 'has_reserved'    => ['type' => 'boolean', 'description' => 'The user has a pending/active reservation for this book.'],
                 'has_wishlisted'  => ['type' => 'boolean', 'description' => 'This book is in the user\'s wishlist.'],
                 'has_active_loan' => ['type' => 'boolean', 'description' => 'The user currently has this book on loan.'],
+                'has_pending_request' => ['type' => 'boolean', 'description' => 'The user has a pending loan request for this book.'],
             ],
         ];
     }
@@ -929,8 +969,7 @@ final class OpenApiController
             'type'       => 'object',
             'properties' => [
                 'id'       => ['type' => 'integer'],
-                'nome'     => ['type' => 'string'],
-                'livello'  => ['type' => 'integer', 'description' => 'Depth: 1 = root, 2 = mid, 3 = leaf.'],
+                'name'     => ['type' => 'string'],
                 'children' => ['type' => 'array', 'items' => ['$ref' => '#/components/schemas/GenreNode']],
             ],
         ];
@@ -955,15 +994,15 @@ final class OpenApiController
         return [
             'type'       => 'object',
             'properties' => [
-                'id'             => ['type' => 'integer'],
-                'libro_id'       => ['type' => 'integer'],
-                'titolo'         => ['type' => 'string'],
-                'copertina_url'  => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
-                'stato'          => ['type' => 'string', 'description' => 'e.g. in_corso, concluso, in_scadenza, scaduto, prenotato, in_attesa.'],
-                'data_prestito'  => ['type' => 'string', 'format' => 'date', 'nullable' => true],
-                'data_scadenza'  => ['type' => 'string', 'format' => 'date', 'nullable' => true],
-                'data_restituzione' => ['type' => 'string', 'format' => 'date', 'nullable' => true],
-                'created_at'     => ['type' => 'string', 'format' => 'date-time'],
+                'id'          => ['type' => 'integer'],
+                'book_id'     => ['type' => 'integer'],
+                'title'       => ['type' => 'string'],
+                'cover_url'   => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'status'      => ['type' => 'string', 'description' => 'Raw prestiti.stato value.'],
+                'loaned_at'   => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'due_at'      => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'returned_at' => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'renewals'    => ['type' => 'integer', 'nullable' => true],
             ],
         ];
     }
@@ -974,15 +1013,16 @@ final class OpenApiController
         return [
             'type'       => 'object',
             'properties' => [
-                'id'            => ['type' => 'integer'],
-                'libro_id'      => ['type' => 'integer'],
-                'titolo'        => ['type' => 'string'],
-                'copertina_url' => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
-                'stato'         => ['type' => 'string'],
-                'data_inizio'   => ['type' => 'string', 'format' => 'date', 'nullable' => true],
-                'data_fine'     => ['type' => 'string', 'format' => 'date', 'nullable' => true],
-                'queue_position'=> ['type' => 'integer', 'nullable' => true],
-                'created_at'    => ['type' => 'string', 'format' => 'date-time'],
+                'id'             => ['type' => 'integer'],
+                'book_id'        => ['type' => 'integer'],
+                'title'          => ['type' => 'string'],
+                'cover_url'      => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'status'         => ['type' => 'string'],
+                'queue_position' => ['type' => 'integer', 'nullable' => true],
+                'requested_from' => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'requested_to'   => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'reserved_at'    => ['type' => 'string', 'format' => 'date-time', 'nullable' => true],
+                'expires_at'     => ['type' => 'string', 'format' => 'date-time', 'nullable' => true],
             ],
         ];
     }
@@ -994,9 +1034,10 @@ final class OpenApiController
             'type'       => 'object',
             'required'   => ['book_id'],
             'properties' => [
-                'book_id'    => ['type' => 'integer'],
-                'start_date' => ['type' => 'string', 'format' => 'date', 'description' => 'Requested start date (ISO-8601). Defaults to today if omitted.'],
-                'end_date'   => ['type' => 'string', 'format' => 'date', 'description' => 'Requested end date (ISO-8601).'],
+                'book_id'      => ['type' => 'integer'],
+                'desired_date' => ['type' => 'string', 'format' => 'date', 'nullable' => true, 'description' => 'Requested start date. Today or omitted means immediate loan when a copy is free; future dates create reservations.'],
+                'start_date'   => ['type' => 'string', 'format' => 'date', 'nullable' => true, 'deprecated' => true],
+                'end_date'     => ['type' => 'string', 'format' => 'date', 'nullable' => true, 'deprecated' => true],
             ],
         ];
     }
@@ -1007,11 +1048,13 @@ final class OpenApiController
         return [
             'type'       => 'object',
             'properties' => [
-                'book_id'       => ['type' => 'integer'],
-                'titolo'        => ['type' => 'string'],
-                'copertina_url' => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
-                'disponibile'   => ['type' => 'boolean'],
-                'added_at'      => ['type' => 'string', 'format' => 'date-time'],
+                'book_id'          => ['type' => 'integer'],
+                'title'            => ['type' => 'string'],
+                'author'           => ['type' => 'string', 'nullable' => true],
+                'year'             => ['type' => 'integer', 'nullable' => true],
+                'cover_url'        => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'copies_available' => ['type' => 'integer'],
+                'loanable_now'     => ['type' => 'boolean'],
             ],
         ];
     }
@@ -1061,10 +1104,11 @@ final class OpenApiController
     {
         return [
             'type'       => 'object',
-            'required'   => ['current_password', 'new_password'],
+            'required'   => ['current_password', 'password', 'password_confirm'],
             'properties' => [
                 'current_password' => ['type' => 'string'],
-                'new_password'     => ['type' => 'string', 'minLength' => 8],
+                'password'         => ['type' => 'string', 'minLength' => 8, 'maxLength' => 72],
+                'password_confirm' => ['type' => 'string', 'minLength' => 8, 'maxLength' => 72],
             ],
         ];
     }
@@ -1091,10 +1135,9 @@ final class OpenApiController
                 'id'         => ['type' => 'string', 'description' => 'Opaque notification identifier.'],
                 'type'       => ['type' => 'string', 'enum' => ['loan_due', 'loan_overdue', 'reservation_ready', 'new_message', 'book_available']],
                 'title'      => ['type' => 'string'],
-                'body'       => ['type' => 'string'],
-                'read'       => ['type' => 'boolean'],
-                'created_at' => ['type' => 'string', 'format' => 'date-time'],
-                'payload'    => ['type' => 'object', 'additionalProperties' => true, 'nullable' => true],
+                'message'    => ['type' => 'string'],
+                'book_id'    => ['type' => 'integer', 'nullable' => true],
+                'date'       => ['type' => 'string', 'nullable' => true, 'description' => 'ISO date or date-time associated with the notification.'],
             ],
         ];
     }

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -1116,12 +1116,24 @@ final class OpenApiController
     /** @return array<string, mixed> */
     private function messageRequestSchema(): array
     {
+        // Mirror the real ActionsController::sendMessage contract: the message
+        // text is `messaggio` (aliases `message` / `body` are accepted); nome/
+        // cognome/email default to the authenticated user when omitted; telefono/
+        // indirizzo are optional. The previous schema wrongly required
+        // subject/body — the controller never reads `subject`.
         return [
-            'type'       => 'object',
-            'required'   => ['subject', 'body'],
-            'properties' => [
-                'subject' => ['type' => 'string', 'maxLength' => 255],
-                'body'    => ['type' => 'string', 'maxLength' => 5000],
+            'type'        => 'object',
+            'required'    => ['messaggio'],
+            'description' => 'nome/cognome/email default to the authenticated user when omitted. The message text is `messaggio` (aliases: `message`, `body`).',
+            'properties'  => [
+                'messaggio' => ['type' => 'string', 'maxLength' => 5000, 'description' => 'Message text.'],
+                'message'   => ['type' => 'string', 'maxLength' => 5000, 'description' => 'Alias of `messaggio`.'],
+                'body'      => ['type' => 'string', 'maxLength' => 5000, 'description' => 'Alias of `messaggio`.'],
+                'nome'      => ['type' => 'string', 'maxLength' => 100],
+                'cognome'   => ['type' => 'string', 'maxLength' => 100],
+                'email'     => ['type' => 'string', 'format' => 'email'],
+                'telefono'  => ['type' => 'string'],
+                'indirizzo' => ['type' => 'string'],
             ],
         ];
     }

--- a/tests/mobile-api-behaviors.spec.js
+++ b/tests/mobile-api-behaviors.spec.js
@@ -600,4 +600,25 @@ test.describe('Reservations', () => {
             clearBorrowerReservations();
         }
     });
+
+    test('26) {available book, desired_date=today} → immediate loan (type=loan), not a reservation', async ({ request }) => {
+        // The app's "Request loan" on an AVAILABLE title sends today's date (its
+        // date picker pre-selects the first free day = today). The backend must
+        // treat today + a free copy as an immediate pending loan, not a
+        // reservation — otherwise the available-now flow silently queues instead
+        // of requesting a loan. A FUTURE date stays a reservation (test 22).
+        clearBorrowerReservations();
+        try {
+            const book = pickAvailableBook();
+            const res = await call(request, 'POST', '/reservations', {
+                token: ctx.userToken,
+                body: { book_id: book, desired_date: todayYmd() },
+            });
+            expect(res.status(), 'created').toBe(201);
+            const j = await jsonOf(res);
+            expect(j?.data?.type, 'today + available → immediate loan').toBe('loan');
+        } finally {
+            clearBorrowerReservations();
+        }
+    });
 });

--- a/tests/mobile-api-idempotency.spec.js
+++ b/tests/mobile-api-idempotency.spec.js
@@ -313,7 +313,7 @@ test.describe('Mobile API — two calls per endpoint (idempotency + ETag/304)', 
         } catch { ctx.reservationId = 0; }
 
         // Pre-add the wishlist book so DELETE /me/wishlist/{bookId} has something to remove on call #1.
-        try { dbExec(`INSERT IGNORE INTO wishlist (utente_id, libro_id, created_at) VALUES (${ctx.userId}, ${ctx.bookId}, NOW())`); } catch {}
+        try { dbExec(`INSERT IGNORE INTO wishlist (utente_id, libro_id) VALUES (${ctx.userId}, ${ctx.bookId})`); } catch {}
     });
 
     test.afterAll(async () => {


### PR DESCRIPTION
Consolidated mobile-API ⇄ Android contract work. Supersedes #191 and #193 (their changes are included here) and adds:

**Backend**
- **Plugin settings reachable + saveable** — generic *Impostazioni* button for any plugin with a settings page; POST delegates self-rendering pages to settingsPage() so the **Mobile API access toggle** persists.
- **Loan vs reservation** — `desired_date` empty *or today* on an available book is an immediate loan, not a reservation.
- **Availability calendar contract** — `CatalogController::normalizeMobileAvailabilityDays` maps website labels to the app's `free|partial|full` states.
- **OpenAPI coherence** — the generated spec aligned with the live endpoints.
- E2E: mobile-api-behaviors + idempotency updated.

**Verification:** PHPStan L5 clean · 57 mobile-api E2E pass.

The matching Android changes (register/forgot UI, feature-flag gating, contract alignment) are in the Android repo's companion PR.