### PR TITLE
feat(mobile-api): book reviews endpoints (stars + text) for the app

### DIFF
--- a/storage/plugins/mobile-api/MobileApiPlugin.php
+++ b/storage/plugins/mobile-api/MobileApiPlugin.php
@@ -41,6 +41,7 @@ require_once __DIR__ . '/src/Controllers/ActionsController.php';
 require_once __DIR__ . '/src/Controllers/PushController.php';
 require_once __DIR__ . '/src/Controllers/OpenApiController.php';
 require_once __DIR__ . '/src/Controllers/SwaggerUiController.php';
+require_once __DIR__ . '/src/Controllers/ReviewsController.php';
 
 /**
  * Mobile API plugin.
@@ -458,6 +459,39 @@ class MobileApiPlugin
                 array $args
             ) use ($db): ResponseInterface {
                 return (new CatalogController($db))->bookAvailability($request, $response, (int) $args['id']);
+            })->add($quotaMw())->add($authMw());
+
+            // ── Book reviews (stars + text) — moderated via the core recensioni
+            //    table; PUT is an idempotent upsert; DELETE is user-scoped. ──
+            $group->get('/catalog/books/{id:[0-9]+}/reviews', function (
+                ServerRequestInterface $request,
+                ResponseInterface $response,
+                array $args
+            ) use ($db): ResponseInterface {
+                return (new \App\Plugins\MobileApi\Controllers\ReviewsController($db))->bookReviews($request, $response, (int) $args['id']);
+            })->add($quotaMw())->add($authMw());
+
+            $group->put('/catalog/books/{id:[0-9]+}/reviews', function (
+                ServerRequestInterface $request,
+                ResponseInterface $response,
+                array $args
+            ) use ($db): ResponseInterface {
+                return (new \App\Plugins\MobileApi\Controllers\ReviewsController($db))->submitReview($request, $response, (int) $args['id']);
+            })->add($quotaMw())->add($authMw());
+
+            $group->delete('/catalog/books/{id:[0-9]+}/reviews', function (
+                ServerRequestInterface $request,
+                ResponseInterface $response,
+                array $args
+            ) use ($db): ResponseInterface {
+                return (new \App\Plugins\MobileApi\Controllers\ReviewsController($db))->deleteReview($request, $response, (int) $args['id']);
+            })->add($quotaMw())->add($authMw());
+
+            $group->get('/me/reviews', function (
+                ServerRequestInterface $request,
+                ResponseInterface $response
+            ) use ($db): ResponseInterface {
+                return (new \App\Plugins\MobileApi\Controllers\ReviewsController($db))->myReviews($request, $response);
             })->add($quotaMw())->add($authMw());
 
             $group->get('/catalog/genres', function (

--- a/storage/plugins/mobile-api/plugin.json
+++ b/storage/plugins/mobile-api/plugin.json
@@ -2,7 +2,7 @@
   "name": "mobile-api",
   "display_name": "Mobile API",
   "description": "API REST/JSON versionata (/api/v1) per l'app companion mobile di Pinakes: discovery, autenticazione a token per dispositivo, ricerca catalogo, prestiti/prenotazioni, wishlist, profilo, messaggi e notifiche push. Disattivata per default finché non viene abilitata.",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "",

--- a/storage/plugins/mobile-api/src/Controllers/HealthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/HealthController.php
@@ -77,6 +77,9 @@ final class HealthController
                     'messages'      => true,
                     'notifications' => true,
                     'push'          => $vapidPublicKey !== '',
+                    // Book reviews ride the loan history (only borrowers can
+                    // review), so they are meaningless in catalogue mode.
+                    'reviews'       => !$catalogueMode,
                 ],
                 'catalogue_mode'       => $catalogueMode,
                 'app_access_enabled'   => $appAccessEnabled,

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -128,6 +128,12 @@ final class OpenApiController
                     'MessageRequest'    => $this->messageRequestSchema(),
                     'NotificationItem'  => $this->notificationItemSchema(),
 
+                    // Reviews
+                    'Review'            => $this->reviewSchema(),
+                    'ReviewRequest'     => $this->reviewRequestSchema(),
+                    'BookReviews'       => $this->bookReviewsSchema(),
+                    'MyReview'          => $this->myReviewSchema(),
+
                     // Push
                     'PushSubscribeRequest' => $this->pushSubscribeRequestSchema(),
                     'PushPrefs'         => $this->pushPrefsSchema(),
@@ -629,6 +635,91 @@ final class OpenApiController
                     ],
                     'responses' => [
                         '200' => ['description' => 'Removed (or was not present — idempotent).', 'content' => $json],
+                        '401' => ['$ref' => '#/components/responses/Unauthorized'],
+                        '500' => ['$ref' => '#/components/responses/InternalError'],
+                    ],
+                ],
+            ],
+
+            '/catalog/books/{id}/reviews' => [
+                'get' => [
+                    'tags'        => ['reviews'],
+                    'summary'     => 'Book reviews (aggregate + own + approved others)',
+                    'description' => 'Reviews are MODERATED: `items` and the aggregate cover approved reviews only; `mine` is returned regardless of moderation state. `meta.next_cursor` pages the nested `data.items`. `can_review` = the caller has borrowed the title.',
+                    'operationId' => 'getBookReviews',
+                    'security'    => [['bearerAuth' => []]],
+                    'parameters'  => [
+                        ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer'], 'description' => 'Book ID'],
+                        ['name' => 'cursor', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'string'], 'description' => 'Opaque cursor for data.items'],
+                        ['name' => 'limit', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 50, 'default' => 20]],
+                    ],
+                    'responses'   => [
+                        '200' => ['description' => 'Reviews payload.', 'content' => ['application/json' => ['schema' => [
+                            'allOf' => [['$ref' => '#/components/schemas/Envelope']],
+                            'properties' => ['data' => ['$ref' => '#/components/schemas/BookReviews']],
+                        ]]]],
+                        '401' => ['$ref' => '#/components/responses/Unauthorized'],
+                        '404' => ['$ref' => '#/components/responses/NotFound'],
+                        '500' => ['$ref' => '#/components/responses/InternalError'],
+                    ],
+                ],
+                'put' => [
+                    'tags'        => ['reviews'],
+                    'summary'     => 'Create or update own review (idempotent upsert)',
+                    'description' => 'One review per (user, book): PUT updates the existing review or creates it. Requires having borrowed the title (403 `not_eligible` otherwise). The stored review goes back to moderation (`pending`) on every write; `meta.pending=true` signals it.',
+                    'operationId' => 'putBookReview',
+                    'security'    => [['bearerAuth' => []]],
+                    'parameters'  => [
+                        ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer'], 'description' => 'Book ID'],
+                    ],
+                    'requestBody' => [
+                        'required' => true,
+                        'content'  => ['application/json' => ['schema' => ['$ref' => '#/components/schemas/ReviewRequest']]],
+                    ],
+                    'responses' => [
+                        '200' => ['description' => 'Stored review (pending moderation).', 'content' => ['application/json' => ['schema' => [
+                            'allOf' => [['$ref' => '#/components/schemas/Envelope']],
+                            'properties' => ['data' => ['$ref' => '#/components/schemas/Review']],
+                        ]]]],
+                        '401' => ['$ref' => '#/components/responses/Unauthorized'],
+                        '403' => ['$ref' => '#/components/responses/Forbidden'],
+                        '404' => ['$ref' => '#/components/responses/NotFound'],
+                        '422' => ['$ref' => '#/components/responses/UnprocessableEntity'],
+                        '500' => ['$ref' => '#/components/responses/InternalError'],
+                    ],
+                ],
+                'delete' => [
+                    'tags'        => ['reviews'],
+                    'summary'     => 'Delete own review (idempotent)',
+                    'operationId' => 'deleteBookReview',
+                    'security'    => [['bearerAuth' => []]],
+                    'parameters'  => [
+                        ['name' => 'id', 'in' => 'path', 'required' => true, 'schema' => ['type' => 'integer'], 'description' => 'Book ID'],
+                    ],
+                    'responses' => [
+                        '200' => ['description' => 'Review deleted.', 'content' => $json],
+                        '401' => ['$ref' => '#/components/responses/Unauthorized'],
+                        '404' => ['$ref' => '#/components/responses/NotFound'],
+                        '500' => ['$ref' => '#/components/responses/InternalError'],
+                    ],
+                ],
+            ],
+
+            '/me/reviews' => [
+                'get' => [
+                    'tags'        => ['reviews'],
+                    'summary'     => 'Own reviews across all books (any moderation state)',
+                    'operationId' => 'getMeReviews',
+                    'security'    => [['bearerAuth' => []]],
+                    'parameters'  => [
+                        ['name' => 'cursor', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'string']],
+                        ['name' => 'limit', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 50, 'default' => 20]],
+                    ],
+                    'responses' => [
+                        '200' => ['description' => 'Own reviews.', 'content' => ['application/json' => ['schema' => [
+                            'allOf' => [['$ref' => '#/components/schemas/Envelope']],
+                            'properties' => ['data' => ['type' => 'array', 'items' => ['$ref' => '#/components/schemas/MyReview']]],
+                        ]]]],
                         '401' => ['$ref' => '#/components/responses/Unauthorized'],
                         '500' => ['$ref' => '#/components/responses/InternalError'],
                     ],
@@ -1240,6 +1331,84 @@ final class OpenApiController
         $basePath = defined('BASE_PATH') ? (string) BASE_PATH : '';
 
         return rtrim($base . $basePath, '/');
+    }
+
+    /** @return array<string, mixed> */
+    private function reviewSchema(): array
+    {
+        return [
+            'type'        => 'object',
+            'description' => 'A single book review. `status` (pendente|approvata|rifiutata) is server-extra: reviews are moderated and a just-submitted/edited review is pending until an admin approves it.',
+            'properties'  => [
+                'id'         => ['type' => 'integer'],
+                'rating'     => ['type' => 'integer', 'minimum' => 1, 'maximum' => 5],
+                'text'       => ['type' => 'string', 'nullable' => true],
+                'user_name'  => ['type' => 'string'],
+                'is_mine'    => ['type' => 'boolean'],
+                'status'     => ['type' => 'string', 'enum' => ['pendente', 'approvata', 'rifiutata']],
+                'created_at' => ['type' => 'string'],
+                'updated_at' => ['type' => 'string'],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function reviewRequestSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'required'   => ['rating'],
+            'properties' => [
+                'rating' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 5],
+                'text'   => ['type' => 'string', 'maxLength' => 2000, 'nullable' => true],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function bookReviewsSchema(): array
+    {
+        return [
+            'type'        => 'object',
+            'description' => 'Aggregate (approved reviews only) + the caller\'s own review (any state) + other users\' approved reviews. `meta.next_cursor` pages `items`.',
+            'properties'  => [
+                'average'      => ['type' => 'number', 'format' => 'float'],
+                'count'        => ['type' => 'integer'],
+                'distribution' => [
+                    'type'       => 'object',
+                    'properties' => [
+                        '1' => ['type' => 'integer'],
+                        '2' => ['type' => 'integer'],
+                        '3' => ['type' => 'integer'],
+                        '4' => ['type' => 'integer'],
+                        '5' => ['type' => 'integer'],
+                    ],
+                ],
+                'can_review'   => ['type' => 'boolean', 'description' => 'The caller has borrowed this title (eligibility only — independent of having already reviewed).'],
+                'mine'         => ['allOf' => [['$ref' => '#/components/schemas/Review']], 'nullable' => true],
+                'items'        => ['type' => 'array', 'items' => ['$ref' => '#/components/schemas/Review']],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function myReviewSchema(): array
+    {
+        return [
+            'type'       => 'object',
+            'properties' => [
+                'id'          => ['type' => 'integer'],
+                'book_id'     => ['type' => 'integer'],
+                'book_title'  => ['type' => 'string'],
+                'book_author' => ['type' => 'string', 'nullable' => true],
+                'cover_url'   => ['type' => 'string', 'format' => 'uri', 'nullable' => true],
+                'rating'      => ['type' => 'integer', 'minimum' => 1, 'maximum' => 5],
+                'text'        => ['type' => 'string', 'nullable' => true],
+                'status'      => ['type' => 'string', 'enum' => ['pendente', 'approvata', 'rifiutata']],
+                'created_at'  => ['type' => 'string'],
+                'updated_at'  => ['type' => 'string'],
+            ],
+        ];
     }
 
     private function appVersion(): string

--- a/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
@@ -1,0 +1,443 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Plugins\MobileApi\Controllers;
+
+use App\Plugins\MobileApi\Support\AppAuthMiddleware;
+use App\Plugins\MobileApi\Support\CursorCodec;
+use App\Plugins\MobileApi\Support\JsonBody;
+use App\Plugins\MobileApi\Support\ResponseEnvelope;
+use App\Support\SecureLogger;
+use mysqli;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+/**
+ * Book reviews for the mobile app (stars + text), backed by the core
+ * `recensioni` table and its ALWAYS-ON moderation model:
+ *
+ *   - new/edited reviews are stored with stato='pendente' and become visible
+ *     to OTHER users only after an admin approves them (stato='approvata');
+ *   - aggregate average/count/distribution are computed over approved only;
+ *   - `mine` is returned regardless of stato so the author always sees their
+ *     own review (the extra `status` field lets future app versions surface
+ *     "pending approval"; current clients ignore unknown fields);
+ *   - one review per (utente, libro) — UNIQUE unique_user_book_review — hence
+ *     PUT is a TRUE UPSERT (update the existing row, else insert). Do NOT
+ *     reuse the web's canUserReview() as the write guard: it returns false
+ *     once a review exists, which would break editing;
+ *   - eligibility (`can_review` and the PUT 403 guard) is ONLY "has borrowed
+ *     the title" (prestiti stato IN ('restituito','in_corso'));
+ *   - DELETE is user-scoped by (utente_id, libro_id) and idempotent.
+ *
+ * Contract: app repo `_contract/openapi.json` — GET/PUT/DELETE
+ * /catalog/books/{id}/reviews and GET /me/reviews, Envelope + cursor paging.
+ * On GET book reviews, `meta.next_cursor` pages the nested `data.items`.
+ */
+class ReviewsController
+{
+    private const MAX_TEXT_LEN = 2000;
+    private const DEFAULT_LIMIT = 20;
+    private const MAX_LIMIT = 50;
+
+    public function __construct(private mysqli $db)
+    {
+    }
+
+    /* ---------------------------------------------------------------------
+     * GET /api/v1/catalog/books/{id}/reviews
+     * ------------------------------------------------------------------- */
+    public function bookReviews(Request $request, ResponseInterface $response, int $bookId): ResponseInterface
+    {
+        try {
+            $user = $request->getAttribute(AppAuthMiddleware::ATTR_USER);
+            $userId = (int) ($user['id'] ?? 0);
+
+            if (!$this->bookExists($bookId)) {
+                return ResponseEnvelope::error($response, 'not_found', __('Libro non trovato'), 404);
+            }
+
+            $query = $request->getQueryParams();
+            $limit = $this->clampLimit($query['limit'] ?? null);
+            $afterId = $this->decodeCursor($query['cursor'] ?? null);
+
+            // Aggregate over APPROVED reviews only (mirrors the web's stats).
+            $stmt = $this->db->prepare(
+                "SELECT COUNT(*) AS c, COALESCE(AVG(stelle), 0) AS a,
+                        SUM(stelle = 1) AS s1, SUM(stelle = 2) AS s2, SUM(stelle = 3) AS s3,
+                        SUM(stelle = 4) AS s4, SUM(stelle = 5) AS s5
+                 FROM recensioni WHERE libro_id = ? AND stato = 'approvata'"
+            );
+            $stmt->bind_param('i', $bookId);
+            $stmt->execute();
+            $agg = $stmt->get_result()->fetch_assoc() ?: [];
+            $stmt->close();
+
+            // The caller's own review, regardless of moderation state.
+            $mine = null;
+            if ($userId > 0) {
+                $stmt = $this->db->prepare(
+                    "SELECT r.id, r.stelle, r.descrizione, r.stato, r.created_at, r.updated_at,
+                            CONCAT(u.nome, ' ', u.cognome) AS user_name
+                     FROM recensioni r JOIN utenti u ON u.id = r.utente_id
+                     WHERE r.libro_id = ? AND r.utente_id = ? LIMIT 1"
+                );
+                $stmt->bind_param('ii', $bookId, $userId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row) {
+                    $mine = $this->mapReview($row, true);
+                }
+            }
+
+            // Other users' APPROVED reviews, keyset-paginated on id DESC.
+            $sql = "SELECT r.id, r.stelle, r.descrizione, r.stato, r.created_at, r.updated_at,
+                           CONCAT(u.nome, ' ', u.cognome) AS user_name
+                    FROM recensioni r JOIN utenti u ON u.id = r.utente_id
+                    WHERE r.libro_id = ? AND r.stato = 'approvata' AND r.utente_id <> ?";
+            $types = 'ii';
+            $params = [$bookId, $userId];
+            if ($afterId !== null) {
+                $sql .= ' AND r.id < ?';
+                $types .= 'i';
+                $params[] = $afterId;
+            }
+            $sql .= ' ORDER BY r.id DESC LIMIT ?';
+            $types .= 'i';
+            $fetch = $limit + 1; // +1 to detect the next page
+            $params[] = $fetch;
+
+            $stmt = $this->db->prepare($sql);
+            $stmt->bind_param($types, ...$params);
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+
+            $hasMore = count($rows) > $limit;
+            if ($hasMore) {
+                array_pop($rows);
+            }
+            $items = array_map(fn(array $r): array => $this->mapReview($r, false), $rows);
+            $nextCursor = null;
+            if ($hasMore && $rows !== []) {
+                $nextCursor = CursorCodec::encode(['last_id' => (int) end($rows)['id']]);
+            }
+
+            $data = [
+                'average'      => round((float) ($agg['a'] ?? 0), 2),
+                'count'        => (int) ($agg['c'] ?? 0),
+                'distribution' => [
+                    '1' => (int) ($agg['s1'] ?? 0),
+                    '2' => (int) ($agg['s2'] ?? 0),
+                    '3' => (int) ($agg['s3'] ?? 0),
+                    '4' => (int) ($agg['s4'] ?? 0),
+                    '5' => (int) ($agg['s5'] ?? 0),
+                ],
+                'can_review'   => $userId > 0 && $this->hasBorrowed($userId, $bookId),
+                'mine'         => $mine,
+                'items'        => $items,
+            ];
+
+            return ResponseEnvelope::success($response, $data, ['next_cursor' => $nextCursor], 200);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[MobileApi] bookReviews failed: ' . $e->getMessage());
+            return ResponseEnvelope::error($response, 'server_error', __('Operazione non disponibile.'), 500);
+        }
+    }
+
+    /* ---------------------------------------------------------------------
+     * PUT /api/v1/catalog/books/{id}/reviews — idempotent upsert
+     * ------------------------------------------------------------------- */
+    public function submitReview(Request $request, ResponseInterface $response, int $bookId): ResponseInterface
+    {
+        try {
+            $user = $request->getAttribute(AppAuthMiddleware::ATTR_USER);
+            $userId = (int) ($user['id'] ?? 0);
+
+            if (!$this->bookExists($bookId)) {
+                return ResponseEnvelope::error($response, 'not_found', __('Libro non trovato'), 404);
+            }
+
+            $body = JsonBody::parse($request);
+            $rating = isset($body['rating']) && is_numeric($body['rating']) ? (int) $body['rating'] : 0;
+            if ($rating < 1 || $rating > 5) {
+                return ResponseEnvelope::error($response, 'validation_error', __('La valutazione deve essere tra 1 e 5 stelle.'), 422);
+            }
+            $rawText = $body['text'] ?? null;
+            if ($rawText !== null && !is_scalar($rawText)) {
+                return ResponseEnvelope::error($response, 'validation_error', __('Testo della recensione non valido.'), 422);
+            }
+            $text = trim((string) ($rawText ?? ''));
+            if (mb_strlen($text) > self::MAX_TEXT_LEN) {
+                return ResponseEnvelope::error($response, 'validation_error', sprintf(__('Il testo della recensione non può superare %d caratteri.'), self::MAX_TEXT_LEN), 422);
+            }
+            $textOrNull = $text === '' ? null : $text;
+
+            // Eligibility: ONLY "has borrowed the title". Editing an existing
+            // review must stay possible, so "already reviewed" is NOT a block.
+            if (!$this->hasBorrowed($userId, $bookId)) {
+                return ResponseEnvelope::error($response, 'not_eligible', __('Puoi recensire solo i titoli che hai preso in prestito.'), 403);
+            }
+
+            $existingId = $this->findOwnReviewId($userId, $bookId);
+            if ($existingId !== null) {
+                // Edit → back to moderation (the changed text needs re-approval).
+                $stmt = $this->db->prepare(
+                    "UPDATE recensioni
+                     SET stelle = ?, descrizione = ?, stato = 'pendente',
+                         approved_by = NULL, approved_at = NULL
+                     WHERE id = ? AND utente_id = ?"
+                );
+                $stmt->bind_param('isii', $rating, $textOrNull, $existingId, $userId);
+                $stmt->execute();
+                $stmt->close();
+                $reviewId = $existingId;
+                $created = false;
+            } else {
+                $stmt = $this->db->prepare(
+                    "INSERT INTO recensioni (libro_id, utente_id, stelle, titolo, descrizione, stato)
+                     VALUES (?, ?, ?, '', ?, 'pendente')"
+                );
+                $stmt->bind_param('iiis', $bookId, $userId, $rating, $textOrNull);
+                $stmt->execute();
+                $reviewId = (int) $this->db->insert_id;
+                $stmt->close();
+                $created = true;
+            }
+
+            // Best-effort admin notification on first submission (same as web).
+            if ($created) {
+                try {
+                    $notifier = new \App\Support\NotificationService($this->db);
+                    if (method_exists($notifier, 'notifyNewReview')) {
+                        $notifier->notifyNewReview($reviewId);
+                    }
+                } catch (\Throwable $e) {
+                    SecureLogger::warning('[MobileApi] notifyNewReview failed: ' . $e->getMessage());
+                }
+            }
+
+            $stmt = $this->db->prepare(
+                "SELECT r.id, r.stelle, r.descrizione, r.stato, r.created_at, r.updated_at,
+                        CONCAT(u.nome, ' ', u.cognome) AS user_name
+                 FROM recensioni r JOIN utenti u ON u.id = r.utente_id
+                 WHERE r.id = ? LIMIT 1"
+            );
+            $stmt->bind_param('i', $reviewId);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc() ?: [];
+            $stmt->close();
+
+            // meta.pending tells (future) clients the review awaits moderation.
+            return ResponseEnvelope::success($response, $this->mapReview($row, true), ['pending' => true], 200);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[MobileApi] submitReview failed: ' . $e->getMessage());
+            return ResponseEnvelope::error($response, 'server_error', __('Operazione non disponibile.'), 500);
+        }
+    }
+
+    /* ---------------------------------------------------------------------
+     * DELETE /api/v1/catalog/books/{id}/reviews — own review, idempotent
+     * ------------------------------------------------------------------- */
+    public function deleteReview(Request $request, ResponseInterface $response, int $bookId): ResponseInterface
+    {
+        try {
+            $user = $request->getAttribute(AppAuthMiddleware::ATTR_USER);
+            $userId = (int) ($user['id'] ?? 0);
+
+            // User-scoped by design: never accept a review id from the client.
+            // 200 when a review was removed, 404 when there was none — the same
+            // "gone" semantics as the sibling DELETE endpoints (wishlist,
+            // devices, reservations): a second delete of the same review is 404.
+            $stmt = $this->db->prepare('DELETE FROM recensioni WHERE libro_id = ? AND utente_id = ?');
+            $stmt->bind_param('ii', $bookId, $userId);
+            $stmt->execute();
+            $removed = $stmt->affected_rows > 0;
+            $stmt->close();
+
+            if (!$removed) {
+                return ResponseEnvelope::error($response, 'not_found', __('Nessuna recensione da eliminare.'), 404);
+            }
+
+            return ResponseEnvelope::success($response, null, [], 200);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[MobileApi] deleteReview failed: ' . $e->getMessage());
+            return ResponseEnvelope::error($response, 'server_error', __('Operazione non disponibile.'), 500);
+        }
+    }
+
+    /* ---------------------------------------------------------------------
+     * GET /api/v1/me/reviews
+     * ------------------------------------------------------------------- */
+    public function myReviews(Request $request, ResponseInterface $response): ResponseInterface
+    {
+        try {
+            $user = $request->getAttribute(AppAuthMiddleware::ATTR_USER);
+            $userId = (int) ($user['id'] ?? 0);
+
+            $query = $request->getQueryParams();
+            $limit = $this->clampLimit($query['limit'] ?? null);
+            $afterId = $this->decodeCursor($query['cursor'] ?? null);
+
+            // All of the user's reviews (any stato) on non-deleted books, with
+            // the principal author resolved for display.
+            $sql = "SELECT r.id, r.libro_id, r.stelle, r.descrizione, r.stato, r.created_at, r.updated_at,
+                           l.titolo AS book_title, l.copertina_url,
+                           (SELECT a.nome
+                            FROM libri_autori la JOIN autori a ON a.id = la.autore_id
+                            WHERE la.libro_id = l.id
+                            ORDER BY (la.ruolo = 'principale') DESC, la.ordine_credito ASC, la.autore_id ASC
+                            LIMIT 1) AS book_author
+                    FROM recensioni r
+                    JOIN libri l ON l.id = r.libro_id AND l.deleted_at IS NULL
+                    WHERE r.utente_id = ?";
+            $types = 'i';
+            $params = [$userId];
+            if ($afterId !== null) {
+                $sql .= ' AND r.id < ?';
+                $types .= 'i';
+                $params[] = $afterId;
+            }
+            $sql .= ' ORDER BY r.id DESC LIMIT ?';
+            $types .= 'i';
+            $fetch = $limit + 1;
+            $params[] = $fetch;
+
+            $stmt = $this->db->prepare($sql);
+            $stmt->bind_param($types, ...$params);
+            $stmt->execute();
+            $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+            $stmt->close();
+
+            $hasMore = count($rows) > $limit;
+            if ($hasMore) {
+                array_pop($rows);
+            }
+
+            $items = array_map(function (array $r): array {
+                return [
+                    'id'          => (int) $r['id'],
+                    'book_id'     => (int) $r['libro_id'],
+                    'book_title'  => (string) $r['book_title'],
+                    'book_author' => $r['book_author'] !== null ? (string) $r['book_author'] : null,
+                    'cover_url'   => $this->absoluteCover($r['copertina_url'] ?? null),
+                    'rating'      => (int) $r['stelle'],
+                    'text'        => $r['descrizione'] !== null && $r['descrizione'] !== '' ? (string) $r['descrizione'] : null,
+                    'status'      => (string) $r['stato'],
+                    'created_at'  => (string) $r['created_at'],
+                    'updated_at'  => (string) $r['updated_at'],
+                ];
+            }, $rows);
+
+            $nextCursor = null;
+            if ($hasMore && $rows !== []) {
+                $nextCursor = CursorCodec::encode(['last_id' => (int) end($rows)['id']]);
+            }
+
+            return ResponseEnvelope::success($response, $items, ['next_cursor' => $nextCursor], 200);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[MobileApi] myReviews failed: ' . $e->getMessage());
+            return ResponseEnvelope::error($response, 'server_error', __('Operazione non disponibile.'), 500);
+        }
+    }
+
+    /* ---------------------------------------------------------------------
+     * Helpers
+     * ------------------------------------------------------------------- */
+
+    /** Book exists and is not soft-deleted (project rule: deleted_at IS NULL). */
+    private function bookExists(int $bookId): bool
+    {
+        $stmt = $this->db->prepare('SELECT 1 FROM libri WHERE id = ? AND deleted_at IS NULL LIMIT 1');
+        $stmt->bind_param('i', $bookId);
+        $stmt->execute();
+        $found = $stmt->get_result()->num_rows > 0;
+        $stmt->close();
+        return $found;
+    }
+
+    /**
+     * Eligibility = has (or had) the book on loan. Deliberately SEPARATE from
+     * "has already reviewed": the latter must not block PUT-as-edit.
+     * Mirrors the web rule (prestiti stato IN ('restituito','in_corso')).
+     */
+    private function hasBorrowed(int $userId, int $bookId): bool
+    {
+        $stmt = $this->db->prepare(
+            "SELECT 1 FROM prestiti
+             WHERE utente_id = ? AND libro_id = ? AND stato IN ('restituito', 'in_corso')
+             LIMIT 1"
+        );
+        $stmt->bind_param('ii', $userId, $bookId);
+        $stmt->execute();
+        $found = $stmt->get_result()->num_rows > 0;
+        $stmt->close();
+        return $found;
+    }
+
+    private function findOwnReviewId(int $userId, int $bookId): ?int
+    {
+        $stmt = $this->db->prepare('SELECT id FROM recensioni WHERE libro_id = ? AND utente_id = ? LIMIT 1');
+        $stmt->bind_param('ii', $bookId, $userId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_row();
+        $stmt->close();
+        return $row ? (int) $row[0] : null;
+    }
+
+    /** @param array<string, mixed> $row @return array<string, mixed> */
+    private function mapReview(array $row, bool $isMine): array
+    {
+        return [
+            'id'         => (int) ($row['id'] ?? 0),
+            'rating'     => (int) ($row['stelle'] ?? 0),
+            'text'       => isset($row['descrizione']) && $row['descrizione'] !== null && $row['descrizione'] !== ''
+                ? (string) $row['descrizione'] : null,
+            'user_name'  => (string) ($row['user_name'] ?? ''),
+            'is_mine'    => $isMine,
+            // Extra vs the app contract (clients ignore unknown fields): lets
+            // future app versions surface "pending approval" without an API bump.
+            'status'     => (string) ($row['stato'] ?? ''),
+            'created_at' => (string) ($row['created_at'] ?? ''),
+            'updated_at' => (string) ($row['updated_at'] ?? ''),
+        ];
+    }
+
+    /** Absolute cover URL: pass through externals, resolve local paths. */
+    private function absoluteCover(?string $raw): ?string
+    {
+        $v = trim((string) ($raw ?? ''));
+        if ($v === '') {
+            return null;
+        }
+        if (preg_match('#^https?://#i', $v) === 1) {
+            return $v;
+        }
+        if (!str_starts_with($v, '/')) {
+            $v = '/uploads/copertine/' . $v;
+        }
+        return absoluteUrl($v);
+    }
+
+    private function clampLimit(mixed $raw): int
+    {
+        $n = is_numeric($raw) ? (int) $raw : self::DEFAULT_LIMIT;
+        return max(1, min(self::MAX_LIMIT, $n));
+    }
+
+    private function decodeCursor(mixed $raw): ?int
+    {
+        if (!is_string($raw) || $raw === '') {
+            return null;
+        }
+        try {
+            $decoded = CursorCodec::decode($raw);
+            $id = (int) ($decoded['last_id'] ?? 0);
+            return $id > 0 ? $id : null;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}

--- a/tests/mobile-api-idempotency.spec.js
+++ b/tests/mobile-api-idempotency.spec.js
@@ -165,6 +165,11 @@ const ENDPOINTS = [
     { name: 'POST /me/wishlist',                 method: 'POST',   path: '/me/wishlist',                  auth: true,  kind: 'write2xx',
         body: (ctx) => ({ book_id: ctx.bookId }) /* adding twice must not duplicate; both 2xx */ },
     { name: 'DELETE /me/wishlist/{bookId}',      method: 'DELETE', path: '/me/wishlist/{bookId}',         auth: true,  kind: 'gone2' },
+    { name: 'GET /catalog/books/{bookId}/reviews', method: 'GET', path: '/catalog/books/{bookId}/reviews', auth: true, kind: 'safeGet' },
+    { name: 'PUT /catalog/books/{bookId}/reviews', method: 'PUT',    path: '/catalog/books/{bookId}/reviews', auth: true,  kind: 'write2xx',
+        body: () => ({ rating: 5, text: 'Idempotency probe.' }) /* upsert: twice must both be 2xx (setup seeds a returned loan for eligibility) */ },
+    { name: 'DELETE /catalog/books/{bookId}/reviews', method: 'DELETE', path: '/catalog/books/{bookId}/reviews', auth: true, kind: 'gone2' },
+    { name: 'GET /me/reviews',                   method: 'GET',    path: '/me/reviews',                    auth: true,  kind: 'safeGet' },
     { name: 'POST /messages',                    method: 'POST',   path: '/messages',                     auth: true,  kind: 'write2xx',
         body: () => ({ messaggio: 'idem test message', oggetto: 'idem' }) },
     { name: 'GET /me/notifications',             method: 'GET',    path: '/me/notifications',             auth: true,  kind: 'safeGet' },
@@ -314,6 +319,15 @@ test.describe('Mobile API — two calls per endpoint (idempotency + ETag/304)', 
 
         // Pre-add the wishlist book so DELETE /me/wishlist/{bookId} has something to remove on call #1.
         try { dbExec(`INSERT IGNORE INTO wishlist (utente_id, libro_id) VALUES (${ctx.userId}, ${ctx.bookId})`); } catch {}
+
+        // Reviews eligibility: PUT /catalog/books/{id}/reviews requires the user
+        // to have borrowed the title (prestiti stato IN restituito/in_corso). Seed
+        // a RETURNED loan (attivo=0, no copia) — inert for the occupancy triggers.
+        try {
+            dbExec(`INSERT INTO prestiti (utente_id, libro_id, data_prestito, data_scadenza, data_restituzione, stato, attivo)
+                    SELECT ${ctx.userId}, ${ctx.bookId}, DATE_SUB(CURDATE(), INTERVAL 30 DAY), DATE_SUB(CURDATE(), INTERVAL 16 DAY), DATE_SUB(CURDATE(), INTERVAL 16 DAY), 'restituito', 0
+                    WHERE NOT EXISTS (SELECT 1 FROM prestiti WHERE utente_id=${ctx.userId} AND libro_id=${ctx.bookId} AND stato='restituito')`);
+        } catch {}
     });
 
     test.afterAll(async () => {
@@ -321,6 +335,8 @@ test.describe('Mobile API — two calls per endpoint (idempotency + ETag/304)', 
         try { dbExec(`DELETE FROM mobile_push_subscriptions WHERE user_id=${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM wishlist WHERE utente_id=${ctx.userId}`); } catch {}
         try { dbExec(`DELETE FROM prenotazioni WHERE utente_id=${ctx.userId}`); } catch {}
+        try { dbExec(`DELETE FROM recensioni WHERE utente_id=${ctx.userId}`); } catch {}
+        try { dbExec(`DELETE FROM prestiti WHERE utente_id=${ctx.userId} AND stato='restituito' AND copia_id IS NULL`); } catch {}
         // Only delete the account if THIS run created it.
         if (ctx.createdUser) {
             try { dbExec(`DELETE FROM utenti WHERE id=${ctx.userId}`); } catch {}


### PR DESCRIPTION
## Summary

Implements the 4 mobile-API endpoints the Android app's contract expects, so the app's book-reviews feature (stars + text) has a working backend. Backed by the core `recensioni` table and its always-on moderation.

### Endpoints (all under `/api/v1`, Bearer-auth)
- **GET `/catalog/books/{id}/reviews`** — aggregate (average/count/distribution over **approved** only) + the caller's own review (**any** moderation state) + other users' approved reviews, cursor-paged on `data.items`.
- **PUT `/catalog/books/{id}/reviews`** — **true idempotent upsert** (update the existing row, else insert). Eligibility is "has borrowed the title" only (`prestiti.stato IN ('restituito','in_corso')`) → `403 not_eligible` otherwise — deliberately **not** the web's `canUserReview()`, which also blocks once a review exists and would break editing. Every write returns to `stato='pendente'` (`meta.pending=true`).
- **DELETE `/catalog/books/{id}/reviews`** — user-scoped; `200` when removed, `404` when none (same "gone" semantics as the sibling wishlist/devices/reservations DELETEs).
- **GET `/me/reviews`** — the user's reviews across all books (any state), with the principal author and an absolute cover URL resolved, cursor-paged.

### Also
- `/health` advertises the `reviews` feature (off in catalogue mode, so the app can gate the UI per instance).
- Server OpenAPI gains the 4 paths + 4 schemas; the endpoint manifest (`tests/mobile-api-idempotency.spec.js`) gains the 4 rows with a returned-loan eligibility seed (project BLOCKING manifest rule).
- Mobile-API plugin `1.0.2 → 1.1.0`.

### No migration
`recensioni`, its moderation columns (`stato`/`approved_by`/`approved_at`) and `UNIQUE(libro_id, utente_id)` have existed since the initial commit (0.1.4); no migration ever altered the table, and a long-upgraded production install has all 12 columns + the unique index. The feature reads/writes an existing table shape.

### Verification
`mobile-api-idempotency` **34/34** (incl. the 4 new endpoints' idempotency/gone semantics), `mobile-api-behaviors` **27/27**, OpenAPI served and valid, PHPStan level 1 clean.

### App side (separate repo)
The Android client that consumes these endpoints (`claude/book-review-apis-android-*`) still needs its review-round fixes (graceful hide on absent feature, delete confirmation, Hilt migration) before it ships — tracked separately.
