### PR TITLE
fix: length validation in characters, not bytes (reviews + users)

### DIFF
--- a/app/Controllers/RecensioniController.php
+++ b/app/Controllers/RecensioniController.php
@@ -88,12 +88,15 @@ class RecensioniController
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }
 
-        if (strlen($titolo) > 255) {
+        // mb_strlen: i limiti dei messaggi sono in caratteri, non in byte —
+        // con strlen() un titolo UTF-8 con accenti/emoji da meno di 255
+        // caratteri veniva rifiutato (es. 130 emoji = 520 byte).
+        if (mb_strlen($titolo) > 255) {
             $response->getBody()->write(json_encode(['success' => false, 'message' => __('Titolo troppo lungo (max 255 caratteri)')]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }
 
-        if (strlen($descrizione) > 2000) {
+        if (mb_strlen($descrizione) > 2000) {
             $response->getBody()->write(json_encode(['success' => false, 'message' => __('Descrizione troppo lunga (max 2000 caratteri)')]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -93,15 +93,15 @@ class UsersController
         }
 
         // Validate input lengths
-        if (strlen($nome) > 100 || strlen($cognome) > 100) {
+        if (mb_strlen($nome) > 100 || mb_strlen($cognome) > 100) {
             return $response->withHeader('Location', url('/admin/users/create?error=name_too_long'))->withStatus(302);
         }
 
-        if (strlen($email) > 255) {
+        if (mb_strlen($email) > 255) {
             return $response->withHeader('Location', url('/admin/users/create?error=email_too_long'))->withStatus(302);
         }
 
-        if (strlen($telefono) > 20) {
+        if (mb_strlen($telefono) > 20) {
             return $response->withHeader('Location', url('/admin/users/create?error=phone_too_long'))->withStatus(302);
         }
 
@@ -370,11 +370,12 @@ class UsersController
             $newPassword = (string) $data['password'];
 
             // Validate password complexity (max 72 — bcrypt silently truncates beyond)
-            if (strlen($newPassword) < 8) {
+            if (mb_strlen($newPassword) < 8) {
                 $_SESSION['error_message'] = __('La password deve essere lunga almeno 8 caratteri.');
                 return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=password_too_short'))->withStatus(302);
             }
 
+            // bcrypt truncates at 72 BYTES, so this limit is deliberately byte-based.
             if (strlen($newPassword) > 72) {
                 $_SESSION['error_message'] = __('La password non può superare i 72 caratteri.');
                 return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=password_too_long'))->withStatus(302);


### PR DESCRIPTION
`strlen()` counts UTF-8 bytes, not characters, so review titles/descriptions and user names with accents or emoji were rejected well under the advertised limits (a 130-emoji review description = 520 bytes tripped the 255 check). The DB columns are utf8mb4 `varchar(n)` — which counts characters — so `mb_strlen()` is the correct comparison.

- `RecensioniController`: title ≤255 and description ≤2000 validated with `mb_strlen()` (the mobile-api `ReviewsController` already did this — web and app are now consistent).
- `UsersController`: same fix for name/surname (100), email (255), phone (20) and the password minimum (8 characters); the 72 maximum deliberately stays byte-based because bcrypt truncates at 72 **bytes** (commented in code).

PHPStan clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la validazione di alcuni campi testuali per gestire correttamente caratteri multibyte, evitando rifiuti errati con testi contenenti accenti o emoji.
  * Corretto il controllo della lunghezza minima della password in modo più preciso per contenuti UTF-8.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->