### PR TITLE
fix(pdf): use Unicode dejavusans font so non-Latin-1 characters render

### DIFF
--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2716,7 +2716,7 @@ class LibriController
         $totalHeight += 3.5; // App name
 
         // Calculate title height (using getStringHeight)
-        $pdf->SetFont('helvetica', 'B', $fontSizeTitle);
+        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
         $titleHeight = $pdf->getStringHeight($availableWidth, $titolo);
         $totalHeight += $titleHeight + 0.5;
 
@@ -2758,20 +2758,20 @@ class LibriController
         $currentY = $margin + $verticalOffset;
 
         // App name
-        $pdf->SetFont('helvetica', 'B', $fontSizeApp);
+        $pdf->SetFont('dejavusans', 'B', $fontSizeApp);
         $pdf->SetXY($margin, $currentY);
         $pdf->Cell($availableWidth, 3, $appNameShort, 0, 0, 'C');
         $currentY += 3.5;
 
         // Titolo libro (wrapped)
-        $pdf->SetFont('helvetica', 'B', $fontSizeTitle);
+        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
         $pdf->SetXY($margin, $currentY);
         $pdf->MultiCell($availableWidth, 2.5, $titolo, 0, 'C', false, 1);
         $currentY = $pdf->GetY() + 0.5;
 
         // Autore
         if ($includeAuthor) {
-            $pdf->SetFont('helvetica', '', $fontSizeAuthor);
+            $pdf->SetFont('dejavusans', '', $fontSizeAuthor);
             $pdf->SetXY($margin, $currentY);
             $pdf->Cell($availableWidth, 2, $autoreShort, 0, 0, 'C');
             $currentY += 2.5;
@@ -2787,7 +2787,7 @@ class LibriController
 
             // EAN text under barcode
             if (!empty($eanText)) {
-                $pdf->SetFont('helvetica', '', $fontSizeSmall);
+                $pdf->SetFont('dejavusans', '', $fontSizeSmall);
                 $pdf->SetXY($margin, $currentY);
                 $pdf->Cell($availableWidth, 2, $eanText, 0, 0, 'C');
                 $currentY += 2;
@@ -2796,7 +2796,7 @@ class LibriController
 
         // Dewey classification
         if ($includeDewey) {
-            $pdf->SetFont('helvetica', 'I', $fontSizeSmall);
+            $pdf->SetFont('dejavusans', 'I', $fontSizeSmall);
             $pdf->SetXY($margin, $currentY);
             $deweyShort = mb_substr($dewey, 0, 15);
             $pdf->Cell($availableWidth, 2, "Dewey: {$deweyShort}", 0, 0, 'C');
@@ -2805,7 +2805,7 @@ class LibriController
 
         // Position/Collocazione
         if ($posColText) {
-            $pdf->SetFont('helvetica', 'B', $fontSizePosition);
+            $pdf->SetFont('dejavusans', 'B', $fontSizePosition);
             $pdf->SetXY($margin, $currentY);
             $posShort = mb_substr($posColText, 0, 12);
             $pdf->Cell($availableWidth, 3, $posShort, 0, 0, 'C');
@@ -2903,20 +2903,20 @@ class LibriController
         $currentY = $margin + $verticalOffset;
 
         // App name
-        $pdf->SetFont('helvetica', 'B', $fontSizeApp);
+        $pdf->SetFont('dejavusans', 'B', $fontSizeApp);
         $pdf->SetXY($margin, $currentY);
         $pdf->Cell($availableWidth, 4, $appName, 0, 0, 'C');
         $currentY += 4.5;
 
         // Titolo libro
-        $pdf->SetFont('helvetica', 'B', $fontSizeTitle);
+        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
         $pdf->SetXY($margin, $currentY);
         $pdf->Cell($availableWidth, 3.5, $titolo, 0, 0, 'C');
         $currentY += 4;
 
         // Autore ed editore
         if ($includeInfo) {
-            $pdf->SetFont('helvetica', '', $fontSizeAuthor);
+            $pdf->SetFont('dejavusans', '', $fontSizeAuthor);
             $pdf->SetXY($margin, $currentY);
             $pdf->Cell($availableWidth, 2.5, $infoText, 0, 0, 'C');
             $currentY += 3;
@@ -2932,7 +2932,7 @@ class LibriController
 
             // EAN text under barcode
             if (!empty($eanText)) {
-                $pdf->SetFont('helvetica', '', $fontSizeSmall);
+                $pdf->SetFont('dejavusans', '', $fontSizeSmall);
                 $pdf->SetXY($margin, $currentY);
                 $pdf->Cell($availableWidth, 2.5, $eanText, 0, 0, 'C');
                 $currentY += 2.5;
@@ -2941,7 +2941,7 @@ class LibriController
 
         // Dewey classification
         if ($includeDewey) {
-            $pdf->SetFont('helvetica', 'I', $fontSizeSmall);
+            $pdf->SetFont('dejavusans', 'I', $fontSizeSmall);
             $pdf->SetXY($margin, $currentY);
             $deweyShort = mb_substr($dewey, 0, 20);
             $pdf->Cell($availableWidth, 2.5, "Dewey: {$deweyShort}", 0, 0, 'C');
@@ -2950,7 +2950,7 @@ class LibriController
 
         // Position text
         if ($includePosition) {
-            $pdf->SetFont('helvetica', 'B', $fontSizeAuthor);
+            $pdf->SetFont('dejavusans', 'B', $fontSizeAuthor);
             $pdf->SetXY($margin, $currentY);
             $pdf->Cell($availableWidth, 3, $positionText, 0, 0, 'C');
             $currentY += 3.5;
@@ -2958,7 +2958,7 @@ class LibriController
 
         // Collocazione
         if ($includeCollocazione) {
-            $pdf->SetFont('helvetica', 'B', $fontSizePosition);
+            $pdf->SetFont('dejavusans', 'B', $fontSizePosition);
             $pdf->SetXY($margin, $currentY);
             $pdf->Cell($availableWidth, 4, $collocazione, 0, 0, 'C');
         }

--- a/app/Support/LoanPdfGenerator.php
+++ b/app/Support/LoanPdfGenerator.php
@@ -151,11 +151,11 @@ class LoanPdfGenerator
         }
 
         // Library name (centered, bold, large)
-        $pdf->SetFont('helvetica', 'B', 18);
+        $pdf->SetFont('dejavusans', 'B', 18);
         $pdf->Cell(0, 10, $appName, 0, 1, 'C');
 
         // Document title (centered, regular, medium)
-        $pdf->SetFont('helvetica', '', 14);
+        $pdf->SetFont('dejavusans', '', 14);
         $pdf->Cell(0, 8, __('Ricevuta di Prestito'), 0, 1, 'C');
 
         // Separator line
@@ -170,7 +170,7 @@ class LoanPdfGenerator
      */
     private function renderLoanDetails(TCPDF $pdf, array $loan): void
     {
-        $pdf->SetFont('helvetica', '', 10);
+        $pdf->SetFont('dejavusans', '', 10);
 
         // Section 1: Loan Information
         $this->renderSection($pdf, __('Informazioni Prestito'), [
@@ -225,13 +225,13 @@ class LoanPdfGenerator
     private function renderSection(TCPDF $pdf, string $title, array $fields): void
     {
         // Section title (gray background)
-        $pdf->SetFont('helvetica', 'B', 12);
+        $pdf->SetFont('dejavusans', 'B', 12);
         $pdf->SetFillColor(240, 240, 240);
         $pdf->Cell(0, 8, $title, 0, 1, 'L', true);
         $pdf->Ln(2);
 
         // Fields (label: value pairs)
-        $pdf->SetFont('helvetica', '', 10);
+        $pdf->SetFont('dejavusans', '', 10);
         foreach ($fields as $label => $value) {
             if ($label === '') {
                 // Special case: no label (e.g., notes)
@@ -257,7 +257,7 @@ class LoanPdfGenerator
         $pdf->Ln(3);
 
         // Generation timestamp (centered, small, gray)
-        $pdf->SetFont('helvetica', 'I', 8);
+        $pdf->SetFont('dejavusans', 'I', 8);
         $pdf->SetTextColor(128, 128, 128);
         $tz = ConfigStore::get('app.timezone', 'Europe/Rome');
         try {


### PR DESCRIPTION
Reported on a live instance: the generated loan PDF shows broken special characters.

## Cause
`LoanPdfGenerator` (loan receipt) and the book-label export in `LibriController` set the font to TCPDF's **core `helvetica`**. A core font is limited to **CP1252 / WinAnsi**, so any character outside that range renders as `?` even though the TCPDF document is initialised as UTF-8. CP1252 covers Italian accents (à è ò), curly quotes, em-dash and €, which is why it looked fine in testing — but names/titles in Polish, Turkish, Czech, Vietnamese, Cyrillic, Baltic (macrons), etc. break.

## Fix
Switch every `SetFont()` to TCPDF's bundled Unicode TTF **`dejavusans`** (B/I variants included), which covers the full Latin/Cyrillic/Greek range.

## Verified
Rendered the same string with both fonts and compared the rasterised output:

| font | `Łódź Ateş İstanbul Đặng Достоевский ā ē ō` |
|------|--------|
| helvetica (before) | `?ód? Ate? ?stanbul ??ng ??????????? ? ? ?` |
| dejavusans (after) | renders every glyph correctly |

php -l + PHPStan L5 clean. Trade-off: the PDF embeds a DejaVu Sans subset (larger file), which is the correct cost for correct Unicode output.