### PR TITLE
fix(loans): promote the waitlist head when reservations fully subscribe the copies (#157)

### DIFF
--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -187,7 +187,16 @@ class ReservationManager
                 // $reservation['data_fine_richiesta'] for the loan period).
                 $nextReservation['data_fine_richiesta'] = $endDate;
 
-                if ($this->isDateRangeAvailable($bookId, $startDate, $endDate, (int) $nextReservation['id'])) {
+                // #157: pass the promoted reservation's queue_position so the
+                // capacity gate ignores waitlist entries BEHIND it (they would
+                // otherwise block the head when the waitlist fully subscribes the
+                // copies — e.g. 1 copy + 2 queued reservations promoted 0).
+                // isset() is false for both an absent key and a NULL value, so it
+                // covers a legacy NULL queue_position without a redundant null check.
+                $headQueuePos = isset($nextReservation['queue_position'])
+                    ? (int) $nextReservation['queue_position']
+                    : null;
+                if ($this->isDateRangeAvailable($bookId, $startDate, $endDate, (int) $nextReservation['id'], $headQueuePos)) {
                     // Create the loan - check return value to handle race conditions
                     // Note: createLoanFromReservation() handles its own transaction internally
                     // when called standalone, but here we're already in a transaction
@@ -270,7 +279,7 @@ class ReservationManager
      * @param string|null $endDate End date (Y-m-d format)
      * @return bool True if at least one copy is available
      */
-    private function isDateRangeAvailable($bookId, $startDate, $endDate, ?int $excludeReservationId = null)
+    private function isDateRangeAvailable($bookId, $startDate, $endDate, ?int $excludeReservationId = null, ?int $excludeReservationsAfterQueuePos = null)
     {
         if (!$startDate || !$endDate) {
             return false;
@@ -287,7 +296,8 @@ class ReservationManager
             (int) $bookId,
             (string) $startDate,
             (string) $endDate,
-            excludeReservationId: $excludeReservationId
+            excludeReservationId: $excludeReservationId,
+            excludeReservationsAfterQueuePos: $excludeReservationsAfterQueuePos
         );
     }
 

--- a/app/Services/CapacityService.php
+++ b/app/Services/CapacityService.php
@@ -93,11 +93,12 @@ final class CapacityService
         string $end,
         ?int $excludePrestitoId = null,
         ?int $excludeReservationId = null,
-        ?int $excludeUserId = null
+        ?int $excludeUserId = null,
+        ?int $excludeReservationsAfterQueuePos = null
     ): int {
         $intervals = array_merge(
             $this->holdingLoanIntervals($libroId, $start, $end, $excludePrestitoId, $excludeUserId),
-            $this->activeReservationIntervals($libroId, $start, $end, $excludeReservationId, $excludeUserId)
+            $this->activeReservationIntervals($libroId, $start, $end, $excludeReservationId, $excludeUserId, $excludeReservationsAfterQueuePos)
         );
         return $this->sweepPeak($intervals);
     }
@@ -109,13 +110,14 @@ final class CapacityService
         string $end,
         ?int $excludePrestitoId = null,
         ?int $excludeReservationId = null,
-        ?int $excludeUserId = null
+        ?int $excludeUserId = null,
+        ?int $excludeReservationsAfterQueuePos = null
     ): bool {
         $total = $this->totalCopies($libroId);
         if ($total <= 0) {
             return false;
         }
-        $occ = $this->occupiedCount($libroId, $start, $end, $excludePrestitoId, $excludeReservationId, $excludeUserId);
+        $occ = $this->occupiedCount($libroId, $start, $end, $excludePrestitoId, $excludeReservationId, $excludeUserId, $excludeReservationsAfterQueuePos);
         return $occ < $total;
     }
 
@@ -150,7 +152,7 @@ final class CapacityService
      * Active reservation intervals overlapping [$start,$end], clamped to the window.
      * @return list<array{0:string,1:string}>
      */
-    private function activeReservationIntervals(int $libroId, string $start, string $end, ?int $excludeReservationId, ?int $excludeUserId): array
+    private function activeReservationIntervals(int $libroId, string $start, string $end, ?int $excludeReservationId, ?int $excludeUserId, ?int $excludeReservationsAfterQueuePos = null): array
     {
         // Canonical 3-step coalesce chain for the reservation end (no 2-step variants).
         $rEnd = 'COALESCE(r.data_fine_richiesta, DATE(r.data_scadenza_prenotazione), r.data_inizio_richiesta)';
@@ -172,6 +174,16 @@ final class CapacityService
             $sql .= ' AND r.utente_id <> ?';
             $types .= 'i';
             $params[] = $excludeUserId;
+        }
+        // Promotion gate (#157): when promoting the queue head, the waitlist
+        // entries BEHIND it must not occupy capacity — they are lower-priority
+        // and are promoted in later runs as copies free up. Exclude reservations
+        // with a known queue_position strictly greater than the promoted one.
+        // NULL queue_position rows still count (conservative — never overbook).
+        if ($excludeReservationsAfterQueuePos !== null) {
+            $sql .= ' AND NOT (r.queue_position IS NOT NULL AND r.queue_position > ?)';
+            $types .= 'i';
+            $params[] = $excludeReservationsAfterQueuePos;
         }
         return $this->fetchIntervals($sql, $types, $params);
     }


### PR DESCRIPTION
## Problem
Reservation maintenance (`cron/full-maintenance.php` → `MaintenanceService::processScheduledReservations`) promoted **no** reservation to a pending loan when a waitlist fully subscribed a title: **1 copy + 2 active reservations → 0 promoted** instead of 1.

## Cause
The promotion gate (`ReservationManager::processBookAvailability` → `isDateRangeAvailable` → `CapacityService::hasFreeCapacity`) counted **every** overlapping active reservation as occupying a capacity unit, excluding only the one being promoted. With 1 copy and 2 reservations, promoting the head (`queue_position=1`) still counted the second (`queue_position=2`) as occupying the only copy → `occ == total` → head never promoted. Both runs converted 0; test **F.21b (#157)** saw 0 pending instead of 1.

## Fix
The promotion path now passes the promoted reservation's `queue_position`, so the capacity gate **ignores active reservations with a strictly greater `queue_position`** (lower-priority waitlist entries, promoted in later runs as copies free up).
- Reservations **ahead** in the queue (lower position) still count.
- A legacy NULL `queue_position` still counts (conservative — never overbook).
- The new parameter is optional (`default null`): the **admin-creation gate and overbooked-auditor**, which share `CapacityService`, are unchanged.

## Verification
- **PHPStan level 5** clean.
- Cron repro: run 1 → **1 pending**, run 2 → still **1** (no double-conversion).
- E2E: **loan-reservation-complete 26/26** (F.21b now passes), **loan-overlap 35/35** (overbook prevention intact), **loan-state-model 4/4**.

_Surfaced while running the full E2E suite; pre-existing on `main`, independent of the Swagger PR #197._