### PR TITLE
fix(loans): reverse-proxy 404, deleted-book availability leak, email locale + confirmations, queue-jump

### DIFF
--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -543,7 +543,7 @@ class PrestitiController
 
                 // Get book and user details for notification
                 $infoStmt = $db->prepare("
-                    SELECT l.titolo, CONCAT(u.nome, ' ', u.cognome) as utente_nome
+                    SELECT l.titolo, CONCAT(u.nome, ' ', u.cognome) as utente_nome, p.stato
                     FROM prestiti p
                     JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
                     JOIN utenti u ON p.utente_id = u.id
@@ -562,6 +562,16 @@ class PrestitiController
                         url('/admin/loans'),
                         $newLoanId
                     );
+
+                    // #14: an admin-created (origine='diretto') loan sent the borrower no
+                    // confirmation, unlike the request→approve flow which always emails.
+                    // Mirror approveLoan() for the scheduled states. 'in_corso' means the
+                    // patron is at the desk right now, so no email is needed there.
+                    if (($loanInfo['stato'] ?? '') === 'prenotato') {
+                        $notificationService->sendLoanApprovedNotification($newLoanId);
+                    } elseif (($loanInfo['stato'] ?? '') === 'da_ritirare') {
+                        $notificationService->sendPickupReadyNotification($newLoanId);
+                    }
                 }
             } catch (\Throwable $e) {
                 SecureLogger::warning(__('Notifica prestito fallita'), ['error' => $e->getMessage()]);

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -235,8 +235,23 @@ class ReservationsAdminController
                 }
             }
 
-            $stmt = $db->prepare("UPDATE prenotazioni SET stato=?, data_prenotazione=?, data_scadenza_prenotazione=?, data_inizio_richiesta=?, data_fine_richiesta=? WHERE id=?");
-            $stmt->bind_param('sssssi', $stato, $startDt, $endDt, $dataInizioRichiesta, $dataFineRichiesta, $id);
+            // #13: reactivating a cancelled/completed reservation must NOT keep its old
+            // (small) queue_position — that would jump it ahead of everyone who waited
+            // continuously. Append it to the tail, exactly like store() does.
+            $reactivating = ($oldStato !== 'attiva' && $stato === 'attiva');
+            if ($reactivating) {
+                $posStmt = $db->prepare("SELECT COALESCE(MAX(queue_position), 0) + 1 AS position FROM prenotazioni WHERE libro_id = ? AND stato = 'attiva'");
+                $posStmt->bind_param('i', $libroId);
+                $posStmt->execute();
+                $newPosition = (int) ($posStmt->get_result()->fetch_assoc()['position'] ?? 1);
+                $posStmt->close();
+
+                $stmt = $db->prepare("UPDATE prenotazioni SET stato=?, data_prenotazione=?, data_scadenza_prenotazione=?, data_inizio_richiesta=?, data_fine_richiesta=?, queue_position=? WHERE id=?");
+                $stmt->bind_param('sssssii', $stato, $startDt, $endDt, $dataInizioRichiesta, $dataFineRichiesta, $newPosition, $id);
+            } else {
+                $stmt = $db->prepare("UPDATE prenotazioni SET stato=?, data_prenotazione=?, data_scadenza_prenotazione=?, data_inizio_richiesta=?, data_fine_richiesta=? WHERE id=?");
+                $stmt->bind_param('sssssi', $stato, $startDt, $endDt, $dataInizioRichiesta, $dataFineRichiesta, $id);
+            }
             if (!$stmt->execute()) {
                 throw new \RuntimeException('Reservation update failed');
             }

--- a/app/Controllers/ReservationsController.php
+++ b/app/Controllers/ReservationsController.php
@@ -43,6 +43,20 @@ class ReservationsController
     public function getBookAvailability($request, $response, $args)
     {
         $bookId = (int) $args['id'];
+
+        // A soft-deleted (or non-existent) book must not leak availability — getBookTotalCopies()
+        // counts copie rows directly, which survive the book's soft-delete, so this public
+        // endpoint would otherwise serve real counts for an invisible book.
+        $existsStmt = $this->db->prepare("SELECT 1 FROM libri WHERE id = ? AND deleted_at IS NULL LIMIT 1");
+        $existsStmt->bind_param('i', $bookId);
+        $existsStmt->execute();
+        $bookExists = $existsStmt->get_result()->num_rows > 0;
+        $existsStmt->close();
+        if (!$bookExists) {
+            $response->getBody()->write(json_encode(['error' => true, 'message' => __('Libro non trovato')]));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(404);
+        }
+
         $totalCopies = $this->getBookTotalCopies($bookId);
 
         // Get current and future loans for this book. Approved states always

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -957,7 +957,7 @@ class NotificationService {
                 'pickup_instructions' => 'Recati in biblioteca durante gli orari di apertura per ritirare il libro.'
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_approved', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_approved', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send loan approved notification: " . $e->getMessage());
@@ -994,7 +994,7 @@ class NotificationService {
                 'motivo_rifiuto' => $reason ?: __('Nessun motivo specificato')
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_rejected', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_rejected', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send loan rejected notification: " . $e->getMessage());
@@ -1024,7 +1024,7 @@ class NotificationService {
                 'motivo_rifiuto' => $reason ?: __('Nessun motivo specificato')
             ];
 
-            return $this->emailService->sendTemplate($userEmail, 'loan_rejected', $variables);
+            return $this->emailService->sendTemplate($userEmail, 'loan_rejected', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send loan rejected notification (direct): " . $e->getMessage());
@@ -1070,7 +1070,7 @@ class NotificationService {
                 'pickup_instructions' => __('Recati in biblioteca durante gli orari di apertura per ritirare il libro.')
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_ready', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_ready', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send pickup ready notification: " . $e->getMessage());
@@ -1107,7 +1107,7 @@ class NotificationService {
                 'scadenza_ritiro' => $loan['pickup_deadline'] ? $this->formatEmailDate($loan['pickup_deadline']) : ''
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_expired', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_expired', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send pickup expired notification: " . $e->getMessage());
@@ -1144,7 +1144,7 @@ class NotificationService {
                 'motivo' => $reason ?: __('Ritiro non effettuato entro la scadenza')
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_cancelled', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_pickup_cancelled', $variables, \App\Support\I18n::getInstallationLocale());
 
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send pickup cancelled notification: " . $e->getMessage());
@@ -1156,7 +1156,7 @@ class NotificationService {
      * Send reservation book available notification
      */
     public function sendReservationBookAvailable(string $email, array $variables): bool {
-        return $this->emailService->sendTemplate($email, 'reservation_book_available', $variables);
+        return $this->emailService->sendTemplate($email, 'reservation_book_available', $variables, \App\Support\I18n::getInstallationLocale());
     }
 
     /**
@@ -1191,7 +1191,7 @@ class NotificationService {
                 'data_restituzione' => $this->formatEmailDate($loan['data_restituzione'] ?? DateHelper::today()),
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_returned', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'loan_returned', $variables, \App\Support\I18n::getInstallationLocale());
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send loan returned notification: " . $e->getMessage());
             return false;
@@ -1232,7 +1232,7 @@ class NotificationService {
                 'data_scadenza' => $this->formatEmailDate($scadenza),
             ];
 
-            return $this->emailService->sendTemplate($loan['utente_email'], 'reservation_expired', $variables);
+            return $this->emailService->sendTemplate($loan['utente_email'], 'reservation_expired', $variables, \App\Support\I18n::getInstallationLocale());
         } catch (\Throwable $e) {
             SecureLogger::error("Failed to send reservation expired notification: " . $e->getMessage());
             return false;
@@ -1246,7 +1246,7 @@ class NotificationService {
         if (empty($email)) {
             return false;
         }
-        return $this->emailService->sendTemplate($email, 'copy_unavailable_user', $variables);
+        return $this->emailService->sendTemplate($email, 'copy_unavailable_user', $variables, \App\Support\I18n::getInstallationLocale());
     }
 
     /**
@@ -1262,7 +1262,7 @@ class NotificationService {
         if (!empty($variables['data_scadenza'])) {
             $variables['data_scadenza'] = $this->formatEmailDate((string)$variables['data_scadenza']);
         }
-        return $this->emailService->sendTemplate($email, 'reservation_expired', $variables);
+        return $this->emailService->sendTemplate($email, 'reservation_expired', $variables, \App\Support\I18n::getInstallationLocale());
     }
 
     /**
@@ -1273,7 +1273,7 @@ class NotificationService {
         if (empty($email)) {
             return false;
         }
-        return $this->emailService->sendTemplate($email, 'reservation_cancelled', $variables);
+        return $this->emailService->sendTemplate($email, 'reservation_cancelled', $variables, \App\Support\I18n::getInstallationLocale());
     }
 
     /**
@@ -1290,7 +1290,7 @@ class NotificationService {
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {
             try {
-                if ($this->emailService->sendTemplate($email, $template, $variables)) {
+                if ($this->emailService->sendTemplate($email, $template, $variables, \App\Support\I18n::getInstallationLocale())) {
                     if ($attempt > 1) {
                         SecureLogger::info("Email to {$email} succeeded on attempt {$attempt}");
                     }

--- a/app/Views/partials/loan-actions-swal.php
+++ b/app/Views/partials/loan-actions-swal.php
@@ -129,7 +129,11 @@ $loanActionTranslations = array_merge([
   };
 
   const sendRequest = async (url, payload, csrf) => {
-    const response = await fetch(url, {
+    // Prefix the app base path so the admin loan actions work on subdirectory installs
+    // (e.g. https://host/biblioteca/…). The call sites pass root-relative paths like
+    // '/admin/loans/approve'; without BASE_PATH they'd 404 and the action silently fails.
+    const base = (typeof window !== 'undefined' && window.BASE_PATH) ? window.BASE_PATH : '';
+    const response = await fetch(base + url, {
       method: 'POST',
       credentials: 'same-origin',
       headers: {


### PR DESCRIPTION
Low-severity findings from the deep loan/reservation review (the higher-value subset).

- **#9 — admin loan actions 404 on subdirectory installs.** `loan-actions-swal.php` posted approve/reject/confirm-pickup/cancel-pickup to hardcoded root paths (no `BASE_PATH`), so on `/biblioteca/…` they 404 and the action silently failed. `sendRequest()` now prefixes `window.BASE_PATH`.
- **#17 — deleted book leaks availability.** `getBookAvailability()` starts from `getBookTotalCopies()`, which counts `copie` rows directly — they survive the book's soft-delete — so the public availability calendar served real counts for an invisible book. Added a `libri.deleted_at IS NULL` guard → 404.
- **#15 — borrower emails use the admin's session locale.** The admin-triggered emails (approved/rejected/pickup/returned/reservation) were sent without the locale arg → the acting admin's session locale instead of the installation locale. A bilingual admin switching their dashboard to en_US made Italian patrons get English mail. All now pass `I18n::getInstallationLocale()` (cron paths already did).
- **#14 — admin-direct loan sends no confirmation.** An `origine=diretto` loan only fired an admin in-app notice, unlike approve. Now sends `loan_approved` (prenotato) / `pickup_ready` (da_ritirare); `in_corso` (patron at the desk) stays silent.
- **#13 — queue-jump on reactivation.** Reactivating a cancelled/completed reservation kept its old (small) `queue_position` and jumped ahead of everyone who waited — now it appends to the tail (`MAX+1`), like `store()`.

## Tested
`loan-overlap` 38/38, `loan-reservation-complete` 26/26. PHPStan L5 clean.

**Remaining Low** tracked separately: #10–#12 (narrow `update()` reassignment guard gaps) and #16 (cosmetic i18n cleanup).