### PR TITLE
style(sidebar): stack the logo above the title

### DIFF
--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -111,7 +111,7 @@ $htmlLang = substr($currentLocale, 0, 2);
 
       <!-- Sidebar Header -->
       <div class="flex items-center justify-between px-6 py-5 flex-shrink-0">
-        <a href="<?= htmlspecialchars(url('/'), ENT_QUOTES, 'UTF-8') ?>" class="flex items-center space-x-3 hover:opacity-80 transition-opacity cursor-pointer">
+        <a href="<?= htmlspecialchars(url('/'), ENT_QUOTES, 'UTF-8') ?>" class="flex flex-col items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer">
           <div class="w-12 h-12 rounded-xl bg-white flex items-center justify-center">
             <?php if ($appLogo !== ''): ?>
               <img src="<?php echo HtmlHelper::e($appLogo); ?>" alt="<?php echo HtmlHelper::e($appName); ?>"
@@ -120,8 +120,8 @@ $htmlLang = substr($currentLocale, 0, 2);
               <span class="text-gray-700 font-semibold text-lg"><?php echo HtmlHelper::e($appInitial); ?></span>
             <?php endif; ?>
           </div>
-          <div class="leading-none">
-            <span class="font-bold text-lg text-gray-900 block"><?php echo HtmlHelper::e($appName); ?></span>
+          <div class="leading-none text-center">
+            <span class="font-bold text-lg leading-tight text-gray-900 block"><?php echo HtmlHelper::e($appName); ?></span>
             <div class="text-[11px] uppercase tracking-wide font-semibold text-gray-500">
               <?= __("Library Management System") ?>
             </div>

--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -109,8 +109,9 @@ $htmlLang = substr($currentLocale, 0, 2);
       class="fixed lg:static inset-y-0 left-0 z-50 w-72 lg:w-64 xl:w-72 bg-white border-r border-gray-200 shadow-lg transform -translate-x-full lg:translate-x-0 transition-all duration-300 ease-in-out flex flex-col"
       style="<?= $sidebarStyle ?>">
 
-      <!-- Sidebar Header -->
-      <div class="flex items-center justify-between px-6 py-5 flex-shrink-0">
+      <!-- Sidebar Header: blocco logo centrato; il close mobile è in absolute
+           così non sbilancia il centraggio (visibile solo < lg) -->
+      <div class="relative flex items-center justify-center px-6 py-5 flex-shrink-0">
         <a href="<?= htmlspecialchars(url('/'), ENT_QUOTES, 'UTF-8') ?>" class="flex flex-col items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer">
           <div class="w-12 h-12 rounded-xl bg-white flex items-center justify-center">
             <?php if ($appLogo !== ''): ?>
@@ -130,7 +131,7 @@ $htmlLang = substr($currentLocale, 0, 2);
         </a>
 
         <!-- Mobile Close Button -->
-        <button id="close-mobile-menu" class="lg:hidden p-2 rounded-lg hover:bg-gray-100 transition-colors">
+        <button id="close-mobile-menu" class="lg:hidden absolute right-3 top-6 p-2 rounded-lg hover:bg-gray-100 transition-colors">
           <i class="fas fa-times text-gray-500"></i>
         </button>
       </div>

--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -111,7 +111,7 @@ $htmlLang = substr($currentLocale, 0, 2);
 
       <!-- Sidebar Header: blocco logo centrato; il close mobile è in absolute
            così non sbilancia il centraggio (visibile solo < lg) -->
-      <div class="relative flex items-center justify-center px-6 py-5 flex-shrink-0">
+      <div class="relative flex items-center justify-center px-6 flex-shrink-0">
         <a href="<?= htmlspecialchars(url('/'), ENT_QUOTES, 'UTF-8') ?>" class="flex flex-col items-center gap-2 hover:opacity-80 transition-opacity cursor-pointer">
           <div class="w-12 h-12 rounded-xl bg-white flex items-center justify-center">
             <?php if ($appLogo !== ''): ?>


### PR DESCRIPTION
Desktop sidebar header: the logo now sits above the app name instead of beside it, centered, with a tighter title line-height (`leading-tight`). Uses only already-compiled Tailwind classes (no CSS rebuild). Verified visually on the admin sidebar at 1440px.