### PR TITLE
test(gate): activate every activatable plugin, not just book-club

### DIFF
--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -136,17 +136,28 @@ async function dismissSwal(page) {
   } catch (_) { /* already closed */ }
 }
 
-/** Return today's date as YYYY-MM-DD. */
-function todayISO() {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+// Reservation dates are validated server-side against DateHelper::today(), which
+// runs in the app timezone (Europe/Rome by default). The CI runner is UTC, so a
+// plain `new Date()` yields the UTC calendar day — and when CI runs late in the UTC
+// day (Rome is an hour or two ahead), that's Rome's *yesterday*, which the server
+// rejects as `past_date`. Compute these dates in the app timezone so the test's
+// "today" always matches the server's, regardless of where the runner clock sits.
+const APP_TZ = 'Europe/Rome';
+/** Format a Date as YYYY-MM-DD in the app timezone (en-CA gives ISO order). */
+function isoInAppTz(date) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: APP_TZ, year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(date);
 }
 
-/** Return a future date as YYYY-MM-DD. */
+/** Return today's date (app timezone) as YYYY-MM-DD. */
+function todayISO() {
+  return isoInAppTz(new Date());
+}
+
+/** Return a future date (app timezone) as YYYY-MM-DD. */
 function futureISO(daysFromNow) {
-  const d = new Date();
-  d.setDate(d.getDate() + daysFromNow);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  return isoInAppTz(new Date(Date.now() + daysFromNow * 86400000));
 }
 
 /**

--- a/tests/plugin-integrity.spec.js
+++ b/tests/plugin-integrity.spec.js
@@ -159,4 +159,61 @@ test.describe.serial('Plugin integrity regression (#101)', () => {
         expect(tail, 'Main file not found error in recent log').not.toContain('Main file not found');
         expect(tail, 'Failed to load plugin recent log').not.toMatch(/Failed to load plugin/);
     });
+
+    test('6. Every activatable plugin activates cleanly (schema lands)', async () => {
+        // Generalises the book-club activation failure (#233): book-club shipped a
+        // hard FK to a core table that doesn't exist on every install, so its very
+        // first CREATE TABLE aborted the whole activation — and that reached a real
+        // user. The same blind spot exists for EVERY plugin, and for any added later.
+        //
+        // Here we activate every plugin that isn't already active and assert its
+        // onActivate/ensureSchema succeeds (a failure comes back from the endpoint as
+        // { success:false, message:"... Schema activation failed for: <table> ..." })
+        // and that it ends up active. The plugin list is read from the DB, so a plugin
+        // added in the future is covered automatically — no per-plugin test to write.
+        //
+        // The three external-API plugins (see test 4) are the deliberate exception:
+        // their onActivate reaches out to discogs/deezer/musicbrainz and legitimately
+        // throws when the CI host is offline, so they stay opt-in and are excluded.
+        const EXTERNAL_OPT_IN = ['discogs', 'deezer', 'musicbrainz'];
+
+        await page.goto(`${BASE}/admin/plugins`);
+        await page.waitForLoadState('domcontentloaded');
+        const csrf = await page.evaluate(() =>
+            document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || ''
+        );
+
+        const plugins = dbQuery('SELECT id, name FROM plugins WHERE is_active = 0 ORDER BY id')
+            .split('\n')
+            .filter(Boolean)
+            .map((r) => {
+                const parts = r.split('\t');
+                return { id: Number(parts[0]), name: parts.slice(1).join('\t') };
+            })
+            .filter((p) => !EXTERNAL_OPT_IN.includes(p.name));
+
+        test.skip(plugins.length === 0, 'no activatable inactive plugins');
+
+        const failures = [];
+        for (const p of plugins) {
+            const res = await page.evaluate(async ({ base, id, token }) => {
+                const r = await fetch(`${base}/admin/plugins/${id}/activate`, {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'X-CSRF-Token': token, 'Content-Type': 'application/json' },
+                    body: '{}',
+                });
+                let data = {};
+                try { data = await r.json(); } catch (_) { /* non-JSON body */ }
+                return { status: r.status, data };
+            }, { base: BASE, id: p.id, token: csrf });
+
+            const active = dbQuery(`SELECT is_active FROM plugins WHERE id=${p.id}`);
+            if (!res.data.success || active !== '1') {
+                failures.push(`${p.name} (#${p.id}): ${res.data.message || ('HTTP ' + res.status)}`);
+            }
+        }
+
+        expect(failures, `plugin activation failed:\n${failures.join('\n')}`).toHaveLength(0);
+    });
 });


### PR DESCRIPTION
The book-club activation failure (#233) reached a real install because the gate never activated the plugin. The same blind spot exists for **every other bundled plugin**, and for any added in the future.

Adds **test 6** to `plugin-integrity.spec.js`: it enumerates the plugins from the DB and activates every one that isn't active yet through the real `/admin/plugins/{id}/activate` endpoint, asserting `onActivate`/`ensureSchema` succeeds (a failure comes back as `{success:false, "Schema activation failed for: <table>"}`) and that it ends up active. The list is **read from the DB**, so a plugin added later is covered automatically.

**Why plugin-integrity and not full-test:** it's a dedicated, plugin-focused spec that already runs post-install AND post-upgrade in both CI and `scripts/reinstall-test.sh` (Test A + Test B), and it isn't hostage to full-test's 20-phase serial chain.

The three external-API plugins (discogs/deezer/musicbrainz) are excluded — **test 4** already documents that their `onActivate` throws when the CI host is offline, so they stay opt-in. (An earlier draft of this PR tried to activate *all* inactive plugins inside full-test; that would have failed on exactly those three.)