### PR TITLE
fix(updater): full path in writable-check labels (#205)

### DIFF
--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -3797,16 +3797,21 @@ class Updater
         ];
         if (!$zipMet) $allMet = false;
 
-        $writablePaths = [
-            $this->rootPath,
-            $this->backupPath,
-            $this->rootPath . '/storage',
+        // Label each writable-target with WHAT it is + its full path, not just
+        // basename(): a bare "html" (basename of an install root at .../Web/html)
+        // told a QNAP user nothing about which directory to fix (#205). The path
+        // is admin-only (this runs in the update panel) and is exactly what the
+        // operator needs to chown/chmod.
+        $writableTargets = [
+            [__('Cartella radice'), $this->rootPath],
+            [__('Cartella backup'), $this->backupPath],
+            [__('Cartella storage'), $this->rootPath . '/storage'],
         ];
 
-        foreach ($writablePaths as $path) {
+        foreach ($writableTargets as [$label, $path]) {
             $writable = is_writable($path);
             $requirements[] = [
-                'name' => __('Scrittura') . ': ' . basename($path),
+                'name' => __('Scrittura') . ' — ' . $label . ' (' . $path . ')',
                 'required' => __('Scrivibile'),
                 'current' => $writable ? __('Scrivibile') : __('Non scrivibile'),
                 'met' => $writable

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5445,5 +5445,8 @@
   "Prestito non trovato o non chiudibile.": "Ausleihe nicht gefunden oder kann nicht abgeschlossen werden.",
   "Si è verificato un errore. Riprova più tardi.": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut.",
   "Non sei idoneo al prestito: account sospeso o tessera scaduta.": "Sie sind nicht ausleihberechtigt: Konto gesperrt oder Ausweis abgelaufen.",
-  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Aktualisierung vor jeder Änderung abgebrochen: Der PHP-Prozess kann in diese Pfade nicht schreiben: %s. Korrigieren Sie die Berechtigungen (Eigentümer/Schreibzugriff für den Webserver-Benutzer) und versuchen Sie es erneut, oder führen Sie die Aktualisierung über die Kommandozeile als Dateieigentümer aus: php scripts/manual-upgrade.php <Release-ZIP>"
+  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Aktualisierung vor jeder Änderung abgebrochen: Der PHP-Prozess kann in diese Pfade nicht schreiben: %s. Korrigieren Sie die Berechtigungen (Eigentümer/Schreibzugriff für den Webserver-Benutzer) und versuchen Sie es erneut, oder führen Sie die Aktualisierung über die Kommandozeile als Dateieigentümer aus: php scripts/manual-upgrade.php <Release-ZIP>",
+  "Cartella radice": "Stammverzeichnis",
+  "Cartella backup": "Backup-Verzeichnis",
+  "Cartella storage": "Speicherverzeichnis"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5445,5 +5445,8 @@
   "Prestito non trovato o non chiudibile.": "Loan not found or cannot be closed.",
   "Si è verificato un errore. Riprova più tardi.": "An error occurred. Please try again later.",
   "Non sei idoneo al prestito: account sospeso o tessera scaduta.": "You are not eligible to borrow: account suspended or card expired.",
-  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Update aborted before any change: the PHP process cannot write to these paths: %s. Fix the permissions (ownership/write access for the web-server user) and retry, or run the update from the command line as the file owner: php scripts/manual-upgrade.php <release-zip>"
+  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Update aborted before any change: the PHP process cannot write to these paths: %s. Fix the permissions (ownership/write access for the web-server user) and retry, or run the update from the command line as the file owner: php scripts/manual-upgrade.php <release-zip>",
+  "Cartella radice": "Installation root",
+  "Cartella backup": "Backup directory",
+  "Cartella storage": "Storage directory"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5445,5 +5445,8 @@
   "Prestito non trovato o non chiudibile.": "Prêt introuvable ou impossible à clôturer.",
   "Si è verificato un errore. Riprova più tardi.": "Une erreur s'est produite. Veuillez réessayer plus tard.",
   "Non sei idoneo al prestito: account sospeso o tessera scaduta.": "Vous n'êtes pas éligible à l'emprunt : compte suspendu ou carte expirée.",
-  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Mise à jour annulée avant toute modification : le processus PHP ne peut pas écrire dans ces chemins : %s. Corrigez les permissions (propriétaire/écriture pour l'utilisateur du serveur web) et réessayez, ou lancez la mise à jour en ligne de commande en tant que propriétaire des fichiers : php scripts/manual-upgrade.php <zip-release>"
+  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Mise à jour annulée avant toute modification : le processus PHP ne peut pas écrire dans ces chemins : %s. Corrigez les permissions (propriétaire/écriture pour l'utilisateur du serveur web) et réessayez, ou lancez la mise à jour en ligne de commande en tant que propriétaire des fichiers : php scripts/manual-upgrade.php <zip-release>",
+  "Cartella radice": "Dossier racine",
+  "Cartella backup": "Dossier de sauvegarde",
+  "Cartella storage": "Dossier de stockage"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5445,5 +5445,8 @@
   "Prestito non trovato o non chiudibile.": "Prestito non trovato o non chiudibile.",
   "Si è verificato un errore. Riprova più tardi.": "Si è verificato un errore. Riprova più tardi.",
   "Non sei idoneo al prestito: account sospeso o tessera scaduta.": "Non sei idoneo al prestito: account sospeso o tessera scaduta.",
-  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>"
+  "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>": "Aggiornamento annullato prima di ogni modifica: il processo PHP non può scrivere in questi percorsi: %s. Correggi i permessi (proprietario/scrittura per l'utente del web server) e riprova, oppure esegui l'aggiornamento da riga di comando come proprietario dei file: php scripts/manual-upgrade.php <zip-release>",
+  "Cartella radice": "Cartella radice",
+  "Cartella backup": "Cartella backup",
+  "Cartella storage": "Cartella storage"
 }


### PR DESCRIPTION
The update panel's system-requirements list labelled each writable target with only `basename($path)`, so an install root at `.../Web/html` rendered as a bare **"Write: html"**. A QNAP user in #205 hit exactly this after fixing `public/assets` permissions — the updater's new preflight then correctly flagged the still-unwritable **install root**, but as "html", and they had to ask which folder that even was.

Label each writable target with what it is + its full path:

- `Write — Installation root (/share/…/html)`
- `Write — Backup directory (…)`
- `Write — Storage directory (…/storage)`

so the operator knows exactly which directory to `chown`/`chmod`. Paths are admin-only (this runs in the update panel). New i18n keys added to all 4 locales; verified live that `checkRequirements()` prints the labelled full paths.

Refs #205.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Migliorati i controlli preliminari dell’aggiornamento con verifiche più chiare sulle cartelle richieste.
  * Le directory vengono ora mostrate con etichette esplicite e tradotte, incluse cartella radice, backup e storage.

* **Localizzazione**
  * Aggiunte nuove traduzioni per le etichette delle cartelle in più lingue, così i messaggi risultano più comprensibili nell’interfaccia.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->