### PR TITLE
fix(loans): promote queue on admin cancel, reassign all holds on lost copy, gate renew eligibility

### DIFF
--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -998,7 +998,21 @@ class PrestitiController
                 // come fa CopyController::updateCopy per lo stesso evento.
                 $reassignmentService = new \App\Services\ReservationReassignmentService($db);
                 $reassignmentService->setExternalTransaction(true);
-                $reassignmentService->reassignOnCopyLost((int) $copia_id);
+                // A lost copy can hold MORE THAN ONE non-overlapping future reservation
+                // (period-based pre-booking, see the comment above). reassignOnCopyLost()
+                // handles a single hold, so loop until none is left pointing at the dead
+                // copy — each call either reassigns the hold to another copy or nulls its
+                // copia_id, so it always makes progress (bounded guard for safety).
+                for ($reassignGuard = 0; $reassignGuard < 1000; $reassignGuard++) {
+                    $stillHeld = $db->query(
+                        "SELECT 1 FROM prestiti WHERE copia_id = " . (int) $copia_id
+                        . " AND stato IN ('prenotato','da_ritirare') AND attivo = 1 LIMIT 1"
+                    );
+                    if (!$stillHeld || $stillHeld->num_rows === 0) {
+                        break;
+                    }
+                    $reassignmentService->reassignOnCopyLost((int) $copia_id);
+                }
             }
 
             // Ricalcola le copie disponibili DOPO l'eventuale riassegnazione/conversione
@@ -1191,6 +1205,17 @@ class PrestitiController
             $errorUrl = $redirectTo ?? url('/admin/loans');
             $separator = strpos($errorUrl, '?') === false ? '?' : '&';
             return $response->withHeader('Location', url($errorUrl . $separator . 'error=loan_not_picked_up'))->withStatus(302);
+        }
+
+        // Borrower eligibility: a suspended / card-expired user must not keep the book via
+        // repeated renewals. This is the single-point-eligibility invariant that store(),
+        // update()'s reassignment and approveLoan() all enforce — renew() was the one
+        // benefit-conferring write path that skipped it.
+        $eligibilityError = \App\Support\LoanEligibility::checkUser($db, (int) $loan['utente_id']);
+        if ($eligibilityError !== null) {
+            $errorUrl = $redirectTo ?? url('/admin/loans');
+            $separator = strpos($errorUrl, '?') === false ? '?' : '&';
+            return $response->withHeader('Location', url($errorUrl . $separator . 'error=' . $eligibilityError))->withStatus(302);
         }
 
         // Check renewal limit (max_renewals configurabile, default 3) — F2

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -249,7 +249,24 @@ class ReservationsAdminController
             $integrity = new \App\Support\DataIntegrity($db);
             $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
 
+            // Cancelling/completing an active reservation frees a slot: promote the next
+            // queued reservation(s) right away, exactly like every other release path
+            // (LoanApproval, Prestiti, …) — otherwise the next in line waits for the
+            // periodic MaintenanceService sweep and the book looks free in the meantime.
+            $reservationManager = null;
+            if ($oldStato === 'attiva' && $stato !== 'attiva') {
+                $reservationManager = new \App\Controllers\ReservationManager($db);
+                $reservationManager->setExternalTransaction(true); // already inside a transaction
+                for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
+                    // promote until the freed capacity is exhausted
+                }
+            }
+
             $db->commit();
+
+            if ($reservationManager !== null) {
+                $reservationManager->flushDeferredNotifications();
+            }
             return $response->withHeader('Location', url('/admin/reservations') . '?updated=1')->withStatus(302);
 
         } catch (\Throwable $e) {

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -261,6 +261,7 @@ class ReservationReassignmentService
             WHERE copia_id = ?
             AND stato IN ('prenotato', 'da_ritirare')
             AND attivo = 1
+            ORDER BY data_prestito ASC, id ASC
             LIMIT 1
         ");
         $stmt->bind_param('i', $copiaId);


### PR DESCRIPTION
Three Medium findings from the deep loan/reservation review.

- **#4 — admin cancel doesn't promote the waitlist.** `ReservationsAdminController::update()` frees a slot when an active reservation is cancelled/completed, but only reordered the queue + recalculated counters — it never promoted the next entry (no `processBookAvailability`, no `reservation_book_available` email). The next in line waited for the periodic sweep while the book looked free and a walk-in could jump the queue. Now runs the same in-transaction promotion loop as every other release path, then `flushDeferredNotifications()`.

- **#5 — lost copy reassigns only one hold.** `reassignOnCopyLost()` handled a single hold (`LIMIT 1`, no loop), but one copy can carry multiple non-overlapping future reservations (period pre-booking). Losing it left the others pinned to a dead copy, unnotified. The lost-copy call site now loops until no hold points at the copy (each call reassigns or nulls `copia_id` → always progresses; bounded guard), and the SELECT is `ORDER BY data_prestito ASC, id ASC`.

- **#6 — renew skips eligibility.** `renew()` never called `LoanEligibility::checkUser`, so a suspended / card-expired borrower could keep the book via repeated renewals — the one benefit-conferring loan write that skipped the single-point-eligibility invariant `store()`/`update()`/`approveLoan()` all enforce. Added the check before the renewal.

## Tested
`loan-overlap` 38/38, `loan-reservation-complete` 26/26 (incl. H.25 renew — the eligibility gate doesn't block eligible users). PHPStan L5 clean.

**#7** (DataIntegrity `CURDATE()`/`NOW()` vs app-tz `DateHelper`) is intentionally **not** in this PR — it's transient/self-healing and spans 18 sites in the core recalc engine, so it gets its own careful PR.