### PR TITLE
fix(loans): overdue (in_ritardo) loans keep their copy occupied — no double-booking

### DIFF
--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -369,7 +369,7 @@ class LoanApprovalController
                         WHERE p.copia_id = c.id
                         AND p.id != ?
                         AND p.data_prestito <= ?
-                        AND p.data_scadenza >= ?
+                        AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                         AND (
                             (p.attivo = 1 AND p.stato IN ('in_corso', 'prenotato', 'da_ritirare', 'in_ritardo'))
                             OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
@@ -396,7 +396,7 @@ class LoanApprovalController
                 $loanCountStmt = $db->prepare("
                     SELECT COUNT(*) as count FROM prestiti
                     WHERE libro_id = ? AND id != ?
-                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                     AND (
                         (attivo = 1 AND stato IN ('in_corso', 'prenotato', 'da_ritirare', 'in_ritardo'))
                         OR (stato = 'pendente' AND copia_id IS NOT NULL)
@@ -438,12 +438,12 @@ class LoanApprovalController
                 $overlapStmt = $db->prepare("
                     SELECT c.id FROM copie c
                     WHERE c.libro_id = ?
-                    AND c.stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')
+                    AND c.stato IN ('disponibile', 'prenotato')
                     AND NOT EXISTS (
                         SELECT 1 FROM prestiti p
                         WHERE p.copia_id = c.id
                         AND p.data_prestito <= ?
-                        AND p.data_scadenza >= ?
+                        AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                         AND (
                             (p.attivo = 1 AND p.stato IN ('in_corso', 'prenotato', 'da_ritirare', 'in_ritardo'))
                             OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
@@ -490,7 +490,7 @@ class LoanApprovalController
             $overlapCopyStmt = $db->prepare("
                 SELECT 1 FROM prestiti
                 WHERE copia_id = ? AND id != ?
-                AND data_prestito <= ? AND data_scadenza >= ?
+                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 AND (
                     (attivo = 1 AND stato IN ('in_corso','prenotato','da_ritirare','in_ritardo'))
                     OR (stato = 'pendente' AND copia_id IS NOT NULL)

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -264,7 +264,7 @@ class PrestitiController
                 $loanCountStmt = $db->prepare("
                 SELECT COUNT(*) as count FROM prestiti
                 WHERE libro_id = ?
-                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 AND (
                     (attivo = 1 AND stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                     OR (stato = 'pendente' AND copia_id IS NOT NULL)
@@ -307,7 +307,7 @@ class PrestitiController
                         SELECT 1 FROM prestiti p
                         WHERE p.copia_id = c.id
                         AND p.data_prestito <= ?
-                        AND p.data_scadenza >= ?
+                        AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                         AND (
                             (p.attivo = 1 AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                             OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
@@ -337,7 +337,7 @@ class PrestitiController
                 $loanCountStmt = $db->prepare("
                 SELECT COUNT(*) as count FROM prestiti
                 WHERE libro_id = ?
-                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 AND (
                     (attivo = 1 AND stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                     OR (stato = 'pendente' AND copia_id IS NOT NULL)
@@ -380,7 +380,7 @@ class PrestitiController
                         SELECT 1 FROM prestiti p
                         WHERE p.copia_id = c.id
                         AND p.data_prestito <= ?
-                        AND p.data_scadenza >= ?
+                        AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                         AND (
                             (p.attivo = 1 AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                             OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
@@ -415,7 +415,7 @@ class PrestitiController
                 SELECT 1 FROM prestiti
                 WHERE copia_id = ? AND attivo = 1
                 AND stato IN ('in_corso','da_ritirare','prenotato','in_ritardo')
-                AND data_prestito <= ? AND data_scadenza >= ?
+                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 LIMIT 1
             ");
             $overlapCopyStmt->bind_param('iss', $selectedCopy['id'], $data_scadenza, $data_prestito);
@@ -1297,7 +1297,7 @@ class PrestitiController
                 SELECT COUNT(*) as count FROM prestiti
                 WHERE libro_id = ? AND id != ? AND attivo = 1
                 AND stato IN ('prenotato', 'da_ritirare', 'in_corso', 'in_ritardo')
-                AND data_prestito <= ? AND data_scadenza >= ?
+                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
             ");
             $conflictStmt->bind_param('iiss', $libroId, $id, $extensionEnd, $extensionStart);
             $conflictStmt->execute();
@@ -1348,7 +1348,7 @@ class PrestitiController
                 $copyOvlStmt = $db->prepare("
                     SELECT 1 FROM prestiti
                     WHERE copia_id = ? AND id <> ?
-                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                     AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
                           OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
                     LIMIT 1

--- a/app/Controllers/ReservationsController.php
+++ b/app/Controllers/ReservationsController.php
@@ -121,6 +121,12 @@ class ReservationsController
                 // even though they haven't picked it up yet
                 $endDateLoan = $loan['data_scadenza']
                     ?? (new DateTime($startDateLoan))->add(new DateInterval('P7D'))->format('Y-m-d');
+            } elseif ($loanStatus === 'in_ritardo' && empty($loan['data_restituzione'])) {
+                // Overdue and not yet returned: the copy is physically still out and its
+                // original data_scadenza is in the PAST — using it would free the copy on
+                // the availability calendar and let a new request slip in (double-booking).
+                // Keep it blocked open-ended until it is actually returned.
+                $endDateLoan = '9999-12-31';
             } else {
                 // For other states: data_restituzione > data_scadenza > null
                 $endDateLoan = $loan['data_restituzione'] ?? $loan['data_scadenza'] ?? null;

--- a/installer/database/triggers.sql
+++ b/installer/database/triggers.sql
@@ -39,7 +39,7 @@ BEGIN
             FROM prestiti p
             WHERE p.copia_id = NEW.copia_id
               AND p.data_prestito <= NEW.data_scadenza
-              AND p.data_scadenza >= NEW.data_prestito
+              AND (p.stato = 'in_ritardo' OR p.data_scadenza >= NEW.data_prestito)
               AND (
                   (p.attivo = 1 AND p.stato IN ('in_corso','in_ritardo','prenotato','da_ritirare'))
                   OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
@@ -92,7 +92,7 @@ BEGIN
             WHERE p.copia_id = NEW.copia_id
               AND p.id <> NEW.id
               AND p.data_prestito <= NEW.data_scadenza
-              AND p.data_scadenza >= NEW.data_prestito
+              AND (p.stato = 'in_ritardo' OR p.data_scadenza >= NEW.data_prestito)
               AND (
                   (p.attivo = 1 AND p.stato IN ('in_corso','in_ritardo','prenotato','da_ritirare'))
                   OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)

--- a/scripts/check-expired-reservations.php
+++ b/scripts/check-expired-reservations.php
@@ -14,6 +14,23 @@ if (php_sapi_name() !== 'cli') {
     die("This script can only be run from the command line.");
 }
 
+// Process lock: prevent two overlapping runs from both expiring the same
+// reservation and desyncing copy state / reassignment (mirrors maintenance.php).
+$lockFile = __DIR__ . '/../storage/cache/check-expired-reservations.lock';
+$lockDir = dirname($lockFile);
+if (!is_dir($lockDir)) {
+    @mkdir($lockDir, 0755, true);
+}
+$lockHandle = fopen($lockFile, 'c');
+if ($lockHandle === false || !flock($lockHandle, LOCK_EX | LOCK_NB)) {
+    fwrite(STDERR, "INFO: another check-expired-reservations run is in progress. Exiting.\n");
+    exit(0);
+}
+register_shutdown_function(static function () use ($lockHandle) {
+    flock($lockHandle, LOCK_UN);
+    fclose($lockHandle);
+});
+
 // Load environment
 $dotenv = Dotenv::createImmutable(__DIR__ . '/..');
 $dotenv->load();
@@ -29,8 +46,10 @@ if ($db->connect_error) {
 echo "[" . date('Y-m-d H:i:s') . "] Starting expired reservations check...\n";
 
 // Find expired reservations (prestiti with stato='prenotato' and data_scadenza < TODAY)
-// attivi=1
-$today = date('Y-m-d');
+// attivi=1. "Today" must be the app timezone (DateHelper), not the PHP process tz —
+// the rest of the loan pipeline compares against app-tz dates, so a raw date() here
+// would skip/early-expire reservations in the pre-midnight local offset window.
+$today = \App\Support\DateHelper::today();
 
 $stmt = $db->prepare("
     SELECT id, libro_id, copia_id, utente_id
@@ -57,18 +76,27 @@ while ($reservation = $result->fetch_assoc()) {
 
     $db->begin_transaction();
     try {
-        // Mark as expired
+        // Mark as expired — mark-then-act: the state guard + affected_rows check make
+        // this idempotent, so a concurrent run (or a row whose state changed since the
+        // SELECT) does NOT re-free the copy and re-run reassignment.
         $updateStmt = $db->prepare("
             UPDATE prestiti
             SET stato = 'scaduto',
                 attivo = 0,
                 updated_at = NOW(),
                 note = CONCAT(COALESCE(note, ''), '\n[System] Scaduta il ', DATE_FORMAT(CURDATE(), '%d/%m/%Y'))
-            WHERE id = ?
+            WHERE id = ? AND stato = 'prenotato' AND attivo = 1
         ");
         $updateStmt->bind_param('i', $id);
         $updateStmt->execute();
+        $claimed = $updateStmt->affected_rows === 1;
         $updateStmt->close();
+
+        if (!$claimed) {
+            // Already expired/changed by another run — skip without touching the copy.
+            $db->rollback();
+            continue;
+        }
 
         // If a copy was assigned, make it available (if currently 'prenotato')
         if ($copiaId) {

--- a/tests/loan-overlap.spec.js
+++ b/tests/loan-overlap.spec.js
@@ -94,7 +94,8 @@ test.describe.serial('Loan overlap model (#157) — 35 scenarios', () => {
         AND NOT EXISTS (
           SELECT 1 FROM prestiti p
           WHERE p.copia_id = c.id
-            AND p.data_prestito <= '${end}' AND p.data_scadenza >= '${start}'
+            AND p.data_prestito <= '${end}'
+            AND (p.stato = 'in_ritardo' OR p.data_scadenza >= '${start}')
             AND ((p.attivo = 1 AND p.stato IN ('in_corso','in_ritardo','da_ritirare','prenotato'))
                  OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL))
         )`);
@@ -501,5 +502,42 @@ test.describe.serial('Loan overlap model (#157) — 35 scenarios', () => {
     expect(freeCopies(b, dISO(3), dISO(8))).toBe(0);            // da_ritirare holds it
     dbQuery(`UPDATE prestiti SET stato='in_corso' WHERE id=${id}`);
     expect(freeCopies(b, dISO(3), dISO(8))).toBe(0);            // in_corso holds it
+  });
+
+  // ════════════════════════════════════════════════════════════════════════
+  // GROUP G — overdue (in_ritardo) keeps its copy blocked open-ended
+  //   Regression for the availability bug: an unreturned overdue loan has a
+  //   PAST data_scadenza, so the naive `data_scadenza >= start` predicate let a
+  //   later request slip in → double-booking of a physical copy still on loan.
+  // ════════════════════════════════════════════════════════════════════════
+
+  test('G.36 an overdue (in_ritardo) unreturned loan keeps its copy occupied for a LATER window', () => {
+    const b = mkBook('G36'); const c = mkCopy(b, 1, 'prestato');
+    // Due 10 days ago, never returned, still active/overdue.
+    expect(tryInsertLoan({ bookId: b, copyId: c, userId: u1, start: dISO(-30), end: dISO(-10), stato: 'in_ritardo', attivo: 1 }).ok).toBe(true);
+    // A window well AFTER the (past) due date must still see the copy as taken.
+    expect(freeCopies(b, dISO(5), dISO(9))).toBe(0);
+  });
+
+  test('G.37 availability calendar reports 0 for future dates while an overdue loan is unreturned', async ({ page }) => {
+    await adminLogin(page);
+    const b = mkBook('G37'); const c = mkCopy(b, 1, 'prestato');
+    tryInsertLoan({ bookId: b, copyId: c, userId: u1, start: dISO(-40), end: dISO(-5), stato: 'in_ritardo', attivo: 1 });
+    const data = await availabilityByDate(page, b);
+    expect(data).toBeTruthy();
+    const byDate = Object.fromEntries((Array.isArray(data.days) ? data.days : []).map(d => [d.date, Number(d.available)]));
+    const fut = dISO(7);
+    expect(byDate[fut], `availability-calendar days[] must include ${fut}`).not.toBeUndefined();
+    expect(byDate[fut]).toBe(0);
+  });
+
+  test('G.38 the DB trigger blocks a new overlapping loan on a copy held by an overdue loan', () => {
+    const b = mkBook('G38'); const c = mkCopy(b, 1, 'prestato');
+    expect(tryInsertLoan({ bookId: b, copyId: c, userId: u1, start: dISO(-25), end: dISO(-8), stato: 'in_ritardo', attivo: 1 }).ok).toBe(true);
+    // A future loan on the SAME copy must be rejected by the trigger (SIGNAL 45000),
+    // because the overdue loan still occupies the copy open-ended.
+    const r = tryInsertLoan({ bookId: b, copyId: c, userId: u2, start: dISO(3), end: dISO(12), stato: 'prenotato', attivo: 1 });
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/sovrapposto|45000/i);
   });
 });


### PR DESCRIPTION
Highest-severity finding from the deep loan/reservation review.

## The bug
Every availability/overlap predicate used `data_prestito <= ? AND data_scadenza >= ?`, treating `data_scadenza` as the end of occupancy. For an **overdue, never-returned loan** (`stato=in_ritardo`), `data_scadenza` is the *original* due date — now in the past — while the copy is still physically out. Any new request starting after that stale date dropped the overdue loan from every count → the copy looked free and could be **double-booked at admin approval time**, and the public availability calendar reported out-of-stock books as free.

## The fix
Corrected the predicate to `(stato = in_ritardo OR data_scadenza >= ?)` everywhere occupancy is computed, so an overdue loan blocks its copy **open-ended** until returned:

- **PrestitiController** — `store()` count + copy-select + race re-check, `renew()` conflict count + copy-overlap (7 sites).
- **LoanApprovalController** — `approveLoan()` pre-assigned-copy check, overlap count, copy-select, #157 `FOR UPDATE` re-check (4 sites). Plus the copy-selection now requires `c.stato IN (disponibile,prenotato)` (it was only excluding perso/danneggiato/…) — **the real hole**: a still-out `prestato` copy could be picked. `store()` already had this guard.
- **ReservationsController::calculateAvailability()** — an `in_ritardo` loan with no `data_restituzione` is blocked open-ended (was collapsing to a single-day block → the calendar overcount, finding #2).
- **installer/database/triggers.sql** — both `trg_check_active_prestito_before_insert/update` use the corrected predicate (DB-level backstop). **No migration needed**: the Updater re-applies `triggers.sql` on every 0.7.17+ upgrade (`reapplyTriggers()`), which the reinstall gate Test B exercises.

Also hardened **`scripts/check-expired-reservations.php`** (finding #3/#8): a `flock()` process lock, a state guard + `affected_rows` check on the expiry UPDATE (mark-then-act, idempotent under concurrent runs), and app-tz `DateHelper::today()` instead of the process-tz `date()`.

## Tested
- `tests/loan-overlap.spec.js` → **38/38** (3 new `G.36–G.38`: the SQL predicate, the availability calendar, and the trigger all block the overdue-held copy).
- `loan-state-model` + `loan-reservation-complete` still green (no regression on the 35 existing overlap scenarios either).
- PHPStan L5 clean.