### PR TITLE
fix(book-club): open_key column must be VIRTUAL, not STORED (activation 500)

### DIFF
--- a/storage/plugins/book-club/src/Modules/AbstractModule.php
+++ b/storage/plugins/book-club/src/Modules/AbstractModule.php
@@ -127,14 +127,26 @@ abstract class AbstractModule implements ModuleInterface
         return (int) ($row['n'] ?? 0) > 0;
     }
 
-    /** Idempotent ALTER TABLE … ADD COLUMN. $definition is trusted plugin code. */
+    /**
+     * Idempotent ALTER TABLE … ADD COLUMN. $definition is trusted plugin code.
+     *
+     * The query is wrapped in try/catch because the app runs mysqli in exception mode
+     * (mysqli_report(MYSQLI_REPORT_ERROR)), so a failing ALTER throws rather than returning
+     * false — and an uncaught throw here would propagate out of ensureSchema()/onActivate()
+     * and 500 the whole app on every request. A failed migration is logged and skipped;
+     * the feature degrades instead of taking the site down.
+     */
     protected function addColumnIfMissing(string $table, string $column, string $definition): void
     {
         if ($this->columnExists($table, $column)) {
             return;
         }
-        if ($this->db->query("ALTER TABLE {$table} ADD COLUMN {$column} {$definition}") === false) {
-            SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD COLUMN {$table}.{$column} failed: " . $this->db->error);
+        try {
+            if ($this->db->query("ALTER TABLE {$table} ADD COLUMN {$column} {$definition}") === false) {
+                SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD COLUMN {$table}.{$column} failed: " . $this->db->error);
+            }
+        } catch (\Throwable $e) {
+            SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD COLUMN {$table}.{$column} failed: " . $e->getMessage());
         }
     }
 
@@ -155,14 +167,19 @@ abstract class AbstractModule implements ModuleInterface
         return (int) ($row['n'] ?? 0) > 0;
     }
 
-    /** Idempotent ALTER TABLE … ADD UNIQUE KEY. $columns is trusted plugin code. */
+    /** Idempotent ALTER TABLE … ADD UNIQUE KEY. $columns is trusted plugin code. Same
+     *  exception-safety rationale as addColumnIfMissing(). */
     protected function addUniqueIndexIfMissing(string $table, string $index, string $columns): void
     {
         if ($this->indexExists($table, $index)) {
             return;
         }
-        if ($this->db->query("ALTER TABLE {$table} ADD UNIQUE KEY {$index} ({$columns})") === false) {
-            SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD UNIQUE KEY {$table}.{$index} failed: " . $this->db->error);
+        try {
+            if ($this->db->query("ALTER TABLE {$table} ADD UNIQUE KEY {$index} ({$columns})") === false) {
+                SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD UNIQUE KEY {$table}.{$index} failed: " . $this->db->error);
+            }
+        } catch (\Throwable $e) {
+            SecureLogger::warning('[BookClub:' . $this->slug() . "] ADD UNIQUE KEY {$table}.{$index} failed: " . $e->getMessage());
         }
     }
 

--- a/storage/plugins/book-club/src/Modules/LendingModule.php
+++ b/storage/plugins/book-club/src/Modules/LendingModule.php
@@ -67,9 +67,13 @@ class LendingModule extends AbstractModule
      * backstop the INSERT … WHERE NOT EXISTS in LendingRepo::createOffer() can't
      * guarantee on its own under REPEATABLE READ.
      */
+    // VIRTUAL, not STORED: bookclub_member_loans has three foreign keys, and adding a
+    // STORED generated column forces an ALGORITHM=COPY table rebuild that re-creates those
+    // FKs and fails with "ERROR 1215: Cannot add foreign key constraint". A VIRTUAL column
+    // adds INPLACE (no rebuild) and can still back a UNIQUE index (MySQL 5.7+).
     private const OPEN_KEY_DEF =
         "VARCHAR(32) GENERATED ALWAYS AS (CASE WHEN status IN ('offered','requested','active') "
-        . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) STORED";
+        . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) VIRTUAL";
 
     public function ensureSchema(): array
     {

--- a/tests/migration-bookclub-loan-openkey.unit.php
+++ b/tests/migration-bookclub-loan-openkey.unit.php
@@ -69,14 +69,21 @@ $db->set_charset('utf8mb4');
 const SANDBOX = 'zz_mig_member_loans';
 
 // The generated-column definition the migration adds. Kept in sync with
-// LendingModule::OPEN_KEY_DEF via the drift guard (check 1).
+// LendingModule::OPEN_KEY_DEF via the drift guard (check 1). MUST be VIRTUAL, not
+// STORED: the real table has foreign keys and a STORED column forces a rebuild that
+// fails with "1215 Cannot add foreign key constraint" — the sandbox below reproduces
+// that FK condition so this test catches a regression back to STORED.
 const OPEN_KEY_DEF =
     "VARCHAR(32) GENERATED ALWAYS AS (CASE WHEN status IN ('offered','requested','active') "
-    . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) STORED";
+    . "THEN CONCAT(club_book_id, ':', lender_id) ELSE NULL END) VIRTUAL";
+
+const SANDBOX_PARENT = 'zz_mig_loan_parent';
 
 function mlCleanup(mysqli $db): void
 {
+    // Child first (FK), then parent.
     $db->query('DROP TABLE IF EXISTS `' . SANDBOX . '`');
+    $db->query('DROP TABLE IF EXISTS `' . SANDBOX_PARENT . '`');
 }
 
 set_exception_handler(static function (\Throwable $e) use ($db): void {
@@ -132,12 +139,20 @@ $src = (string) file_get_contents($root . '/storage/plugins/book-club/src/Module
 check(
     str_contains($src, "CONCAT(club_book_id, ':', lender_id)")
         && str_contains($src, "status IN ('offered','requested','active')")
-        && str_contains($src, 'uq_bcmloan_open'),
-    "LendingModule source still defines the open_key expression + uq_bcmloan_open"
+        && str_contains($src, 'uq_bcmloan_open')
+        && str_contains($src, 'VIRTUAL')
+        && !preg_match('/END\)\s+STORED/', $src),
+    "LendingModule source defines the open_key expression + uq_bcmloan_open, and uses VIRTUAL (not STORED, which 1215s on the FK table)"
 );
 
-/* ---- build the OLD sandbox schema (no open_key, no unique index) ---- */
+/* ---- build the OLD sandbox schema (no open_key, no unique index) ----
+ * A foreign key is REQUIRED here: the real bookclub_member_loans has three FKs, and
+ * that's exactly what makes a STORED generated column fail (the ADD COLUMN rebuild
+ * re-creates the FKs → 1215). Without a FK the sandbox would pass even with STORED — the
+ * false-green that shipped the bug. The parent + FK reproduce the real condition. */
 mlCleanup($db);
+$db->query("CREATE TABLE `" . SANDBOX_PARENT . "` (id INT NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB");
+$db->query("INSERT INTO `" . SANDBOX_PARENT . "` (id) VALUES (1)");
 $db->query(
     "CREATE TABLE `" . SANDBOX . "` (
         id INT NOT NULL AUTO_INCREMENT,
@@ -149,7 +164,8 @@ $db->query(
         offered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
         PRIMARY KEY (id),
         KEY idx_book (club_book_id),
-        KEY idx_lender (lender_id)
+        KEY idx_lender (lender_id),
+        CONSTRAINT fk_sandbox_parent FOREIGN KEY (club_id) REFERENCES `" . SANDBOX_PARENT . "` (id) ON DELETE CASCADE
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
 );
 


### PR DESCRIPTION
Caught by a **real install** (thanks to the "verify the actual installation" push): activating book-club on the current merged code **500s every request**.

## Root cause
`bookclub_member_loans` has three foreign keys. Adding a **STORED** generated column forces an `ALGORITHM=COPY` table rebuild that re-creates those FKs and fails with `ERROR 1215: Cannot add foreign key constraint`. Because the app runs mysqli in exception mode, the failing `ALTER` **threw** out of `ensureSchema()` → `onActivate()`; PluginManager rolled the plugin version back and the exception surfaced as a **500 on the whole app**, not just the lending feature.

My earlier unit test gave a false green: its sandbox table had **no foreign keys**, so the STORED `ADD COLUMN` succeeded there.

## Fix
- **LendingModule**: `open_key` is now **VIRTUAL** — adds `INPLACE` (no rebuild, no FK re-creation) and still backs a `UNIQUE` index (MySQL 5.7+). Verified on the live FK table: `STORED → 1215`, `VIRTUAL → ok`, for both the fresh `CREATE TABLE` and the `ALTER` migration.
- **AbstractModule**: `addColumnIfMissing()` / `addUniqueIndexIfMissing()` now **catch `\Throwable`**, so a failing migration is logged and skipped (feature degrades) instead of taking the whole site down with a 500. This is defense-in-depth for any future plugin schema change.
- **migration test**: the sandbox now carries a real `FOREIGN KEY` (the FK-less sandbox was the false green), and the drift guard asserts the source uses `VIRTUAL`, not `STORED`. 11/11.

## Verified end-to-end on a real install
Reproduced the exact upgrade: DB at book-club 1.2.0 with an old `member_loans` (no open_key) + a seeded duplicate-open pair → deployed this code (plugin 1.3.0) → hit the app → PluginManager’s version-bump path ran `onActivate` → `ensureSchema` → the migration de-duped, added the VIRTUAL column + UNIQUE index, and the app went from **500 back to 200**, plugin version now 1.3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la gestione degli errori durante gli aggiornamenti automatici del database, evitando interruzioni dell’app quando il driver segnala eccezioni.
  * Risolta una condizione che poteva causare problemi con colonne generate e vincoli esistenti, rendendo più affidabili le migrazioni.
* **Tests**
  * Aggiornati i controlli automatici per coprire meglio lo сценарio di migrazione con chiavi esterne e colonna generata.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->