### PR TITLE
fix(bin): permissions script must never make things worse (#205)

### DIFF
--- a/bin/setup-permissions.sh
+++ b/bin/setup-permissions.sh
@@ -2,54 +2,46 @@
 #
 # Pinakes — filesystem permissions setup
 # ============================================================================
-# Makes a Pinakes installation writable by the web-server (PHP) user so that:
-#   • the app can write at runtime (uploads, cache, logs, backups, .env, …), and
-#   • the in-app updater can apply releases — which means CREATING new files and
-#     directories and OVERWRITING existing code, so the PHP user must OWN the
-#     whole install tree, not just a few sub-folders.
+# Grants the web-server (PHP) user the access it needs so the app runs and the
+# in-app updater can apply releases. Works for ANY install layout — a normal
+# host (Apache/nginx + PHP), shared hosting (cPanel), a NAS, or a Docker
+# bind-mount where PHP runs inside the container.
 #
-# This is the one-shot fix for the classic "Update failed: Unable to create
-# directory / Not writable" errors (e.g. GitHub issue #205 on a QNAP NAS): the
-# install ROOT itself, and every writable data directory, are handed to the PHP
-# user in a single run.
+# DESIGN: GRANT, NEVER RESET.
+#   The script only ADDS the ownership and read/write bits that are missing.
+#   It never strips existing access, never changes a group you didn't ask it
+#   to change, and never touches `.env`'s existing readers. (An earlier version
+#   reset modes and switched the group, which locked PHP out of a Docker
+#   install — see issue #205. This one cannot do that.)
 #
-# WHAT IT DOES
-#   1. Detects the web-server/PHP user (or use --user).
-#   2. Creates any missing writable data directories.
-#   3. chown -R <php-user>:<group> on the whole install tree  (the thing the
-#      updater actually needs), then applies conservative modes:
-#        • code/dirs      → u=rwX,go=rX   (owner writes; NO world-write; the
-#                           capital X only adds +x to dirs & already-exec files,
-#                           so shell scripts stay runnable and plain files don't
-#                           become executable)
-#        • data dirs      → u=rwX,g=rwX,o=rX + setgid, so files the PHP user
-#                           creates keep the right group
-#        • .env           → 0640 (secrets: owner rw, group r, world none)
-#   4. Never uses `chmod 777`.
+# CHOOSING THE OWNER
+#   • Normal / NAS / cPanel:  the PHP user owns the files on the host.
+#       --user www-data           (or httpdusr, apache, your cPanel account…)
+#     Omit --user and it is auto-detected from the running web/PHP process.
+#     Omit --group and the EXISTING group is preserved (not changed).
+#   • Docker bind-mount: PHP runs INSIDE the container with its own uid/gid,
+#     which is what must own the files on the host. Let the script read it
+#     straight from the container:
+#       --from-container pinakes         (your container name from `docker ps`)
+#     It runs `docker exec … id` and chowns to that NUMERIC uid:gid, which is
+#     the only thing that maps correctly across a bind-mount.
 #
 # SAFETY
-#   • DRY-RUN BY DEFAULT — prints exactly what it would do and changes nothing.
-#     Re-run with --apply to make the changes.
-#   • Idempotent — safe to run repeatedly.
-#   • POSIX-friendly — works on Linux, QNAP QTS (busybox), Synology, cPanel,
-#     macOS. chown needs root (run with sudo, or as admin on a NAS).
+#   • DRY-RUN BY DEFAULT — prints what it would do; --apply to make changes.
+#   • Idempotent; best-effort (one un-touchable file won't abort the run).
+#   • chown needs root (sudo / NAS admin). Without it, only chmod runs.
 #
 # USAGE
-#   bin/setup-permissions.sh                         # dry-run (default)
-#   sudo bin/setup-permissions.sh --apply            # apply, auto-detect user
-#   sudo bin/setup-permissions.sh --apply --user httpdusr           # QNAP
-#   sudo bin/setup-permissions.sh --apply --user httpdusr --group everyone
-#   bin/setup-permissions.sh --apply --root /share/CACHEDEV1_DATA/Web/pinakes
+#   bin/setup-permissions.sh                              # dry-run, auto-detect
+#   sudo bin/setup-permissions.sh --apply                 # normal host
+#   sudo bin/setup-permissions.sh --apply --user www-data
+#   sudo bin/setup-permissions.sh --apply --from-container pinakes   # Docker
+#   sudo bin/setup-permissions.sh --apply --root /path/to/install --user httpdusr
 #   bin/setup-permissions.sh --help
 # ============================================================================
 
-# -u only: a mass chmod/chown over an install tree WILL hit the odd file it
-# can't touch (a stray root-owned file, setgid without privilege on macOS, …).
-# Those must not abort the whole run — each command is best-effort (see run()),
-# and every hard precondition below has its own explicit exit.
 set -u
 
-# ── Colors (disabled when not a TTY) ────────────────────────────────────────
 if [ -t 1 ]; then
     RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'
     BLUE=$'\033[0;34m'; BOLD=$'\033[1m'; NC=$'\033[0m'
@@ -61,24 +53,24 @@ APPLY=0
 PHP_USER=""
 PHP_GROUP=""
 ROOT=""
+FROM_CONTAINER=""
+GROUP_EXPLICIT=0
 
-usage() {
-    sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'
-    exit 0
-}
+usage() { sed -n '2,45p' "$0" | sed 's/^# \{0,1\}//'; exit 0; }
 
-# ── Parse arguments ─────────────────────────────────────────────────────────
 while [ $# -gt 0 ]; do
     case "$1" in
-        --apply)        APPLY=1 ;;
-        --dry-run)      APPLY=0 ;;
-        --user)         PHP_USER="${2:-}"; shift ;;
-        --user=*)       PHP_USER="${1#*=}" ;;
-        --group)        PHP_GROUP="${2:-}"; shift ;;
-        --group=*)      PHP_GROUP="${1#*=}" ;;
-        --root)         ROOT="${2:-}"; shift ;;
-        --root=*)       ROOT="${1#*=}" ;;
-        -h|--help)      usage ;;
+        --apply)            APPLY=1 ;;
+        --dry-run)          APPLY=0 ;;
+        --user)             PHP_USER="${2:-}"; shift ;;
+        --user=*)           PHP_USER="${1#*=}" ;;
+        --group)            PHP_GROUP="${2:-}"; GROUP_EXPLICIT=1; shift ;;
+        --group=*)          PHP_GROUP="${1#*=}"; GROUP_EXPLICIT=1 ;;
+        --root)             ROOT="${2:-}"; shift ;;
+        --root=*)           ROOT="${1#*=}" ;;
+        --from-container)   FROM_CONTAINER="${2:-}"; shift ;;
+        --from-container=*) FROM_CONTAINER="${1#*=}" ;;
+        -h|--help)          usage ;;
         *) echo "${RED}Unknown option: $1${NC}" >&2; echo "Try --help." >&2; exit 2 ;;
     esac
     shift
@@ -87,11 +79,10 @@ done
 # ── Resolve the install root ────────────────────────────────────────────────
 if [ -z "$ROOT" ]; then
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-    ROOT="$(dirname "$SCRIPT_DIR")"   # bin/ is one level below the install root
+    ROOT="$(dirname "$SCRIPT_DIR")"
 fi
 ROOT="$(cd "$ROOT" 2>/dev/null && pwd || echo "$ROOT")"
 
-# Sanity: is this really a Pinakes install root?
 if [ ! -f "$ROOT/version.json" ] || [ ! -f "$ROOT/public/index.php" ]; then
     echo "${RED}✗ $ROOT does not look like a Pinakes install${NC}" >&2
     echo "  (expected version.json and public/index.php). Use --root <path>." >&2
@@ -103,117 +94,88 @@ echo "${BOLD}║   Pinakes — filesystem permissions setup     ║${NC}"
 echo "${BOLD}╚══════════════════════════════════════════════╝${NC}"
 echo "  Install root : ${BLUE}$ROOT${NC}"
 
-# ── Detect the web-server/PHP user ──────────────────────────────────────────
-detect_php_user() {
-    # Look for a running web/PHP worker owned by a NON-root user. Try several
-    # `ps` dialects (GNU, BSD, busybox) and process names.
-    _names='php-fpm php_fpm php-cgi lsphp httpd apache2 apache nginx'
-    for _p in $_names; do
-        _u=$(ps -eo user,comm 2>/dev/null | awk -v p="$_p" 'index($2,p)>0 && $1!="root" && $1!="USER"{print $1; exit}') || true
-        [ -z "${_u:-}" ] && _u=$(ps aux 2>/dev/null | awk -v p="$_p" 'index($0,p)>0 && $1!="root" && $1!="USER"{print $1; exit}') || true
-        [ -z "${_u:-}" ] && _u=$(ps -ef 2>/dev/null | awk -v p="$_p" 'index($0,p)>0 && $1!="root" && $1!="UID"{print $1; exit}') || true
-        if [ -n "${_u:-}" ]; then echo "$_u"; return 0; fi
-    done
-    return 1
-}
+# ── Determine the owner spec ────────────────────────────────────────────────
+# OWNER_SPEC is what we hand to chown. GROUP_KNOWN=1 means we have a group we're
+# allowed to grant group-write to; otherwise we preserve whatever group exists.
+OWNER_SPEC=""
+GROUP_KNOWN=0
 
-if [ -z "$PHP_USER" ]; then
-    PHP_USER="$(detect_php_user || true)"
-fi
-
-if [ -z "$PHP_USER" ]; then
-    echo ""
-    echo "${YELLOW}⚠ Could not auto-detect the web-server user.${NC}"
-    echo "  Re-run with --user <name>. Common values:"
-    echo "    • QNAP QTS ...... httpdusr    (group: everyone)"
-    echo "    • cPanel ........ your cPanel account name"
-    echo "    • Debian/Ubuntu . www-data"
-    echo "    • RHEL/CentOS ... apache      (or nginx)"
-    echo "    • Synology ...... http"
-    echo ""
-    echo "  Find it yourself with:  ps aux | grep -E 'php-fpm|apache|httpd|nginx'"
-    exit 1
-fi
-
-# User must exist.
-if ! id "$PHP_USER" >/dev/null 2>&1; then
-    echo "${RED}✗ User '$PHP_USER' does not exist on this system.${NC}" >&2
-    exit 1
-fi
-
-# Group: explicit, else the user's primary group, else the user name.
-if [ -z "$PHP_GROUP" ]; then
-    PHP_GROUP="$(id -gn "$PHP_USER" 2>/dev/null || echo "$PHP_USER")"
-fi
-
-echo "  PHP user     : ${BLUE}$PHP_USER${NC}   group: ${BLUE}$PHP_GROUP${NC}"
-
-# ── Can we chown? (needs root / CAP_CHOWN) ──────────────────────────────────
-CUR_UID="$(id -u 2>/dev/null || echo 1000)"
-CAN_CHOWN=1
-[ "$CUR_UID" != "0" ] && CAN_CHOWN=0
-
-if [ "$APPLY" -eq 1 ]; then
-    echo "  Mode         : ${GREEN}${BOLD}APPLY${NC}"
+if [ -n "$FROM_CONTAINER" ]; then
+    # Docker: read the uid/gid PHP actually runs as inside the container.
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "${RED}✗ --from-container given but 'docker' is not on PATH.${NC}" >&2; exit 1
+    fi
+    _uid="$(docker exec "$FROM_CONTAINER" id -u 2>/dev/null || true)"
+    _gid="$(docker exec "$FROM_CONTAINER" id -g 2>/dev/null || true)"
+    if [ -z "$_uid" ] || [ -z "$_gid" ]; then
+        echo "${RED}✗ Could not read the uid/gid from container '$FROM_CONTAINER'.${NC}" >&2
+        echo "  Check the name with 'docker ps' and that the container is running." >&2
+        exit 1
+    fi
+    OWNER_SPEC="$_uid:$_gid"     # numeric — the only thing correct across a bind-mount
+    GROUP_KNOWN=1
+    echo "  Container    : ${BLUE}$FROM_CONTAINER${NC} → PHP runs as uid:gid ${BLUE}$_uid:$_gid${NC}"
 else
-    echo "  Mode         : ${YELLOW}dry-run${NC} (nothing will change — use --apply)"
+    # Host install: detect or accept the PHP user.
+    if [ -z "$PHP_USER" ]; then
+        _names='php-fpm php_fpm php-cgi lsphp httpd apache2 apache nginx'
+        for _p in $_names; do
+            _u=$(ps -eo user,comm 2>/dev/null | awk -v p="$_p" 'index($2,p)>0 && $1!="root" && $1!="USER"{print $1; exit}') || true
+            [ -z "${_u:-}" ] && _u=$(ps aux 2>/dev/null | awk -v p="$_p" 'index($0,p)>0 && $1!="root" && $1!="USER"{print $1; exit}') || true
+            [ -z "${_u:-}" ] && _u=$(ps -ef 2>/dev/null | awk -v p="$_p" 'index($0,p)>0 && $1!="root" && $1!="UID"{print $1; exit}') || true
+            [ -n "${_u:-}" ] && { PHP_USER="$_u"; break; }
+        done
+    fi
+    if [ -z "$PHP_USER" ]; then
+        echo ""
+        echo "${YELLOW}⚠ Could not auto-detect the web-server user.${NC}"
+        echo "  Re-run with --user <name> (QNAP: httpdusr · Debian: www-data ·"
+        echo "  RHEL: apache · cPanel: your account) — or, if this is a Docker"
+        echo "  install, with ${BOLD}--from-container <name>${NC}."
+        echo "  Find it: ps aux | grep -E 'php-fpm|apache|httpd|nginx'"
+        exit 1
+    fi
+    if ! id "$PHP_USER" >/dev/null 2>&1; then
+        echo "${RED}✗ User '$PHP_USER' does not exist on this host.${NC}" >&2
+        echo "  If PHP runs inside a container, use --from-container <name> instead." >&2
+        exit 1
+    fi
+    if [ "$GROUP_EXPLICIT" -eq 1 ]; then
+        OWNER_SPEC="$PHP_USER:$PHP_GROUP"; GROUP_KNOWN=1
+    else
+        # Preserve the existing group — do NOT switch it (that's what broke #205).
+        OWNER_SPEC="$PHP_USER"; GROUP_KNOWN=0
+    fi
+    echo "  PHP user     : ${BLUE}$PHP_USER${NC}$([ "$GROUP_KNOWN" -eq 1 ] && echo "   group: ${BLUE}$PHP_GROUP${NC}" || echo "   group: ${BLUE}(preserved)${NC}")"
 fi
-if [ "$CAN_CHOWN" -eq 0 ]; then
-    echo "  ${YELLOW}Note: not running as root — will skip chown and fall back to chmod g+w."
-    echo "        For a full fix run with sudo (or as admin on a NAS).${NC}"
-fi
+
+CUR_UID="$(id -u 2>/dev/null || echo 1000)"
+CAN_CHOWN=1; [ "$CUR_UID" != "0" ] && CAN_CHOWN=0
+
+if [ "$APPLY" -eq 1 ]; then echo "  Mode         : ${GREEN}${BOLD}APPLY${NC}"
+else echo "  Mode         : ${YELLOW}dry-run${NC} (nothing will change — use --apply)"; fi
+[ "$CAN_CHOWN" -eq 0 ] && echo "  ${YELLOW}Note: not root — chown is skipped; only chmod (grant) runs. For a full fix use sudo / NAS admin.${NC}"
 echo ""
 
-# ── The writable DATA directories (from a code audit of every FS write) ─────
-# Created if missing; group-writable + setgid so PHP-created files keep group.
+# ── Writable data directories (audited from every runtime FS write) ─────────
 WRITABLE_DIRS="
-storage
-storage/logs
-storage/cache
-storage/tmp
-storage/backups
-storage/calendar
-storage/sessions
-storage/rate_limits
-storage/plugins
-storage/uploads
-storage/uploads/plugins
-storage/uploads/cms
-public/uploads
-public/uploads/copertine
-public/uploads/autori
-public/uploads/settings
-public/uploads/events
-public/uploads/assets
-public/uploads/digital
-public/uploads/archives
-public/uploads/archives/covers
-public/uploads/archives/documents
-public/assets
-data/dewey
-writable/uploads
-locale
+storage storage/logs storage/cache storage/tmp storage/backups
+storage/calendar storage/sessions storage/rate_limits storage/plugins
+storage/uploads storage/uploads/plugins storage/uploads/cms
+public/uploads public/uploads/copertine public/uploads/autori
+public/uploads/settings public/uploads/events public/uploads/assets
+public/uploads/digital public/uploads/archives public/uploads/archives/covers
+public/uploads/archives/documents public/assets data/dewey writable/uploads locale
 "
-
-# Individual writable files (or their parent must allow create). .env holds
-# secrets → tighter mode handled separately.
 WRITABLE_FILES="version.json .installed .htaccess public/sitemap.xml"
 
-# ── Helper: run or echo depending on mode ───────────────────────────────────
 run() {
     if [ "$APPLY" -eq 1 ]; then
-        # Best-effort: a single un-touchable file must not abort the run.
         if ! "$@" 2>/dev/null; then
-            local _I="$IFS"; IFS=' '
-            echo "    ${YELLOW}⚠ skipped (permission denied):${NC} $*"
-            IFS="$_I"
+            local _I="$IFS"; IFS=' '; echo "    ${YELLOW}⚠ skipped (permission denied):${NC} $*"; IFS="$_I"
         fi
     else
-        # Force space separation for the printed command — callers may have IFS
-        # set to newline while iterating the path lists.
-        local _IFS="$IFS"; IFS=' '
-        echo "    ${BLUE}[dry-run]${NC} $*"
-        IFS="$_IFS"
+        local _I="$IFS"; IFS=' '; echo "    ${BLUE}[dry-run]${NC} $*"; IFS="$_I"
     fi
 }
 
@@ -221,75 +183,72 @@ cd "$ROOT"
 
 # ── 1. Create missing writable directories ──────────────────────────────────
 echo "${BOLD}› Ensuring writable data directories exist${NC}"
-_created=0
-OLDIFS="$IFS"; IFS='
-'
-for d in $WRITABLE_DIRS; do
+_created=0; for d in $WRITABLE_DIRS; do
     [ -z "$d" ] && continue
-    if [ ! -d "$d" ]; then
-        run mkdir -p "$d"
-        echo "    ${GREEN}+${NC} $d ${YELLOW}(created)${NC}"
-        _created=$((_created+1))
-    fi
+    if [ ! -d "$d" ]; then run mkdir -p "$d"; echo "    ${GREEN}+${NC} $d ${YELLOW}(created)${NC}"; _created=$((_created+1)); fi
 done
-IFS="$OLDIFS"
 [ "$_created" -eq 0 ] && echo "    all present"
 
-# ── 2. Own the whole tree as the PHP user (the update-critical step) ────────
-echo "${BOLD}› Ownership → $PHP_USER:$PHP_GROUP (whole install tree)${NC}"
+# ── 2. Ownership → the PHP user (group preserved unless you named one) ───────
+echo "${BOLD}› Ownership → $OWNER_SPEC$([ "$GROUP_KNOWN" -eq 0 ] && echo " (group preserved)")${NC}"
 if [ "$CAN_CHOWN" -eq 1 ]; then
-    run chown -R "$PHP_USER:$PHP_GROUP" "$ROOT"
-    echo "    ${GREEN}✓${NC} chown -R applied to the install root"
+    run chown -R "$OWNER_SPEC" "$ROOT"
+    echo "    ${GREEN}✓${NC} chown -R applied"
 else
-    echo "    ${YELLOW}skipped (not root)${NC} — relying on group-write instead"
+    echo "    ${YELLOW}skipped (not root)${NC}"
 fi
 
-# ── 3. Baseline modes on the whole tree (no world-write, keep execs) ────────
-echo "${BOLD}› Baseline modes (dirs 755 / files 644, execs preserved)${NC}"
-run chmod -R u=rwX,go=rX "$ROOT"
-echo "    ${GREEN}✓${NC} owner rw + traversal; group/other read-only"
+# ── 3. GRANT read+traverse to the owner across the tree (never strips) ──────
+# u+rX: owner can read every file and enter every dir. Capital X only adds +x
+# to directories and already-executable files, so scripts stay runnable and
+# plain files don't become executable. No g/o bits are touched → nothing that
+# currently works loses access.
+echo "${BOLD}› Grant owner read/traverse (additive, strips nothing)${NC}"
+run chmod -R u+rX "$ROOT"
+echo "    ${GREEN}✓${NC} owner can read + traverse the whole tree"
 
-# ── 4. Relax the data directories to group-writable + setgid ────────────────
-echo "${BOLD}› Data directories → group-writable + setgid${NC}"
-OLDIFS="$IFS"; IFS='
-'
+# ── 4. GRANT write on the data dirs to owner+group (+ setgid) ───────────────
+echo "${BOLD}› Grant write on data directories (owner+group, +setgid)${NC}"
 for d in $WRITABLE_DIRS; do
-    [ -z "$d" ] && continue
-    [ -d "$d" ] || continue
-    run chmod -R u=rwX,g=rwX,o=rX "$d"
+    [ -z "$d" ] && continue; [ -d "$d" ] || continue
+    run chmod -R ug+rwX "$d"
     run chmod g+s "$d"
 done
-IFS="$OLDIFS"
-echo "    ${GREEN}✓${NC} PHP user (and its group) can create/modify data files"
+echo "    ${GREEN}✓${NC} the PHP user (via owner or its group) can create/modify data"
 
-# ── 5. Individual writable files ────────────────────────────────────────────
-echo "${BOLD}› Writable files${NC}"
-OLDIFS="$IFS"; IFS=' '
+# ── 5. Writable files ───────────────────────────────────────────────────────
+echo "${BOLD}› Grant write on runtime files${NC}"
 for f in $WRITABLE_FILES; do
-    [ -f "$f" ] || continue
-    run chmod u=rw,g=rw,o=r "$f"
-    echo "    ${GREEN}✓${NC} $f (0664)"
+    [ -f "$f" ] || continue; run chmod ug+rw "$f"; echo "    ${GREEN}✓${NC} $f"
 done
-IFS="$OLDIFS"
-# .env is secret → owner+group only, never world-readable.
+# .env: make sure owner (and group) can read+write it. Do NOT strip existing
+# readers — locking it to 0640 once locked PHP out of a Docker install (#205).
+# Instead, warn if it's world-readable so the operator can tighten it safely.
 if [ -f ".env" ]; then
-    run chmod u=rw,g=r,o= ".env"
-    echo "    ${GREEN}✓${NC} .env (0640 — secrets, not world-readable)"
+    run chmod ug+rw ".env"
+    echo "    ${GREEN}✓${NC} .env readable/writable by owner+group"
+    if [ -r ".env" ] && ls -l ".env" 2>/dev/null | cut -c8 | grep -q 'r'; then
+        echo "    ${YELLOW}note: .env is world-readable. Once the app works, you can tighten it with:"
+        echo "          chmod o-rwx .env   (only if the PHP user is the owner or in its group)${NC}"
+    fi
 fi
 
-# ── Done / verification ─────────────────────────────────────────────────────
+# ── Done ────────────────────────────────────────────────────────────────────
 echo ""
 if [ "$APPLY" -eq 1 ]; then
-    echo "${GREEN}${BOLD}✅ Permissions applied.${NC}"
-    echo "${BOLD}› Verification (updater's required-writable paths)${NC}"
-    for p in "$ROOT" "$ROOT/storage" "$ROOT/storage/backups"; do
-        _own="$(ls -ld "$p" 2>/dev/null | awk '{print $3":"$4}')"
-        echo "    ${GREEN}✓${NC} $p — owner $_own"
+    echo "${GREEN}${BOLD}✅ Permissions granted.${NC}"
+    echo "${BOLD}› Ownership of the updater's required-writable paths${NC}"
+    for p in "$ROOT" "$ROOT/storage" "$ROOT/storage/tmp" "$ROOT/storage/backups"; do
+        [ -e "$p" ] && echo "    $(ls -ld "$p" 2>/dev/null | awk '{print $1, $3":"$4}')  $p"
     done
     echo ""
-    echo "Next: retry the update from the admin panel (Aggiornamenti → Aggiorna)."
-    echo "Re-running an interrupted update is safe — it re-copies every file."
+    echo "Next: retry the update from the admin panel. Re-running an interrupted"
+    echo "update is safe — the updater re-copies every file."
 else
     echo "${YELLOW}${BOLD}Dry-run complete — nothing was changed.${NC}"
-    echo "Re-run to apply:  ${BOLD}sudo $0 --apply${NC}${PHP_USER:+ --user $PHP_USER}"
+    if [ -n "$FROM_CONTAINER" ]; then
+        echo "Apply:  ${BOLD}sudo $0 --apply --from-container $FROM_CONTAINER${NC}"
+    else
+        echo "Apply:  ${BOLD}sudo $0 --apply${PHP_USER:+ --user $PHP_USER}${NC}"
+    fi
 fi

--- a/tests/setup-permissions.test.sh
+++ b/tests/setup-permissions.test.sh
@@ -3,120 +3,113 @@
 # Test for bin/setup-permissions.sh
 # ============================================================================
 # Builds a throwaway mock install, runs the permissions script against it, and
-# asserts the resulting modes/ownership. Runs WITHOUT root: it chowns to the
-# CURRENT user/group (chowning to yourself needs no privilege), so the chown
-# path is exercised too. Everything else — dir creation, safe modes, exec
-# preservation, .env protection, no-777, idempotency, and the two hard-exit
-# guards — is checked directly.
+# asserts the "grant, never reset" contract — including the two regressions
+# from issue #205 that an earlier, destructive version caused on a Docker
+# install: it must NOT switch the group when none was asked for, and it must
+# NOT strip .env's existing readers.
 #
-# Usage:  tests/setup-permissions.test.sh
-# Exit 0 iff every assertion passes.
+# Runs WITHOUT root: chowns to the CURRENT user (needs no privilege), so the
+# chown path is exercised. Everything else is checked directly.
+#
+# Usage:  tests/setup-permissions.test.sh   → exit 0 iff every assertion passes.
 # ============================================================================
 
 set -u
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SCRIPT="$REPO_ROOT/bin/setup-permissions.sh"
-PASS=0
-FAIL=0
-
-ok()   { echo "  [OK]  $1"; PASS=$((PASS+1)); }
-bad()  { echo "  [!!]  $1"; FAIL=$((FAIL+1)); }
-
-# mode(path) → octal perms, portable across GNU (stat -c) and BSD/macOS (stat -f)
+PASS=0; FAIL=0
+ok()  { echo "  [OK]  $1"; PASS=$((PASS+1)); }
+bad() { echo "  [!!]  $1"; FAIL=$((FAIL+1)); }
 mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+grp()  { ls -ld "$1" 2>/dev/null | awk '{print $4}'; }
 
 CUR_USER="$(id -un)"
-CUR_GROUP="$(id -gn)"
 
 # ── Build a mock install ────────────────────────────────────────────────────
 SB="$(mktemp -d 2>/dev/null || echo /tmp/pinakes-perm-$$)"
-mkdir -p "$SB/bin" "$SB/public" "$SB/app/Support" "$SB/storage/backups" "$SB/vendor"
-cp "$SCRIPT" "$SB/bin/setup-permissions.sh"
-chmod +x "$SB/bin/setup-permissions.sh"
-echo '{"version":"0.7.27"}'          > "$SB/version.json"
-echo '<?php'                          > "$SB/public/index.php"
-echo '<?php class Foo {}'             > "$SB/app/Support/Foo.php"
-printf '#!/bin/sh\necho hi\n'         > "$SB/bin/tool.sh"; chmod 755 "$SB/bin/tool.sh"
-echo 'DB_PASS=secret'                 > "$SB/.env"; chmod 600 "$SB/.env"
+mkdir -p "$SB/bin" "$SB/public" "$SB/app/Support" "$SB/storage/backups" \
+         "$SB/storage/tmp" "$SB/vendor"
+cp "$SCRIPT" "$SB/bin/setup-permissions.sh"; chmod +x "$SB/bin/setup-permissions.sh"
+echo '{"version":"0.7.27"}'      > "$SB/version.json"
+echo '<?php'                      > "$SB/public/index.php"
+echo '<?php class Foo {}'         > "$SB/app/Support/Foo.php"
+printf '#!/bin/sh\necho hi\n'     > "$SB/bin/tool.sh"; chmod 755 "$SB/bin/tool.sh"
+# .env world-readable (0644) — the state a working Docker install had before
+# the destructive version locked it to 0640 and broke PHP (#205).
+echo 'DB_PASS=secret'             > "$SB/.env"; chmod 644 "$SB/.env"
+_env_grp_before="$(grp "$SB/.env")"
 
 echo "── Test: bin/setup-permissions.sh (sandbox: $SB) ──"
 
 # ── 1. Syntax ───────────────────────────────────────────────────────────────
-if bash -n "$SCRIPT"; then ok "script parses (bash -n)"; else bad "syntax error"; fi
+bash -n "$SCRIPT" && ok "script parses (bash -n)" || bad "syntax error"
 
-# ── 2. Guard: rejects a non-install directory ───────────────────────────────
+# ── 2. Guards ───────────────────────────────────────────────────────────────
 BADDIR="$(mktemp -d 2>/dev/null || echo /tmp/pinakes-nope-$$)"
-if bash "$SCRIPT" --root "$BADDIR" >/dev/null 2>&1; then
-    bad "should reject a non-install dir (no version.json)"
-else
-    ok "rejects a non-install directory"
-fi
+bash "$SCRIPT" --root "$BADDIR" >/dev/null 2>&1 && bad "should reject non-install dir" || ok "rejects a non-install directory"
 rm -rf "$BADDIR"
+bash "$SCRIPT" --root "$SB" --user __no_such_user__ >/dev/null 2>&1 && bad "should reject unknown --user" || ok "rejects a non-existent user"
 
-# ── 3. Guard: rejects a non-existent user ───────────────────────────────────
-if bash "$SCRIPT" --root "$SB" --user __definitely_no_such_user__ >/dev/null 2>&1; then
-    bad "should reject a non-existent --user"
-else
-    ok "rejects a non-existent user"
-fi
+# ── 3. Dry-run changes nothing ──────────────────────────────────────────────
+_before="$(mode "$SB/.env")"
+bash "$SCRIPT" --root "$SB" --user "$CUR_USER" >/dev/null 2>&1
+[ ! -d "$SB/storage/logs" ] && [ "$(mode "$SB/.env")" = "$_before" ] && ok "dry-run changes nothing" || bad "dry-run modified the filesystem"
 
-# ── 4. Dry-run changes nothing ──────────────────────────────────────────────
-_env_before="$(mode "$SB/.env")"
-bash "$SCRIPT" --root "$SB" --user "$CUR_USER" --group "$CUR_GROUP" >/dev/null 2>&1
-if [ ! -d "$SB/storage/logs" ] && [ "$(mode "$SB/.env")" = "$_env_before" ]; then
-    ok "dry-run creates nothing / changes nothing"
-else
-    bad "dry-run modified the filesystem"
-fi
+# ── 4. Apply (no --group → group preserved) ─────────────────────────────────
+bash "$SCRIPT" --apply --root "$SB" --user "$CUR_USER" >/dev/null 2>&1
 
-# ── 5. Apply ────────────────────────────────────────────────────────────────
-bash "$SCRIPT" --apply --root "$SB" --user "$CUR_USER" --group "$CUR_GROUP" >/dev/null 2>&1
-
-# 5a. writable dirs created
 _missing=0
 for d in storage/logs storage/cache storage/tmp storage/backups public/uploads \
-         public/uploads/copertine public/uploads/archives/covers data/dewey \
-         writable/uploads locale storage/uploads/plugins; do
+         public/uploads/archives/covers data/dewey writable/uploads locale \
+         storage/uploads/plugins; do
     [ -d "$SB/$d" ] || { _missing=1; echo "      missing: $d"; }
 done
 [ "$_missing" -eq 0 ] && ok "all writable data directories created" || bad "some writable dirs missing"
 
-# 5b. code file → 644, not executable
+# 4a. code file still readable by owner, no +x added
 m="$(mode "$SB/app/Support/Foo.php")"
-[ "$m" = "644" ] && ok "code file is 0644 ($m)" || bad "code file mode is $m (want 644)"
+case "$m" in 6??|644|664) ok "code file readable, not executable ($m)";; *) bad "code file mode is $m";; esac
 
-# 5c. shell script keeps its execute bit
-m="$(mode "$SB/bin/tool.sh")"
-case "$m" in 7??|75?|55?) ok "shell script stays executable ($m)";; *) bad "tool.sh lost +x (mode $m)";; esac
+# 4b. shell script keeps +x
+m="$(mode "$SB/bin/tool.sh")"; case "$m" in 7??|75?|55?) ok "shell script stays executable ($m)";; *) bad "tool.sh lost +x ($m)";; esac
 
-# 5d. .env is not group/other writable and not world-readable (0640)
+# 4c. REGRESSION #205: .env's world-read must NOT be stripped
 m="$(mode "$SB/.env")"
-[ "$m" = "640" ] && ok ".env is 0640 (secret-safe)" || bad ".env mode is $m (want 640)"
+case "$m" in *4|*5|*6|*7) ok ".env keeps its existing readers ($m, not locked to 640)";; *) bad ".env readers stripped: mode $m (regression #205)";; esac
+# and .env must still be world-readable specifically (it was 644 before)
+if ls -ld "$SB/.env" | cut -c8 | grep -q 'r'; then ok ".env still world-readable (grant, not reset)"; else bad ".env lost world-read (#205 regression)"; fi
 
-# 5e. data dir is group-writable (0775)
-m="$(mode "$SB/storage")"
-[ "$m" = "775" ] || [ "$m" = "2775" ] && ok "storage is group-writable ($m)" || bad "storage mode is $m (want 775/2775)"
+# 4d. REGRESSION #205: group preserved when --group not given
+[ "$(grp "$SB/.env")" = "$_env_grp_before" ] && ok "group preserved (not switched)" || bad "group was changed without --group (regression #205)"
 
-# 5f. NOTHING is world-writable (no 777, no o+w anywhere)
+# 4e. data dirs group-writable — BOTH tmp and backups (IFS split-bug regression)
+for d in storage/tmp storage/backups public/uploads; do
+    m="$(mode "$SB/$d")"
+    case "$m" in *7?|*6?|2*7?|2*6?) ok "$d group-writable ($m)";; *) bad "$d not group-writable: $m";; esac
+done
+
+# 4f. nothing world-writable (no 777)
 _ww="$(find "$SB" -perm -0002 2>/dev/null | grep -v '/storage/sessions' | head -1)"
-[ -z "$_ww" ] && ok "nothing is world-writable (no 777)" || bad "world-writable path found: $_ww"
+[ -z "$_ww" ] && ok "nothing world-writable (no 777)" || bad "world-writable path: $_ww"
 
-# 5g. ownership set to the target user (chown path exercised)
-_own="$(ls -ld "$SB/storage" | awk '{print $3}')"
-[ "$_own" = "$CUR_USER" ] && ok "chown applied (storage owned by $CUR_USER)" || bad "storage owner is $_own (want $CUR_USER)"
+# 4g. chown applied
+[ "$(ls -ld "$SB/storage" | awk '{print $3}')" = "$CUR_USER" ] && ok "chown applied (storage owned by $CUR_USER)" || bad "storage owner wrong"
 
-# ── 6. Idempotency: a second apply succeeds and keeps the modes ─────────────
-bash "$SCRIPT" --apply --root "$SB" --user "$CUR_USER" --group "$CUR_GROUP" >/dev/null 2>&1
-rc=$?
-m1="$(mode "$SB/app/Support/Foo.php")"; m2="$(mode "$SB/.env")"
-if [ "$rc" -eq 0 ] && [ "$m1" = "644" ] && [ "$m2" = "640" ]; then
-    ok "idempotent (second apply OK, modes stable)"
+# ── 5. --from-container guard (docker absent → clear error, no crash) ────────
+if ! command -v docker >/dev/null 2>&1; then
+    bash "$SCRIPT" --root "$SB" --from-container whatever >/dev/null 2>&1 \
+        && bad "--from-container should fail when docker is absent" \
+        || ok "--from-container errors cleanly without docker"
 else
-    bad "second apply changed something (rc=$rc Foo=$m1 env=$m2)"
+    ok "--from-container guard (docker present — skipped)"
 fi
 
-# ── Cleanup + verdict ───────────────────────────────────────────────────────
+# ── 6. Idempotency ──────────────────────────────────────────────────────────
+bash "$SCRIPT" --apply --root "$SB" --user "$CUR_USER" >/dev/null 2>&1; rc=$?
+m1="$(mode "$SB/app/Support/Foo.php")"
+[ "$rc" -eq 0 ] && ok "idempotent (second apply OK)" || bad "second apply failed (rc=$rc)"
+
 rm -rf "$SB"
 echo ""
 echo "  $PASS passed, $FAIL failed"


### PR DESCRIPTION
The 0.7.27 permissions helper was **destructive** — it reset modes, switched the group, and locked `.env` to `0640`. On a **Docker bind-mount** install (PHP runs inside the container and reached the files via the `administrators` group) this stripped group access and made `.env` unreadable → **500 on every page** (#205).

Rewritten around **grant, never reset**:
- only ADDS ownership + read/write bits; never strips existing access;
- **preserves the existing group** unless `--group` is passed (the group switch is what broke #205);
- `.env`: grants owner/group rw, never removes existing readers — warns if world-readable instead of silently locking it;
- new **`--from-container <name>`**: reads the real uid:gid PHP runs as *inside* the container and chowns to that numeric id — the only thing correct across a bind-mount, so the script now works for Docker installs too;
- fixes an IFS split bug that left `storage/backups` without group-write.

Test rewritten (17 assertions) covering the two #205 regressions + the IFS bug. Verified 17/17 locally.

Refs #205.