### PR TITLE
fix(book-club): CodeRabbit follow-ups — poll close idempotency + explicit mb_strlen encoding

### DIFF
--- a/app/Controllers/RecensioniController.php
+++ b/app/Controllers/RecensioniController.php
@@ -91,12 +91,12 @@ class RecensioniController
         // mb_strlen: i limiti dei messaggi sono in caratteri, non in byte —
         // con strlen() un titolo UTF-8 con accenti/emoji da meno di 255
         // caratteri veniva rifiutato (es. 130 emoji = 520 byte).
-        if (mb_strlen($titolo) > 255) {
+        if (mb_strlen($titolo, 'UTF-8') > 255) {
             $response->getBody()->write(json_encode(['success' => false, 'message' => __('Titolo troppo lungo (max 255 caratteri)')]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }
 
-        if (mb_strlen($descrizione) > 2000) {
+        if (mb_strlen($descrizione, 'UTF-8') > 2000) {
             $response->getBody()->write(json_encode(['success' => false, 'message' => __('Descrizione troppo lunga (max 2000 caratteri)')]));
             return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
         }

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -93,15 +93,15 @@ class UsersController
         }
 
         // Validate input lengths
-        if (mb_strlen($nome) > 100 || mb_strlen($cognome) > 100) {
+        if (mb_strlen($nome, 'UTF-8') > 100 || mb_strlen($cognome, 'UTF-8') > 100) {
             return $response->withHeader('Location', url('/admin/users/create?error=name_too_long'))->withStatus(302);
         }
 
-        if (mb_strlen($email) > 255) {
+        if (mb_strlen($email, 'UTF-8') > 255) {
             return $response->withHeader('Location', url('/admin/users/create?error=email_too_long'))->withStatus(302);
         }
 
-        if (mb_strlen($telefono) > 20) {
+        if (mb_strlen($telefono, 'UTF-8') > 20) {
             return $response->withHeader('Location', url('/admin/users/create?error=phone_too_long'))->withStatus(302);
         }
 
@@ -370,7 +370,7 @@ class UsersController
             $newPassword = (string) $data['password'];
 
             // Validate password complexity (max 72 — bcrypt silently truncates beyond)
-            if (mb_strlen($newPassword) < 8) {
+            if (mb_strlen($newPassword, 'UTF-8') < 8) {
                 $_SESSION['error_message'] = __('La password deve essere lunga almeno 8 caratteri.');
                 return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=password_too_short'))->withStatus(302);
             }

--- a/storage/plugins/book-club/src/Repo.php
+++ b/storage/plugins/book-club/src/Repo.php
@@ -757,11 +757,27 @@ class Repo
 
     public function closePoll(int $pollId, ?int $winnerClubBookId): bool
     {
-        return $this->exec(
-            "UPDATE bookclub_polls SET status = 'closed', closed_at = NOW(), winner_club_book_id = ? WHERE id = ? AND status = 'open'",
-            'ii',
-            [$winnerClubBookId, $pollId]
+        // Idempotency guard: return true ONLY when this call actually flipped the
+        // row open → closed. exec() returns true even when the WHERE status='open'
+        // clause matches nothing, so two concurrent resolvePoll() readers could both
+        // pass the `if (!closePoll(...))` gate and double-run transitionBooks() + the
+        // poll.closed hook. Checking affected_rows makes the loser see false → 'noop'.
+        $stmt = $this->db->prepare(
+            "UPDATE bookclub_polls SET status = 'closed', closed_at = NOW(), winner_club_book_id = ? WHERE id = ? AND status = 'open'"
         );
+        if ($stmt === false) {
+            SecureLogger::error('[BookClub] closePoll prepare failed: ' . $this->db->error);
+            return false;
+        }
+        $stmt->bind_param('ii', $winnerClubBookId, $pollId);
+        if (!$stmt->execute()) {
+            SecureLogger::error('[BookClub] closePoll execute failed: ' . $stmt->error);
+            $stmt->close();
+            return false;
+        }
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+        return $affected > 0;
     }
 
     /** @return list<array<string, mixed>> */


### PR DESCRIPTION
Two review comments from CodeRabbit that were genuinely unaddressed (a sweep of the merged book-club PRs found the rest were already handled in-context):

- **Poll close idempotency (#218, Major)** — `Repo::closePoll()` returned `true` whenever `execute()` succeeded, even when the `UPDATE ... WHERE status = 'open'` matched no rows. `resolvePoll()` guards double-processing on `if (!closePoll(...))`, so two concurrent lazy-close readers could both pass the gate and double-run `transitionBooks()` + the `bookclub.poll.closed` hook. Now returns `affected_rows > 0`, so the race loser sees `false` and returns `noop`. All six callers already use the `if (!closePoll(...))` pattern, so they all benefit.
- **Explicit mb_strlen encoding (#217, Trivial)** — the character-based length checks now pass `'UTF-8'` explicitly instead of relying on `mb_internal_encoding()`.

Verified: `php -l` + PHPStan L5 clean.

Sweep note: the other CodeRabbit Major comments on #215 were already correct in the merged code — ExtensionsRepo buddy select already uses LEFT JOIN (with an explicit comment), StatsController already applies csvSafe, AiService already sets full SSL/SSRF cURL hardening, LendingRepo.createOffer is already atomic via INSERT ... WHERE NOT EXISTS, and meetings have no seat cap so RSVP can't overbook.