### PR TITLE
fix: CodeRabbit round 2 — openapi hookManager binding + en_US language label

### DIFF
--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6409,7 +6409,7 @@
   "francese": "French",
   "in coda dal club: %d": "in queue from the club: %d",
   "inglese": "English",
-  "italiano": "English",
+  "italiano": "Italian",
   "tedesco": "German",
   "È una tua offerta": "This is your offer",
   "App mobile": "Mobile app",

--- a/storage/plugins/book-club/src/LendingRepo.php
+++ b/storage/plugins/book-club/src/LendingRepo.php
@@ -219,20 +219,30 @@ class LendingRepo
     public function createOffer(int $clubId, int $clubBookId, int $lenderId, string $notes): ?int
     {
         $notesOrNull = $notes !== '' ? $notes : null;
-        // Atomic check-and-insert: the controller's hasOpenOffer() pre-check
-        // is only UX — two concurrent submits must not both insert, so the
-        // one-open-offer invariant is re-enforced inside the INSERT itself.
-        $ok = $this->execAffected(
-            "INSERT INTO bookclub_member_loans (club_id, club_book_id, lender_id, status, notes)
-             SELECT ?, ?, ?, 'offered', ? FROM DUAL
-              WHERE NOT EXISTS (
-                    SELECT 1 FROM bookclub_member_loans
-                     WHERE club_book_id = ? AND lender_id = ?
-                       AND status IN ('offered','requested','active')
-              )",
-            'iiisii',
-            [$clubId, $clubBookId, $lenderId, $notesOrNull, $clubBookId, $lenderId]
-        );
+        // Atomic check-and-insert: the controller's hasOpenOffer() pre-check is only
+        // UX. The NOT EXISTS clause blocks the common case, and the UNIQUE index on the
+        // generated open_key column (see LendingModule) is the real backstop — under
+        // REPEATABLE READ two concurrent inserts can both pass NOT EXISTS, and the
+        // second then trips the constraint (error 1062), which we treat as "already
+        // has an open offer" and return null, exactly like the NOT EXISTS path.
+        try {
+            $ok = $this->execAffected(
+                "INSERT INTO bookclub_member_loans (club_id, club_book_id, lender_id, status, notes)
+                 SELECT ?, ?, ?, 'offered', ? FROM DUAL
+                  WHERE NOT EXISTS (
+                        SELECT 1 FROM bookclub_member_loans
+                         WHERE club_book_id = ? AND lender_id = ?
+                           AND status IN ('offered','requested','active')
+                  )",
+                'iiisii',
+                [$clubId, $clubBookId, $lenderId, $notesOrNull, $clubBookId, $lenderId]
+            );
+        } catch (\mysqli_sql_exception $e) {
+            if ($e->getCode() === 1062) {
+                return null;
+            }
+            throw $e;
+        }
         return $ok > 0 ? (int) $this->db->insert_id : null;
     }
 

--- a/storage/plugins/book-club/src/Modules/AbstractModule.php
+++ b/storage/plugins/book-club/src/Modules/AbstractModule.php
@@ -138,6 +138,34 @@ abstract class AbstractModule implements ModuleInterface
         }
     }
 
+    protected function indexExists(string $table, string $index): bool
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS n FROM INFORMATION_SCHEMA.STATISTICS
+              WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?'
+        );
+        if ($stmt === false) {
+            return false;
+        }
+        $stmt->bind_param('ss', $table, $index);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $row = $res ? $res->fetch_assoc() : null;
+        $stmt->close();
+        return (int) ($row['n'] ?? 0) > 0;
+    }
+
+    /** Idempotent ALTER TABLE … ADD UNIQUE KEY. $columns is trusted plugin code. */
+    protected function addUniqueIndexIfMissing(string $table, string $index, string $columns): void
+    {
+        if ($this->indexExists($table, $index)) {
+            return;
+        }
+        if ($this->db->query("ALTER TABLE {$table} ADD UNIQUE KEY {$index} ({$columns})") === false) {
+            SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD UNIQUE KEY {$table}.{$index} failed: " . $this->db->error);
+        }
+    }
+
     // ------------------------------------------------------------------
     // Rendering
     // ------------------------------------------------------------------

--- a/storage/plugins/book-club/src/Modules/LendingModule.php
+++ b/storage/plugins/book-club/src/Modules/LendingModule.php
@@ -58,9 +58,22 @@ class LendingModule extends AbstractModule
     // Schema
     // ------------------------------------------------------------------
 
+    /**
+     * The generated column + UNIQUE index enforce the "at most one OPEN loan per
+     * (club_book_id, lender_id)" invariant atomically at the DB level: open_key is
+     * the pair key while the loan is open and NULL otherwise (MySQL allows many
+     * NULLs in a UNIQUE index), so any number of closed/cancelled/returned rows
+     * coexist but a second concurrent open offer hits the constraint. This is the
+     * backstop the INSERT … WHERE NOT EXISTS in LendingRepo::createOffer() can't
+     * guarantee on its own under REPEATABLE READ.
+     */
+    private const OPEN_KEY_DEF =
+        "VARCHAR(32) GENERATED ALWAYS AS (CASE WHEN status IN ('offered','requested','active') "
+        . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) STORED";
+
     public function ensureSchema(): array
     {
-        return $this->runDdl([
+        $result = $this->runDdl([
             'bookclub_member_loans' => "CREATE TABLE IF NOT EXISTS bookclub_member_loans (
                 id INT NOT NULL AUTO_INCREMENT,
                 club_id INT NOT NULL,
@@ -73,11 +86,13 @@ class LendingModule extends AbstractModule
                 offered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 lent_at DATETIME NULL,
                 returned_at DATETIME NULL,
+                open_key " . self::OPEN_KEY_DEF . ",
                 PRIMARY KEY (id),
                 KEY idx_bcmloan_club_status (club_id, status),
                 KEY idx_bcmloan_book (club_book_id),
                 KEY idx_bcmloan_lender (lender_id),
                 KEY idx_bcmloan_borrower (borrower_id),
+                UNIQUE KEY uq_bcmloan_open (open_key),
                 CONSTRAINT fk_bcmloan_club FOREIGN KEY (club_id)
                     REFERENCES bookclub_clubs (id) ON DELETE CASCADE,
                 CONSTRAINT fk_bcmloan_book FOREIGN KEY (club_book_id)
@@ -86,6 +101,31 @@ class LendingModule extends AbstractModule
                     REFERENCES utenti (id) ON DELETE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci",
         ]);
+
+        // Migration for installs created before the open_key invariant existed
+        // (e.g. book-club shipped in 0.7.29-rc.1/rc.2). Idempotent: guarded on the
+        // column/index presence so it's a no-op on fresh installs and safe to re-run.
+        if (!$this->columnExists('bookclub_member_loans', 'open_key')) {
+            // Resolve any pre-existing duplicate OPEN loans first, else adding the
+            // UNIQUE index would fail: keep the earliest open row per
+            // (club_book_id, lender_id) and cancel the rest.
+            $this->db->query(
+                "UPDATE bookclub_member_loans m
+                    JOIN (
+                        SELECT club_book_id, lender_id, MIN(id) AS keep_id
+                          FROM bookclub_member_loans
+                         WHERE status IN ('offered','requested','active')
+                         GROUP BY club_book_id, lender_id
+                        HAVING COUNT(*) > 1
+                    ) d ON d.club_book_id = m.club_book_id AND d.lender_id = m.lender_id
+                    SET m.status = 'cancelled'
+                  WHERE m.status IN ('offered','requested','active') AND m.id <> d.keep_id"
+            );
+            $this->addColumnIfMissing('bookclub_member_loans', 'open_key', self::OPEN_KEY_DEF);
+        }
+        $this->addUniqueIndexIfMissing('bookclub_member_loans', 'uq_bcmloan_open', 'open_key');
+
+        return $result;
     }
 
     // ------------------------------------------------------------------

--- a/storage/plugins/mobile-api/MobileApiPlugin.php
+++ b/storage/plugins/mobile-api/MobileApiPlugin.php
@@ -348,6 +348,7 @@ class MobileApiPlugin
     {
         $plugin = $this;
         $db     = $this->db;
+        $hookManager = $this->hookManager;
         $appAccessEnabled = $this->isAppAccessEnabled();
 
         // Shared per-token quota + bearer auth for the authenticated surface.
@@ -357,13 +358,17 @@ class MobileApiPlugin
         $authMw  = static fn (): AppAuthMiddleware => new AppAuthMiddleware($db, $appAccessEnabled);
         $quotaMw = static fn (): TokenQuotaMiddleware => new TokenQuotaMiddleware();
 
-        $group = $app->group('/api/v1', function (\Slim\Routing\RouteCollectorProxy $group) use ($plugin, $db, $authMw, $quotaMw): void {
+        $group = $app->group('/api/v1', function (\Slim\Routing\RouteCollectorProxy $group) use ($plugin, $db, $authMw, $quotaMw, $hookManager): void {
             // ── OpenAPI document + Swagger UI (public, no token) ──────────────
+            // Capture $hookManager via use(): inside a Slim route closure $this is
+            // bound to the container, not the plugin, so $this->hookManager would be
+            // null and the mobile_api.openapi filter (book-club bridge paths) would
+            // never run.
             $group->get('/openapi.json', function (
                 ServerRequestInterface $request,
                 ResponseInterface $response
-            ): ResponseInterface {
-                return (new \App\Plugins\MobileApi\Controllers\OpenApiController($this->hookManager))->document($request, $response);
+            ) use ($hookManager): ResponseInterface {
+                return (new \App\Plugins\MobileApi\Controllers\OpenApiController($hookManager))->document($request, $response);
             });
 
             $group->get('/docs', function (

--- a/tests/migration-bookclub-loan-openkey.unit.php
+++ b/tests/migration-bookclub-loan-openkey.unit.php
@@ -1,0 +1,240 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral suite for the bookclub_member_loans "one open loan per
+ * (club_book_id, lender_id)" migration (LendingModule::ensureSchema()).
+ *
+ * The invariant used to rest only on an INSERT … WHERE NOT EXISTS in
+ * LendingRepo::createOffer(), which under REPEATABLE READ lets two concurrent
+ * offers both slip through. The fix adds a STORED generated column `open_key`
+ * (the pair key while the loan is open, NULL otherwise) plus a UNIQUE index, and
+ * an idempotent migration that de-dupes any pre-existing duplicate open loans
+ * before adding the index.
+ *
+ * Strategy (mirrors tests/migration-0.7.25.unit.php): build a sandbox table
+ * `zz_mig_member_loans` with the OLD schema (no open_key / no unique index),
+ * seed it — INCLUDING a pre-existing duplicate open pair — then run the REAL
+ * migration statements against it and assert: de-dup, column + index added,
+ * generated values correct, the UNIQUE constraint actually blocks a second open
+ * offer, and idempotency. A drift guard confirms the tested open_key expression
+ * still matches LendingModule.php's source.
+ *
+ * Runs against the LIVE local MySQL; touches only `zz_mig_member_loans`.
+ * Run:  php tests/migration-bookclub-loan-openkey.unit.php
+ * Exit: 0 only if all checks pass; prints "ALL <n> PASS".
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+function mlLoadEnv(string $path): array
+{
+    $env = [];
+    foreach (preg_split('/\r?\n/', (string) @file_get_contents($path)) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env = mlLoadEnv($root . '/.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user = $env['DB_USER'] ?? '';
+$pass = $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '');
+$name = $env['DB_NAME'] ?? '';
+try {
+    if (is_string($socket) && $socket !== '' && file_exists($socket)) {
+        $db = new mysqli(null, $user, $pass, $name, 0, $socket);
+    } else {
+        $db = new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+    }
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+const SANDBOX = 'zz_mig_member_loans';
+
+// The generated-column definition the migration adds. Kept in sync with
+// LendingModule::OPEN_KEY_DEF via the drift guard (check 1).
+const OPEN_KEY_DEF =
+    "VARCHAR(32) GENERATED ALWAYS AS (CASE WHEN status IN ('offered','requested','active') "
+    . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) STORED";
+
+function mlCleanup(mysqli $db): void
+{
+    $db->query('DROP TABLE IF EXISTS `' . SANDBOX . '`');
+}
+
+set_exception_handler(static function (\Throwable $e) use ($db): void {
+    try {
+        mlCleanup($db);
+    } catch (\Throwable $ignored) {
+    }
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n");
+    exit(1);
+});
+
+$TESTNO = 0;
+function check(bool $cond, string $desc): void
+{
+    global $TESTNO;
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+
+$columnExists = function (string $col) use ($db): bool {
+    $stmt = $db->prepare(
+        "SELECT COUNT(*) FROM information_schema.COLUMNS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?"
+    );
+    $t = SANDBOX;
+    $stmt->bind_param('ss', $t, $col);
+    $stmt->execute();
+    $n = (int) $stmt->get_result()->fetch_row()[0];
+    $stmt->close();
+    return $n > 0;
+};
+$indexExists = function (string $idx) use ($db): bool {
+    $stmt = $db->prepare(
+        "SELECT COUNT(*) FROM information_schema.STATISTICS
+          WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?"
+    );
+    $t = SANDBOX;
+    $stmt->bind_param('ss', $t, $idx);
+    $stmt->execute();
+    $n = (int) $stmt->get_result()->fetch_row()[0];
+    $stmt->close();
+    return $n > 0;
+};
+$scalar = function (string $sql) use ($db): int {
+    return (int) $db->query($sql)->fetch_row()[0];
+};
+
+/* ---- 1. drift guard: source still uses the tested expression ---- */
+$src = (string) file_get_contents($root . '/storage/plugins/book-club/src/Modules/LendingModule.php');
+check(
+    str_contains($src, "CONCAT(club_book_id, ':', lender_id)")
+        && str_contains($src, "status IN ('offered','requested','active')")
+        && str_contains($src, 'uq_bcmloan_open'),
+    "LendingModule source still defines the open_key expression + uq_bcmloan_open"
+);
+
+/* ---- build the OLD sandbox schema (no open_key, no unique index) ---- */
+mlCleanup($db);
+$db->query(
+    "CREATE TABLE `" . SANDBOX . "` (
+        id INT NOT NULL AUTO_INCREMENT,
+        club_id INT NOT NULL,
+        club_book_id INT NOT NULL,
+        lender_id INT NOT NULL,
+        borrower_id INT NULL,
+        status ENUM('offered','requested','active','returned','cancelled') NOT NULL DEFAULT 'offered',
+        offered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        KEY idx_book (club_book_id),
+        KEY idx_lender (lender_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+);
+
+// Seed: pair (10,20) has TWO open rows (a pre-existing duplicate); pair (11,20)
+// has one open row; one closed ('returned') row for (10,21).
+$db->query("INSERT INTO `" . SANDBOX . "` (id, club_id, club_book_id, lender_id, status) VALUES
+    (1, 1, 10, 20, 'offered'),
+    (2, 1, 10, 20, 'active'),
+    (3, 1, 11, 20, 'offered'),
+    (4, 1, 10, 21, 'returned')");
+check($scalar("SELECT COUNT(*) FROM `" . SANDBOX . "`") === 4, "seeded 4 rows incl. a duplicate open pair");
+
+/* ---- run the REAL migration statements against the sandbox ---- */
+$runMigration = function () use ($db, $columnExists, $indexExists): void {
+    $t = SANDBOX;
+    if (!$columnExists('open_key')) {
+        $db->query(
+            "UPDATE `{$t}` m
+                JOIN (
+                    SELECT club_book_id, lender_id, MIN(id) AS keep_id
+                      FROM `{$t}`
+                     WHERE status IN ('offered','requested','active')
+                     GROUP BY club_book_id, lender_id
+                    HAVING COUNT(*) > 1
+                ) d ON d.club_book_id = m.club_book_id AND d.lender_id = m.lender_id
+                SET m.status = 'cancelled'
+              WHERE m.status IN ('offered','requested','active') AND m.id <> d.keep_id"
+        );
+        $db->query("ALTER TABLE `{$t}` ADD COLUMN open_key " . OPEN_KEY_DEF);
+    }
+    if (!$indexExists('uq_bcmloan_open')) {
+        $db->query("ALTER TABLE `{$t}` ADD UNIQUE KEY uq_bcmloan_open (open_key)");
+    }
+};
+$runMigration();
+
+/* ---- 2..7 effect assertions ---- */
+check($columnExists('open_key'), "open_key column added");
+check($indexExists('uq_bcmloan_open'), "uq_bcmloan_open UNIQUE index added");
+
+// De-dup: pair (10,20) keeps exactly one open row (the earliest, id=1).
+check(
+    $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "` WHERE club_book_id=10 AND lender_id=20 AND status IN ('offered','requested','active')") === 1,
+    "duplicate open pair de-duped to a single open row"
+);
+check(
+    $scalar("SELECT status='offered' FROM `" . SANDBOX . "` WHERE id=1") === 1
+        && $scalar("SELECT status='cancelled' FROM `" . SANDBOX . "` WHERE id=2") === 1,
+    "earliest open row (id=1) kept unchanged, the later one (id=2) cancelled"
+);
+// Generated value: open rows carry the pair key, closed rows are NULL.
+check(
+    $scalar("SELECT open_key='10:20' FROM `" . SANDBOX . "` WHERE id=1") === 1
+        && $scalar("SELECT open_key='11:20' FROM `" . SANDBOX . "` WHERE id=3") === 1,
+    "open rows compute open_key = 'club_book_id:lender_id'"
+);
+check(
+    $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "` WHERE open_key IS NULL") === 2,
+    "closed/cancelled rows have NULL open_key (id=2 cancelled, id=4 returned)"
+);
+
+/* ---- 8. enforcement: a second concurrent open offer is rejected ---- */
+$rejected = false;
+try {
+    $db->query("INSERT INTO `" . SANDBOX . "` (club_id, club_book_id, lender_id, status) VALUES (1, 11, 20, 'offered')");
+} catch (\mysqli_sql_exception $e) {
+    $rejected = ($e->getCode() === 1062);
+}
+check($rejected, "a second OPEN offer for an existing open pair is blocked by the UNIQUE index (1062)");
+
+// A NEW pair, and a CLOSED duplicate of an existing open pair, are both still allowed.
+$db->query("INSERT INTO `" . SANDBOX . "` (club_id, club_book_id, lender_id, status) VALUES (1, 99, 20, 'offered')");
+$db->query("INSERT INTO `" . SANDBOX . "` (club_id, club_book_id, lender_id, status) VALUES (1, 11, 20, 'returned')");
+check(
+    $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "` WHERE club_book_id=99 AND status='offered'") === 1
+        && $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "` WHERE club_book_id=11 AND lender_id=20 AND status='returned'") === 1,
+    "a new open pair and a closed duplicate of an open pair are both accepted"
+);
+
+/* ---- 9. idempotency: re-running the migration is a no-op ---- */
+$before = $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "`");
+$runMigration();
+$after = $scalar("SELECT COUNT(*) FROM `" . SANDBOX . "`");
+check($before === $after && $columnExists('open_key') && $indexExists('uq_bcmloan_open'), "migration is idempotent on re-run");
+
+mlCleanup($db);
+printf("\nALL %d PASS\n", $TESTNO);
+exit(0);


### PR DESCRIPTION
Two genuinely-unaddressed CodeRabbit findings I missed on the first sweep (I was too quick to call it clean).

- **openapi HookManager was null (Major)** — the `/api/v1/openapi.json` route built `new OpenApiController($this->hookManager)` **inside a Slim route closure**, where `$this` is bound to the container, not the plugin. So the HookManager was null and the `mobile_api.openapi` filter — the whole mechanism that appends the book-club bridge paths to the OpenAPI doc — never ran. Captured `$hookManager` via `use()` instead. **Verified against the running instance:** `/api/v1/openapi.json` now exposes the 9 `/bookclub` paths; before the fix it exposed 0.
- **en_US language label (Minor)** — `"italiano": "English"` (copy-paste slip); de/it/fr were already correct. Fixed to `"Italian"`.

`php -l` + PHPStan L5 clean.

(Already-addressed CodeRabbit items verified as fixed on main and skipped: closePoll affected-rows guard #221, mb_strlen UTF-8 encoding #221, cleartext base-config gate #20. The LendingRepo one-open-offer race is a separate heavier item — see the note I left for the maintainer.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corretta la traduzione inglese di una voce di lingua: ora “italiano” viene mostrato come “Italian”.
  * Migliorata l’affidabilità della documentazione API, così il relativo endpoint risponde in modo più consistente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->