### PR TITLE
fix(registration): clear errors for duplicate email + all failure paths, never a 500

### DIFF
--- a/app/Controllers/RegistrationController.php
+++ b/app/Controllers/RegistrationController.php
@@ -9,6 +9,7 @@ use App\Support\Mailer;
 use App\Support\ConfigStore;
 use App\Support\NotificationService;
 use App\Support\RouteTranslator;
+use App\Support\SecureLogger;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -164,27 +165,42 @@ class RegistrationController
             INSERT INTO utenti ({$columns}) VALUES ({$placeholders})
         ");
         $stmt->bind_param($types, ...$values);
-        if (!$stmt->execute()) {
+        // mysqli runs in exception mode (ConfigStore), so a failed INSERT throws instead of
+        // returning false — an unguarded execute() surfaces as a 500. Map the email UNIQUE
+        // violation (error 1062, e.g. a race past the pre-check above) to the same clear
+        // "email already registered" message, and any other DB error to a generic one.
+        try {
+            $stmt->execute();
+            $userId = (int) $stmt->insert_id;
+        } catch (\mysqli_sql_exception $e) {
+            $errCode = $e->getCode() === 1062 ? 'email_exists' : 'db';
+            if ($e->getCode() !== 1062) {
+                SecureLogger::error('[Registration] user INSERT failed: ' . $e->getMessage());
+            }
+            return $response->withHeader('Location', RouteTranslator::route('register') . '?error=' . $errCode)->withStatus(302);
+        } finally {
             $stmt->close();
-            return $response->withHeader('Location', RouteTranslator::route('register') . '?error=db')->withStatus(302);
         }
-        $userId = (int) $stmt->insert_id;
-        $stmt->close();
 
-        // GDPR: Log consent in audit trail (Article 7 compliance)
-        $this->logConsent($db, $userId, 'privacy_policy', true, $privacy_policy_version, $request);
+        // The account is now created. Everything below is a best-effort side-effect
+        // (audit log, welcome/admin emails, in-app notice): a failure here — an SMTP
+        // outage, a missing consent_log table on an old install — must NOT turn a
+        // successful registration into a 500. Log it and still land the user on success.
+        try {
+            // GDPR: Log consent in audit trail (Article 7 compliance)
+            $this->logConsent($db, $userId, 'privacy_policy', true, $privacy_policy_version, $request);
 
-        // Send notification emails using new service
-        $notificationService = new NotificationService($db);
-
-        // Send welcome email to user
-        $notificationService->sendUserRegistrationPending($userId);
-
-        // Notify admins of new registration (email)
-        $notificationService->notifyNewUserRegistration($userId);
-
-        // Create in-app notification for admins
-        $notificationService->notifyNewUserInApp($userId, $nome . ' ' . $cognome, $email);
+            // Send notification emails using new service
+            $notificationService = new NotificationService($db);
+            // Send welcome email to user
+            $notificationService->sendUserRegistrationPending($userId);
+            // Notify admins of new registration (email)
+            $notificationService->notifyNewUserRegistration($userId);
+            // Create in-app notification for admins
+            $notificationService->notifyNewUserInApp($userId, $nome . ' ' . $cognome, $email);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[Registration] post-registration side-effect failed (account ' . $userId . ' was created): ' . $e->getMessage());
+        }
 
         // Redirect to success page
         return $response->withHeader('Location', RouteTranslator::route('register_success'))->withStatus(302);

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -101,6 +101,18 @@ class UsersController
             return $response->withHeader('Location', url('/admin/users/create?error=email_too_long'))->withStatus(302);
         }
 
+        // Reject a duplicate email up front with a clear message instead of letting the
+        // INSERT trip the UNIQUE(email) constraint (which, with mysqli in exception mode,
+        // would surface as a 500).
+        $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? LIMIT 1");
+        $dupStmt->bind_param('s', $email);
+        $dupStmt->execute();
+        $emailTaken = $dupStmt->get_result()->num_rows > 0;
+        $dupStmt->close();
+        if ($emailTaken) {
+            return $response->withHeader('Location', url('/admin/users/create?error=email_exists'))->withStatus(302);
+        }
+
         if (mb_strlen($telefono, 'UTF-8') > 20) {
             return $response->withHeader('Location', url('/admin/users/create?error=phone_too_long'))->withStatus(302);
         }
@@ -190,13 +202,21 @@ class UsersController
             $dataTokenReset
         );
 
-        if (!$stmt->execute()) {
+        // Exception mode: a failed INSERT throws. Catch the email UNIQUE violation (a race
+        // past the pre-check) as email_exists, everything else as a generic db_error — never
+        // a 500.
+        try {
+            $stmt->execute();
+            $userId = (int) $stmt->insert_id;
+        } catch (\mysqli_sql_exception $e) {
+            $code = $e->getCode() === 1062 ? 'email_exists' : 'db_error';
+            if ($e->getCode() !== 1062) {
+                \App\Support\SecureLogger::error('[Users] create INSERT failed: ' . $e->getMessage());
+            }
+            return $response->withHeader('Location', url('/admin/users/create?error=' . $code))->withStatus(302);
+        } finally {
             $stmt->close();
-            return $response->withHeader('Location', url('/admin/users/create?error=db_error'))->withStatus(302);
         }
-
-        $userId = (int) $stmt->insert_id;
-        $stmt->close();
 
         $notifier = new NotificationService($db);
 
@@ -300,6 +320,17 @@ class UsersController
 
         if (!$isAdmin && $telefono === '') {
             return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=missing_fields'))->withStatus(302);
+        }
+
+        // Reject an email already used by ANOTHER user with a clear message, rather than
+        // letting the UPDATE trip UNIQUE(email) and 500 under mysqli exception mode.
+        $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? AND id != ? LIMIT 1");
+        $dupStmt->bind_param('si', $email, $id);
+        $dupStmt->execute();
+        $emailTaken = $dupStmt->get_result()->num_rows > 0;
+        $dupStmt->close();
+        if ($emailTaken) {
+            return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=email_exists'))->withStatus(302);
         }
 
         $indirizzo = trim(strip_tags((string) ($data['indirizzo'] ?? '')));
@@ -421,12 +452,19 @@ class UsersController
             $id
         );
 
-        $success = $stmt->execute();
-        $stmt->close();
-
-        if (!$success) {
-            return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=db_error'))->withStatus(302);
+        // Exception mode: a failed UPDATE throws. Catch the email UNIQUE violation (a race
+        // past the pre-check) as email_exists, everything else as a generic db_error.
+        try {
+            $stmt->execute();
+        } catch (\mysqli_sql_exception $e) {
+            $stmt->close();
+            $code = $e->getCode() === 1062 ? 'email_exists' : 'db_error';
+            if ($e->getCode() !== 1062) {
+                \App\Support\SecureLogger::error('[Users] update failed for user ' . $id . ': ' . $e->getMessage());
+            }
+            return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=' . $code))->withStatus(302);
         }
+        $stmt->close();
 
         // Audit logging for critical actions
         if (($original['tipo_utente'] ?? '') !== $role) {

--- a/app/Views/utenti/crea_utente.php
+++ b/app/Views/utenti/crea_utente.php
@@ -16,6 +16,14 @@ $errorKey = (string)($_GET['error'] ?? '');
       <div class="mb-6 border border-red-200 bg-red-50 text-red-700 rounded-lg px-4 py-3 text-sm" role="alert">
         <?php if ($errorKey === 'missing_fields'): ?>
           <?= __("Compila tutti i campi obbligatori prima di salvare.") ?>
+        <?php elseif ($errorKey === 'email_exists'): ?>
+          <?= __("Email già registrata") ?>
+        <?php elseif ($errorKey === 'name_too_long'): ?>
+          <?= __("Nome o cognome troppo lungo (massimo 100 caratteri)") ?>
+        <?php elseif ($errorKey === 'email_too_long'): ?>
+          <?= __("Email troppo lunga (massimo 255 caratteri)") ?>
+        <?php elseif ($errorKey === 'phone_too_long'): ?>
+          <?= __("Numero di telefono troppo lungo") ?>
         <?php elseif ($errorKey === 'db_error'): ?>
           <?= __("Impossibile salvare l'utente. Riprova più tardi.") ?>
         <?php elseif ($errorKey === 'csrf'): ?>

--- a/app/Views/utenti/modifica_utente.php
+++ b/app/Views/utenti/modifica_utente.php
@@ -30,6 +30,8 @@ $note = HtmlHelper::e($utente['note_utente'] ?? '');
       <div class="mb-6 border border-red-200 bg-red-50 text-red-700 rounded-lg px-4 py-3 text-sm" role="alert">
         <?php if ($errorKey === 'missing_fields'): ?>
           <?= __("Compila tutti i campi obbligatori prima di salvare.") ?>
+        <?php elseif ($errorKey === 'email_exists'): ?>
+          <?= __("Email già registrata") ?>
         <?php elseif ($errorKey === 'db_error'): ?>
           <?= __("Impossibile aggiornare l'utente. Riprova più tardi.") ?>
         <?php elseif ($errorKey === 'csrf'): ?>

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -1359,6 +1359,7 @@
   "Email o password non corretti. Verifica le credenziali e riprova": "E-Mail oder Passwort falsch. Überprüfen Sie Ihre Zugangsdaten und versuchen Sie es erneut",
   "Email per notifiche": "E-Mail für Benachrichtigungen",
   "Email troppo lunga (massimo 255 caratteri)": "E-Mail zu lang (maximal 255 Zeichen)",
+  "Numero di telefono troppo lungo": "Telefonnummer zu lang",
   "Email utente": "Benutzer-E-Mail",
   "Email verificata con successo! Il tuo account è ora in attesa di approvazione da parte dell'amministratore. Riceverai un'email quando sarà attivato.": "E-Mail erfolgreich verifiziert! Ihr Konto wartet nun auf die Genehmigung durch den Administrator. Sie erhalten eine E-Mail, wenn es aktiviert wird.",
   "Email:": "E-Mail:",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1359,6 +1359,7 @@
   "Email o password non corretti. Verifica le credenziali e riprova": "Email or password incorrect. Check your credentials and try again",
   "Email per notifiche": "Email for notifications",
   "Email troppo lunga (massimo 255 caratteri)": "Email too long (maximum 255 characters)",
+  "Numero di telefono troppo lungo": "Phone number too long",
   "Email utente": "User email",
   "Email verificata con successo! Il tuo account è ora in attesa di approvazione da parte dell'amministratore. Riceverai un'email quando sarà attivato.": "Email verified successfully! Your account is now pending administrator approval. You will receive an email when it is activated.",
   "Email:": "Email:",

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -1359,6 +1359,7 @@
   "Email o password non corretti. Verifica le credenziali e riprova": "E-mail ou mot de passe incorrect. Vérifiez vos identifiants et réessayez",
   "Email per notifiche": "E-mail pour les notifications",
   "Email troppo lunga (massimo 255 caratteri)": "E-mail trop long (maximum 255 caractères)",
+  "Numero di telefono troppo lungo": "Numéro de téléphone trop long",
   "Email utente": "E-mail de l'utilisateur",
   "Email verificata con successo! Il tuo account è ora in attesa di approvazione da parte dell'amministratore. Riceverai un'email quando sarà attivato.": "E-mail vérifié avec succès ! Votre compte est maintenant en attente d'approbation par l'administrateur. Vous recevrez un e-mail quand il sera activé.",
   "Email:": "E-mail :",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -1359,6 +1359,7 @@
   "Email o password non corretti. Verifica le credenziali e riprova": "Email o password non corretti. Verifica le credenziali e riprova",
   "Email per notifiche": "Email per notifiche",
   "Email troppo lunga (massimo 255 caratteri)": "Email troppo lunga (massimo 255 caratteri)",
+  "Numero di telefono troppo lungo": "Numero di telefono troppo lungo",
   "Email utente": "Email utente",
   "Email verificata con successo! Il tuo account è ora in attesa di approvazione da parte dell'amministratore. Riceverai un'email quando sarà attivato.": "Email verificata con successo! Il tuo account è ora in attesa di approvazione da parte dell'amministratore. Riceverai un'email quando sarà attivato.",
   "Email:": "Email:",


### PR DESCRIPTION
Reported from a real install (bibliotecafemminista.nudmpd.it): creating an account with an email already in the DB returned **HTTP 500** instead of a clear message.

## Root cause
mysqli runs in **exception mode** (`ConfigStore`), so a failing `INSERT`/`UPDATE` **throws** — the `if (!$stmt->execute())` guards were dead code, and the `UNIQUE(email)` violation surfaced as an uncaught `mysqli_sql_exception` → 500. The server log showed exactly this:
```
[ERROR] Duplicate entry …@gmail.com for key email in app/Controllers/UsersController.php:193
```

## Fix (all user-creation paths return a clear message, never a 500)
- **`UsersController::store()` / `update()`** — pre-check the email up front (`?error=email_exists`) and wrap the `INSERT`/`UPDATE` in `try/catch` mapping error **1062 → email_exists** (race backstop) and anything else → `db_error`. The admin create/edit views (`crea_utente` / `modifica_utente`) now render `email_exists` plus the length errors the controller can emit.
- **`RegistrationController::register()`** — wrap the `INSERT` in the same `try/catch` (the pre-check already existed; this covers the TOCTOU race + other DB errors), and make the post-creation side-effects (consent log, welcome/admin emails, in-app notice) **best-effort** — an SMTP outage must not turn a *successful* registration into a 500.
- **i18n** — new key `Numero di telefono troppo lungo` added to **all four** locales; every other message reused is already present in it/en/de/fr.

## Verified in a real browser (localhost:8081)
- Public registration with a duplicate email → `?error=email_exists` + "Email già registrata", no 500.
- Admin user creation with a duplicate email → `?error=email_exists` + "Email già registrata", no 500, **no duplicate row created**.

PHPStan L5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la gestione degli errori durante la creazione e modifica degli utenti, con messaggi più chiari per email già registrata e altri casi di validazione.
  * Evitato che problemi non critici dopo la registrazione interrompano il flusso di creazione dell’account.
  * Aggiunti controlli e messaggi localizzati per il numero di telefono troppo lungo.

* **Localization**
  * Aggiornate le traduzioni per i nuovi messaggi di errore in più lingue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->