### PR TITLE
feat(mobile-api): configurable trusted proxies + reverse-proxy auto-diagnosis

### DIFF
--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6431,5 +6431,9 @@
   "La valutazione deve essere tra 1 e 5 stelle.": "Die Bewertung muss zwischen 1 und 5 Sternen liegen.",
   "Nessuna recensione da eliminare.": "Keine Rezension zum Löschen.",
   "Puoi recensire solo i titoli che hai preso in prestito.": "Du kannst nur Titel rezensieren, die du ausgeliehen hast.",
-  "Testo della recensione non valido.": "Ungültiger Rezensionstext."
+  "Testo della recensione non valido.": "Ungültiger Rezensionstext.",
+  "Proxy fidati (reverse proxy)": "Vertrauenswürdige Proxys (Reverse Proxy)",
+  "Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l'app accetta l'header X-Forwarded-Proto e l'API non risponde \"HTTPS richiesto\" anche su HTTPS reale.": "Wenn Pinakes hinter einem Reverse Proxy (NAS/QNAP/Synology/nginx/Docker) läuft, der TLS terminiert, tragen Sie hier die IPs oder Netze (CIDR) des Proxys ein: nur dann akzeptiert die App den X-Forwarded-Proto-Header und die API antwortet nicht mehr mit „HTTPS erforderlich“ – auch über echtes HTTPS.",
+  "Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell'indirizzo non è ancora fidato: l'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.": "Reverse Proxy unter %s erkannt, der HTTPS weiterleitet, aber diese Adresse ist noch nicht vertrauenswürdig: die App würde einen HTTPS-Fehler erhalten. Fügen Sie sie oben zur Liste hinzu und speichern Sie.",
+  "Aggiungi %s": "%s hinzufügen"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6431,5 +6431,9 @@
   "La valutazione deve essere tra 1 e 5 stelle.": "The rating must be between 1 and 5 stars.",
   "Nessuna recensione da eliminare.": "No review to delete.",
   "Puoi recensire solo i titoli che hai preso in prestito.": "You can only review titles you have borrowed.",
-  "Testo della recensione non valido.": "Invalid review text."
+  "Testo della recensione non valido.": "Invalid review text.",
+  "Proxy fidati (reverse proxy)": "Trusted proxies (reverse proxy)",
+  "Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l'app accetta l'header X-Forwarded-Proto e l'API non risponde \"HTTPS richiesto\" anche su HTTPS reale.": "If Pinakes runs behind a reverse proxy (NAS/QNAP/Synology/nginx/Docker) that terminates TLS, list the proxy's IPs or networks (CIDR) here: only then does the app accept the X-Forwarded-Proto header and the API stops answering \"HTTPS required\" even over real HTTPS.",
+  "Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell'indirizzo non è ancora fidato: l'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.": "Detected a reverse proxy at %s forwarding HTTPS, but that address isn't trusted yet: the app would get an HTTPS error. Add it to the list above and save.",
+  "Aggiungi %s": "Add %s"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6431,5 +6431,9 @@
   "La valutazione deve essere tra 1 e 5 stelle.": "La note doit être comprise entre 1 et 5 étoiles.",
   "Nessuna recensione da eliminare.": "Aucune critique à supprimer.",
   "Puoi recensire solo i titoli che hai preso in prestito.": "Vous ne pouvez évaluer que les titres que vous avez empruntés.",
-  "Testo della recensione non valido.": "Texte de critique non valide."
+  "Testo della recensione non valido.": "Texte de critique non valide.",
+  "Proxy fidati (reverse proxy)": "Proxys de confiance (reverse proxy)",
+  "Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l'app accetta l'header X-Forwarded-Proto e l'API non risponde \"HTTPS richiesto\" anche su HTTPS reale.": "Si Pinakes est derrière un reverse proxy (NAS/QNAP/Synology/nginx/Docker) qui termine le TLS, indiquez ici les IP ou réseaux (CIDR) du proxy : c'est la seule façon pour que l'app accepte l'en-tête X-Forwarded-Proto et que l'API cesse de répondre « HTTPS requis » même en HTTPS réel.",
+  "Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell'indirizzo non è ancora fidato: l'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.": "Reverse proxy détecté à %s qui transmet HTTPS, mais cette adresse n'est pas encore de confiance : l'app recevrait une erreur HTTPS. Ajoutez-la à la liste ci-dessus et enregistrez.",
+  "Aggiungi %s": "Ajouter %s"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6431,5 +6431,9 @@
   "La valutazione deve essere tra 1 e 5 stelle.": "La valutazione deve essere tra 1 e 5 stelle.",
   "Nessuna recensione da eliminare.": "Nessuna recensione da eliminare.",
   "Puoi recensire solo i titoli che hai preso in prestito.": "Puoi recensire solo i titoli che hai preso in prestito.",
-  "Testo della recensione non valido.": "Testo della recensione non valido."
+  "Testo della recensione non valido.": "Testo della recensione non valido.",
+  "Proxy fidati (reverse proxy)": "Proxy fidati (reverse proxy)",
+  "Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l'app accetta l'header X-Forwarded-Proto e l'API non risponde \"HTTPS richiesto\" anche su HTTPS reale.": "Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l'app accetta l'header X-Forwarded-Proto e l'API non risponde \"HTTPS richiesto\" anche su HTTPS reale.",
+  "Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell'indirizzo non è ancora fidato: l'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.": "Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell'indirizzo non è ancora fidato: l'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.",
+  "Aggiungi %s": "Aggiungi %s"
 }

--- a/storage/plugins/mobile-api/MobileApiPlugin.php
+++ b/storage/plugins/mobile-api/MobileApiPlugin.php
@@ -82,6 +82,11 @@ class MobileApiPlugin
     private const PUSH_PROVIDER_KEY        = 'push_provider';
     private const PUSH_VAPID_SUBJECT_KEY   = 'push_vapid_subject';
     private const PUSH_FCM_CREDENTIALS_KEY = 'push_fcm_credentials';
+    // Trusted reverse-proxy peers (IP / CIDR, comma-separated). When the app-facing
+    // request arrives over a proxy that terminates TLS, X-Forwarded-Proto: https is only
+    // honoured from these peers (see ProxyTrust). Configurable here so operators behind a
+    // NAS/reverse proxy don't have to edit .env to stop the /api/v1 HTTPS 426.
+    private const TRUSTED_PROXIES_KEY      = 'trusted_proxies';
     // VAPID keypair (RFC 8292), generated once per instance. Public key is shared
     // with the app (applicationServerKey) and sent as the `k=` value; the private
     // key is stored encrypted at rest (SettingsEncryption).
@@ -680,6 +685,7 @@ class MobileApiPlugin
             'enabled'              => $repo->get(self::ENABLE_CATEGORY, self::ENABLE_KEY, '0') ?? '0',
             'push_provider'        => $repo->get(self::ENABLE_CATEGORY, self::PUSH_PROVIDER_KEY, 'unifiedpush') ?? 'unifiedpush',
             'push_vapid_subject'   => $repo->get(self::ENABLE_CATEGORY, self::PUSH_VAPID_SUBJECT_KEY, '') ?? '',
+            'trusted_proxies'      => $repo->get(self::ENABLE_CATEGORY, self::TRUSTED_PROXIES_KEY, '') ?? '',
             'push_fcm_credentials' => $this->fcmCredentials(),
             'push_vapid_public_key' => $repo->get(self::ENABLE_CATEGORY, self::PUSH_VAPID_PUBLIC_KEY, '') ?? '',
         ];
@@ -750,6 +756,30 @@ class MobileApiPlugin
                 $repo->set(self::ENABLE_CATEGORY, self::ENABLE_KEY, $value);
                 // Keep ConfigStore's cache coherent for in-request reads.
                 \App\Support\ConfigStore::set(self::ENABLE_CATEGORY . '.' . self::ENABLE_KEY, $value);
+            }
+
+            if (array_key_exists('trusted_proxies', $settings)) {
+                // Keep only valid IPs / CIDRs so an invalid entry can't poison ProxyTrust's
+                // parser; store as a normalised comma list. ConfigStore::set keeps the value
+                // readable in the same request (ProxyTrust reads it via ConfigStore::get).
+                $clean = [];
+                foreach (explode(',', (string) $settings['trusted_proxies']) as $entry) {
+                    $entry = trim($entry);
+                    if ($entry === '') {
+                        continue;
+                    }
+                    if (strpos($entry, '/') !== false) {
+                        [$net, $len] = explode('/', $entry, 2);
+                        if (filter_var($net, FILTER_VALIDATE_IP) !== false && ctype_digit($len)) {
+                            $clean[] = $entry;
+                        }
+                    } elseif (filter_var($entry, FILTER_VALIDATE_IP) !== false) {
+                        $clean[] = $entry;
+                    }
+                }
+                $value = implode(', ', $clean);
+                $repo->set(self::ENABLE_CATEGORY, self::TRUSTED_PROXIES_KEY, $value);
+                \App\Support\ConfigStore::set(self::ENABLE_CATEGORY . '.' . self::TRUSTED_PROXIES_KEY, $value);
             }
 
             if (array_key_exists('push_provider', $settings)) {

--- a/storage/plugins/mobile-api/plugin.json
+++ b/storage/plugins/mobile-api/plugin.json
@@ -2,7 +2,7 @@
   "name": "mobile-api",
   "display_name": "Mobile API",
   "description": "API REST/JSON versionata (/api/v1) per l'app companion mobile di Pinakes: discovery, autenticazione a token per dispositivo, ricerca catalogo, prestiti/prenotazioni, wishlist, profilo, messaggi e notifiche push. Disattivata per default finché non viene abilitata.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "",

--- a/storage/plugins/mobile-api/src/Support/ProxyTrust.php
+++ b/storage/plugins/mobile-api/src/Support/ProxyTrust.php
@@ -20,16 +20,91 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 final class ProxyTrust
 {
     /**
-     * Whether the request's TCP peer is in the configured TRUSTED_PROXIES list.
+     * The configured trusted-proxy entries (exact IPs / CIDRs), from BOTH the
+     * TRUSTED_PROXIES env var AND the `mobile_api.trusted_proxies` admin setting.
+     * Either source is enough — so an operator behind a reverse proxy (QNAP/Synology/
+     * nginx/Docker) can fix the "HTTPS required / 426" case from the settings UI without
+     * editing .env.
+     *
+     * @return list<string>
+     */
+    /** Per-request cache of the DB setting so the middleware doesn't re-query per call. */
+    private static ?string $settingCache = null;
+
+    public static function trustedEntries(): array
+    {
+        $sources = [];
+        $env = $_ENV['TRUSTED_PROXIES'] ?? getenv('TRUSTED_PROXIES');
+        if (is_string($env)) {
+            $sources[] = $env;
+        }
+        // The mobile_api.trusted_proxies admin setting lives in system_settings; ConfigStore
+        // only exposes a fixed set of known paths, so read it directly (mirrors how the
+        // plugin persists it via its settings repo).
+        $sources[] = self::settingValue();
+
+        $entries = [];
+        foreach ($sources as $raw) {
+            foreach (explode(',', $raw) as $entry) {
+                $entry = trim($entry);
+                if ($entry !== '') {
+                    $entries[] = $entry;
+                }
+            }
+        }
+        return $entries;
+    }
+
+    /**
+     * Read mobile_api.trusted_proxies straight from system_settings (ConfigStore only
+     * exposes a fixed set of known paths). Cached per request. Any failure yields '' — a
+     * settings read must never turn the HTTPS gate into a hard error.
+     */
+    private static function settingValue(): string
+    {
+        if (self::$settingCache !== null) {
+            return self::$settingCache;
+        }
+        self::$settingCache = '';
+
+        $host   = (string) ($_ENV['DB_HOST'] ?? getenv('DB_HOST') ?: 'localhost');
+        $name   = (string) ($_ENV['DB_NAME'] ?? getenv('DB_NAME') ?: '');
+        $user   = (string) ($_ENV['DB_USER'] ?? getenv('DB_USER') ?: '');
+        $pass   = (string) ($_ENV['DB_PASS'] ?? getenv('DB_PASS') ?: ($_ENV['DB_PASSWORD'] ?? getenv('DB_PASSWORD') ?: ''));
+        $port   = (int) ($_ENV['DB_PORT'] ?? getenv('DB_PORT') ?: 3306);
+        $socket = (string) ($_ENV['DB_SOCKET'] ?? getenv('DB_SOCKET') ?: '');
+        if ($name === '' || $user === '') {
+            return self::$settingCache;
+        }
+
+        try {
+            $db = $socket !== ''
+                ? new \mysqli(null, $user, $pass, $name, 0, $socket)
+                : new \mysqli($host, $user, $pass, $name, $port);
+            $stmt = $db->prepare("SELECT setting_value FROM system_settings WHERE category = 'mobile_api' AND setting_key = 'trusted_proxies' LIMIT 1");
+            if ($stmt !== false) {
+                $stmt->execute();
+                $res = $stmt->get_result();
+                $row = $res ? $res->fetch_row() : null;
+                if ($row !== null && is_string($row[0])) {
+                    self::$settingCache = $row[0];
+                }
+                $stmt->close();
+            }
+            $db->close();
+        } catch (\Throwable $e) {
+            // stay with '' — never break the HTTPS gate on a settings-read failure
+        }
+
+        return self::$settingCache;
+    }
+
+    /**
+     * Whether the request's TCP peer is in the configured trusted-proxy list
+     * (TRUSTED_PROXIES env + mobile_api.trusted_proxies setting).
      */
     public static function isTrustedProxy(Request $request): bool
     {
-        $trustedRaw = $_ENV['TRUSTED_PROXIES'] ?? getenv('TRUSTED_PROXIES');
-        $trustedEnv = is_string($trustedRaw) ? trim($trustedRaw) : '';
-        if ($trustedEnv === '') {
-            return false;
-        }
-
         $server     = $request->getServerParams();
         $remoteAddr = trim((string) ($server['REMOTE_ADDR'] ?? ''));
         if ($remoteAddr === '') {
@@ -41,7 +116,11 @@ final class ProxyTrust
             return false;
         }
 
-        $entries = array_map('trim', explode(',', $trustedEnv));
+        $entries = self::trustedEntries();
+        if ($entries === []) {
+            return false;
+        }
+
         foreach ($entries as $entry) {
             if ($entry === '') {
                 continue;

--- a/storage/plugins/mobile-api/views/settings.php
+++ b/storage/plugins/mobile-api/views/settings.php
@@ -57,6 +57,7 @@ if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'POST') {
             'push_provider'        => $pushProvider,
             'push_vapid_subject'   => (string) ($_POST['push_vapid_subject'] ?? ''),
             'push_fcm_credentials' => (string) ($_POST['push_fcm_credentials'] ?? ''),
+            'trusted_proxies'      => (string) ($_POST['trusted_proxies'] ?? ''),
         ])) {
             $successMessage = __('Impostazioni salvate correttamente.');
         } else {
@@ -72,6 +73,25 @@ $isEnabled = (($settings['enabled'] ?? '0') === '1');
 $pushProvider = (string) ($settings['push_provider'] ?? 'unifiedpush');
 /** @var string $vapidSubject */
 $vapidSubject = (string) ($settings['push_vapid_subject'] ?? '');
+/** @var string $trustedProxies */
+$trustedProxies = (string) ($settings['trusted_proxies'] ?? '');
+
+// Reverse-proxy auto-diagnosis: if THIS admin request arrived with X-Forwarded-Proto set
+// by a proxy whose IP isn't trusted yet, the app-facing /api/v1 will 426 ("HTTPS required")
+// even over real HTTPS. Detect it so we can offer the exact IP to add.
+$fwdProto = strtolower(trim((string) ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '')));
+$proxyRemoteAddr = trim((string) ($_SERVER['REMOTE_ADDR'] ?? ''));
+$proxyTrusted = false;
+if ($proxyRemoteAddr !== '') {
+    foreach (\App\Plugins\MobileApi\Support\ProxyTrust::trustedEntries() as $entry) {
+        if ($entry === $proxyRemoteAddr) {
+            $proxyTrusted = true;
+            break;
+        }
+    }
+}
+$isLoopbackPeer = ($proxyRemoteAddr === '::1' || preg_match('/^127\./', $proxyRemoteAddr) === 1);
+$showProxyHint = ($fwdProto !== '' && $proxyRemoteAddr !== '' && !$proxyTrusted && !$isLoopbackPeer);
 /** @var string $fcmCredentials */
 $fcmCredentials = (string) ($settings['push_fcm_credentials'] ?? '');
 $csrfToken = \App\Support\Csrf::ensureToken();
@@ -227,6 +247,30 @@ $tabDevicesUrl  = htmlspecialchars(url('/admin/plugins/' . $resolvedId . '/setti
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
               <?= htmlspecialchars(__('Lascia vuoto per usare solo UnifiedPush / feed in-app.'), ENT_QUOTES, 'UTF-8') ?>
             </p>
+          </div>
+
+          <div>
+            <label for="trusted_proxies" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <?= htmlspecialchars(__('Proxy fidati (reverse proxy)'), ENT_QUOTES, 'UTF-8') ?>
+            </label>
+            <input type="text" id="trusted_proxies" name="trusted_proxies"
+                   value="<?= htmlspecialchars($trustedProxies, ENT_QUOTES, 'UTF-8') ?>"
+                   placeholder="127.0.0.1, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16"
+                   class="block w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white text-sm font-mono focus:border-blue-500 focus:ring-blue-500">
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              <?= htmlspecialchars(__('Se Pinakes è dietro un reverse proxy (NAS/QNAP/Synology/nginx/Docker) che termina il TLS, elenca qui gli IP o le reti (CIDR) del proxy: solo così l\'app accetta l\'header X-Forwarded-Proto e l\'API non risponde "HTTPS richiesto" anche su HTTPS reale.'), ENT_QUOTES, 'UTF-8') ?>
+            </p>
+            <?php if ($showProxyHint): ?>
+              <div class="mt-2 rounded-lg border border-amber-300 bg-amber-50 dark:border-amber-700 dark:bg-amber-900/30 p-3 text-xs text-amber-800 dark:text-amber-200">
+                <i class="fas fa-triangle-exclamation mr-1"></i>
+                <?= htmlspecialchars(sprintf(__('Rilevato un reverse proxy da %s che inoltra HTTPS, ma quell\'indirizzo non è ancora fidato: l\'app riceverebbe un errore HTTPS. Aggiungilo alla lista qui sopra e salva.'), $proxyRemoteAddr), ENT_QUOTES, 'UTF-8') ?>
+                <button type="button"
+                        onclick="var f=document.getElementById('trusted_proxies');f.value=(f.value.trim()?f.value.trim().replace(/,\s*$/,'')+', ':'')+<?= json_encode($proxyRemoteAddr, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;"
+                        class="ml-1 underline font-medium">
+                  <?= htmlspecialchars(sprintf(__('Aggiungi %s'), $proxyRemoteAddr), ENT_QUOTES, 'UTF-8') ?>
+                </button>
+              </div>
+            <?php endif; ?>
           </div>
         </div>
       </div>

--- a/tests/mobile-api-proxy-trust.unit.php
+++ b/tests/mobile-api-proxy-trust.unit.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral test for App\Plugins\MobileApi\Support\ProxyTrust — the gate that decides
+ * whether X-Forwarded-Proto from a reverse proxy is honoured on the /api/v1 HTTPS check.
+ *
+ * The mobile_api.trusted_proxies admin setting (added so operators behind a NAS/reverse
+ * proxy can fix the 426 from the UI) is read straight from system_settings — ConfigStore
+ * only exposes a fixed set of known paths — and matched against the request's REMOTE_ADDR
+ * with exact-IP and CIDR support. This asserts that read + the matching, then restores the
+ * original setting.
+ *
+ * Run:  php tests/mobile-api-proxy-trust.unit.php   Exit 0 on "ALL <n> PASS".
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+require $root . '/storage/plugins/mobile-api/src/Support/ProxyTrust.php';
+
+use App\Plugins\MobileApi\Support\ProxyTrust;
+use App\Support\ConfigStore;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+// Load .env so ConfigStore/ProxyTrust can reach the DB; skip cleanly if unavailable.
+try {
+    \Dotenv\Dotenv::createImmutable($root)->safeLoad();
+} catch (\Throwable $e) {
+    // safeLoad never throws on a missing file, but be defensive.
+}
+if (($_ENV['DB_NAME'] ?? getenv('DB_NAME')) === false && ($_ENV['DB_NAME'] ?? '') === '') {
+    echo "SKIP: no DB config in environment\n";
+    exit(0);
+}
+
+$TESTNO = 0;
+function check(bool $cond, string $desc): void
+{
+    global $TESTNO;
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+
+// Preserve whatever the instance already has, so the test is non-destructive. Read it with
+// a direct query — ConfigStore::get doesn't expose this path, and calling ProxyTrust here
+// would prime its per-request cache before we write the test value.
+$readOriginal = static function (): string {
+    $host = (string) ($_ENV['DB_HOST'] ?? getenv('DB_HOST') ?: 'localhost');
+    $name = (string) ($_ENV['DB_NAME'] ?? getenv('DB_NAME') ?: '');
+    $user = (string) ($_ENV['DB_USER'] ?? getenv('DB_USER') ?: '');
+    $pass = (string) ($_ENV['DB_PASS'] ?? getenv('DB_PASS') ?: ($_ENV['DB_PASSWORD'] ?? getenv('DB_PASSWORD') ?: ''));
+    $port = (int) ($_ENV['DB_PORT'] ?? getenv('DB_PORT') ?: 3306);
+    $sock = (string) ($_ENV['DB_SOCKET'] ?? getenv('DB_SOCKET') ?: '');
+    try {
+        $db = $sock !== '' ? new \mysqli(null, $user, $pass, $name, 0, $sock) : new \mysqli($host, $user, $pass, $name, $port);
+        $r = $db->query("SELECT setting_value FROM system_settings WHERE category='mobile_api' AND setting_key='trusted_proxies' LIMIT 1");
+        $row = $r ? $r->fetch_row() : null;
+        $db->close();
+        return ($row !== null && is_string($row[0])) ? $row[0] : '';
+    } catch (\Throwable $e) {
+        return '';
+    }
+};
+$original = $readOriginal();
+$restore = static function () use ($original): void {
+    try {
+        ConfigStore::set('mobile_api.trusted_proxies', $original);
+    } catch (\Throwable $ignored) {
+    }
+};
+set_exception_handler(static function (\Throwable $e) use ($restore): void {
+    $restore();
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n");
+    exit(1);
+});
+
+try {
+    ConfigStore::set('mobile_api.trusted_proxies', '203.0.113.7, 10.1.0.0/16, 2001:db8::/32');
+} catch (\Throwable $e) {
+    echo "SKIP: cannot write settings (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+
+// The per-request static cache must be primed against the value we just wrote — it is null
+// on first read here, so trustedEntries() will query system_settings fresh.
+$entries = ProxyTrust::trustedEntries();
+check(in_array('203.0.113.7', $entries, true), "trustedEntries() reads the DB setting (exact IPv4)");
+check(in_array('10.1.0.0/16', $entries, true), "trustedEntries() reads the DB setting (CIDR)");
+
+$fac = new ServerRequestFactory();
+$peer = static function (string $ip) use ($fac) {
+    return $fac->createServerRequest('GET', 'https://host/api/v1/health', ['REMOTE_ADDR' => $ip]);
+};
+
+check(ProxyTrust::isTrustedProxy($peer('203.0.113.7')) === true, "exact IPv4 match is trusted");
+check(ProxyTrust::isTrustedProxy($peer('10.1.2.3')) === true, "an IPv4 inside 10.1.0.0/16 is trusted");
+check(ProxyTrust::isTrustedProxy($peer('10.2.0.1')) === false, "an IPv4 outside the CIDR is not trusted");
+check(ProxyTrust::isTrustedProxy($peer('8.8.8.8')) === false, "an unrelated IPv4 is not trusted");
+check(ProxyTrust::isTrustedProxy($peer('2001:db8::1')) === true, "an IPv6 inside 2001:db8::/32 is trusted");
+check(ProxyTrust::isTrustedProxy($peer('')) === false, "an empty REMOTE_ADDR is never trusted");
+
+$restore();
+printf("\nALL %d PASS\n", $TESTNO);
+exit(0);


### PR DESCRIPTION
Makes the reverse-proxy setup that tripped up issue #16 fixable from the UI, for everyone.

## The problem
A self-hoster behind a reverse proxy that terminates TLS (QNAP / Synology / nginx / Traefik / Docker) gets a confusing **HTTP 426 "HTTPS required"** on `/api/v1` even over real HTTPS. The proxy forwards the request internally as HTTP with `X-Forwarded-Proto: https`, but `ProxyTrust` only honours that header from a peer listed in `TRUSTED_PROXIES` — and the only way to set it was the `.env` file, with no hint about *which* IP to add. (In #16 the untrusted peer was the QNAP Docker gateway, `172.29.0.1`.)

## The fix
- **New `mobile_api.trusted_proxies` admin setting** (IP / CIDR list, IPv4 + IPv6). `ProxyTrust` now reads it — **directly from `system_settings`**, because `ConfigStore` only exposes a fixed set of known paths — **merged** with the `TRUSTED_PROXIES` env var, so either source works. The reverse-proxy case is now fixable from the settings UI without touching `.env`.
- **Settings page**: a "Trusted proxies" field, plus **auto-diagnosis** — when the admins own request arrives with `X-Forwarded-Proto` from a not-yet-trusted, non-loopback peer, a banner shows the **exact detected IP** with a one-click "add it".
- i18n for all four locales; mobile-api plugin bumped `1.2.0 → 1.2.1`.

## Tested
- `tests/mobile-api-proxy-trust.unit.php` — 8 checks: real DB read of the setting + exact-IP / CIDR / IPv6 matching, non-destructive (saves & restores the original value). Runs in CI via the `tests/*.unit.php` glob.
- Browser: the field + placeholder render on the mobile-api settings page.
- PHPStan L5 clean.

Note: issue #16s *immediate* case is now a TLS-chain issue on the reporters NAS (server serves the expired DST Root CA X3), which no code change fixes — but this makes the 426/trusted-proxy step, which every reverse-proxy user hits, self-service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta la configurazione dei **proxy fidati** nelle impostazioni Mobile API, con supporto per IP e range CIDR.
  * La pagina segnala automaticamente quando rileva un reverse proxy non ancora fidato e propone di aggiungerlo con un clic.

* **Bug Fixes**
  * Migliorata la gestione di `X-Forwarded-Proto` per evitare errori di accesso HTTPS quando TLS termina su un proxy intermedio.
  * Aggiunti messaggi localizzati aggiornati in più lingue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->