### PR TITLE
feat(users): server-side PDF export of the users list (replaces dead jsPDF)

### DIFF
--- a/app/Controllers/UtentiApiController.php
+++ b/app/Controllers/UtentiApiController.php
@@ -159,4 +159,81 @@ class UtentiApiController
         $response->getBody()->write(json_encode($payload, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES));
         return $response->withHeader('Content-Type', 'application/json');
     }
+
+    /**
+     * Server-side PDF export of the (filtered) users list. Applies the SAME filters as
+     * list() — search_text / role_filter / status_filter / created_from — so the PDF is
+     * "what you see", then streams a TCPDF built by UsersPdfGenerator (Unicode-safe).
+     */
+    public function exportPdf(Request $request, Response $response, mysqli $db): Response
+    {
+        $q = $request->getQueryParams();
+
+        $where = ' WHERE 1=1 ';
+        $params = [];
+        $types = '';
+
+        $search_value = trim((string)($q['search_text'] ?? ($q['search_value'] ?? '')));
+        if ($search_value !== '') {
+            $searchParam = "%$search_value%";
+            $where .= ' AND (u.nome LIKE ? OR u.cognome LIKE ? OR u.email LIKE ? OR u.telefono LIKE ? OR u.codice_tessera LIKE ?)';
+            $params = array_fill(0, 5, $searchParam);
+            $types = 'sssss';
+        }
+        $role = trim((string)($q['role_filter'] ?? ''));
+        if ($role !== '') {
+            $where .= ' AND u.tipo_utente = ? ';
+            $params[] = $role;
+            $types .= 's';
+        }
+        $status = trim((string)($q['status_filter'] ?? ''));
+        if ($status !== '') {
+            $where .= ' AND u.stato = ? ';
+            $params[] = $status;
+            $types .= 's';
+        }
+        $createdFrom = trim((string)($q['created_from'] ?? ''));
+        if ($createdFrom !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $createdFrom)) {
+            $where .= ' AND DATE(u.created_at) >= ? ';
+            $params[] = $createdFrom;
+            $types .= 's';
+        }
+
+        // Unfiltered total for the header summary ("N filtered out of M total").
+        $total = 0;
+        if ($totRes = $db->query('SELECT COUNT(*) AS c FROM utenti')) {
+            $total = (int)($totRes->fetch_assoc()['c'] ?? 0);
+        }
+
+        // All matching rows, capped so a very large library can't build a runaway PDF.
+        $sql = "SELECT u.nome, u.cognome, u.email, u.telefono, u.tipo_utente, u.stato, u.codice_tessera
+                FROM utenti u $where
+                ORDER BY u.cognome ASC, u.nome ASC
+                LIMIT 5000";
+        $stmt = $db->prepare($sql);
+        if ($stmt === false) {
+            AppLog::error('utenti.export.prepare_failed', ['error' => $db->error]);
+            return $response->withStatus(500);
+        }
+        if (!empty($params)) {
+            $stmt->bind_param($types, ...$params);
+        }
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $rows = [];
+        while ($r = $res->fetch_assoc()) {
+            // Localize the enum labels the same way the on-screen columns present them.
+            $r['tipo_utente'] = __((string)($r['tipo_utente'] ?? ''));
+            $r['stato'] = __((string)($r['stato'] ?? ''));
+            $rows[] = $r;
+        }
+        $stmt->close();
+
+        $pdf = (new \App\Support\UsersPdfGenerator())->generate($rows, $total);
+        $filename = 'utenti_' . date('Ymd') . '.pdf';
+        $response->getBody()->write($pdf);
+        return $response
+            ->withHeader('Content-Type', 'application/pdf')
+            ->withHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
+    }
 }

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -1858,6 +1858,14 @@ return function (App $app): void {
         return $controller->list($request, $response, $db);
     })->add(new \App\Middleware\RateLimitMiddleware(30, 60))->add(new AdminAuthMiddleware()); // 30 requests per minute
 
+    // Server-side PDF export of the (filtered) users list — reuses UtentiApiController's
+    // filter logic so the PDF matches the on-screen table. Replaces a dead client-side jsPDF.
+    $app->get('/admin/users/export-pdf', function ($request, $response) use ($app) {
+        $controller = new \App\Controllers\UtentiApiController();
+        $db = $app->getContainer()->get('db');
+        return $controller->exportPdf($request, $response, $db);
+    })->add(new \App\Middleware\RateLimitMiddleware(10, 60))->add(new AdminAuthMiddleware());
+
     // Reservations (admin)
     $app->get('/admin/reservations', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');

--- a/app/Support/UsersPdfGenerator.php
+++ b/app/Support/UsersPdfGenerator.php
@@ -1,0 +1,145 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+use TCPDF;
+
+/**
+ * Server-side PDF export of the users list (admin → Users → "Export PDF").
+ *
+ * Replaces a dead client-side jsPDF export: jsPDF was never bundled (the asset 404s),
+ * and even if it were, its core Helvetica font can't render non-Latin-1 names. This uses
+ * TCPDF with the bundled Unicode 'dejavusans' font — the same choice as the loan receipt
+ * and book-label PDFs — so Polish/Turkish/Cyrillic/etc. names render correctly.
+ *
+ * The caller (UtentiApiController::exportPdf) applies the SAME filters as the on-screen
+ * DataTables list, so the PDF is "what you see".
+ */
+class UsersPdfGenerator
+{
+    private const FONT = 'dejavusans';
+
+    /**
+     * @param list<array<string,mixed>> $users Rows with nome, cognome, email, telefono,
+     *                                          tipo_utente, stato, codice_tessera.
+     * @param int $totalCount    Total users in the library (unfiltered).
+     * @return string PDF binary content.
+     */
+    public function generate(array $users, int $totalCount): string
+    {
+        $appName = (string) ConfigStore::get('app.name', 'Biblioteca');
+
+        // Landscape A4: the user table is wide (name/email/role/status/card).
+        $pdf = new TCPDF('L', 'mm', 'A4', true, 'UTF-8', false);
+        $pdf->SetCreator($appName);
+        $pdf->SetAuthor($appName);
+        $pdf->SetTitle(__('Elenco Utenti'));
+        $pdf->setPrintHeader(false);
+        $pdf->setPrintFooter(false);
+        $pdf->SetMargins(12, 12, 12);
+        $pdf->SetAutoPageBreak(true, 12);
+        $pdf->AddPage();
+
+        $this->renderHeader($pdf, $appName, count($users), $totalCount);
+        $this->renderTable($pdf, $users);
+        $this->renderFooter($pdf);
+
+        return $pdf->Output('', 'S');
+    }
+
+    private function renderHeader(TCPDF $pdf, string $appName, int $shown, int $total): void
+    {
+        $pdf->SetFont(self::FONT, 'B', 16);
+        $pdf->Cell(0, 9, $appName, 0, 1, 'C');
+        $pdf->SetFont(self::FONT, '', 12);
+        $pdf->Cell(0, 7, __('Elenco Utenti'), 0, 1, 'C');
+
+        $pdf->SetFont(self::FONT, '', 9);
+        $pdf->SetTextColor(90, 90, 90);
+        // "shown" == "total" when no filter is active; otherwise it's the filtered subset.
+        $summary = ($shown === $total)
+            ? sprintf(__('%d utenti'), $total)
+            : sprintf(__('%d utenti filtrati su %d totali'), $shown, $total);
+        $pdf->Cell(0, 6, $summary, 0, 1, 'C');
+        $pdf->SetTextColor(0, 0, 0);
+        $pdf->Ln(2);
+    }
+
+    /**
+     * @param list<array<string,mixed>> $users
+     */
+    private function renderTable(TCPDF $pdf, array $users): void
+    {
+        // Column widths (mm) sum to the ~273mm printable width of landscape A4 minus margins.
+        $cols = [
+            ['label' => __('Nome'),    'key' => 'nome',           'w' => 45],
+            ['label' => __('Cognome'), 'key' => 'cognome',        'w' => 45],
+            ['label' => __('Email'),   'key' => 'email',          'w' => 78],
+            ['label' => __('Ruolo'),   'key' => 'tipo_utente',    'w' => 32],
+            ['label' => __('Stato'),   'key' => 'stato',          'w' => 30],
+            ['label' => __('Tessera'), 'key' => 'codice_tessera', 'w' => 43],
+        ];
+
+        // Header row.
+        $pdf->SetFont(self::FONT, 'B', 9);
+        $pdf->SetFillColor(235, 235, 235);
+        foreach ($cols as $c) {
+            $pdf->Cell($c['w'], 7, $c['label'], 1, 0, 'L', true);
+        }
+        $pdf->Ln();
+
+        // Data rows.
+        $pdf->SetFont(self::FONT, '', 8);
+        $fill = false;
+        foreach ($users as $u) {
+            $pdf->SetFillColor(249, 249, 249);
+            foreach ($cols as $c) {
+                $value = (string) ($u[$c['key']] ?? '');
+                // Keep each cell on one line — truncate over-long values so the row grid holds.
+                $value = $this->fit($value, $c['w']);
+                $pdf->Cell($c['w'], 6, $value, 1, 0, 'L', $fill);
+            }
+            $pdf->Ln();
+            $fill = !$fill;
+        }
+
+        if ($users === []) {
+            $pdf->SetFont(self::FONT, 'I', 9);
+            $pdf->Cell(0, 8, __('Nessun utente da esportare.'), 0, 1, 'C');
+        }
+    }
+
+    /**
+     * Trim a value to roughly fit the given column width (mm) at the table font size,
+     * appending an ellipsis when cut. TCPDF would otherwise overflow the fixed-width cell.
+     */
+    private function fit(string $value, float $widthMm): string
+    {
+        // ~1.9mm per glyph at 8pt DejaVu Sans; conservative so cells never overflow.
+        $max = (int) max(4, floor($widthMm / 1.9));
+        if (mb_strlen($value) <= $max) {
+            return $value;
+        }
+        return mb_substr($value, 0, $max - 1) . '…';
+    }
+
+    private function renderFooter(TCPDF $pdf): void
+    {
+        $pdf->Ln(4);
+        $pdf->SetFont(self::FONT, 'I', 8);
+        $pdf->SetTextColor(128, 128, 128);
+        $tz = (string) ConfigStore::get('app.timezone', 'Europe/Rome');
+        try {
+            $timezone = new \DateTimeZone($tz);
+        } catch (\Throwable $e) {
+            $timezone = new \DateTimeZone('Europe/Rome');
+        }
+        $now = new \DateTime('now', $timezone);
+        $pdf->Cell(0, 5, sprintf(
+            __('Documento generato il %s alle %s'),
+            format_date($now->format('Y-m-d'), false, '/'),
+            $now->format('H:i')
+        ), 0, 1, 'C');
+    }
+}

--- a/app/Views/utenti/index.php
+++ b/app/Views/utenti/index.php
@@ -668,100 +668,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // PDF export
     document.getElementById('export-pdf').addEventListener('click', function() {
-      const currentData = table.rows({search: 'applied'}).data().toArray();
-      if (currentData.length === 0) {
-        if (window.Swal) {
-          Swal.fire({
-            icon: 'info',
-            title: __('Nessun dato'),
-            text: __('Non ci sono dati da esportare')
-          });
-        }
-        return;
-      }
-
-      // Create PDF content using jsPDF
-      if (typeof window.jspdf === 'undefined') {
-        // Load jsPDF if not available
-        const script = document.createElement('script');
-        script.src = <?= json_encode(assetUrl("js/jspdf.umd.min.js"), JSON_HEX_TAG) ?>;
-        script.onload = function() {
-          generatePDF(currentData);
-        };
-        document.head.appendChild(script);
-      } else {
-        generatePDF(currentData);
-      }
+      // Server-side PDF export: navigate to /admin/users/export-pdf with the current filter
+      // values so the PDF matches the on-screen list. The old client-side jsPDF path was
+      // dead (the jsPDF asset was never shipped) and couldn't render non-Latin-1 names.
+      const params = new URLSearchParams();
+      const s = document.getElementById('search_text');
+      const r = document.getElementById('role_filter');
+      const st = document.getElementById('status_filter');
+      const cf = document.getElementById('created_from');
+      if (s && s.value.trim()) params.set('search_text', s.value.trim());
+      if (r && r.value) params.set('role_filter', r.value);
+      if (st && st.value) params.set('status_filter', st.value);
+      if (cf && cf.value) params.set('created_from', cf.value);
+      const base = (window.BASE_PATH || '') + '/admin/users/export-pdf';
+      const qs = params.toString();
+      window.location.href = qs ? `${base}?${qs}` : base;
     });
-
-    function generatePDF(data) {
-      const { jsPDF } = window.jspdf;
-      const doc = new jsPDF();
-
-      // Title
-      doc.setFontSize(18);
-      doc.text(__('Elenco Utenti - Biblioteca'), 14, 22);
-
-      // Date
-      doc.setFontSize(11);
-      doc.text(`${__('Generato il:')} ${formatDateLocale(new Date())}`, 14, 30);
-
-      // Total count
-      doc.text(`${__('Totale utenti:')} ${data.length}`, 14, 38);
-
-      // Table headers
-      const headers = [__('Nome'), __('Cognome'), __('Email'), __('Ruolo'), __('Stato')];
-      let yPos = 50;
-
-      // Set font for table
-      doc.setFontSize(10);
-
-      // Column widths
-      const colWidths = [40, 40, 60, 25, 25];
-      const startX = 14;
-
-      // Draw headers
-      headers.forEach((header, i) => {
-        doc.text(header, startX + colWidths.slice(0, i).reduce((a, b) => a + b, 0), yPos);
-      });
-
-      yPos += 8;
-
-      // Draw data
-      data.forEach((row, index) => {
-        if (yPos > 280) {
-          doc.addPage();
-          yPos = 20;
-        }
-
-        const rowData = [
-          (decodeHtml(row.nome) || '').substring(0, 20),
-          (decodeHtml(row.cognome) || '').substring(0, 20),
-          (row.email || '').substring(0, 35),
-          (row.tipo_utente || '').substring(0, 15),
-          (row.stato || '').substring(0, 15)
-        ];
-
-        rowData.forEach((cell, i) => {
-          doc.text(cell, startX + colWidths.slice(0, i).reduce((a, b) => a + b, 0), yPos);
-        });
-
-        yPos += 7;
-      });
-
-      // Save the PDF
-      doc.save(`utenti_${new Date().toISOString().slice(0, 10)}.pdf`);
-
-      if (window.Swal) {
-        Swal.fire({
-          icon: 'success',
-          title: __('PDF generato!'),
-          text: __('Il download dovrebbe iniziare automaticamente'),
-          timer: 2000,
-          showConfirmButton: false
-        });
-      }
-    }
   }
 
 });

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6440,5 +6440,9 @@
   "L'utente ha già un prestito attivo per questo libro": "Der Benutzer hat bereits eine aktive Ausleihe für dieses Buch",
   "L'utente ha già una prenotazione attiva per questo libro": "Der Benutzer hat bereits eine aktive Reservierung für dieses Buch",
   "Errore durante l'annullamento della prenotazione": "Fehler beim Stornieren der Reservierung",
-  "Hai già una prenotazione attiva per questo libro": "Du hast bereits eine aktive Reservierung für dieses Buch"
+  "Hai già una prenotazione attiva per questo libro": "Du hast bereits eine aktive Reservierung für dieses Buch",
+  "Tessera": "Ausweis",
+  "%d utenti": "%d Benutzer",
+  "%d utenti filtrati su %d totali": "%d gefilterte Benutzer von %d insgesamt",
+  "Nessun utente da esportare.": "Keine Benutzer zum Exportieren."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6440,5 +6440,9 @@
   "L'utente ha già un prestito attivo per questo libro": "The user already has an active loan for this book",
   "L'utente ha già una prenotazione attiva per questo libro": "The user already has an active reservation for this book",
   "Errore durante l'annullamento della prenotazione": "Error while cancelling the reservation",
-  "Hai già una prenotazione attiva per questo libro": "You already have an active reservation for this book"
+  "Hai già una prenotazione attiva per questo libro": "You already have an active reservation for this book",
+  "Tessera": "Card",
+  "%d utenti": "%d users",
+  "%d utenti filtrati su %d totali": "%d filtered users out of %d total",
+  "Nessun utente da esportare.": "No users to export."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6440,5 +6440,9 @@
   "L'utente ha già un prestito attivo per questo libro": "L'utilisateur a déjà un emprunt actif pour ce livre",
   "L'utente ha già una prenotazione attiva per questo libro": "L'utilisateur a déjà une réservation active pour ce livre",
   "Errore durante l'annullamento della prenotazione": "Erreur lors de l'annulation de la réservation",
-  "Hai già una prenotazione attiva per questo libro": "Vous avez déjà une réservation active pour ce livre"
+  "Hai già una prenotazione attiva per questo libro": "Vous avez déjà une réservation active pour ce livre",
+  "Tessera": "Carte",
+  "%d utenti": "%d utilisateurs",
+  "%d utenti filtrati su %d totali": "%d utilisateurs filtrés sur %d au total",
+  "Nessun utente da esportare.": "Aucun utilisateur à exporter."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6440,5 +6440,9 @@
   "L'utente ha già un prestito attivo per questo libro": "L'utente ha già un prestito attivo per questo libro",
   "L'utente ha già una prenotazione attiva per questo libro": "L'utente ha già una prenotazione attiva per questo libro",
   "Errore durante l'annullamento della prenotazione": "Errore durante l'annullamento della prenotazione",
-  "Hai già una prenotazione attiva per questo libro": "Hai già una prenotazione attiva per questo libro"
+  "Hai già una prenotazione attiva per questo libro": "Hai già una prenotazione attiva per questo libro",
+  "Tessera": "Tessera",
+  "%d utenti": "%d utenti",
+  "%d utenti filtrati su %d totali": "%d utenti filtrati su %d totali",
+  "Nessun utente da esportare.": "Nessun utente da esportare."
 }


### PR DESCRIPTION
The users-list "Export PDF" button lazy-loaded `/assets/js/jspdf.umd.min.js` — a file that has **never been shipped** (not in git, not in the release ZIP, **404 on the live instance**). So the export has been **dead since v0.1.4**. And jsPDF's core Helvetica font can't render non-Latin-1 names anyway.

Rebuilt server-side, consistent with the loan-receipt and book-label PDFs (which I just moved to `dejavusans` in #232):

- **`UsersPdfGenerator`** — TCPDF with the bundled Unicode **`dejavusans`** font, landscape A4 table (Nome / Cognome / Email / Ruolo / Stato / Tessera), header with app name + filtered/total count, footer timestamp.
- **`UtentiApiController::exportPdf`** reuses the **exact** `list()` filters (`search_text` / `role_filter` / `status_filter` / `created_from`) so the PDF is "what you see", capped at 5000 rows. Route `GET /admin/users/export-pdf` behind `AdminAuth` + rate limit.
- The button now navigates to that endpoint with the current filter values; the jsPDF code path is removed.
- i18n for the 4 new strings across **all four locales**.

## Verified
Rendered the PDF with mixed-script names — **Łukasz / Ayşe / Фёдор Достоевский / Đặng Nguyễn / İST-42 / РУ-7** all render correctly (screenshot-tested). php -l + PHPStan L5 clean.