### PR TITLE
fix(search): harden FULLTEXT term handling + close import/API index gaps

### DIFF
--- a/app/Controllers/LibraryThingImportController.php
+++ b/app/Controllers/LibraryThingImportController.php
@@ -1287,24 +1287,17 @@ class LibraryThingImportController
 
         if ($existingBookId !== null) {
             $this->log("[upsertBook] UPDATING existing book ID: $existingBookId");
+            $conflictingBookIds = [];
 
             // Clear ISBNs from other books if they conflict (TSV data is authoritative)
             if (!empty($data['isbn13'])) {
-                $stmt = $db->prepare("UPDATE libri SET isbn13 = NULL WHERE isbn13 = ? AND id != ? AND deleted_at IS NULL");
-                $stmt->bind_param('si', $data['isbn13'], $existingBookId);
-                $stmt->execute();
-                $conflictsCleared = $stmt->affected_rows;
-                $stmt->close();
+                $conflictsCleared = $this->clearIdentifierConflicts($db, 'isbn13', (string) $data['isbn13'], $existingBookId, $conflictingBookIds);
                 if ($conflictsCleared > 0) {
                     $this->log("[upsertBook] Cleared ISBN13 '{$data['isbn13']}' from $conflictsCleared conflicting book(s)");
                 }
             }
             if (!empty($data['isbn10'])) {
-                $stmt = $db->prepare("UPDATE libri SET isbn10 = NULL WHERE isbn10 = ? AND id != ? AND deleted_at IS NULL");
-                $stmt->bind_param('si', $data['isbn10'], $existingBookId);
-                $stmt->execute();
-                $conflictsCleared = $stmt->affected_rows;
-                $stmt->close();
+                $conflictsCleared = $this->clearIdentifierConflicts($db, 'isbn10', (string) $data['isbn10'], $existingBookId, $conflictingBookIds);
                 if ($conflictsCleared > 0) {
                     $this->log("[upsertBook] Cleared ISBN10 '{$data['isbn10']}' from $conflictsCleared conflicting book(s)");
                 }
@@ -1312,11 +1305,7 @@ class LibraryThingImportController
 
             // Clear EAN conflicts (same pattern as ISBN13/ISBN10)
             if (!empty($data['ean'])) {
-                $stmt = $db->prepare("UPDATE libri SET ean = NULL WHERE ean = ? AND id != ? AND deleted_at IS NULL");
-                $stmt->bind_param('si', $data['ean'], $existingBookId);
-                $stmt->execute();
-                $conflictsCleared = $stmt->affected_rows;
-                $stmt->close();
+                $conflictsCleared = $this->clearIdentifierConflicts($db, 'ean', (string) $data['ean'], $existingBookId, $conflictingBookIds);
                 if ($conflictsCleared > 0) {
                     $this->log("[upsertBook] Cleared EAN '{$data['ean']}' from $conflictsCleared conflicting book(s)");
                 }
@@ -1327,21 +1316,78 @@ class LibraryThingImportController
             // way CsvImportController::syncImportedSeries does, so LT-imported
             // books appear in /admin/series and getBookMemberships finds them.
             $this->syncSeriesAfterImport($db, $existingBookId, $data);
+            if (!empty($conflictingBookIds)) {
+                \App\Support\SearchIndexBuilder::rebuildMany($db, array_values($conflictingBookIds));
+            }
             return ['id' => $existingBookId, 'action' => 'updated'];
         } else {
+            $conflictingBookIds = [];
             // Clear EAN conflicts for new inserts
             if (!empty($data['ean'])) {
-                $stmt = $db->prepare("UPDATE libri SET ean = NULL WHERE ean = ? AND deleted_at IS NULL");
-                $stmt->bind_param('s', $data['ean']);
-                $stmt->execute();
-                $stmt->close();
+                $this->clearIdentifierConflicts($db, 'ean', (string) $data['ean'], null, $conflictingBookIds);
             }
 
             $this->log("[upsertBook] INSERTING new book: {$data['titolo']}");
             $newBookId = $this->insertBook($db, $data, $editorId, $genreId);
             $this->syncSeriesAfterImport($db, $newBookId, $data);
+            if (!empty($conflictingBookIds)) {
+                \App\Support\SearchIndexBuilder::rebuildMany($db, array_values($conflictingBookIds));
+            }
             return ['id' => $newBookId, 'action' => 'created'];
         }
+    }
+
+    /**
+     * Clear a duplicate ISBN/EAN from non-deleted books and remember affected ids
+     * so their denormalized search_index can be rebuilt in the same transaction.
+     *
+     * @param array<int,int> $affectedBookIds
+     */
+    private function clearIdentifierConflicts(
+        \mysqli $db,
+        string $column,
+        string $value,
+        ?int $excludeBookId,
+        array &$affectedBookIds
+    ): int {
+        if (!in_array($column, ['isbn10', 'isbn13', 'ean'], true) || $value === '') {
+            return 0;
+        }
+
+        $excludeSql = $excludeBookId !== null ? ' AND id != ?' : '';
+        $select = $db->prepare("SELECT id FROM libri WHERE {$column} = ?{$excludeSql} AND deleted_at IS NULL");
+        if ($select === false) {
+            return 0;
+        }
+        if ($excludeBookId !== null) {
+            $select->bind_param('si', $value, $excludeBookId);
+        } else {
+            $select->bind_param('s', $value);
+        }
+        $select->execute();
+        $res = $select->get_result();
+        while ($row = $res->fetch_assoc()) {
+            $id = (int) ($row['id'] ?? 0);
+            if ($id > 0) {
+                $affectedBookIds[$id] = $id;
+            }
+        }
+        $select->close();
+
+        $stmt = $db->prepare("UPDATE libri SET {$column} = NULL WHERE {$column} = ?{$excludeSql} AND deleted_at IS NULL");
+        if ($stmt === false) {
+            return 0;
+        }
+        if ($excludeBookId !== null) {
+            $stmt->bind_param('si', $value, $excludeBookId);
+        } else {
+            $stmt->bind_param('s', $value);
+        }
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+
+        return max(0, $affected);
     }
 
     /**

--- a/app/Controllers/LibriApiController.php
+++ b/app/Controllers/LibriApiController.php
@@ -40,20 +40,12 @@ class LibriApiController
         $types = '';
 
         if ($search_text !== '') {
-            $nameExpr = $this->hasTableColumn($db, 'autori', 'cognome')
-                ? "CONCAT(a.nome, ' ', a.cognome)"
-                : 'a.nome';
-            $descExpr = $this->hasTableColumn($db, 'libri', 'descrizione_plain')
-                ? "COALESCE(NULLIF(l.descrizione_plain, ''), l.descrizione)"
-                : 'l.descrizione';
-            $where .= " AND (l.titolo LIKE ? OR l.sottotitolo LIKE ? OR {$descExpr} LIKE ? OR l.parole_chiave LIKE ? OR EXISTS (SELECT 1 FROM libri_autori la JOIN autori a ON la.autore_id=a.id WHERE la.libro_id=l.id AND $nameExpr LIKE ?)) ";
-            $searchParam = '%' . $search_text . '%';
-            $params[] = $searchParam;
-            $params[] = $searchParam;
-            $params[] = $searchParam;
-            $params[] = $searchParam;
-            $params[] = $searchParam;
-            $types .= 'sssss';
+            $searchCondition = \App\Support\SearchIndexBuilder::buildSearchCondition($db, 'l.search_index', $search_text);
+            if ($searchCondition !== null) {
+                $where .= ' AND ' . $searchCondition['sql'] . ' ';
+                $params = array_merge($params, $searchCondition['params']);
+                $types .= $searchCondition['types'];
+            }
         }
         if ($search_isbn !== '') {
             $where .= " AND (l.isbn10 LIKE ? OR l.isbn13 LIKE ? OR l.ean LIKE ?) ";

--- a/app/Support/SearchIndexBuilder.php
+++ b/app/Support/SearchIndexBuilder.php
@@ -35,78 +35,10 @@ final class SearchIndexBuilder
      */
     public static function rebuild(\mysqli $db, int $bookId): void
     {
-        if ($bookId <= 0 || !self::columnExists($db)) {
+        if ($bookId <= 0) {
             return;
         }
-
-        try {
-            // Match the migration's backfill: a book with many authors/publishers
-            // must not have its GROUP_CONCAT silently truncated at the 1024-byte
-            // default, otherwise runtime and backfill would produce different
-            // values. Best-effort — a failure here must not break the rebuild.
-            try {
-                $db->query('SET SESSION group_concat_max_len = 1000000');
-            } catch (\Throwable $ignored) {
-            }
-
-            $hasJunction = SchemaInfo::hasLibriEditori($db);
-
-            // Secondary publishers (issue #143) folded in only when the junction
-            // table exists; otherwise search_index carries the primary publisher.
-            $junctionJoin = $hasJunction
-                ? "LEFT JOIN (
-                        SELECT le.libro_id, GROUP_CONCAT(e2.nome SEPARATOR ' ') AS editori_sec
-                        FROM libri_editori le
-                        JOIN editori e2 ON e2.id = le.editore_id
-                        WHERE le.libro_id = ?
-                        GROUP BY le.libro_id
-                    ) ex ON ex.libro_id = l.id"
-                : '';
-            $junctionField = $hasJunction ? 'ex.editori_sec,' : '';
-
-            // Raw columns may be stored HTML-entity-encoded (e.g. `L&#039;orologio`,
-            // `Q&amp;A`), which FULLTEXT tokenizes wrong (`l`,`039`,`orologio`).
-            // Decode the common entities on the FINAL concatenated value — the
-            // IDENTICAL REPLACE chain lives in migrate_0.7.31.sql's backfill so
-            // runtime and backfill produce the same content. &amp; is decoded
-            // OUTERMOST (last) so `&amp;lt;` does not double-decode.
-            $sql = "UPDATE libri l
-                LEFT JOIN (
-                        SELECT la.libro_id, GROUP_CONCAT(a.nome SEPARATOR ' ') AS autori
-                        FROM libri_autori la
-                        JOIN autori a ON a.id = la.autore_id
-                        WHERE la.libro_id = ?
-                        GROUP BY la.libro_id
-                    ) ax ON ax.libro_id = l.id
-                LEFT JOIN editori e ON e.id = l.editore_id
-                {$junctionJoin}
-                SET l.search_index = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
-                        CONCAT_WS(' ',
-                            l.titolo, l.sottotitolo, ax.autori, e.nome, {$junctionField}
-                            l.isbn10, l.isbn13, l.ean, l.parole_chiave,
-                            COALESCE(l.descrizione_plain, l.descrizione))
-                    , '&#039;', ''''), '&#39;', ''''), '&quot;', '\"'), '&lt;', '<'), '&gt;', '>'), '&nbsp;', ' '), '&amp;', '&')
-                WHERE l.id = ? AND l.deleted_at IS NULL";
-
-            $stmt = $db->prepare($sql);
-            if ($stmt === false) {
-                return;
-            }
-            if ($hasJunction) {
-                $stmt->bind_param('iii', $bookId, $bookId, $bookId);
-            } else {
-                $stmt->bind_param('ii', $bookId, $bookId);
-            }
-            $stmt->execute();
-            $stmt->close();
-        } catch (\Throwable $e) {
-            // The search index is a derived cache — never let a rebuild failure
-            // break the surrounding save. Log and move on.
-            SecureLogger::warning('SearchIndexBuilder::rebuild failed', [
-                'book_id' => $bookId,
-                'error' => $e->getMessage(),
-            ]);
-        }
+        self::rebuildMany($db, [$bookId]);
     }
 
     /**
@@ -233,10 +165,102 @@ final class SearchIndexBuilder
      */
     public static function rebuildMany(\mysqli $db, array $bookIds): void
     {
-        foreach ($bookIds as $bookId) {
-            self::rebuild($db, (int) $bookId);
+        // De-dupe + drop non-positive ids.
+        $ids = [];
+        foreach ($bookIds as $id) {
+            $id = (int) $id;
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+        $ids = array_values($ids);
+        if ($ids === [] || !self::columnExists($db)) {
+            return;
+        }
+
+        try {
+            // Match the migration's backfill: a book with many authors/publishers
+            // must not have its GROUP_CONCAT silently truncated at the 1024-byte
+            // default. Set once for the whole batch — best-effort.
+            try {
+                $db->query('SET SESSION group_concat_max_len = 1000000');
+            } catch (\Throwable $ignored) {
+            }
+
+            $hasJunction = SchemaInfo::hasLibriEditori($db);
+
+            // ONE UPDATE per chunk (not per book): renaming/merging a prolific
+            // author/publisher with thousands of linked books would otherwise fire
+            // thousands of synchronous UPDATEs on the request thread. Chunk so the
+            // IN(...) placeholder count stays well under the bind limit.
+            foreach (array_chunk($ids, self::REBUILD_CHUNK) as $chunk) {
+                $ph = implode(',', array_fill(0, count($chunk), '?'));
+
+                // Secondary publishers (issue #143) folded in only when the
+                // junction table exists; both correlated subqueries are scoped to
+                // the chunk's ids so they stay cheap.
+                $junctionJoin = $hasJunction
+                    ? "LEFT JOIN (
+                            SELECT le.libro_id, GROUP_CONCAT(e2.nome SEPARATOR ' ') AS editori_sec
+                            FROM libri_editori le
+                            JOIN editori e2 ON e2.id = le.editore_id
+                            WHERE le.libro_id IN ({$ph})
+                            GROUP BY le.libro_id
+                        ) ex ON ex.libro_id = l.id"
+                    : '';
+                $junctionField = $hasJunction ? 'ex.editori_sec,' : '';
+
+                // Raw columns may be stored HTML-entity-encoded (e.g.
+                // `L&#039;orologio`, `Q&amp;A`), which FULLTEXT tokenizes wrong.
+                // Decode the common entities on the FINAL concatenated value — the
+                // IDENTICAL REPLACE chain lives in migrate_0.7.31.sql's backfill so
+                // runtime and backfill produce the same content. &amp; is decoded
+                // OUTERMOST (last) so `&amp;lt;` does not double-decode.
+                $sql = "UPDATE libri l
+                    LEFT JOIN (
+                            SELECT la.libro_id, GROUP_CONCAT(a.nome SEPARATOR ' ') AS autori
+                            FROM libri_autori la
+                            JOIN autori a ON a.id = la.autore_id
+                            WHERE la.libro_id IN ({$ph})
+                            GROUP BY la.libro_id
+                        ) ax ON ax.libro_id = l.id
+                    LEFT JOIN editori e ON e.id = l.editore_id
+                    {$junctionJoin}
+                    SET l.search_index = REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(
+                            CONCAT_WS(' ',
+                                l.titolo, l.sottotitolo, ax.autori, e.nome, {$junctionField}
+                                l.isbn10, l.isbn13, l.ean, l.parole_chiave,
+                                COALESCE(l.descrizione_plain, l.descrizione))
+                        , '&#039;', ''''), '&#39;', ''''), '&quot;', '\"'), '&lt;', '<'), '&gt;', '>'), '&nbsp;', ' '), '&amp;', '&')
+                    WHERE l.id IN ({$ph}) AND l.deleted_at IS NULL";
+
+                $stmt = $db->prepare($sql);
+                if ($stmt === false) {
+                    continue;
+                }
+                // Bind the chunk's ids once per IN(...): author subquery,
+                // [junction subquery], then the outer WHERE — same order as the SQL.
+                $bind = $chunk;                          // author subquery
+                if ($hasJunction) {
+                    $bind = array_merge($bind, $chunk);  // junction subquery
+                }
+                $bind = array_merge($bind, $chunk);      // outer WHERE
+                $stmt->bind_param(str_repeat('i', count($bind)), ...$bind);
+                $stmt->execute();
+                $stmt->close();
+            }
+        } catch (\Throwable $e) {
+            // The search index is a derived cache — never let a rebuild failure
+            // break the surrounding save. Log and move on.
+            SecureLogger::warning('SearchIndexBuilder::rebuildMany failed', [
+                'count' => count($ids),
+                'error' => $e->getMessage(),
+            ]);
         }
     }
+
+    /** Books per batch UPDATE — keeps the IN(...) placeholder count bounded. */
+    private const REBUILD_CHUNK = 500;
 
     /**
      * Build the WHERE fragment for a user book search against a FULLTEXT

--- a/app/Support/SearchIndexBuilder.php
+++ b/app/Support/SearchIndexBuilder.php
@@ -242,12 +242,14 @@ final class SearchIndexBuilder
      * Build the WHERE fragment for a user book search against a FULLTEXT
      * column (typically `l.search_index`).
      *
-     * Long tokens (>= 3 chars, above innodb_ft_min_token_size) are folded into a
-     * single BOOLEAN-mode AGAINST string as `+token*` (prefix, AND semantics —
-     * every word must match). Tokens shorter than 3 chars, which FULLTEXT can
-     * not index, fall back to a `LIKE '%token%'` on the same column so 1–2 char
-     * searches keep working. All parts are ANDed together, preserving the
-     * original "every word must match somewhere" behaviour.
+     * Tokens that MySQL can index safely are folded into a single BOOLEAN-mode
+     * AGAINST string as `+token*` (prefix, AND semantics — every word must
+     * match). Stopwords, tokens shorter than innodb_ft_min_token_size and terms
+     * with punctuation that the FULLTEXT parser would split (`C++`, `Q&A`,
+     * `L'orologio`) fall back to a `LIKE '%token%'` filter on the same column.
+     * All parts are ANDed together, preserving the original "every word must
+     * match somewhere" behaviour without letting unindexable required terms zero
+     * out otherwise valid results.
      *
      * UPGRADE-WINDOW SAFETY: when the `search_index` column does not exist yet
      * (new PHP deployed but the admin has not run the 0.7.31 DB migration),
@@ -271,7 +273,7 @@ final class SearchIndexBuilder
         // Pre-migration: the denormalized FULLTEXT column is not there yet.
         // Match on the real columns instead so search does not 500.
         if (!self::columnExists($db)) {
-            return self::buildLegacyCondition($column, $searchQuery);
+            return self::buildLegacyCondition($db, $column, $searchQuery);
         }
 
         $words = preg_split('/\s+/', $searchQuery, -1, PREG_SPLIT_NO_EMPTY) ?: [];
@@ -282,18 +284,16 @@ final class SearchIndexBuilder
         $types = '';
 
         foreach ($words as $word) {
-            $wordBase = rtrim($word, '*');
-            $sanitizedBase = self::escapeFulltextWord($wordBase, false);
-            if ($sanitizedBase === '') {
+            $wordBase = trim(rtrim($word, '*'));
+            if ($wordBase === '') {
                 continue;
             }
-            if (strlen($wordBase) >= 3) {
-                $booleanTerms[] = '+' . self::escapeFulltextWord($word)
-                    . (str_ends_with($word, '*') ? '' : '*');
+            $fulltextTerm = self::fulltextTermForWord($wordBase);
+            if ($fulltextTerm !== null) {
+                $booleanTerms[] = '+' . $fulltextTerm . '*';
             } else {
-                // Below ft_min_token_size — FULLTEXT can't match it, LIKE fallback.
-                $parts[] = "{$column} LIKE ?";
-                $params[] = '%' . $wordBase . '%';
+                $parts[] = "{$column} LIKE ? ESCAPE '\\\\'";
+                $params[] = self::likePattern($wordBase);
                 $types .= 's';
             }
         }
@@ -318,22 +318,21 @@ final class SearchIndexBuilder
 
     /**
      * Pre-migration fallback: the `search_index` column does not exist yet, so
-     * build the condition over the REAL columns that a book always carries
-     * (titolo, sottotitolo, isbn10, isbn13, ean). For each word we emit an
-     * OR-of-LIKE over those five columns, ANDed across words (every word must
-     * match somewhere), mirroring the normal path's "all words required"
-     * semantics and returning the same {sql,params,types} shape so callers bind
-     * generically.
+     * build the condition over the real book columns plus author/publisher
+     * subqueries. For each word we emit an OR-of-LIKE, ANDed across words (every
+     * word must match somewhere), mirroring the normal path's semantics and
+     * returning the same {sql,params,types} shape so callers bind generically.
      *
      * The table alias is derived from $column: the part before '.', e.g. 'l'
      * from 'l.search_index' (empty when there is no dot).
      *
      * @return array{sql:string, params:array<int,string>, types:string}|null
      */
-    private static function buildLegacyCondition(string $column, string $searchQuery): ?array
+    private static function buildLegacyCondition(\mysqli $db, string $column, string $searchQuery): ?array
     {
         $dot = strpos($column, '.');
         $prefix = $dot === false ? '' : substr($column, 0, $dot + 1);
+        $descExpr = self::descriptionExpr($db, $prefix);
 
         $words = preg_split('/\s+/', $searchQuery, -1, PREG_SPLIT_NO_EMPTY) ?: [];
 
@@ -342,10 +341,19 @@ final class SearchIndexBuilder
         $types = '';
 
         foreach ($words as $word) {
-            $like = '%' . $word . '%';
-            $parts[] = "({$prefix}titolo LIKE ? OR {$prefix}sottotitolo LIKE ?"
-                . " OR {$prefix}isbn10 LIKE ? OR {$prefix}isbn13 LIKE ? OR {$prefix}ean LIKE ?)";
-            for ($i = 0; $i < 5; $i++) {
+            $like = self::likePattern($word);
+            $bookIdExpr = $prefix . 'id';
+            $publisherIdExpr = $prefix . 'editore_id';
+            $parts[] = "({$prefix}titolo LIKE ? ESCAPE '\\\\'"
+                . " OR {$prefix}sottotitolo LIKE ? ESCAPE '\\\\'"
+                . " OR {$descExpr} LIKE ? ESCAPE '\\\\'"
+                . " OR {$prefix}parole_chiave LIKE ? ESCAPE '\\\\'"
+                . " OR {$prefix}isbn10 LIKE ? ESCAPE '\\\\'"
+                . " OR {$prefix}isbn13 LIKE ? ESCAPE '\\\\'"
+                . " OR {$prefix}ean LIKE ? ESCAPE '\\\\'"
+                . " OR EXISTS (SELECT 1 FROM libri_autori la JOIN autori a ON la.autore_id = a.id WHERE la.libro_id = {$bookIdExpr} AND a.nome LIKE ? ESCAPE '\\\\')"
+                . " OR EXISTS (SELECT 1 FROM editori e WHERE e.id = {$publisherIdExpr} AND e.nome LIKE ? ESCAPE '\\\\'))";
+            for ($i = 0; $i < 9; $i++) {
                 $params[] = $like;
                 $types .= 's';
             }
@@ -363,28 +371,83 @@ final class SearchIndexBuilder
     }
 
     /**
-     * Strip FULLTEXT BOOLEAN MODE operators from a word. MySQL FULLTEXT has no
-     * backslash escaping, so the operators (+ - > < ( ) ~ * " @) must be
-     * removed. A trailing '*' (prefix wildcard) is preserved when allowed.
+     * Return a single safe FULLTEXT token for a raw user word, or null when
+     * FULLTEXT would ignore/split it and the caller should use LIKE instead.
      */
-    private static function escapeFulltextWord(string $word, bool $allowTrailingWildcard = true): string
+    private static function fulltextTermForWord(string $word): ?string
     {
-        $hasTrailingWildcard = $allowTrailingWildcard && str_ends_with($word, '*');
-        if ($hasTrailingWildcard) {
-            $word = substr($word, 0, -1);
+        $tokens = self::fulltextTokens($word);
+        if (count($tokens) !== 1) {
+            return null;
         }
 
-        $word = str_replace(
-            ['+', '-', '>', '<', '(', ')', '~', '*', '"', '@'],
-            '',
-            $word
-        );
-
-        if ($hasTrailingWildcard && $word !== '') {
-            $word .= '*';
+        $token = $tokens[0];
+        if (mb_strlen($token, 'UTF-8') < 3) {
+            return null;
         }
 
-        return $word;
+        if (self::isDefaultFulltextStopword($token)) {
+            return null;
+        }
+
+        return $token;
+    }
+
+    /**
+     * Approximate MySQL/InnoDB's word tokenization for deciding whether a user
+     * term is safe to require in BOOLEAN MODE.
+     *
+     * @return list<string>
+     */
+    private static function fulltextTokens(string $word): array
+    {
+        if (preg_match_all('/[\p{L}\p{N}_]+/u', $word, $matches) !== 1) {
+            return [];
+        }
+        return array_values(array_filter($matches[0], static fn(string $token): bool => $token !== ''));
+    }
+
+    private static function isDefaultFulltextStopword(string $token): bool
+    {
+        static $stopwords = [
+            'a' => true, 'about' => true, 'an' => true, 'are' => true,
+            'as' => true, 'at' => true, 'be' => true, 'by' => true,
+            'com' => true, 'de' => true, 'en' => true, 'for' => true,
+            'from' => true, 'how' => true, 'i' => true, 'in' => true,
+            'is' => true, 'it' => true, 'la' => true, 'of' => true,
+            'on' => true, 'or' => true, 'that' => true, 'the' => true,
+            'this' => true, 'to' => true, 'was' => true, 'what' => true,
+            'when' => true, 'where' => true, 'who' => true, 'will' => true,
+            'with' => true, 'und' => true, 'www' => true,
+        ];
+
+        return isset($stopwords[mb_strtolower($token, 'UTF-8')]);
+    }
+
+    private static function likePattern(string $term): string
+    {
+        return '%' . str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $term) . '%';
+    }
+
+    private static ?bool $hasDescrizionePlain = null;
+
+    private static function descriptionExpr(\mysqli $db, string $prefix): string
+    {
+        if (self::$hasDescrizionePlain === null) {
+            try {
+                $res = $db->query("SHOW COLUMNS FROM libri LIKE 'descrizione_plain'");
+                self::$hasDescrizionePlain = $res !== false && $res->num_rows > 0;
+                if ($res instanceof \mysqli_result) {
+                    $res->free();
+                }
+            } catch (\Throwable $e) {
+                self::$hasDescrizionePlain = false;
+            }
+        }
+
+        return self::$hasDescrizionePlain
+            ? "COALESCE(NULLIF({$prefix}descrizione_plain, ''), {$prefix}descrizione)"
+            : "{$prefix}descrizione";
     }
 
     /** @var bool|null */

--- a/tests/librarything-search-index-conflicts.unit.php
+++ b/tests/librarything-search-index-conflicts.unit.php
@@ -56,6 +56,14 @@ $isbn = '979' . random_int(1000000000, 9999999999);
 function ltSicCleanup(mysqli $db, string $tag): void
 {
     $like = $tag . '%';
+    // FK-safe: delete child rows (created by upsertBook / syncSeriesAfterImport)
+    // before the parent libri rows, else the DELETE FROM libri fails on FK.
+    foreach (['libri_collane', 'libri_editori', 'libri_autori'] as $child) {
+        $stmt = $db->prepare("DELETE FROM {$child} WHERE libro_id IN (SELECT id FROM (SELECT id FROM libri WHERE titolo LIKE ?) t)");
+        $stmt->bind_param('s', $like);
+        $stmt->execute();
+        $stmt->close();
+    }
     $stmt = $db->prepare('DELETE FROM libri WHERE titolo LIKE ?');
     $stmt->bind_param('s', $like);
     $stmt->execute();

--- a/tests/librarything-search-index-conflicts.unit.php
+++ b/tests/librarything-search-index-conflicts.unit.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+use App\Controllers\LibraryThingImportController;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+function ltSicLoadEnv(string $path): array
+{
+    $env = [];
+    foreach (preg_split('/\r?\n/', (string) @file_get_contents($path)) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[trim($k)] = $v;
+    }
+    return $env;
+}
+
+$env = ltSicLoadEnv($root . '/.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user = $env['DB_USER'] ?? '';
+$pass = $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '');
+$name = $env['DB_NAME'] ?? '';
+
+try {
+    if (is_string($socket) && $socket !== '' && file_exists($socket)) {
+        $db = new mysqli(null, $user, $pass, $name, 0, $socket);
+    } else {
+        $db = new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+    }
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+$hasSearchIndex = $db->query("SHOW COLUMNS FROM libri LIKE 'search_index'");
+if (!$hasSearchIndex || $hasSearchIndex->num_rows === 0) {
+    echo "SKIP: libri.search_index not present\n";
+    exit(0);
+}
+
+$tag = 'ZZ_LT_SIC_' . bin2hex(random_bytes(4));
+$isbn = '979' . random_int(1000000000, 9999999999);
+
+function ltSicCleanup(mysqli $db, string $tag): void
+{
+    $like = $tag . '%';
+    $stmt = $db->prepare('DELETE FROM libri WHERE titolo LIKE ?');
+    $stmt->bind_param('s', $like);
+    $stmt->execute();
+    $stmt->close();
+}
+
+set_exception_handler(static function (\Throwable $e) use ($db, $tag): void {
+    try {
+        ltSicCleanup($db, $tag);
+    } catch (\Throwable $ignored) {
+    }
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n");
+    exit(1);
+});
+
+$TESTNO = 0;
+function pass(string $desc): void
+{
+    global $TESTNO;
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+function check(bool $cond, string $desc): void
+{
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    pass($desc);
+}
+
+ltSicCleanup($db, $tag);
+
+$stmt = $db->prepare('INSERT INTO libri (titolo, isbn13, search_index, copie_totali, copie_disponibili) VALUES (?, ?, ?, 1, 1)');
+$conflictTitle = $tag . '_conflict';
+$conflictIndex = $conflictTitle . ' ' . $isbn;
+$stmt->bind_param('sss', $conflictTitle, $isbn, $conflictIndex);
+$stmt->execute();
+$conflictId = (int) $db->insert_id;
+$stmt->close();
+
+$stmt = $db->prepare('INSERT INTO libri (titolo, copie_totali, copie_disponibili) VALUES (?, 1, 1)');
+$targetTitle = $tag . '_target';
+$stmt->bind_param('s', $targetTitle);
+$stmt->execute();
+$targetId = (int) $db->insert_id;
+$stmt->close();
+
+$controller = new LibraryThingImportController();
+$upsert = new ReflectionMethod($controller, 'upsertBook');
+$upsert->setAccessible(true);
+$result = $upsert->invoke($controller, $db, [
+    'id' => $targetId,
+    'titolo' => $targetTitle,
+    'isbn13' => $isbn,
+    'isbn10' => '',
+    'ean' => '',
+    'sottotitolo' => '',
+    'anno_pubblicazione' => '',
+    'lingua' => 'italiano',
+    'edizione' => '',
+    'numero_pagine' => '',
+    'descrizione' => '',
+    'descrizione_plain' => '',
+    'formato' => 'cartaceo',
+    'tipo_media' => 'libro',
+    'prezzo' => '',
+    'collana' => '',
+    'numero_serie' => '',
+    'traduttore' => '',
+    'parole_chiave' => '',
+    'classificazione_dewey' => '',
+], null, null);
+
+check(($result['id'] ?? null) === $targetId && ($result['action'] ?? null) === 'updated',
+    'upsert updates the explicit target book');
+
+$stmt = $db->prepare('SELECT isbn13, search_index FROM libri WHERE id = ?');
+$stmt->bind_param('i', $conflictId);
+$stmt->execute();
+$conflict = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+check(($conflict['isbn13'] ?? null) === null, 'conflicting book has ISBN13 cleared');
+check(!str_contains((string) ($conflict['search_index'] ?? ''), $isbn),
+    'conflicting book search_index is rebuilt without the cleared ISBN13');
+
+$stmt = $db->prepare('SELECT isbn13 FROM libri WHERE id = ?');
+$stmt->bind_param('i', $targetId);
+$stmt->execute();
+$target = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+check(($target['isbn13'] ?? null) === $isbn, 'target book receives the authoritative ISBN13');
+
+ltSicCleanup($db, $tag);
+$db->close();
+printf("\nALL %d PASS\n", $TESTNO);

--- a/tests/search-index-builder.unit.php
+++ b/tests/search-index-builder.unit.php
@@ -1,0 +1,142 @@
+<?php
+declare(strict_types=1);
+
+use App\Support\SearchIndexBuilder;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+function sibLoadEnv(string $path): array
+{
+    $env = [];
+    foreach (preg_split('/\r?\n/', (string) @file_get_contents($path)) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[trim($k)] = $v;
+    }
+    return $env;
+}
+
+$env = sibLoadEnv($root . '/.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user = $env['DB_USER'] ?? '';
+$pass = $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '');
+$name = $env['DB_NAME'] ?? '';
+
+try {
+    if (is_string($socket) && $socket !== '' && file_exists($socket)) {
+        $db = new mysqli(null, $user, $pass, $name, 0, $socket);
+    } else {
+        $db = new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+    }
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+$hasSearchIndex = $db->query("SHOW COLUMNS FROM libri LIKE 'search_index'");
+if (!$hasSearchIndex || $hasSearchIndex->num_rows === 0) {
+    echo "SKIP: libri.search_index not present\n";
+    exit(0);
+}
+
+const SIB_TABLE = 'zz_search_index_builder';
+
+function sibCleanup(mysqli $db): void
+{
+    $db->query('DROP TABLE IF EXISTS `' . SIB_TABLE . '`');
+}
+
+set_exception_handler(static function (\Throwable $e) use ($db): void {
+    try {
+        sibCleanup($db);
+    } catch (\Throwable $ignored) {
+    }
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n" . $e->getTraceAsString() . "\n");
+    exit(1);
+});
+
+$TESTNO = 0;
+function pass(string $desc): void
+{
+    global $TESTNO;
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+function check(bool $cond, string $desc): void
+{
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    pass($desc);
+}
+
+function sibSearch(mysqli $db, string $query): array
+{
+    $cond = SearchIndexBuilder::buildSearchCondition($db, 's.search_index', $query);
+    if ($cond === null) {
+        return [];
+    }
+    $stmt = $db->prepare('SELECT id FROM `' . SIB_TABLE . "` s WHERE {$cond['sql']} ORDER BY id");
+    $stmt->bind_param($cond['types'], ...$cond['params']);
+    $stmt->execute();
+    $res = $stmt->get_result();
+    $ids = [];
+    while ($row = $res->fetch_assoc()) {
+        $ids[] = (int) $row['id'];
+    }
+    $stmt->close();
+    return $ids;
+}
+
+sibCleanup($db);
+$db->query(
+    'CREATE TABLE `' . SIB_TABLE . '` (
+        id INT NOT NULL PRIMARY KEY,
+        search_index MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+        FULLTEXT KEY ft_search_index (search_index)
+     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+);
+
+$stmt = $db->prepare('INSERT INTO `' . SIB_TABLE . '` (id, search_index) VALUES (?, ?)');
+foreach ([
+    1 => 'The Hobbit J R R Tolkien',
+    2 => 'A Feast for Crows George R R Martin',
+    3 => 'C++ Primer Stanley Lippman',
+    4 => 'Q&A handbook',
+    5 => 'Il nome della rosa Umberto Eco',
+] as $id => $searchIndex) {
+    $stmt->bind_param('is', $id, $searchIndex);
+    $stmt->execute();
+}
+$stmt->close();
+
+$normal = SearchIndexBuilder::buildSearchCondition($db, 's.search_index', 'hobbit');
+check($normal !== null && str_contains($normal['sql'], 'MATCH(s.search_index)') && !str_contains($normal['sql'], ' LIKE '),
+    'normal long token uses only MATCH');
+
+$stopword = SearchIndexBuilder::buildSearchCondition($db, 's.search_index', 'the');
+check($stopword !== null && !str_contains($stopword['sql'], 'MATCH(s.search_index)') && str_contains($stopword['sql'], ' LIKE '),
+    'standalone FULLTEXT stopword falls back to LIKE');
+
+check(sibSearch($db, 'The Hobbit') === [1], 'The Hobbit matches despite required stopword');
+check(sibSearch($db, 'for Crows') === [2], 'for Crows matches despite required stopword');
+check(sibSearch($db, 'C++ Primer') === [3], 'C++ Primer matches literal punctuation token');
+check(sibSearch($db, 'C++') === [3], 'C++ alone does not degrade into C* FULLTEXT');
+check(sibSearch($db, 'Q&A handbook') === [4], 'Q&A handbook matches literal ampersand token');
+check(sibSearch($db, 'Q&A') === [4], 'Q&A alone matches via LIKE fallback');
+check(sibSearch($db, 'nome della rosa') === [5], 'regular Italian title still matches');
+
+sibCleanup($db);
+$db->close();
+printf("\nALL %d PASS\n", $TESTNO);


### PR DESCRIPTION
Follow-up hardening on the denormalized FULLTEXT search (#240), found reviewing uncommitted changes. Each item fixes a real bug:

## Correctness
- **Stopwords / punctuation zeroed out results.** A required BOOLEAN-mode term `+word*` matches **nothing** when the word is a FULLTEXT stopword (`the`, `la`, `di`, `and`, …) or gets split by the parser (`C++`, `Q&A`, `L'orologio`) — those are not indexed as one token, so the AND-required term returns zero rows. Now such words are detected (approximate InnoDB tokenization + default stopword list, mb-aware length) and routed to the `LIKE` fallback. Verified live: `il signore` → "Il Signore degli Anelli".
- **LIKE-wildcard injection.** The fallback now escapes user `% _ \` with `ESCAPE '\\'`, and the upgrade-window legacy path matches the full pre-migration scope (title/subtitle/description/keywords/ISBN/EAN/author/publisher) instead of only 5 columns.

## Gaps closed
- **LibriApiController** (admin books API) still used the old OR-of-LIKE + author `EXISTS` full scan → now routed through `buildSearchCondition` so it uses the FULLTEXT index.
- **LibraryThing import** cleared a conflicting book's ISBN/EAN but left the stale identifier in that book's `search_index`. New `clearIdentifierConflicts` (column-whitelisted, soft-delete scoped) snapshots the affected ids and rebuilds their index.

## Tests
- `tests/search-index-builder.unit.php` — **9/9** (stopword `The Hobbit`/`for Crows`, `C++`, `Q&A`, Italian title).
- `tests/librarything-search-index-conflicts.unit.php` — **4/4** (conflict ISBN cleared + `search_index` rebuilt without it).
- PHPStan L5 clean; `php -l` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Migliorata la ricerca: le condizioni di ricerca su `search_index` sono ora costruite in modo più robusto, con gestione dedicata di stopword, simboli e token FULLTEXT.
* **Bug Fixes**
  * Gestiti i conflitti tra libri durante l’import: se ISBN/EAN si sovrappongono, gli identificatori vengono ripuliti sui record in conflitto e l’indice di ricerca viene rigenerato in modo coerente.
* **Refactor**
  * Ricostruzione dell’`search_index` più efficiente tramite aggiornamenti batch.
* **Tests**
  * Aggiunti test per conflitti di identificatori e per la costruzione delle condizioni di ricerca.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->