### PR TITLE
docs(book-club): correct SurveyRepo::nextQuestionKey docblock (key reuse is safe)

### DIFF
--- a/storage/plugins/book-club/src/SurveyRepo.php
+++ b/storage/plugins/book-club/src/SurveyRepo.php
@@ -130,8 +130,12 @@ class SurveyRepo
     }
 
     /**
-     * Next stable question key ("q1", "q2", …). Keys never get reused after
-     * a delete, so stored answers can never point at the wrong question.
+     * Next question key ("q1", "q2", …), derived from the highest existing
+     * number. Deleting the highest-numbered question and adding a new one
+     * therefore REUSES that key — which is safe because the schema is only
+     * ever edited while the survey is in `draft` (see updateSchemaJson's
+     * `status = 'draft'` guard); answers are collected only after it goes
+     * `open`, so no stored answer can point at a since-reused key.
      *
      * @param list<array{key: string, type: string, label: string, options: list<string>, required: bool}> $schema
      */


### PR DESCRIPTION
Follow-up to the book-club review. The `nextQuestionKey()` docblock claimed question keys are never reused after a delete — they **are** (deleting the highest-numbered question and adding one reissues that key). That is safe and intentional: the schema is only editable while the survey is in `draft` (`updateSchemaJson` has a `status = 'draft'` guard), and answers are collected only once it goes `open`, so no stored answer can ever point at a since-reused key. Corrected the comment to state the real invariant. Comment-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentazione**
  * Aggiornata la descrizione di una regola relativa alla generazione delle chiavi nelle domande del sondaggio.
  * Chiarito che le nuove chiavi si basano sul valore massimo già presente e che, dopo una cancellazione, una chiave massima può essere riutilizzata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->