### PR TITLE
feat(mobile-api): sortable catalog search (title/date) with sort-aware keyset

### DIFF
--- a/MOBILE_API_SPEC.md
+++ b/MOBILE_API_SPEC.md
@@ -68,7 +68,7 @@ All FKs respect existing `utenti`/`libri` schema. Follow the soft-delete rule on
 - `POST /auth/logout` — revoke current token.
 - `GET /me` — profile. `PATCH /me` — edit profile. `POST /me/password` — change password.
 - `GET /me/devices` — list devices. `DELETE /me/devices/{id}` — revoke a device.
-- `GET /catalog/search` — filters: `q`, `author`, `publisher`, `genre` (cascade id), `language`, `available` (bool); cursor pagination.
+- `GET /catalog/search` — filters: `q`, `author`, `publisher`, `genre` (cascade id), `language`, `available` (bool); `sort`: `newest` (default), `oldest`, `title_asc`, `title_desc`; cursor pagination.
 - `GET /catalog/books/{id}` — full detail + personal history.
 - `GET /catalog/genres` — genre cascade tree (for filter UI).
 - `GET /me/loans` — own loans (active + history). `GET /me/reservations`.

--- a/storage/plugins/mobile-api/plugin.json
+++ b/storage/plugins/mobile-api/plugin.json
@@ -2,7 +2,7 @@
   "name": "mobile-api",
   "display_name": "Mobile API",
   "description": "API REST/JSON versionata (/api/v1) per l'app companion mobile di Pinakes: discovery, autenticazione a token per dispositivo, ricerca catalogo, prestiti/prenotazioni, wishlist, profilo, messaggi e notifiche push. Disattivata per default finché non viene abilitata.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "",

--- a/storage/plugins/mobile-api/src/Controllers/CatalogController.php
+++ b/storage/plugins/mobile-api/src/Controllers/CatalogController.php
@@ -61,22 +61,43 @@ final class CatalogController
             $params = $request->getQueryParams();
 
             $limit  = $this->clampLimit($params['limit'] ?? null);
+
+            // Sort order — mirrors the web catalog's options. Keyset pagination
+            // stays stable by always tie-breaking on the unique id in the same
+            // direction as the chosen sort column.
+            $sort = $this->sortSpec(isset($params['sort']) ? (string) $params['sort'] : null);
+
             $cursor = CursorCodec::decode(isset($params['cursor']) ? (string) $params['cursor'] : null);
-            // The cursor is opaque to clients but only ever carries the keyset
-            // anchor (last seen id). It is NEVER trusted as authorization input.
-            $afterId = 0;
-            if (is_array($cursor) && isset($cursor['last_id']) && is_numeric($cursor['last_id'])) {
-                $afterId = (int) $cursor['last_id'];
+            // The cursor is opaque to clients and only carries the last row's sort
+            // anchor (value + id). It is NEVER trusted as authorization input. A
+            // cursor minted under a different sort is ignored so switching the sort
+            // order restarts cleanly from the first page.
+            $anchor = null;
+            if (is_array($cursor)
+                && ($cursor['sort'] ?? null) === $sort['key']
+                && isset($cursor['last_id']) && is_numeric($cursor['last_id'])
+                && array_key_exists('last_val', $cursor)
+            ) {
+                $anchor = ['id' => (int) $cursor['last_id'], 'val' => $cursor['last_val']];
             }
 
             [$conditions, $bindParams, $bindTypes] = $this->buildFilters($params);
 
-            // Keyset anchor: id < afterId, newest-first (descending id) — stable
-            // and index-friendly. afterId == 0 means "first page".
-            if ($afterId > 0) {
-                $conditions[]  = 'l.id < ?';
-                $bindParams[]  = $afterId;
-                $bindTypes    .= 'i';
+            // Keyset anchor in the chosen sort direction; id breaks ties so no row
+            // is skipped or repeated across pages. Null anchor == first page.
+            if ($anchor !== null) {
+                $cmp = $sort['dir'] === 'ASC' ? '>' : '<';
+                if ($sort['col'] === 'l.id') {
+                    $conditions[]  = "l.id {$cmp} ?";
+                    $bindParams[]  = $anchor['id'];
+                    $bindTypes    .= 'i';
+                } else {
+                    $conditions[]  = "({$sort['col']} {$cmp} ? OR ({$sort['col']} = ? AND l.id {$cmp} ?))";
+                    $bindParams[]  = (string) $anchor['val'];
+                    $bindParams[]  = (string) $anchor['val'];
+                    $bindParams[]  = $anchor['id'];
+                    $bindTypes    .= 'ssi';
+                }
             }
 
             $where = 'l.deleted_at IS NULL';
@@ -105,7 +126,7 @@ final class CatalogController
                 LEFT JOIN generi sg ON l.sottogenere_id = sg.id
                 WHERE {$where}
                 GROUP BY l.id
-                ORDER BY l.id DESC
+                ORDER BY {$sort['order']}
                 LIMIT ?
             ";
 
@@ -138,8 +159,15 @@ final class CatalogController
 
             $nextCursor = null;
             if ($hasMore && $rows !== []) {
-                $lastId     = (int) $rows[count($rows) - 1]['id'];
-                $nextCursor = CursorCodec::encode(['last_id' => $lastId]);
+                $last    = $rows[count($rows) - 1];
+                $lastVal = $sort['col'] === 'l.id'
+                    ? (int) $last['id']
+                    : (string) ($last[$sort['field']] ?? '');
+                $nextCursor = CursorCodec::encode([
+                    'sort'     => $sort['key'],
+                    'last_id'  => (int) $last['id'],
+                    'last_val' => $lastVal,
+                ]);
             }
 
             $meta = [
@@ -964,6 +992,34 @@ final class CatalogController
     }
 
     // ─── Small utilities ─────────────────────────────────────────────────────
+
+    /**
+     * Resolve the `sort` query param to a keyset-safe spec. Mirrors the web
+     * catalog's options. `col`/`dir` drive the keyset anchor; `order` is the full
+     * ORDER BY (tie-broken on the unique id); `field` is the result-row key whose
+     * value seeds the next cursor. Author sorts are intentionally omitted for now
+     * (the principal author is a per-row subquery, not keyset-friendly).
+     *
+     * @return array{key:string, col:string, dir:string, order:string, field:string}
+     */
+    private function sortSpec(?string $sort): array
+    {
+        switch ($sort) {
+            case 'oldest':
+                return ['key' => 'oldest', 'col' => 'l.id', 'dir' => 'ASC',
+                        'order' => 'l.id ASC', 'field' => 'id'];
+            case 'title_asc':
+                return ['key' => 'title_asc', 'col' => 'l.titolo', 'dir' => 'ASC',
+                        'order' => 'l.titolo ASC, l.id ASC', 'field' => 'titolo'];
+            case 'title_desc':
+                return ['key' => 'title_desc', 'col' => 'l.titolo', 'dir' => 'DESC',
+                        'order' => 'l.titolo DESC, l.id DESC', 'field' => 'titolo'];
+            case 'newest':
+            default:
+                return ['key' => 'newest', 'col' => 'l.id', 'dir' => 'DESC',
+                        'order' => 'l.id DESC', 'field' => 'id'];
+        }
+    }
 
     private function clampLimit(mixed $raw): int
     {

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -428,6 +428,7 @@ final class OpenApiController
                         ['name' => 'genre',     'in' => 'query', 'schema' => ['type' => 'integer'], 'description' => 'Filter by genre ID (cascade: any level)'],
                         ['name' => 'language',  'in' => 'query', 'schema' => ['type' => 'string'], 'description' => 'Filter by ISO 639-1 language code'],
                         ['name' => 'available', 'in' => 'query', 'schema' => ['type' => 'boolean'], 'description' => 'If true, return only books with at least one loanable copy'],
+                        ['name' => 'sort',      'in' => 'query', 'schema' => ['type' => 'string', 'enum' => ['newest', 'oldest', 'title_asc', 'title_desc'], 'default' => 'newest'], 'description' => 'Sort order: newest, oldest, title_asc, or title_desc'],
                         ['name' => 'cursor',    'in' => 'query', 'schema' => ['type' => 'string'], 'description' => 'Opaque pagination cursor from meta.next_cursor'],
                         ['name' => 'limit',     'in' => 'query', 'schema' => ['type' => 'integer', 'minimum' => 1, 'maximum' => 50, 'default' => 20], 'description' => 'Page size (max 50)'],
                     ],


### PR DESCRIPTION
Backend half of Uwe's app remarks (#238-style): the mobile catalog could only ever show **newest-first** (hardcoded `ORDER BY l.id DESC`), with no alphabetical/title order like the web catalog offers.

`GET /api/v1/catalog/search` now takes a **`sort`** param mirroring the web: `newest` (default), `oldest`, `title_asc`, `title_desc`. The opaque keyset cursor is made **sort-aware** — it carries the last row's `(sort value, id)` and pages with `(col </> ? OR (col = ? AND id </> ?))` tie-broken on the unique id, so no row is skipped/repeated in any order. A cursor minted under a different sort is ignored, so switching order restarts cleanly.

Author sorts are intentionally deferred (principal author is a per-row subquery, not keyset-friendly). `plugin.json` 1.2.1 → 1.2.2. Additive + backward compatible: an older server just ignores the param.

Verified against the dev DB: `title_asc` pages continue alphabetically across the keyset boundary with **no overlap**, including apostrophe titles (bound params). php -l + PHPStan L5 clean. The Android sort-picker UI that consumes this is a separate PR on Pinakes-Android.