### PR TITLE
fix(book-club): review follow-ups — soft-delete consistency, CSV injection, JS escaping

### DIFF
--- a/storage/plugins/book-club/BookClubPlugin.php
+++ b/storage/plugins/book-club/BookClubPlugin.php
@@ -673,15 +673,6 @@ class BookClubPlugin
     // ------------------------------------------------------------------
 
     /**
-     * Echo the club members' PUBLIC quotes for this book on the core book
-     * detail page (app/Views/frontend/book-detail.php fires the action with
-     * [$book, $bookId]). Delegates to the quotes module; a plain no-op when
-     * the module or its table is missing.
-     *
-     * @param array<string, mixed>|mixed $book
-     * @param mixed $bookId
-     */
-    /**
      * Filter target for mobile-api's 'mobile_api.openapi' hook: appends the
      * /api/v1/bookclub bridge paths when the bridge is actually mounted.
      *
@@ -693,6 +684,15 @@ class BookClubPlugin
         return \App\Plugins\BookClub\Modules\MobileModule::extendOpenApi($doc, $this->db);
     }
 
+    /**
+     * Echo the club members' PUBLIC quotes for this book on the core book
+     * detail page (app/Views/frontend/book-detail.php fires the action with
+     * [$book, $bookId]). Delegates to the quotes module; a plain no-op when
+     * the module or its table is missing.
+     *
+     * @param array<string, mixed>|mixed $book
+     * @param mixed $bookId
+     */
     public function renderBookQuotes($book = null, $bookId = null): void
     {
         $libroId = is_numeric($bookId) ? (int) $bookId : (int) (is_array($book) ? ($book['id'] ?? 0) : 0);

--- a/storage/plugins/book-club/src/AffinityRepo.php
+++ b/storage/plugins/book-club/src/AffinityRepo.php
@@ -557,6 +557,7 @@ class AffinityRepo
         $rows = $this->rows(
             "SELECT a.id, a.nome, COUNT(DISTINCT l2.id) AS unread_count
                FROM bookclub_books cb
+               JOIN libri l ON l.id = cb.libro_id AND l.deleted_at IS NULL
                JOIN libri_autori la ON la.libro_id = cb.libro_id
                JOIN autori a ON a.id = la.autore_id
                JOIN libri_autori la2 ON la2.autore_id = a.id

--- a/storage/plugins/book-club/src/ChallengeRepo.php
+++ b/storage/plugins/book-club/src/ChallengeRepo.php
@@ -303,6 +303,7 @@ class ChallengeRepo
                     'SELECT COUNT(DISTINCT la.autore_id) AS n
                        FROM bookclub_progress p
                        JOIN bookclub_books cb ON cb.id = p.club_book_id
+                       JOIN libri l ON l.id = cb.libro_id AND l.deleted_at IS NULL
                        JOIN libri_autori la ON la.libro_id = cb.libro_id
                       WHERE cb.club_id = ? AND p.user_id = ?
                         AND p.finished_at >= ? AND p.finished_at < ?',
@@ -315,6 +316,7 @@ class ChallengeRepo
                     'SELECT COUNT(*) AS n
                        FROM bookclub_progress p
                        JOIN bookclub_books cb ON cb.id = p.club_book_id
+                       JOIN libri l ON l.id = cb.libro_id AND l.deleted_at IS NULL
                       WHERE cb.club_id = ? AND p.user_id = ?
                         AND p.finished_at >= ? AND p.finished_at < ?',
                     'iiss',

--- a/storage/plugins/book-club/src/LendingController.php
+++ b/storage/plugins/book-club/src/LendingController.php
@@ -14,7 +14,8 @@ use Psr\Http\Message\ServerRequestInterface;
  * lender hands the copy over and either side marks it returned.
  *
  * Every handler re-checks per-club module enablement (routes are global)
- * and requires an ACTIVE membership (managers included). The state machine
+ * and requires either an ACTIVE membership or manage capability (admins/staff,
+ * who need no membership row — see mayUse()). The state machine
  * lives in LendingRepo as conditional UPDATEs, so two concurrent requests
  * for the same copy cannot both succeed ("first wins").
  */

--- a/storage/plugins/book-club/src/LendingRepo.php
+++ b/storage/plugins/book-club/src/LendingRepo.php
@@ -23,7 +23,8 @@ use mysqli;
  *   cancelled → the lender withdrew an offered/requested row.
  *
  * "Open" = offered/requested/active: at most ONE open row per
- * (club_book_id, lender_id) — enforced in code via hasOpenOffer().
+ * (club_book_id, lender_id) — enforced atomically by the INSERT ... WHERE NOT
+ * EXISTS guard inside createOffer(); hasOpenOffer() is only a UX pre-check.
  */
 class LendingRepo
 {

--- a/storage/plugins/book-club/src/QuoteController.php
+++ b/storage/plugins/book-club/src/QuoteController.php
@@ -420,7 +420,7 @@ class QuoteController extends BaseController
         fputcsv($fh, ['# ' . __('Citazioni')]);
         fputcsv($fh, [__('Libro'), __('Autori'), __('Citazione'), __('Pagina'), __('Nota'), __('Visibilità'), __('Creata il')]);
         foreach ($data['quotes'] as $quote) {
-            fputcsv($fh, [
+            fputcsv($fh, array_map([self::class, 'csvSafe'], [
                 (string) $quote['titolo'],
                 (string) ($quote['autori'] ?? ''),
                 (string) $quote['quote'],
@@ -428,19 +428,19 @@ class QuoteController extends BaseController
                 (string) ($quote['note'] ?? ''),
                 (string) $quote['visibility'],
                 (string) $quote['created_at'],
-            ]);
+            ]));
         }
         fwrite($fh, "\n");
         fputcsv($fh, ['# ' . __('Annotazioni')]);
         fputcsv($fh, [__('Libro'), __('Testo'), __('Visibilità'), __('Creata il'), __('Aggiornata il')]);
         foreach ($data['notes'] as $note) {
-            fputcsv($fh, [
+            fputcsv($fh, array_map([self::class, 'csvSafe'], [
                 (string) $note['titolo'],
                 (string) $note['body'],
                 (string) $note['visibility'],
                 (string) $note['created_at'],
                 (string) ($note['updated_at'] ?? ''),
-            ]);
+            ]));
         }
 
         rewind($fh);
@@ -451,5 +451,19 @@ class QuoteController extends BaseController
         return $response
             ->withHeader('Content-Type', 'text/csv; charset=utf-8')
             ->withHeader('Content-Disposition', 'attachment; filename="book-club-' . $slug . '-quotes-' . date('Ymd') . '.csv"');
+    }
+
+    /**
+     * Neutralize CSV/formula injection: a cell whose first character is one of
+     * =,+,-,@,TAB,CR becomes an executable formula when the export is opened in
+     * a spreadsheet. Prefix it with a single quote. Mirrors StatsController::csvSafe().
+     */
+    private static function csvSafe(mixed $value): string
+    {
+        $cell = (string) $value;
+        if ($cell !== '' && in_array($cell[0], ['=', '+', '-', '@', "\t", "\r"], true)) {
+            return "'" . $cell;
+        }
+        return $cell;
     }
 }

--- a/storage/plugins/book-club/src/SurveyController.php
+++ b/storage/plugins/book-club/src/SurveyController.php
@@ -711,7 +711,7 @@ class SurveyController extends BaseController
         if (!$anonymous) {
             $headers[] = __('Inviata il');
         }
-        fputcsv($fh, $headers);
+        fputcsv($fh, array_map([self::class, 'csvSafe'], $headers));
 
         $n = 0;
         foreach ($this->surveys->answers($surveyId) as $row) {
@@ -728,7 +728,7 @@ class SurveyController extends BaseController
             if (!$anonymous) {
                 $line[] = (string) $row['created_at'];
             }
-            fputcsv($fh, $line);
+            fputcsv($fh, array_map([self::class, 'csvSafe'], $line));
         }
 
         rewind($fh);
@@ -755,6 +755,20 @@ class SurveyController extends BaseController
             'scale_1_5' => is_numeric($value) ? (string) (int) $value : '',
             default => is_string($value) ? $value : '',
         };
+    }
+
+    /**
+     * Neutralize CSV/formula injection: a cell whose first character is one of
+     * =,+,-,@,TAB,CR becomes an executable formula when the export is opened in
+     * a spreadsheet. Prefix it with a single quote. Mirrors StatsController::csvSafe().
+     */
+    private static function csvSafe(mixed $value): string
+    {
+        $cell = (string) $value;
+        if ($cell !== '' && in_array($cell[0], ['=', '+', '-', '@', "\t", "\r"], true)) {
+            return "'" . $cell;
+        }
+        return $cell;
     }
 
     // ------------------------------------------------------------------

--- a/storage/plugins/book-club/views/public/ai.php
+++ b/storage/plugins/book-club/views/public/ai.php
@@ -212,7 +212,7 @@ $capReached = $recentCount >= $dailyCap;
         if (!target || !navigator.clipboard) { return; }
         navigator.clipboard.writeText(target.textContent).then(function () {
           var original = button.innerHTML;
-          button.innerHTML = '<i class="fas fa-check"></i><?= $e(__('Copiato!')) ?>';
+          button.innerHTML = '<i class="fas fa-check"></i>' + <?= json_encode(__('Copiato!'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?>;
           setTimeout(function () { button.innerHTML = original; }, 1500);
         });
       });

--- a/storage/plugins/book-club/views/public/reading.php
+++ b/storage/plugins/book-club/views/public/reading.php
@@ -33,7 +33,7 @@ $unitLabels = [
 $myPercent = $myProgress !== null ? (int) $myProgress['percent'] : 0;
 $myFinished = $myProgress !== null && !empty($myProgress['finished_at']);
 $mySectionId = $myProgress !== null && $myProgress['section_id'] !== null ? (int) $myProgress['section_id'] : null;
-$avgPercent = max(0.0, min(100.0, (float) ($aggregate['avg_percent_all'] ?? $aggregate['avg_percent'])));
+$avgPercent = max(0.0, min(100.0, (float) ($aggregate['avg_percent_all'] ?? $aggregate['avg_percent'] ?? 0)));
 ?>
 <style>
   .bc-card{background:var(--white);border-radius:20px;box-shadow:var(--card-shadow);padding:clamp(1.5rem,3vw,2rem);margin-bottom:1.5rem}
@@ -116,7 +116,7 @@ $avgPercent = max(0.0, min(100.0, (float) ($aggregate['avg_percent_all'] ?? $agg
     </div>
     <p class="bc-muted mt-2 mb-0">
       <?= $e(sprintf(__('%1$d lettori su %2$d membri'), (int) ($aggregate['active_readers'] ?? 0), (int) ($aggregate['members'] ?? $memberCount))) ?>
-      · <?= $e(sprintf(__('%1$d membri su %2$d hanno finito il libro'), (int) $aggregate['finished'], (int) $memberCount)) ?>
+      · <?= $e(sprintf(__('%1$d membri su %2$d hanno finito il libro'), (int) ($aggregate['finished'] ?? 0), (int) $memberCount)) ?>
     </p>
   </section>
 

--- a/storage/plugins/book-club/views/public/show.php
+++ b/storage/plugins/book-club/views/public/show.php
@@ -274,7 +274,7 @@ $kindLabels = ['in_person' => __('In presenza'), 'online' => __('Online'), 'hybr
                 var q = input.value.trim();
                 if (q.length < 2) { box.classList.add('hidden'); return; }
                 timer = setTimeout(function () {
-                  fetch('<?= $e(url('/book-club/' . $slug . '/book-search')) ?>?q=' + encodeURIComponent(q), {headers: {'Accept': 'application/json'}})
+                  fetch(<?= json_encode(url('/book-club/' . $slug . '/book-search'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP) ?> + '?q=' + encodeURIComponent(q), {headers: {'Accept': 'application/json'}})
                     .then(function (r) { return r.json(); })
                     .then(function (data) {
                       box.innerHTML = '';


### PR DESCRIPTION
Post-merge review of the book-club plugin (a multi-lens pass over the whole plugin) surfaced a handful of small but real issues. All confirmed; most low-severity. No behavioral change to the happy path.

## Correctness — soft-delete consistency (RULE 2)
- **ChallengeRepo::computeMetric()**: the `authors` and `books` challenge metrics counted finished books whose catalog row is soft-deleted, while `pages` already excluded them (`JOIN libri ... deleted_at IS NULL`). Added the same guard to both — a soft-deleted book no longer inflates a member's books/authors progress.
- **AffinityRepo::similarAuthors()**: the *source* club books were joined through `libri_autori` without gating on `libri.deleted_at` (only the suggested target was filtered), so authors of a soft-deleted book still seeded suggestions. Added the source guard.

## Security — CSV formula injection
- **SurveyController / QuoteController exportCsv()**: member free-text answers, quotes and notes were written to CSV without the formula-injection guard `StatsController::csvSafe()` already applies elsewhere in the plugin. Added a matching `csvSafe()` to both and wrapped every `fputcsv()` cell. A crafted answer starting with `=`/`+`/`-`/`@` is now prefixed with `'` so it can't execute when the export is opened in Excel/Sheets.

## Minor
- **reading.php**: two `$aggregate` reads lacked the `?? 0` guard their siblings use (undefined-array-key if the key is absent).
- **ai.php / show.php**: two PHP→JS interpolations used `htmlspecialchars` instead of `json_encode(JSON_HEX_TAG|...)` per the JS-escaping rule (non-exploitable static values, but the rule is the rule).
- Corrected three docblocks that overstated/misattributed behavior (extendMobileOpenApi ordering, Lending access requirement, the atomic one-open-offer enforcement).

Verified locally: `php -l` + PHPStan L5 clean on every touched file.

Note: one review finding is left out deliberately — SurveyRepo::nextQuestionKey() can reuse a question key after the highest-numbered question is deleted, which the docblock says never happens. Fixing it is a behavior choice (persist a monotonic counter) vs a doc correction; leaving that decision open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrette le statistiche e i conteggi del club per escludere contenuti eliminati, rendendo i valori più affidabili.
  * Migliorata l’esportazione CSV di quote e sondaggi per ridurre il rischio di apertura errata nei fogli di calcolo.
  * Sistemata la copia negli appunti e la ricerca “Proponi un libro” per un comportamento più robusto.
  * Aggiunti valori di fallback nelle pagine pubbliche per evitare campi vuoti o numeri mancanti.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->