### PR TITLE
fix(users): protect duplicate-check queries + map 1062 to precise unique field

### DIFF
--- a/app/Controllers/RegistrationController.php
+++ b/app/Controllers/RegistrationController.php
@@ -10,7 +10,6 @@ use App\Support\ConfigStore;
 use App\Support\NotificationService;
 use App\Support\RouteTranslator;
 use App\Support\SecureLogger;
-use App\Support\UniqueViolation;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -107,7 +106,11 @@ class RegistrationController
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=db')->withStatus(302);
         }
         if ($emailTaken) {
-            return $response->withHeader('Location', RouteTranslator::route('register') . '?error=email_exists')->withStatus(302);
+            // Public form: a GENERIC "already registered" message, never field-specific.
+            // Saying which field (email / codice fiscale) is taken would let an anonymous
+            // visitor enumerate members (privacy leak, esp. for the CF). Admin flows keep
+            // the precise messages — see UsersController.
+            return $response->withHeader('Location', RouteTranslator::route('register') . '?error=already_registered')->withStatus(302);
         }
 
         $codice_tessera = $this->generateTessera($db);
@@ -183,9 +186,13 @@ class RegistrationController
             $stmt->execute();
             $userId = (int) $stmt->insert_id;
         } catch (\Throwable $e) {
-            $errCode = ($e instanceof \mysqli_sql_exception) ? UniqueViolation::errorCode($e) : 'db_error';
-            if ($errCode === 'db_error') {
-                // errno only — the raw "Duplicate entry '<value>'" message would leak PII.
+            // Public form: collapse ANY unique-key duplicate (email / cod_fiscale /
+            // codice_tessera) into one GENERIC message so an anonymous visitor can't tell
+            // which field is taken (member enumeration). Only a genuine non-duplicate DB
+            // error falls through to the generic 'db' message + errno-only log.
+            if ($e instanceof \mysqli_sql_exception && $e->getCode() === 1062) {
+                $errCode = 'already_registered';
+            } else {
                 SecureLogger::error('[Registration] user INSERT failed (errno ' . (int) $e->getCode() . ')');
                 $errCode = 'db';
             }

--- a/app/Controllers/RegistrationController.php
+++ b/app/Controllers/RegistrationController.php
@@ -10,6 +10,7 @@ use App\Support\ConfigStore;
 use App\Support\NotificationService;
 use App\Support\RouteTranslator;
 use App\Support\SecureLogger;
+use App\Support\UniqueViolation;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 
@@ -90,15 +91,21 @@ class RegistrationController
         if (!preg_match('/[A-Z]/', $password) || !preg_match('/[a-z]/', $password) || !preg_match('/[0-9]/', $password)) {
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=password_needs_upper_lower_number')->withStatus(302);
         }
-        // Check existing email
-        $stmt = $db->prepare("SELECT id FROM utenti WHERE email = ? LIMIT 1");
-        $stmt->bind_param('s', $email);
-        $stmt->execute();
-        if ($stmt->get_result()->num_rows > 0) {
+        // Check existing email. The SELECT is wrapped too: mysqli is in exception mode,
+        // so even a read failure here would otherwise throw and 500 the registration.
+        try {
+            $stmt = $db->prepare("SELECT id FROM utenti WHERE email = ? LIMIT 1");
+            $stmt->bind_param('s', $email);
+            $stmt->execute();
+            $emailTaken = $stmt->get_result()->num_rows > 0;
             $stmt->close();
+        } catch (\mysqli_sql_exception $e) {
+            SecureLogger::error('[Registration] email lookup failed: ' . $e->getMessage());
+            return $response->withHeader('Location', RouteTranslator::route('register') . '?error=db')->withStatus(302);
+        }
+        if ($emailTaken) {
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=email_exists')->withStatus(302);
         }
-        $stmt->close();
 
         $codice_tessera = $this->generateTessera($db);
         $hash = password_hash($password, PASSWORD_DEFAULT);
@@ -166,16 +173,17 @@ class RegistrationController
         ");
         $stmt->bind_param($types, ...$values);
         // mysqli runs in exception mode (ConfigStore), so a failed INSERT throws instead of
-        // returning false — an unguarded execute() surfaces as a 500. Map the email UNIQUE
-        // violation (error 1062, e.g. a race past the pre-check above) to the same clear
-        // "email already registered" message, and any other DB error to a generic one.
+        // returning false — an unguarded execute() surfaces as a 500. A UNIQUE violation
+        // (1062) can be on email OR cod_fiscale (both user-entered) — map to the precise
+        // field so the user is told which one is taken; anything else is a generic error.
         try {
             $stmt->execute();
             $userId = (int) $stmt->insert_id;
         } catch (\mysqli_sql_exception $e) {
-            $errCode = $e->getCode() === 1062 ? 'email_exists' : 'db';
-            if ($e->getCode() !== 1062) {
+            $errCode = $e->getCode() === 1062 ? UniqueViolation::errorCode($e) : 'db';
+            if ($errCode === 'db_error' || $errCode === 'db') {
                 SecureLogger::error('[Registration] user INSERT failed: ' . $e->getMessage());
+                $errCode = 'db';
             }
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=' . $errCode)->withStatus(302);
         } finally {

--- a/app/Controllers/RegistrationController.php
+++ b/app/Controllers/RegistrationController.php
@@ -99,8 +99,11 @@ class RegistrationController
             $stmt->execute();
             $emailTaken = $stmt->get_result()->num_rows > 0;
             $stmt->close();
-        } catch (\mysqli_sql_exception $e) {
-            SecureLogger::error('[Registration] email lookup failed: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            // \Throwable, not \mysqli_sql_exception: if exceptions were ever off, prepare()
+            // returns false and bind_param() raises a \Error. Log only the errno — never the
+            // raw driver message, which for a duplicate carries the offending email/CF.
+            SecureLogger::error('[Registration] email lookup failed (errno ' . (int) $e->getCode() . ')');
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=db')->withStatus(302);
         }
         if ($emailTaken) {
@@ -179,10 +182,11 @@ class RegistrationController
         try {
             $stmt->execute();
             $userId = (int) $stmt->insert_id;
-        } catch (\mysqli_sql_exception $e) {
-            $errCode = $e->getCode() === 1062 ? UniqueViolation::errorCode($e) : 'db';
-            if ($errCode === 'db_error' || $errCode === 'db') {
-                SecureLogger::error('[Registration] user INSERT failed: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            $errCode = ($e instanceof \mysqli_sql_exception) ? UniqueViolation::errorCode($e) : 'db_error';
+            if ($errCode === 'db_error') {
+                // errno only — the raw "Duplicate entry '<value>'" message would leak PII.
+                SecureLogger::error('[Registration] user INSERT failed (errno ' . (int) $e->getCode() . ')');
                 $errCode = 'db';
             }
             return $response->withHeader('Location', RouteTranslator::route('register') . '?error=' . $errCode)->withStatus(302);

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -102,13 +102,18 @@ class UsersController
         }
 
         // Reject a duplicate email up front with a clear message instead of letting the
-        // INSERT trip the UNIQUE(email) constraint (which, with mysqli in exception mode,
-        // would surface as a 500).
-        $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? LIMIT 1");
-        $dupStmt->bind_param('s', $email);
-        $dupStmt->execute();
-        $emailTaken = $dupStmt->get_result()->num_rows > 0;
-        $dupStmt->close();
+        // INSERT trip the UNIQUE(email) constraint. The SELECT is wrapped too: mysqli is in
+        // exception mode, so even a read failure here would otherwise throw and 500.
+        try {
+            $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? LIMIT 1");
+            $dupStmt->bind_param('s', $email);
+            $dupStmt->execute();
+            $emailTaken = $dupStmt->get_result()->num_rows > 0;
+            $dupStmt->close();
+        } catch (\mysqli_sql_exception $e) {
+            \App\Support\SecureLogger::error('[Users] email lookup failed: ' . $e->getMessage());
+            return $response->withHeader('Location', url('/admin/users/create?error=db_error'))->withStatus(302);
+        }
         if ($emailTaken) {
             return $response->withHeader('Location', url('/admin/users/create?error=email_exists'))->withStatus(302);
         }
@@ -202,15 +207,15 @@ class UsersController
             $dataTokenReset
         );
 
-        // Exception mode: a failed INSERT throws. Catch the email UNIQUE violation (a race
-        // past the pre-check) as email_exists, everything else as a generic db_error — never
-        // a 500.
+        // Exception mode: a failed INSERT throws. Map a UNIQUE violation (1062) to the
+        // precise field that collided (email / codice_tessera / cod_fiscale) — the admin can
+        // input all three — everything else is a generic db_error, never a 500.
         try {
             $stmt->execute();
             $userId = (int) $stmt->insert_id;
         } catch (\mysqli_sql_exception $e) {
-            $code = $e->getCode() === 1062 ? 'email_exists' : 'db_error';
-            if ($e->getCode() !== 1062) {
+            $code = \App\Support\UniqueViolation::errorCode($e);
+            if ($code === 'db_error') {
                 \App\Support\SecureLogger::error('[Users] create INSERT failed: ' . $e->getMessage());
             }
             return $response->withHeader('Location', url('/admin/users/create?error=' . $code))->withStatus(302);
@@ -323,12 +328,18 @@ class UsersController
         }
 
         // Reject an email already used by ANOTHER user with a clear message, rather than
-        // letting the UPDATE trip UNIQUE(email) and 500 under mysqli exception mode.
-        $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? AND id != ? LIMIT 1");
-        $dupStmt->bind_param('si', $email, $id);
-        $dupStmt->execute();
-        $emailTaken = $dupStmt->get_result()->num_rows > 0;
-        $dupStmt->close();
+        // letting the UPDATE trip UNIQUE(email). The SELECT is wrapped: mysqli exception mode
+        // would otherwise turn a read failure here into a 500.
+        try {
+            $dupStmt = $db->prepare("SELECT id FROM utenti WHERE email = ? AND id != ? LIMIT 1");
+            $dupStmt->bind_param('si', $email, $id);
+            $dupStmt->execute();
+            $emailTaken = $dupStmt->get_result()->num_rows > 0;
+            $dupStmt->close();
+        } catch (\mysqli_sql_exception $e) {
+            \App\Support\SecureLogger::error('[Users] email lookup failed for user ' . $id . ': ' . $e->getMessage());
+            return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=db_error'))->withStatus(302);
+        }
         if ($emailTaken) {
             return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=email_exists'))->withStatus(302);
         }
@@ -452,14 +463,14 @@ class UsersController
             $id
         );
 
-        // Exception mode: a failed UPDATE throws. Catch the email UNIQUE violation (a race
-        // past the pre-check) as email_exists, everything else as a generic db_error.
+        // Exception mode: a failed UPDATE throws. Map a UNIQUE violation (1062) to the precise
+        // field (email / codice_tessera / cod_fiscale); everything else is a generic db_error.
         try {
             $stmt->execute();
         } catch (\mysqli_sql_exception $e) {
             $stmt->close();
-            $code = $e->getCode() === 1062 ? 'email_exists' : 'db_error';
-            if ($e->getCode() !== 1062) {
+            $code = \App\Support\UniqueViolation::errorCode($e);
+            if ($code === 'db_error') {
                 \App\Support\SecureLogger::error('[Users] update failed for user ' . $id . ': ' . $e->getMessage());
             }
             return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=' . $code))->withStatus(302);

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -110,8 +110,8 @@ class UsersController
             $dupStmt->execute();
             $emailTaken = $dupStmt->get_result()->num_rows > 0;
             $dupStmt->close();
-        } catch (\mysqli_sql_exception $e) {
-            \App\Support\SecureLogger::error('[Users] email lookup failed: ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            \App\Support\SecureLogger::error('[Users] email lookup failed (errno ' . (int) $e->getCode() . ')');
             return $response->withHeader('Location', url('/admin/users/create?error=db_error'))->withStatus(302);
         }
         if ($emailTaken) {
@@ -213,10 +213,10 @@ class UsersController
         try {
             $stmt->execute();
             $userId = (int) $stmt->insert_id;
-        } catch (\mysqli_sql_exception $e) {
-            $code = \App\Support\UniqueViolation::errorCode($e);
+        } catch (\Throwable $e) {
+            $code = ($e instanceof \mysqli_sql_exception) ? \App\Support\UniqueViolation::errorCode($e) : 'db_error';
             if ($code === 'db_error') {
-                \App\Support\SecureLogger::error('[Users] create INSERT failed: ' . $e->getMessage());
+                \App\Support\SecureLogger::error('[Users] create INSERT failed (errno ' . (int) $e->getCode() . ')');
             }
             return $response->withHeader('Location', url('/admin/users/create?error=' . $code))->withStatus(302);
         } finally {
@@ -336,8 +336,8 @@ class UsersController
             $dupStmt->execute();
             $emailTaken = $dupStmt->get_result()->num_rows > 0;
             $dupStmt->close();
-        } catch (\mysqli_sql_exception $e) {
-            \App\Support\SecureLogger::error('[Users] email lookup failed for user ' . $id . ': ' . $e->getMessage());
+        } catch (\Throwable $e) {
+            \App\Support\SecureLogger::error('[Users] email lookup failed for user ' . $id . ' (errno ' . (int) $e->getCode() . ')');
             return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=db_error'))->withStatus(302);
         }
         if ($emailTaken) {
@@ -467,11 +467,11 @@ class UsersController
         // field (email / codice_tessera / cod_fiscale); everything else is a generic db_error.
         try {
             $stmt->execute();
-        } catch (\mysqli_sql_exception $e) {
+        } catch (\Throwable $e) {
             $stmt->close();
-            $code = \App\Support\UniqueViolation::errorCode($e);
+            $code = ($e instanceof \mysqli_sql_exception) ? \App\Support\UniqueViolation::errorCode($e) : 'db_error';
             if ($code === 'db_error') {
-                \App\Support\SecureLogger::error('[Users] update failed for user ' . $id . ': ' . $e->getMessage());
+                \App\Support\SecureLogger::error('[Users] update failed for user ' . $id . ' (errno ' . (int) $e->getCode() . ')');
             }
             return $response->withHeader('Location', url('/admin/users/edit/' . $id . '?error=' . $code))->withStatus(302);
         }

--- a/app/Support/UniqueViolation.php
+++ b/app/Support/UniqueViolation.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Maps a mysqli duplicate-key exception (errno 1062) to the logical `utenti`
+ * field that collided, so user-creation flows can show a precise message
+ * ("email already registered" vs "codice fiscale already registered") instead
+ * of assuming it was always the email.
+ *
+ * The UNIQUE indexes on `utenti` are named after their column (email,
+ * codice_tessera, cod_fiscale). MySQL reports the offending index in the driver
+ * message — "Duplicate entry '…' for key 'email'" (5.7) or "… for key
+ * 'utenti.email'" (8.0) — which this parses. Anything that isn't a recognised
+ * 1062 collision returns 'other' so the caller falls back to a generic error.
+ */
+final class UniqueViolation
+{
+    /** @return 'email'|'codice_tessera'|'cod_fiscale'|'other' */
+    public static function fieldFor(\mysqli_sql_exception $e): string
+    {
+        if ($e->getCode() !== 1062) {
+            return 'other';
+        }
+        // "... for key 'email'" or "... for key 'utenti.email'"
+        if (preg_match("/for key '(?:[^'.]+\\.)?(email|codice_tessera|cod_fiscale)'/i", $e->getMessage(), $m) === 1) {
+            return strtolower($m[1]);
+        }
+        return 'other';
+    }
+
+    /**
+     * The `?error=` code a controller should redirect with for a given field.
+     * 'other' → 'db_error' (generic), so an unexpected duplicate never masquerades
+     * as a specific field.
+     */
+    public static function errorCode(\mysqli_sql_exception $e): string
+    {
+        return match (self::fieldFor($e)) {
+            'email' => 'email_exists',
+            'cod_fiscale' => 'cf_exists',
+            'codice_tessera' => 'tessera_exists',
+            default => 'db_error',
+        };
+    }
+}

--- a/app/Views/auth/register.php
+++ b/app/Views/auth/register.php
@@ -61,10 +61,8 @@ $registerRoute = route_path('register');
                   <?= __('Errore durante la registrazione') ?>
                 <?php elseif ($_GET['error'] === 'csrf'): ?>
                   <?= __('Errore di sicurezza, riprova') ?>
-                <?php elseif ($_GET['error'] === 'email_exists'): ?>
-                  <?= __('Email già registrata') ?>
-                <?php elseif ($_GET['error'] === 'cf_exists'): ?>
-                  <?= __('Codice fiscale già registrato') ?>
+                <?php elseif ($_GET['error'] === 'already_registered'): ?>
+                  <?= __('Questi dati risultano già registrati') ?>
                 <?php elseif ($_GET['error'] === 'missing_fields'): ?>
                   <?= __('Compila tutti i campi richiesti') ?>
                 <?php elseif ($_GET['error'] === 'privacy_required'): ?>

--- a/app/Views/auth/register.php
+++ b/app/Views/auth/register.php
@@ -63,6 +63,8 @@ $registerRoute = route_path('register');
                   <?= __('Errore di sicurezza, riprova') ?>
                 <?php elseif ($_GET['error'] === 'email_exists'): ?>
                   <?= __('Email già registrata') ?>
+                <?php elseif ($_GET['error'] === 'cf_exists'): ?>
+                  <?= __('Codice fiscale già registrato') ?>
                 <?php elseif ($_GET['error'] === 'missing_fields'): ?>
                   <?= __('Compila tutti i campi richiesti') ?>
                 <?php elseif ($_GET['error'] === 'privacy_required'): ?>

--- a/app/Views/utenti/crea_utente.php
+++ b/app/Views/utenti/crea_utente.php
@@ -18,6 +18,10 @@ $errorKey = (string)($_GET['error'] ?? '');
           <?= __("Compila tutti i campi obbligatori prima di salvare.") ?>
         <?php elseif ($errorKey === 'email_exists'): ?>
           <?= __("Email già registrata") ?>
+        <?php elseif ($errorKey === 'cf_exists'): ?>
+          <?= __("Codice fiscale già registrato") ?>
+        <?php elseif ($errorKey === 'tessera_exists'): ?>
+          <?= __("Codice tessera già assegnato") ?>
         <?php elseif ($errorKey === 'name_too_long'): ?>
           <?= __("Nome o cognome troppo lungo (massimo 100 caratteri)") ?>
         <?php elseif ($errorKey === 'email_too_long'): ?>

--- a/app/Views/utenti/modifica_utente.php
+++ b/app/Views/utenti/modifica_utente.php
@@ -32,6 +32,10 @@ $note = HtmlHelper::e($utente['note_utente'] ?? '');
           <?= __("Compila tutti i campi obbligatori prima di salvare.") ?>
         <?php elseif ($errorKey === 'email_exists'): ?>
           <?= __("Email già registrata") ?>
+        <?php elseif ($errorKey === 'cf_exists'): ?>
+          <?= __("Codice fiscale già registrato") ?>
+        <?php elseif ($errorKey === 'tessera_exists'): ?>
+          <?= __("Codice tessera già assegnato") ?>
         <?php elseif ($errorKey === 'db_error'): ?>
           <?= __("Impossibile aggiornare l'utente. Riprova più tardi.") ?>
         <?php elseif ($errorKey === 'csrf'): ?>

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -1353,6 +1353,8 @@
   "Email dove ricevere i messaggi dal form contatti": "E-Mail-Adresse für den Empfang von Nachrichten aus dem Kontaktformular",
   "Email e telefono visibili sulla pagina contatti": "E-Mail und Telefon sichtbar auf der Kontaktseite",
   "Email già registrata": "E-Mail bereits registriert",
+  "Codice fiscale già registrato": "Steuernummer bereits registriert",
+  "Codice tessera già assegnato": "Ausweisnummer bereits vergeben",
   "Email non trovata nel nostro sistema": "E-Mail in unserem System nicht gefunden",
   "Email non valida. Verifica il formato": "Ungültige E-Mail. Überprüfen Sie das Format",
   "Email non verificata. Controlla la tua casella di posta e clicca sul link di verifica": "E-Mail nicht verifiziert. Überprüfen Sie Ihren Posteingang und klicken Sie auf den Bestätigungslink",

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -1353,6 +1353,7 @@
   "Email dove ricevere i messaggi dal form contatti": "E-Mail-Adresse für den Empfang von Nachrichten aus dem Kontaktformular",
   "Email e telefono visibili sulla pagina contatti": "E-Mail und Telefon sichtbar auf der Kontaktseite",
   "Email già registrata": "E-Mail bereits registriert",
+  "Questi dati risultano già registrati": "Diese Daten sind bereits registriert",
   "Codice fiscale già registrato": "Steuernummer bereits registriert",
   "Codice tessera già assegnato": "Ausweisnummer bereits vergeben",
   "Email non trovata nel nostro sistema": "E-Mail in unserem System nicht gefunden",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1353,6 +1353,7 @@
   "Email dove ricevere i messaggi dal form contatti": "Email where to receive messages from contact form",
   "Email e telefono visibili sulla pagina contatti": "Email and phone visible on contact page",
   "Email già registrata": "Email already registered",
+  "Questi dati risultano già registrati": "This information is already registered",
   "Codice fiscale già registrato": "Tax code already registered",
   "Codice tessera già assegnato": "Card number already assigned",
   "Email non trovata nel nostro sistema": "Email not found in our system",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1353,6 +1353,8 @@
   "Email dove ricevere i messaggi dal form contatti": "Email where to receive messages from contact form",
   "Email e telefono visibili sulla pagina contatti": "Email and phone visible on contact page",
   "Email già registrata": "Email already registered",
+  "Codice fiscale già registrato": "Tax code already registered",
+  "Codice tessera già assegnato": "Card number already assigned",
   "Email non trovata nel nostro sistema": "Email not found in our system",
   "Email non valida. Verifica il formato": "Invalid email. Check the format",
   "Email non verificata. Controlla la tua casella di posta e clicca sul link di verifica": "Email not verified. Check your inbox and click the verification link",

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -1353,6 +1353,8 @@
   "Email dove ricevere i messaggi dal form contatti": "E-mail pour recevoir les messages du formulaire de contact",
   "Email e telefono visibili sulla pagina contatti": "E-mail et téléphone visibles sur la page de contact",
   "Email già registrata": "E-mail déjà enregistré",
+  "Codice fiscale già registrato": "Code fiscal déjà enregistré",
+  "Codice tessera già assegnato": "Numéro de carte déjà attribué",
   "Email non trovata nel nostro sistema": "E-mail non trouvé dans notre système",
   "Email non valida. Verifica il formato": "E-mail invalide. Vérifiez le format",
   "Email non verificata. Controlla la tua casella di posta e clicca sul link di verifica": "E-mail non vérifié. Vérifiez votre boîte de réception et cliquez sur le lien de vérification",

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -1353,6 +1353,7 @@
   "Email dove ricevere i messaggi dal form contatti": "E-mail pour recevoir les messages du formulaire de contact",
   "Email e telefono visibili sulla pagina contatti": "E-mail et téléphone visibles sur la page de contact",
   "Email già registrata": "E-mail déjà enregistré",
+  "Questi dati risultano già registrati": "Ces informations sont déjà enregistrées",
   "Codice fiscale già registrato": "Code fiscal déjà enregistré",
   "Codice tessera già assegnato": "Numéro de carte déjà attribué",
   "Email non trovata nel nostro sistema": "E-mail non trouvé dans notre système",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -1353,6 +1353,7 @@
   "Email dove ricevere i messaggi dal form contatti": "Email dove ricevere i messaggi dal form contatti",
   "Email e telefono visibili sulla pagina contatti": "Email e telefono visibili sulla pagina contatti",
   "Email già registrata": "Email già registrata",
+  "Questi dati risultano già registrati": "Questi dati risultano già registrati",
   "Codice fiscale già registrato": "Codice fiscale già registrato",
   "Codice tessera già assegnato": "Codice tessera già assegnato",
   "Email non trovata nel nostro sistema": "Email non trovata nel nostro sistema",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -1353,6 +1353,8 @@
   "Email dove ricevere i messaggi dal form contatti": "Email dove ricevere i messaggi dal form contatti",
   "Email e telefono visibili sulla pagina contatti": "Email e telefono visibili sulla pagina contatti",
   "Email già registrata": "Email già registrata",
+  "Codice fiscale già registrato": "Codice fiscale già registrato",
+  "Codice tessera già assegnato": "Codice tessera già assegnato",
   "Email non trovata nel nostro sistema": "Email non trovata nel nostro sistema",
   "Email non valida. Verifica il formato": "Email non valida. Verifica il formato",
   "Email non verificata. Controlla la tua casella di posta e clicca sul link di verifica": "Email non verificata. Controlla la tua casella di posta e clicca sul link di verifica",

--- a/tests/unique-violation.unit.php
+++ b/tests/unique-violation.unit.php
@@ -1,0 +1,136 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral test for App\Support\UniqueViolation — the parser that maps a mysqli
+ * 1062 duplicate-key exception to the offending `utenti` field so the registration /
+ * user-creation flows show a precise message instead of always "email".
+ *
+ * It asserts against the REAL mysqli_sql_exception message (which differs between
+ * MySQL 5.7 "for key 'email'" and 8.0 "for key 'utenti.email'"), by triggering an
+ * actual duplicate on a sandbox table whose UNIQUE indexes are named exactly like
+ * the ones on `utenti`. A static string would not catch a driver-format change.
+ *
+ * Run:  php tests/unique-violation.unit.php   Exit 0 on "ALL <n> PASS".
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+require $root . '/app/Support/UniqueViolation.php';
+
+use App\Support\UniqueViolation;
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+function uvEnv(string $path): array
+{
+    $env = [];
+    foreach (preg_split('/\r?\n/', (string) @file_get_contents($path)) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env = uvEnv($root . '/.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$pass = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+$name = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+try {
+    if (is_string($socket) && $socket !== '' && file_exists($socket)) {
+        $db = new mysqli(null, $user, $pass, $name, 0, $socket);
+    } else {
+        $db = new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), $user, $pass, $name, (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    }
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+
+const SANDBOX = 'zz_uv_probe';
+$cleanup = static function (mysqli $db): void {
+    $db->query('DROP TABLE IF EXISTS `' . SANDBOX . '`');
+};
+set_exception_handler(static function (\Throwable $e) use ($db, $cleanup): void {
+    try {
+        $cleanup($db);
+    } catch (\Throwable $ignored) {
+    }
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n");
+    exit(1);
+});
+
+$TESTNO = 0;
+function check(bool $cond, string $desc): void
+{
+    global $TESTNO;
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+
+$cleanup($db);
+// UNIQUE index names match utenti (email / codice_tessera / cod_fiscale).
+$db->query(
+    "CREATE TABLE `" . SANDBOX . "` (
+        id INT NOT NULL AUTO_INCREMENT,
+        email VARCHAR(255) NULL,
+        codice_tessera VARCHAR(20) NULL,
+        cod_fiscale VARCHAR(16) NULL,
+        PRIMARY KEY (id),
+        UNIQUE KEY email (email),
+        UNIQUE KEY codice_tessera (codice_tessera),
+        UNIQUE KEY cod_fiscale (cod_fiscale)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"
+);
+
+// Seed one row per column, then insert a colliding value and capture the exception.
+$captureDup = function (string $col, string $val) use ($db): \mysqli_sql_exception {
+    $db->query("INSERT INTO `" . SANDBOX . "` (`$col`) VALUES ('$val')");
+    try {
+        $db->query("INSERT INTO `" . SANDBOX . "` (`$col`) VALUES ('$val')");
+    } catch (\mysqli_sql_exception $e) {
+        return $e;
+    }
+    throw new \RuntimeException("expected a 1062 on $col but none thrown");
+};
+
+$eEmail = $captureDup('email', 'dup@example.test');
+check($eEmail->getCode() === 1062, "email duplicate raises errno 1062");
+check(UniqueViolation::fieldFor($eEmail) === 'email', "fieldFor() detects 'email' from the real driver message");
+check(UniqueViolation::errorCode($eEmail) === 'email_exists', "errorCode() maps email -> email_exists");
+
+$eTessera = $captureDup('codice_tessera', 'BLTESS001');
+check(UniqueViolation::fieldFor($eTessera) === 'codice_tessera', "fieldFor() detects 'codice_tessera'");
+check(UniqueViolation::errorCode($eTessera) === 'tessera_exists', "errorCode() maps codice_tessera -> tessera_exists");
+
+$eCf = $captureDup('cod_fiscale', 'RSSMRA80A01H501U');
+check(UniqueViolation::fieldFor($eCf) === 'cod_fiscale', "fieldFor() detects 'cod_fiscale'");
+check(UniqueViolation::errorCode($eCf) === 'cf_exists', "errorCode() maps cod_fiscale -> cf_exists");
+
+// A non-1062 error must fall back to 'other' / 'db_error'.
+$eOther = null;
+try {
+    $db->query("INSERT INTO `" . SANDBOX . "` (nonexistent_col) VALUES ('x')");
+} catch (\mysqli_sql_exception $e) {
+    $eOther = $e;
+}
+check($eOther !== null && $eOther->getCode() !== 1062, "a non-duplicate DB error has a code != 1062");
+check(UniqueViolation::fieldFor($eOther) === 'other', "fieldFor() returns 'other' for a non-1062 error");
+check(UniqueViolation::errorCode($eOther) === 'db_error', "errorCode() falls back to db_error for 'other'");
+
+$cleanup($db);
+printf("\nALL %d PASS\n", $TESTNO);
+exit(0);


### PR DESCRIPTION
Follow-up hardening on the registration-error fix (#225), addressing two still-valid CodeRabbit findings.

## 1. Unprotected pre-check SELECTs could still 500
`RegistrationController::register()` and `UsersController::store()/update()` pre-check the email with a `SELECT`, but those were **not** wrapped — and mysqli runs in exception mode, so a read failure there would throw and 500 before the intended redirect. All three are now in `try/catch` → a generic `db`/`db_error` redirect.

## 2. Every 1062 was reported as "email already registered"
`utenti` has UNIQUE indexes on **email, codice_tessera AND cod_fiscale**. A duplicate *codice fiscale* (both it and cod_fiscale are user-entered) tripped the INSERT and was shown as "Email already registered". New `App\Support\UniqueViolation` parses the offending index from the driver message — handles both MySQL 5.7 `for key email` and 8.0 `for key utenti.email` — and maps it to a precise code (`email_exists` / `cf_exists` / `tessera_exists`), falling back to `db_error` for anything unexpected. New i18n keys added to **all four locales**; register + admin create/edit views render the new codes.

## Tested
- `tests/unique-violation.unit.php` — 10 checks, triggers a **real** 1062 on a sandbox table whose UNIQUE indexes mirror `utenti`, asserting the parse against the actual driver message (a static string wouldnt catch a version format change). Runs in CI via the `tests/*.unit.php` glob.
- **Browser-verified** end to end: registering with a duplicate `cod_fiscale` now redirects to `?error=cf_exists` and shows "Codice fiscale già registrato" — no 500, no wrong "email" message.
- PHPStan L5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Messaggi più chiari durante registrazione e modifica utente per duplicati di email, codice fiscale e codice tessera, con un messaggio generico quando i dati risultano già registrati.
  * Aggiornata la localizzazione con nuove stringhe per italiano, inglese, francese e tedesco.

* **Bug Fixes**
  * Migliorata la gestione degli errori database: in caso di problemi di lettura/scrittura, l’app evita errori non gestiti e mostra avvisi coerenti.
  * I conflitti su vincoli univoci vengono ora segnalati sul campo corretto.

* **Test**
  * Aggiunto un test dedicato alla logica di rilevamento dei duplicati.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->