### PR TITLE
fix(mail): SMTP connect timeout + circuit-breaker so a down mail server can't stall the cron

### DIFF
--- a/app/Support/Mailer.php
+++ b/app/Support/Mailer.php
@@ -5,6 +5,39 @@ namespace App\Support;
 
 final class Mailer
 {
+    /** Per-request cache of the SMTP reachability probe (null = not yet checked). */
+    private static ?bool $smtpReachable = null;
+
+    /**
+     * Whether the configured SMTP server accepts a TCP connection. Used as a circuit-breaker
+     * before a notification BATCH so a down/misconfigured SMTP costs one short probe instead
+     * of hammering it with a full retry cycle for every recipient. Cached per request, and
+     * always true for the `mail` driver (no host to probe). Logs once when it trips.
+     */
+    public static function isSmtpReachable(): bool
+    {
+        if (self::$smtpReachable !== null) {
+            return self::$smtpReachable;
+        }
+        $driver = (string)ConfigStore::get('mail.driver', 'mail');
+        if ($driver !== 'smtp' && $driver !== 'phpmailer') {
+            return self::$smtpReachable = true;
+        }
+        $host = (string)ConfigStore::get('mail.smtp.host', '');
+        if ($host === '') {
+            return self::$smtpReachable = true; // no host configured — let the send path decide
+        }
+        $port = (int)ConfigStore::get('mail.smtp.port', 587);
+        $errno = 0; $errstr = '';
+        $fp = @stream_socket_client('tcp://' . $host . ':' . $port, $errno, $errstr, 4, STREAM_CLIENT_CONNECT);
+        if ($fp) {
+            fclose($fp);
+            return self::$smtpReachable = true;
+        }
+        SecureLogger::warning("SMTP host {$host}:{$port} unreachable ({$errstr}) — skipping email sends this run");
+        return self::$smtpReachable = false;
+    }
+
     public static function send(string $to, string $subject, string $htmlBody, ?string $textBody = null): bool
     {
         $fromEmail = (string)ConfigStore::get('mail.from_email', 'no-reply@localhost');
@@ -138,6 +171,10 @@ final class Mailer
             $host = (string)ConfigStore::get('mail.smtp.host', '');
             if ($host !== '') {
                 $mailer->isSMTP();
+                // PHPMailer's default Timeout is 300s: if the SMTP host accepts the TCP
+                // connection but then stalls, a single send would block the (cron) request
+                // for 5 minutes. Cap it — the raw-socket path already uses 10s.
+                $mailer->Timeout = (int)ConfigStore::get('mail.smtp.timeout', 10);
                 $mailer->Host = $host;
                 $mailer->Port = (int)ConfigStore::get('mail.smtp.port', 587);
                 $enc  = (string)ConfigStore::get('mail.smtp.encryption', 'tls');

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -1286,6 +1286,15 @@ class NotificationService {
      * @return bool True if email was sent successfully
      */
     private function sendWithRetry(string $email, string $template, array $variables, int $maxRetries = 3, int $retryDelayMs = 1000): bool {
+        // Circuit-breaker: if the SMTP server is unreachable, don't run the full retry cycle
+        // (maxRetries attempts + 1s sleeps) for every recipient in a batch — they would all
+        // fail the same way, hanging the run. Mailer::isSmtpReachable() probes once per
+        // request (cached) and logs a single warning, so a down SMTP costs one short probe
+        // instead of N × maxRetries connection timeouts.
+        if (!\App\Support\Mailer::isSmtpReachable()) {
+            return false;
+        }
+
         $lastError = '';
 
         for ($attempt = 1; $attempt <= $maxRetries; $attempt++) {


### PR DESCRIPTION
Observed on a real instance whose SMTP host was unreachable: the `automatic-notifications` cron logged a wall of `Could not connect to SMTP host` — a full 3-attempt retry cycle (with 1s sleeps) for **every** overdue-loan recipient. Two robustness gaps:

- **No `Timeout` on the PHPMailer path** → PHPMailer's **300s** default. An SMTP host that accepts the TCP connection but then stalls would block the run for **5 minutes per email**. Capped at 10s (configurable via `mail.smtp.timeout`); the raw-socket path already used 10s.
- **No circuit-breaker** → every recipient got the full retry cycle even though they all fail identically when the server is down. Added `Mailer::isSmtpReachable()` — a single short TCP probe (4s), cached per request, logged once — and short-circuit `sendWithRetry` on it, so a down SMTP costs **one probe** instead of N × 3 connection timeouts.

The batch still runs (loans still marked overdue, in-app notifications still created); only the email *attempts* become cheap no-ops when the server is unreachable.

## Verified
Probe returns `false` in **0.00s** on connection-refused and **~4s** on an unroutable host (never the 300s default). php -l + PHPStan L5 clean.

Note: this is defensive robustness — the reported instance's actual problem is its own SMTP config being unreachable, which no code change fixes.