### PR TITLE
fix(auth): honor the "Remember me" checkbox (field-name mismatch)

### DIFF
--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -62,7 +62,12 @@ class AuthController
         $data = (array) ($request->getParsedBody() ?? []);
         $email = trim($data['email'] ?? '');
         $password = $data['password'] ?? '';
-        $remember = !empty($data['remember']);
+        // The login form posts this checkbox as `remember_me` (see
+        // app/Views/auth/login.php). Accept the legacy `remember` name too so a
+        // stale cached form still works, but `remember_me` is the real field —
+        // reading only `remember` meant the box was silently ignored, no token
+        // cookie was ever created, and every session expired despite the tick.
+        $remember = !empty($data['remember_me']) || !empty($data['remember']);
         $returnUrl = $this->sanitizeReturnUrl($data['return_url'] ?? null);
 
         // CSRF validated by CsrfMiddleware

--- a/tests/remember-me.spec.js
+++ b/tests/remember-me.spec.js
@@ -47,7 +47,13 @@ async function login(page, { remember }) {
     await page.check('#remember_me');
   }
   await page.locator('button[type="submit"]').click();
-  await page.waitForURL(url => !url.toString().includes('/accedi'), { timeout: 15000 });
+  // Positive post-login assertion: an admin lands on /admin/... A negative
+  // !includes('/accedi') predicate is both locale-fragile (a non-Italian
+  // install redirects failures to /login?error=…, which does NOT contain
+  // '/accedi', so it would resolve and false-pass) and, on the IT install,
+  // turns every failure into an opaque 15s timeout. Matching /admin is
+  // locale-independent and only a real login can satisfy it.
+  await page.waitForURL(/\/admin(\/|$|\?)/, { timeout: 15000 });
 }
 
 test.describe.serial('Remember Me checkbox', () => {

--- a/tests/remember-me.spec.js
+++ b/tests/remember-me.spec.js
@@ -1,0 +1,109 @@
+// @ts-check
+//
+// Regression test for the "Remember me" checkbox being silently ignored.
+//
+// The login form posts the checkbox as `remember_me` (app/Views/auth/login.php),
+// but AuthController::login used to read `$data['remember']`. The names never
+// matched, so `$remember` was always false: no persistent token was created, no
+// `remember_token` cookie was set, and the session always expired on the next
+// PHP-session teardown despite the box being ticked.
+//
+// These tests pin the behaviour end-to-end through the real form:
+//   1. box ticked   → a `remember_token` cookie is set AND a user_sessions row exists
+//   2. box unticked → neither the cookie nor a row appears (fix is not "always on")
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+
+const DB_USER   = process.env.E2E_DB_USER   || '';
+const DB_PASS   = process.env.E2E_DB_PASS   || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const DB_NAME   = process.env.E2E_DB_NAME   || '';
+
+test.skip(
+  !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_PASS || !DB_NAME,
+  'E2E credentials not configured',
+);
+
+function dbQuery(sql) {
+  const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-N', '-B', '-e', sql];
+  if (DB_SOCKET) args.splice(3, 0, '-S', DB_SOCKET);
+  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 }).trim();
+}
+
+function sqlEscape(s) {
+  return String(s).replace(/'/g, "''");
+}
+
+/** Log in through the real form; optionally tick the "Remember me" box. */
+async function login(page, { remember }) {
+  await page.goto(`${BASE}/accedi`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  if (remember) {
+    await page.check('#remember_me');
+  }
+  await page.locator('button[type="submit"]').click();
+  await page.waitForURL(url => !url.toString().includes('/accedi'), { timeout: 15000 });
+}
+
+test.describe.serial('Remember Me checkbox', () => {
+  let adminId = '';
+
+  test.beforeAll(() => {
+    adminId = dbQuery(`SELECT id FROM utenti WHERE LOWER(email)=LOWER('${sqlEscape(ADMIN_EMAIL)}') LIMIT 1`);
+    expect(adminId, 'admin user must exist').not.toBe('');
+  });
+
+  // Start each case from a clean slate so counts are unambiguous. These are
+  // disposable rows in the E2E database, not a real user's live sessions.
+  test.beforeEach(() => {
+    dbQuery(`DELETE FROM user_sessions WHERE utente_id=${adminId}`);
+  });
+
+  test.afterAll(() => {
+    if (adminId) dbQuery(`DELETE FROM user_sessions WHERE utente_id=${adminId}`);
+  });
+
+  test('ticked → sets remember_token cookie and a user_sessions row', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await login(page, { remember: true });
+
+      const cookies = await context.cookies();
+      const remember = cookies.find(c => c.name === 'remember_token');
+      expect(remember, 'remember_token cookie must be set when the box is ticked').toBeTruthy();
+      // 64-byte token, hex-encoded → 128 chars; HttpOnly by design.
+      expect(remember.value.length).toBe(128);
+      expect(remember.httpOnly).toBe(true);
+
+      const rows = dbQuery(
+        `SELECT COUNT(*) FROM user_sessions WHERE utente_id=${adminId} AND is_revoked=0 AND expires_at > NOW()`,
+      );
+      expect(rows).toBe('1');
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('unticked → no remember_token cookie and no user_sessions row', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await login(page, { remember: false });
+
+      const cookies = await context.cookies();
+      const remember = cookies.find(c => c.name === 'remember_token');
+      expect(remember, 'no remember_token cookie when the box is left unticked').toBeFalsy();
+
+      const rows = dbQuery(`SELECT COUNT(*) FROM user_sessions WHERE utente_id=${adminId}`);
+      expect(rows).toBe('0');
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## The bug

Ticking **"Remember me"** on the login page did nothing — the session still
expired as if the box were never checked. Reported on discussion #238.

## Root cause

A field-name mismatch between the form and the controller:

- The form posts the checkbox as **`remember_me`** (`app/Views/auth/login.php`).
- `AuthController::login` read **`$data['remember']`**.

So `$remember` was **always false**. `RememberMeService::createToken()` was
never called → no `remember_token` cookie, no `user_sessions` row. The whole
database-backed persistent-login mechanism (service, middleware, 30-day token,
session-management UI) was correctly built but never fed — the checkbox was a
no-op.

## Fix

Read `remember_me`, keeping the legacy `remember` name as a fallback so a stale
cached form still works:

```php
$remember = !empty($data['remember_me']) || !empty($data['remember']);
```

## Verification

Manually reproduced and confirmed the fix end-to-end (real form login):
- **ticked** → `Set-Cookie: remember_token=…; Max-Age=2592000` (30 days,
  HttpOnly, SameSite=Lax) **and** a `user_sessions` row created.
- **before the fix** neither appeared.

Added `tests/remember-me.spec.js` — a Playwright regression pinning both
directions through the real form:
- ticked → 128-char HttpOnly `remember_token` cookie + a live `user_sessions` row
- unticked → neither (guards against the fix becoming "always on")

Both tests pass locally.