### PR TITLE
0.7.32: plugin schema self-heals on upgrade (#138 book-club 500) + loan-list script leak fix (#238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,41 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 ---
 
+## What's New in v0.7.32
+
+A hotfix for two bugs reported right after 0.7.31, and the systemic cause behind
+the recurring "a plugin's new table is missing after an upgrade" failures.
+
+### Plugin schema self-heals on upgrade (book-club 500 — [#138](https://github.com/fabiodalez-dev/Pinakes/discussions/138))
+
+- Upgrading with a plugin **already active** could leave one of its new tables
+  uncreated (`bookclub_external_books doesn't exist` → every Book Club page
+  500'd). The cause was generic: the plugin version was marked done in the DB
+  independently of its `ensureSchema()` actually running, and the "same version"
+  path then skipped `ensureSchema()` forever.
+- Fixed at the source: on boot the plugin manager now **re-runs `ensureSchema()`
+  whenever a plugin's declared tables are missing** — a cheap read-only check
+  that runs the schema DDL only when a table is actually absent, so healthy
+  installs pay nothing. A broken install heals itself on the very next page
+  load. One plugin's activation failure also no longer blocks the others.
+- No manual step: just upgrade and open the affected page once.
+
+### Loan list no longer leaks its script (Create Loan — [#238](https://github.com/fabiodalez-dev/Pinakes/discussions/238))
+
+- After creating a loan, the loans list could show a block of raw JavaScript as
+  page text (an inline `<script>` was closed early by a comment). Fixed.
+
+### Release safety
+
+- A mandatory schema gate (`scripts/verify-schema.sh`) now runs the migration
+  tests plus a per-plugin check that every plugin's declared tables match what
+  it creates, and a reproduction of the upgrade-while-active bug — so this class
+  of regression is caught before a release, not by a user after one.
+
+No schema migration in this release; the fix is runtime self-heal.
+
+---
+
 ## What's New in v0.7.31
 
 A feature + hardening release built from real user reports on the catalogue,

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -56,6 +56,46 @@ class PluginManager
      *
      * @return int Number of plugins auto-registered
      */
+    /**
+     * Cheap boot-time schema-presence probe used by the self-heal in
+     * autoRegisterBundledPlugins(). A schema-owning plugin may declare
+     * `expectedTables(): list<string>`; if any of those tables is missing the
+     * plugin's schema is behind and ensureSchema must be re-run. Plugins that
+     * do not declare the method never trigger a rebuild. One read-only
+     * information_schema query, no locks — safe to call on every boot.
+     */
+    private function bundledSchemaIncomplete(object $instance): bool
+    {
+        if (!method_exists($instance, 'expectedTables')) {
+            return false;
+        }
+        try {
+            $tables = $instance->expectedTables();
+        } catch (\Throwable $e) {
+            return false;
+        }
+        if (!is_array($tables) || $tables === []) {
+            return false;
+        }
+        $escaped = [];
+        foreach ($tables as $t) {
+            if (is_string($t) && $t !== '') {
+                $escaped[] = "'" . $this->db->real_escape_string($t) . "'";
+            }
+        }
+        if ($escaped === []) {
+            return false;
+        }
+        $sql = "SELECT COUNT(DISTINCT TABLE_NAME) FROM information_schema.TABLES
+                WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME IN (" . implode(',', $escaped) . ")";
+        $res = $this->db->query($sql);
+        if ($res === false) {
+            return false;
+        }
+        $present = (int) $res->fetch_row()[0];
+        return $present < count($escaped);
+    }
+
     public function autoRegisterBundledPlugins(): int
     {
         $registered = 0;
@@ -153,24 +193,35 @@ class PluginManager
                                     'db_error' => $this->db->error,
                                 ]);
                             }
-                            SecureLogger::warning("[PluginManager] Note: onActivate failed during upgrade for $pluginName; version rolled back to $dbVersion: " . $e->getMessage());
-                            throw new \RuntimeException(
-                                "Bundled plugin upgrade lifecycle failed for $pluginName",
-                                0,
-                                $e
-                            );
+                            // Do NOT rethrow: one bundled plugin's activation
+                            // failure must never abort the sync of the others —
+                            // that left every plugin after it un-synced, so an
+                            // already-active plugin (Uwe #138, book-club) never
+                            // got its new tables. The version is rolled back to
+                            // $dbVersion, so the next boot retries this path; and
+                            // the same-version branch below self-heals a schema
+                            // that is behind. Each plugin now syncs independently.
+                            SecureLogger::error("[PluginManager] onActivate failed during upgrade for $pluginName; version rolled back to $dbVersion, other plugins keep syncing, retry next boot. Error: " . $e->getMessage());
                         }
                     }
                 } elseif ($diskVersion === $dbVersion && (int) ($row['is_active'] ?? 0) === 1) {
-                    // Same version re-deploy: hooks added to the code but not yet in DB
-                    // (e.g. merging branches that extend the same plugin version).
-                    // Only re-run onActivate when the plugin has NO hooks registered
-                    // yet. Re-running it (ensureSchema DDL + hook re-insert) on EVERY
-                    // admin-plugin-page visit is wasteful and, when concurrent requests
-                    // (e.g. the admin layout's background polls) hit it at once,
-                    // deadlocks on plugin_hooks / metadata locks — surfacing as an
-                    // intermittent 500 on unrelated writes. When hooks already exist
-                    // we skip the work entirely; a wipe (count 0) re-triggers the sync.
+                    // Same disk/DB version, active plugin. Re-run onActivate when
+                    // EITHER:
+                    //  (a) hooks are missing — code added hooks not yet in DB
+                    //      (e.g. merging branches that extend the same version), or
+                    //      a wipe left plugin_hooks empty; OR
+                    //  (b) the plugin's declared schema is INCOMPLETE — a partial
+                    //      or aborted upgrade can leave version == disk with a
+                    //      table missing, and without this the "same version"
+                    //      branch would skip ensureSchema FOREVER (Uwe #138:
+                    //      book-club upgraded while active never got
+                    //      bookclub_external_books → permanent 1146 on every page).
+                    // Both are gated by a cheap read: hooks are one COUNT, the
+                    // schema probe is one read-only information_schema query with
+                    // NO locks. The heavy ensureSchema DDL runs ONLY when hooks or
+                    // a table are actually absent, so a healthy install pays
+                    // nothing and the historical deadlock (running DDL on every
+                    // admin-page poll) cannot recur.
                     $pluginIdInt = (int) ($row['id'] ?? 0);
                     $hookCount = 0;
                     $hookStmt = $this->db->prepare('SELECT COUNT(*) FROM plugin_hooks WHERE plugin_id = ?');
@@ -182,22 +233,21 @@ class PluginManager
                         }
                         $hookStmt->close();
                     }
-                    if ((int) $hookCount === 0) {
-                        try {
-                            $syncInstance = $this->instantiatePlugin([
-                                'id'        => $pluginIdInt,
-                                'name'      => $pluginName,
-                                'path'      => $pluginName,
-                                'main_file' => $pluginMeta['main_file'] ?? 'wrapper.php',
-                            ]);
-                            if (method_exists($syncInstance, 'onActivate')) {
-                                $syncInstance->onActivate();
-                            }
-                        } catch (\Throwable $e) {
-                            // Non-fatal: log and continue. Hooks may be stale but the
-                            // plugin keeps running with whatever is currently in the DB.
-                            SecureLogger::warning("[PluginManager] Hook re-sync skipped for $pluginName (same version): " . $e->getMessage());
+                    try {
+                        $syncInstance = $this->instantiatePlugin([
+                            'id'        => $pluginIdInt,
+                            'name'      => $pluginName,
+                            'path'      => $pluginName,
+                            'main_file' => $pluginMeta['main_file'] ?? 'wrapper.php',
+                        ]);
+                        $needsSync = ((int) $hookCount === 0)
+                            || $this->bundledSchemaIncomplete($syncInstance);
+                        if ($needsSync && method_exists($syncInstance, 'onActivate')) {
+                            $syncInstance->onActivate();
                         }
+                    } catch (\Throwable $e) {
+                        // Non-fatal: log and continue. The next boot retries.
+                        SecureLogger::warning("[PluginManager] Schema/hook self-heal skipped for $pluginName (same version): " . $e->getMessage());
                     }
                 }
                 continue;

--- a/app/Views/prestiti/index.php
+++ b/app/Views/prestiti/index.php
@@ -122,11 +122,12 @@ function getStatusBadge($status) {
     <script>
     // Auto-trigger PDF download after loan creation
     (function() {
-      // $pdfIdForDownload is filter_input-validated as int above —
-      // JSON_HEX_TAG is paranoid defense for the same reason
-      // htmlspecialchars guards string contexts: protects against
-      // `</script>` if a future refactor ever lets a non-numeric
-      // value through.
+      // pdfId is filter_input-validated as an int above; encoding it with
+      // JSON_HEX_TAG additionally escapes < > and & so a value could never
+      // break out of this inline block, as defense-in-depth if a future
+      // refactor ever let a non-numeric value through. (This comment must
+      // not itself contain a literal script-closing tag — doing so closes
+      // the block here and dumps the rest of the JS as page text.)
       var pdfId = <?= json_encode($pdfIdForDownload, JSON_HEX_TAG) ?>;
       if (pdfId > 0) {
         var iframe = document.createElement('iframe');

--- a/scripts/verify-schema.sh
+++ b/scripts/verify-schema.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# verify-schema.sh — MANDATORY schema/migration gate for every release.
+#
+# Runs the behavioural migration + plugin-schema test suite against the DB in
+# .env (or E2E_DB_* env). It proves, before a release ships:
+#   • migration-0.7.31.unit.php  — the release migration adds/backfills exactly
+#     the columns/indexes it claims, over OLD-schema sandboxes, idempotently.
+#   • plugin-schema-guard.unit.php — every bundled plugin's expectedTables() is
+#     an EXACT subset of what its ensureSchema() creates (no missing table left
+#     un-healed, no stale entry that would make the boot self-heal thrash), and
+#     ensureSchema is idempotent.
+#   • plugin-schema-selfheal.unit.php — an already-active plugin whose version
+#     is at the target but a table is missing (a partial/aborted upgrade — the
+#     Uwe #138 permanent-500 bug) SELF-HEALS on the next boot sync. This test
+#     FAILS on the pre-fix code on purpose: a schema test that can only pass is
+#     worthless.
+#
+# Exit non-zero if ANY of them fails. Wired into scripts/reinstall-test.sh and
+# meant to be run by hand before scripts/create-release.sh.
+#
+# Usage:
+#   bash scripts/verify-schema.sh
+#   (reads DB creds from .env; override with E2E_DB_USER / E2E_DB_PASS /
+#    E2E_DB_NAME / E2E_DB_SOCKET or E2E_DB_HOST+E2E_DB_PORT)
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+PHP="${PHP_BIN:-php}"
+TESTS=(
+  tests/migration-0.7.31.unit.php
+  tests/plugin-schema-guard.unit.php
+  tests/plugin-schema-selfheal.unit.php
+)
+
+echo "════════════════════════════════════════════════════════════"
+echo " Schema / migration verification gate"
+echo "════════════════════════════════════════════════════════════"
+
+fail=0
+for t in "${TESTS[@]}"; do
+  if [[ ! -f "$t" ]]; then
+    echo "✗ MISSING test file: $t"
+    fail=1
+    continue
+  fi
+  echo ""
+  echo "▶ $t"
+  if out="$("$PHP" "$t" 2>&1)"; then
+    # A test may SKIP cleanly (no DB) — treat that as non-fatal but visible.
+    if grep -q "^SKIP:" <<<"$out"; then
+      echo "  ⚠ SKIPPED: $(grep '^SKIP:' <<<"$out" | head -1)"
+    else
+      echo "  ✓ $(grep -E '^ALL [0-9]+ PASS' <<<"$out" | tail -1)"
+    fi
+  else
+    echo "$out" | tail -20
+    echo "  ✗ FAILED: $t"
+    fail=1
+  fi
+done
+
+echo ""
+echo "════════════════════════════════════════════════════════════"
+if [[ $fail -eq 0 ]]; then
+  echo " ✅ SCHEMA GATE PASSED"
+  echo "════════════════════════════════════════════════════════════"
+  exit 0
+else
+  echo " ❌ SCHEMA GATE FAILED — do NOT release"
+  echo "════════════════════════════════════════════════════════════"
+  exit 1
+fi

--- a/storage/plugins/archives/ArchivesPlugin.php
+++ b/storage/plugins/archives/ArchivesPlugin.php
@@ -302,6 +302,19 @@ class ArchivesPlugin
      * @return array{created: list<string>, failed: list<string>}
      * @throws \RuntimeException If a schema migration step fails.
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['archival_units', 'archival_unit_files', 'archival_unit_authority', 'archive_activities', 'archive_unit_activities', 'archive_agent_identifiers', 'archive_agent_relations', 'archive_places', 'archive_relations', 'authority_records', 'autori_authority_link'];
+    }
+
     public function ensureSchema(): array
     {
         $steps = [

--- a/storage/plugins/archives/wrapper.php
+++ b/storage/plugins/archives/wrapper.php
@@ -34,6 +34,11 @@ if (!class_exists('ArchivesPlugin', false)) {
             \App\Support\SecureLogger::debug('[Archives] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/book-club/BookClubPlugin.php
+++ b/storage/plugins/book-club/BookClubPlugin.php
@@ -201,9 +201,25 @@ class BookClubPlugin
      *
      * @return array{created: list<string>, failed: list<string>}
      */
-    public function ensureSchema(): array
+    /**
+     * The core tables ensureSchema() always creates. Declared so PluginManager
+     * can cheaply self-heal: if any of these is missing on an ACTIVE plugin
+     * (e.g. a partial/aborted upgrade left version == disk but a table absent),
+     * the boot-time sync re-runs onActivate regardless of the version match.
+     * Keep in lock-step with the $steps map in ensureSchema() — a unit test
+     * asserts the two stay identical.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
     {
-        $steps = [
+        return array_keys(self::schemaSteps());
+    }
+
+    /** @return array<string,string> table => CREATE DDL, in dependency order. */
+    private static function schemaSteps(): array
+    {
+        return [
             'bookclub_workflows'     => self::ddlWorkflows(),
             'bookclub_roles'         => self::ddlRoles(),
             'bookclub_clubs'         => self::ddlClubs(),
@@ -218,6 +234,11 @@ class BookClubPlugin
             'bookclub_meetings'      => self::ddlMeetings(),
             'bookclub_meeting_rsvps' => self::ddlMeetingRsvps(),
         ];
+    }
+
+    public function ensureSchema(): array
+    {
+        $steps = self::schemaSteps();
         $created = [];
         $failed = [];
         foreach ($steps as $table => $ddl) {

--- a/storage/plugins/book-club/wrapper.php
+++ b/storage/plugins/book-club/wrapper.php
@@ -43,6 +43,17 @@ if (!class_exists('BookClubPlugin', false)) {
         }
 
         /**
+         * Declared so PluginManager's schema self-heal can detect it with
+         * method_exists() (through the wrapper, not just __call).
+         *
+         * @return list<string>
+         */
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
+        /**
          * Forward any other call (setPluginId, registerRoutes,
          * renderAdminMenuEntry, onMaintenanceTick, ensureSchema, …) to the
          * namespaced instance so PluginManager and HookManager can invoke

--- a/storage/plugins/frbr-lrm/FrbrLrmPlugin.php
+++ b/storage/plugins/frbr-lrm/FrbrLrmPlugin.php
@@ -166,6 +166,19 @@ class FrbrLrmPlugin
      *
      * @return array{created: array<int,string>, failed: array<int,string>}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['opere', 'espressioni', 'libri_autori_ruoli'];
+    }
+
     public function ensureSchema(): array
     {
         $steps = [

--- a/storage/plugins/frbr-lrm/wrapper.php
+++ b/storage/plugins/frbr-lrm/wrapper.php
@@ -29,6 +29,11 @@ if (!class_exists('FrbrLrmPlugin', false)) {
             \App\Support\SecureLogger::debug('[FrbrLrm] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/mobile-api/MobileApiPlugin.php
+++ b/storage/plugins/mobile-api/MobileApiPlugin.php
@@ -189,6 +189,19 @@ class MobileApiPlugin
      *
      * @return array{created:list<string>, failed:list<string>}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['mobile_app_tokens', 'mobile_availability_watchers', 'mobile_push_log', 'mobile_push_prefs', 'mobile_push_subscriptions'];
+    }
+
     public function ensureSchema(): array
     {
         $created = [];

--- a/storage/plugins/mobile-api/wrapper.php
+++ b/storage/plugins/mobile-api/wrapper.php
@@ -33,6 +33,11 @@ if (!class_exists('MobileApiPlugin', false)) {
             \App\Support\SecureLogger::debug('[MobileApi] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/ncip-server/NcipServerPlugin.php
+++ b/storage/plugins/ncip-server/NcipServerPlugin.php
@@ -104,6 +104,19 @@ class NcipServerPlugin
     /**
      * @return array{created:list<string>, failed:list<string>}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['ncip_partners', 'ncip_transactions'];
+    }
+
     public function ensureSchema(): array
     {
         $created = [];

--- a/storage/plugins/ncip-server/wrapper.php
+++ b/storage/plugins/ncip-server/wrapper.php
@@ -30,6 +30,11 @@ if (!class_exists('NcipServerPlugin', false)) {
             \App\Support\SecureLogger::debug('[NcipServer] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/oai-pmh-server/OaiPmhServerPlugin.php
+++ b/storage/plugins/oai-pmh-server/OaiPmhServerPlugin.php
@@ -142,6 +142,19 @@ class OaiPmhServerPlugin
     /**
      * @return array{created:list<string>, failed:list<string>}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['oai_deleted_records', 'oai_resumption_tokens', 'digital_assets', 'mag_project_config'];
+    }
+
     public function ensureSchema(): array
     {
         $created = [];

--- a/storage/plugins/oai-pmh-server/wrapper.php
+++ b/storage/plugins/oai-pmh-server/wrapper.php
@@ -30,6 +30,11 @@ if (!class_exists('OaiPmhServerPlugin', false)) {
             \App\Support\SecureLogger::debug('[OaiPmhServer] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
+++ b/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
@@ -52,6 +52,19 @@ class ViafAuthorityPlugin
     /**
      * @return array{created:list<string>, failed:list<string>}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['author_authority_alternates'];
+    }
+
     public function ensureSchema(): array
     {
         $created = [];

--- a/storage/plugins/viaf-authority/wrapper.php
+++ b/storage/plugins/viaf-authority/wrapper.php
@@ -24,6 +24,11 @@ if (!class_exists('ViafAuthorityPlugin', false)) {
             \App\Support\SecureLogger::debug('[ViafAuthority] Plugin activated');
         }
 
+        public function expectedTables(): array
+        {
+            return $this->instance->expectedTables();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/storage/plugins/z39-server/Z39ServerPlugin.php
+++ b/storage/plugins/z39-server/Z39ServerPlugin.php
@@ -109,6 +109,19 @@ class Z39ServerPlugin
      *
      * @return array{created: string[], failed: string[]}
      */
+    /**
+     * Tables this plugin's ensureSchema() always creates. Declared so
+     * PluginManager's boot-time self-heal re-runs ensureSchema when any is
+     * missing on an already-active plugin (a partial/aborted upgrade). One
+     * cheap read-only probe; DDL only runs when a table is actually absent.
+     *
+     * @return list<string>
+     */
+    public function expectedTables(): array
+    {
+        return ['autore_varianti', 'libri_soggetti', 'soggetti', 'z39_access_logs', 'z39_rate_limits'];
+    }
+
     public function ensureSchema(): array
     {
         $result = ['created' => [], 'failed' => []];

--- a/tests/nikola-loan-workflow.spec.js
+++ b/tests/nikola-loan-workflow.spec.js
@@ -113,6 +113,20 @@ test.describe('Nikola #238 — loan workflow', () => {
     await expect(page.locator('#libro_search')).toHaveValue(new RegExp(BOOK_TITLE));
   });
 
+  test('loan list with ?pdf= does not leak the auto-download script as page text (#238)', async ({ page }) => {
+    await loginAdmin(page);
+    // The "Auto-trigger PDF download" inline <script> had a comment containing a
+    // literal script-closing tag, which closed the block early and dumped the
+    // rest of the JS as visible page text. Guard against the regression.
+    await page.goto(`${BASE}/admin/loans?pdf=1`);
+    const body = await page.locator('body').innerText();
+    expect(body).not.toContain('var pdfId');
+    expect(body).not.toContain('window.history.replaceState');
+    expect(body).not.toContain('document.createElement');
+    // The page still renders its real content.
+    await expect(page.locator('body')).toContainText(/Prestiti|Loans|Ausleihen|Prêts/);
+  });
+
   test('#4/#5 loan details + PDF show the copy inventory and subtitle', async ({ page }) => {
     await loginAdmin(page);
     await page.goto(`${BASE}/admin/loans/create`);

--- a/tests/plugin-schema-guard.unit.php
+++ b/tests/plugin-schema-guard.unit.php
@@ -1,0 +1,154 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Plugin schema guard — the release gate for "a plugin's declared schema must
+ * actually be creatable, and every table it declares must exist after its own
+ * ensureSchema() runs".
+ *
+ * For EVERY bundled plugin that declares expectedTables() this asserts:
+ *   (a) ensureSchema() reports no failed tables;
+ *   (b) every table in expectedTables() exists afterwards (catches a wrong /
+ *       stale list — the exact mistake that lets PluginManager's self-heal
+ *       either miss a real gap or thrash on a table that is never created);
+ *   (c) a second ensureSchema() is a no-op (idempotent, safe to re-run on
+ *       every boot / upgrade).
+ *
+ * This is what makes the boot-time self-heal trustworthy: the heal only re-runs
+ * ensureSchema when an expectedTable is missing, so expectedTables() MUST be an
+ * exact subset of what ensureSchema() creates. A stale entry would make a
+ * healthy install rebuild on every boot; a missing entry would leave a real gap
+ * un-healed. Both are caught here, before release.
+ *
+ * Idempotent + non-destructive: ensureSchema is CREATE TABLE IF NOT EXISTS, so
+ * running it against the dev DB only fills in tables that a full install would
+ * already have.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+function psg_env(string $path): array
+{
+    $env = [];
+    foreach (@file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env    = psg_env(__DIR__ . '/../.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user   = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$pass   = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+$name   = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+
+mysqli_report(MYSQLI_REPORT_OFF);
+try {
+    $db = (is_string($socket) && $socket !== '' && file_exists($socket))
+        ? new mysqli(null, $user, $pass, $name, 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+$TESTNO = 0;
+function pass(string $desc): void
+{
+    global $TESTNO;
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+function check(bool $cond, string $desc): void
+{
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    pass($desc);
+}
+
+$tableExists = function (string $t) use ($db): bool {
+    return (bool) $db->query(
+        "SELECT 1 FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='" . $db->real_escape_string($t) . "'"
+    )->num_rows;
+};
+
+$hm = new \App\Support\HookManager($db);
+
+// Every bundled plugin dir with a global "<Name>Plugin" class we can construct.
+$pluginsDir = __DIR__ . '/../storage/plugins';
+$dirs = array_filter(glob($pluginsDir . '/*', GLOB_ONLYDIR) ?: [], function ($d) {
+    return file_exists($d . '/wrapper.php')
+        || (bool) glob($d . '/*Plugin.php');
+});
+sort($dirs);
+
+$checkedPlugins = 0;
+
+foreach ($dirs as $dir) {
+    $slug = basename($dir);
+    // Load the plugin (wrapper defines the global forwarding class).
+    $wrapper = $dir . '/wrapper.php';
+    $mainGlob = glob($dir . '/*Plugin.php');
+    if (file_exists($wrapper)) {
+        require_once $wrapper;
+    } elseif ($mainGlob) {
+        require_once $mainGlob[0];
+    } else {
+        continue;
+    }
+    // Derive the global class name from the main file (e.g. NcipServerPlugin).
+    $className = $mainGlob ? basename($mainGlob[0], '.php') : null;
+    if ($className === null || !class_exists($className, false)) {
+        continue;
+    }
+
+    try {
+        $instance = new $className($db, $hm);
+    } catch (\Throwable $e) {
+        // Not all bundled plugins take ($db, $hm); skip those cleanly.
+        continue;
+    }
+    if (!is_callable([$instance, 'expectedTables']) || !method_exists($instance, 'expectedTables')) {
+        continue; // plugin owns no declared schema
+    }
+    if (method_exists($instance, 'setPluginId')) {
+        $pidRow = $db->query("SELECT id FROM plugins WHERE name='" . $db->real_escape_string($slug) . "'");
+        $pid = ($pidRow && $pidRow->num_rows) ? (int) $pidRow->fetch_row()[0] : 0;
+        $instance->setPluginId($pid);
+    }
+
+    $expected = $instance->expectedTables();
+    check(is_array($expected) && $expected !== [], "$slug: expectedTables() returns a non-empty list");
+
+    // Run the plugin's own schema creation (idempotent).
+    $result = $instance->ensureSchema();
+    $failed = is_array($result['failed'] ?? null) ? $result['failed'] : [];
+    check($failed === [], "$slug: ensureSchema() reports no failed tables (" . (empty($failed) ? 'ok' : implode(',', $failed)) . ")");
+
+    // Every declared table must now exist — this is the contract the self-heal relies on.
+    $missing = array_values(array_filter($expected, fn($t) => !$tableExists((string) $t)));
+    check($missing === [], "$slug: all expectedTables() exist after ensureSchema (missing: " . (empty($missing) ? 'none' : implode(',', $missing)) . ")");
+
+    // Idempotency: a second run must not report failures either.
+    $result2 = $instance->ensureSchema();
+    $failed2 = is_array($result2['failed'] ?? null) ? $result2['failed'] : [];
+    check($failed2 === [], "$slug: second ensureSchema() is a clean no-op (idempotent)");
+
+    $checkedPlugins++;
+}
+
+check($checkedPlugins >= 6, "covered at least 6 schema-owning plugins (got {$checkedPlugins})");
+
+$db->close();
+printf("\nALL %d PASS (%d plugins verified)\n", $TESTNO, $checkedPlugins);

--- a/tests/plugin-schema-selfheal.unit.php
+++ b/tests/plugin-schema-selfheal.unit.php
@@ -1,0 +1,180 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Plugin schema self-heal — the Uwe #138 / 0.7.31 regression.
+ *
+ * THE BUG this pins down: PluginManager stamps `plugins.version` to the new
+ * disk version BEFORE (and independently of) ensureSchema actually creating the
+ * plugin's tables. If ensureSchema never completes (a sibling plugin aborts the
+ * sync loop, a crash between the version write and the DDL, …), the install is
+ * left at version == disk with a table MISSING. On the next boot the
+ * "same-version, active, hooks present" path SKIPS ensureSchema forever, so the
+ * schema never heals and every plugin page 500s with a 1146 "table doesn't
+ * exist" — exactly what Uwe reported after upgrading with the plugin active.
+ *
+ * These tests reproduce that state against the REAL PluginManager and REAL
+ * BookClubPlugin, then assert the schema self-heals. On the pre-fix code the
+ * "already at target version" case (test 05/06) FAILS — that is the point:
+ * a test that only ever passes proves nothing.
+ *
+ * Safe to run repeatedly: it snapshots the live bookclub_external_books rows,
+ * forces the broken state, runs the sync, and restores the rows at the end.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/* ----------------------------- DB connect ----------------------------- */
+function she_env(string $path): array
+{
+    $env = [];
+    foreach (@file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env    = she_env(__DIR__ . '/../.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user   = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$pass   = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+$name   = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+
+mysqli_report(MYSQLI_REPORT_OFF);
+try {
+    $db = (is_string($socket) && $socket !== '' && file_exists($socket))
+        ? new mysqli(null, $user, $pass, $name, 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+/* ----------------------------- harness ----------------------------- */
+$TESTNO = 0;
+function pass(string $desc): void
+{
+    global $TESTNO;
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+function check(bool $cond, string $desc): void
+{
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    pass($desc);
+}
+
+$tableExists = function (string $t) use ($db): bool {
+    return (bool) $db->query(
+        "SELECT 1 FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='" . $db->real_escape_string($t) . "'"
+    )->num_rows;
+};
+$columnExists = function (string $t, string $c) use ($db): bool {
+    return (bool) $db->query(
+        "SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='" . $db->real_escape_string($t) . "' AND COLUMN_NAME='" . $db->real_escape_string($c) . "'"
+    )->num_rows;
+};
+
+/* --------- require book-club present + active (else SKIP) --------- */
+$row = $db->query("SELECT id, is_active FROM plugins WHERE name='book-club'")->fetch_assoc();
+if (!$row) {
+    echo "SKIP: book-club plugin not registered in this DB\n";
+    exit(0);
+}
+$pluginId = (int) $row['id'];
+$wasActive = (int) $row['is_active'];
+$origVersion = (string) $db->query("SELECT version FROM plugins WHERE name='book-club'")->fetch_row()[0];
+
+require_once __DIR__ . '/../storage/plugins/book-club/BookClubPlugin.php';
+$hm = new \App\Support\HookManager($db);
+
+/* Bring the plugin to a known-good baseline first (active + schema present). */
+$db->query("UPDATE plugins SET is_active=1 WHERE name='book-club'");
+$baseline = new \App\Plugins\BookClub\BookClubPlugin($db, $hm);
+$baseline->setPluginId($pluginId);
+$baseline->onActivate();
+
+/* Snapshot rows so we can restore user data at the end. */
+$db->query("DROP TABLE IF EXISTS zz_she_bak");
+$db->query("CREATE TABLE zz_she_bak AS SELECT * FROM bookclub_external_books");
+
+$diskVersion = (string) (json_decode((string) file_get_contents(__DIR__ . '/../storage/plugins/book-club/plugin.json'), true)['version'] ?? '1.4.0');
+
+/** Force the "table missing" broken state (keeps hooks). */
+$breakSchema = function () use ($db): void {
+    @$db->query("ALTER TABLE bookclub_books DROP FOREIGN KEY fk_bcbooks_external");
+    @$db->query("ALTER TABLE bookclub_books DROP KEY uq_bcbooks_external");
+    @$db->query("ALTER TABLE bookclub_books DROP KEY idx_bcbooks_external");
+    @$db->query("ALTER TABLE bookclub_books DROP COLUMN external_book_id");
+    @$db->query("DROP TABLE IF EXISTS bookclub_external_books");
+};
+$runSync = function () use ($db, $hm): void {
+    (new \App\Support\PluginManager($db, $hm))->autoRegisterBundledPlugins();
+};
+$hookCount = function () use ($db, $pluginId): int {
+    return (int) $db->query("SELECT COUNT(*) FROM plugin_hooks WHERE plugin_id={$pluginId}")->fetch_row()[0];
+};
+
+$cleanup = function () use ($db, $hm, $pluginId, $wasActive, $origVersion, $tableExists): void {
+    // Heal + restore the snapshot, leave the plugin as we found it.
+    require_once __DIR__ . '/../storage/plugins/book-club/BookClubPlugin.php';
+    $p = new \App\Plugins\BookClub\BookClubPlugin($db, $hm);
+    $p->setPluginId($pluginId);
+    try { $p->onActivate(); } catch (\Throwable $e) { /* best effort */ }
+    if ($tableExists('bookclub_external_books')
+        && (int) $db->query("SELECT COUNT(*) FROM bookclub_external_books")->fetch_row()[0] === 0
+        && $tableExists('zz_she_bak')) {
+        @$db->query("INSERT INTO bookclub_external_books SELECT * FROM zz_she_bak");
+    }
+    $db->query("DROP TABLE IF EXISTS zz_she_bak");
+    $ver = $db->real_escape_string($origVersion);
+    $db->query("UPDATE plugins SET is_active={$wasActive}, version='{$ver}' WHERE id={$pluginId}");
+};
+set_exception_handler(function (\Throwable $e) use ($cleanup): void {
+    try { $cleanup(); } catch (\Throwable $ignored) {}
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n");
+    exit(1);
+});
+
+/* ================= Scenario 1 — version-bump upgrade (1.3.x active → disk) ================= */
+$breakSchema();
+$db->query("UPDATE plugins SET version='1.3.0', is_active=1 WHERE name='book-club'");
+check(!$tableExists('bookclub_external_books'), '01 setup: broken state, external_books dropped');
+check($hookCount() > 0, '02 setup: plugin is active with hooks registered (Uwe scenario)');
+
+$runSync();
+check($tableExists('bookclub_external_books'), '03 version-bump sync heals: external_books created');
+check($columnExists('bookclub_books', 'external_book_id'), '04 version-bump sync heals: bookclub_books.external_book_id added');
+
+/* ==== Scenario 2 — THE Uwe bug: version already == disk, table missing, hooks present ==== */
+/* This is the state a partial/aborted upgrade leaves behind. Pre-fix, the
+ * "same version + hooks present" branch skips ensureSchema and this NEVER heals. */
+$breakSchema();
+$ver = $db->real_escape_string($diskVersion);
+$db->query("UPDATE plugins SET version='{$ver}', is_active=1 WHERE name='book-club'");
+check(!$tableExists('bookclub_external_books'), '05 setup: version already at disk, external_books missing, hooks present');
+
+$runSync();
+check($tableExists('bookclub_external_books'), '06 same-version sync SELF-HEALS the missing table (was the permanent-500 bug)');
+check($columnExists('bookclub_books', 'external_book_id'), '07 same-version sync also restores external_book_id');
+
+/* ==== Scenario 3 — idempotent: a healthy install is not needlessly rebuilt ==== */
+$before = $tableExists('bookclub_external_books');
+$runSync();
+check($before && $tableExists('bookclub_external_books'), '08 idempotent: a second sync on a healthy schema leaves the table intact');
+
+$cleanup();
+$db->close();
+printf("\nALL %d PASS\n", $TESTNO);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.31",
+  "version": "0.7.32",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Hotfix for two bugs reported right after 0.7.31, plus the systemic cause behind the recurring "a plugin's new table is missing after an upgrade" failures.

## Book-club 500 after upgrade (#138)
`bookclub_external_books doesn't exist` on every book-club page after upgrading **with the plugin already active**. The cause is generic, not book-club specific: PluginManager stamps `plugins.version` to the new disk version BEFORE (and independently of) `ensureSchema()` actually creating the tables. If ensureSchema doesn't complete (a sibling plugin aborts the sync loop, a crash mid-upgrade), the install is left at version == disk with a table missing — and the "same version, active, hooks present" path then **skips ensureSchema forever**, so the schema never heals.

Reproduced end-to-end and by a single real HTTP request.

**Fixes**
- **Boot-time self-heal**: on the same-version active path, PluginManager re-runs `onActivate` when a plugin's declared `expectedTables()` are missing. Cheap — one read-only `information_schema` probe; the ensureSchema DDL runs ONLY when a table is actually absent, so a healthy install pays nothing and the historical every-request-DDL deadlock cannot recur.
- One bundled plugin's onActivate failure during an upgrade no longer aborts the sync of the others (removed the re-throw that left later plugins un-synced).
- Every schema-owning bundled plugin now declares `expectedTables()` (book-club, archives, frbr-lrm, mobile-api, ncip-server, oai-pmh-server, viaf-authority, z39-server), so the self-heal protects them all.

## Loan list leaked its inline script (#238)
The "auto-trigger PDF download" comment contained a literal script-closing tag, which closed the `<script>` early and dumped the rest of the JS as visible page text. Reworded.

## Gates so this never ships again
- `scripts/verify-schema.sh` — mandatory schema gate (also run by `reinstall-test.sh`'s preflight): migration test + `plugin-schema-guard` (every `expectedTables()` is an exact subset of what `ensureSchema()` creates) + the self-heal reproduction.
- `tests/plugin-schema-selfheal.unit.php` reproduces the Uwe state and **FAILS on the pre-fix code** — a schema test that can only pass is worthless.
- `tests/plugin-schema-guard.unit.php` verifies all 8 schema plugins (33 checks).
- E2E guard that the loan list no longer leaks its script.

No schema migration; the fix is runtime self-heal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto il self-healing dello schema dei plugin durante installazioni e aggiornamenti, anche dopo interruzioni o aggiornamenti parziali.
  * Gli aggiornamenti dei plugin continuano anche se un singolo plugin presenta un errore non bloccante.

* **Correzioni**
  * Risolto il problema per cui la pagina dei prestiti poteva mostrare testo o JavaScript grezzo durante il download automatico del PDF.

* **Documentazione**
  * Aggiornato il changelog alla versione 0.7.32.
  * Precisato che non sono incluse migrazioni dello schema in questa release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->