### PR TITLE
fix(i18n): publication-date field is free text, not "Italian format" (#201)

### DIFF
--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -217,7 +217,7 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
             <div>
               <label for="data_pubblicazione" class="form-label"><?= __("Data di Pubblicazione") ?></label>
               <input id="data_pubblicazione" name="data_pubblicazione" type="text" class="form-input" placeholder="<?= __('es. 26 agosto 2025') ?>" value="<?php echo HtmlHelper::e($book['data_pubblicazione'] ?? ''); ?>" />
-              <p class="text-xs text-gray-500 mt-1"><?= __("Data originale di pubblicazione (formato italiano)") ?></p>
+              <p class="text-xs text-gray-500 mt-1"><?= __("Data di pubblicazione originale (testo libero)") ?></p>
             </div>
             <div>
               <label for="anno_pubblicazione" class="form-label"><?= __("Anno di Pubblicazione") ?></label>

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -1091,7 +1091,7 @@
   "Data nascita a": "Geburtsdatum bis",
   "Data nascita da": "Geburtsdatum von",
   "Data non valida.": "Ungültiges Datum.",
-  "Data originale di pubblicazione (formato italiano)": "Ursprüngliches Erscheinungsdatum (italienisches Format)",
+  "Data di pubblicazione originale (testo libero)": "Ursprüngliches Erscheinungsdatum (Freitext)",
   "Data prestito": "Ausleihdatum",
   "Data prestito (A)": "Ausleihdatum (Bis)",
   "Data prestito (Da)": "Ausleihdatum (Von)",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1091,7 +1091,7 @@
   "Data nascita a": "Birth date to",
   "Data nascita da": "Birth date from",
   "Data non valida.": "Invalid date.",
-  "Data originale di pubblicazione (formato italiano)": "Original publication date (Italian format)",
+  "Data di pubblicazione originale (testo libero)": "Original publication date (free text)",
   "Data prestito": "Loan date",
   "Data prestito (A)": "Loan date (To)",
   "Data prestito (Da)": "Loan date (From)",

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -1091,7 +1091,7 @@
   "Data nascita a": "Date de naissance jusqu'à",
   "Data nascita da": "Date de naissance depuis",
   "Data non valida.": "Date invalide.",
-  "Data originale di pubblicazione (formato italiano)": "Date de publication originale (format français)",
+  "Data di pubblicazione originale (testo libero)": "Date de publication originale (texte libre)",
   "Data prestito": "Date d'emprunt",
   "Data prestito (A)": "Date d'emprunt (jusqu'à)",
   "Data prestito (Da)": "Date d'emprunt (depuis)",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -1091,7 +1091,7 @@
   "Data nascita a": "Data nascita a",
   "Data nascita da": "Data nascita da",
   "Data non valida.": "Data non valida.",
-  "Data originale di pubblicazione (formato italiano)": "Data originale di pubblicazione (formato italiano)",
+  "Data di pubblicazione originale (testo libero)": "Data di pubblicazione originale (testo libero)",
   "Data prestito": "Data prestito",
   "Data prestito (A)": "Data prestito (A)",
   "Data prestito (Da)": "Data prestito (Da)",


### PR DESCRIPTION
Closes #201.

## Problem
The book edit form showed **Publication Date** with placeholder `e.g. August 26, 2025` but a helper saying **"Original publication date (Italian format)"** — contradictory for a non-Italian user. The translations had also drifted (`fr_FR` → "format français", `de_DE`/`en_US` → "Italian format"), so the reporter reasonably asked *"what is the right date format?"*.

## Answer / root cause
There is **no required format**. `data_pubblicazione` is a free-text `varchar(50)`:
- `BookRepository` stores it **verbatim** (bind type `s`, no parsing).
- `format_date()` only reformats values `strtotime()` can parse (English/numeric); anything else — e.g. the real-world value `24 settembre 1991` — is returned unchanged.
- The Italian `DateHelper` parser is **not** applied to this field.

So the "(Italian format)" note never reflected a real constraint.

## Fix
Helper text is now **"Original publication date (free text)"** (+ IT/FR/DE equivalents), matching the free-text nature and the locale-aware placeholder example. Source string + all four locale JSONs updated in the same commit.

| locale | new value |
|---|---|
| it_IT | Data di pubblicazione originale (testo libero) |
| en_US | Original publication date (free text) |
| fr_FR | Date de publication originale (texte libre) |
| de_DE | Ursprüngliches Erscheinungsdatum (Freitext) |

## Verify
- `php -l` clean; the 4 locale JSONs valid.
- Book edit form renders the new helper (browser, it_IT): *"Data di pubblicazione originale (testo libero)"*; placeholder unchanged.
