### PR TITLE
fix(loans): harden reservation/loan lifecycle + copy-number generation (#238)

### DIFF
--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -161,7 +161,7 @@ class CopyController
         // Prestito "in carico" su questa copia (in_corso/in_ritardo): usato per la
         // chiusura automatica quando la copia torna 'disponibile'.
         $stmt = $db->prepare("
-            SELECT id
+            SELECT id, note
             FROM prestiti
             WHERE copia_id = ? AND attivo = 1 AND stato IN ('in_corso', 'in_ritardo')
         ");
@@ -184,74 +184,31 @@ class CopyController
         }
 
         // GESTIONE CAMBIO STATO DA "PRESTATO" A "DISPONIBILE"
-        // Se c'è un prestito in carico e si vuole rendere disponibile, chiudilo.
+        // Se c'è un prestito in carico e si vuole rendere disponibile, delega al
+        // SOLO flusso canonico di restituzione. Questo garantisce insieme: ordine
+        // lock libro->prestito, riassegnazione copia, promozione coda, ricalcolo,
+        // wishlist e mail di conferma, senza una seconda state machine divergente.
         if ($prestito && $statoCorrente === 'prestato' && $stato === 'disponibile') {
-            $db->begin_transaction();
-            try {
-                // Ri-leggi e BLOCCA il prestito da chiudere dentro la transazione.
-                $sel = $db->prepare("
-                    SELECT id, stato, data_scadenza
-                    FROM prestiti
-                    WHERE copia_id = ? AND attivo = 1 AND stato IN ('in_corso','in_ritardo','da_ritirare')
-                    ORDER BY data_prestito DESC
-                    LIMIT 1
-                    FOR UPDATE
-                ");
-                $sel->bind_param('i', $copyId);
-                $sel->execute();
-                $loanRow = $sel->get_result()->fetch_assoc();
-                $sel->close();
-                if (!$loanRow) {
-                    $db->rollback();
-                    $_SESSION['error_message'] = __('Il prestito associato non è più chiudibile. Ricarica la pagina.');
-                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
-                }
-                $prestitoId = (int) $loanRow['id'];
-                // Ritardo calcolato in PHP dalla riga bloccata: nell'UPDATE single-table
-                // non si può riferire il vecchio `stato` dopo averlo riassegnato.
-                $scadenza = (string) ($loanRow['data_scadenza'] ?? '');
-                $wasLate = ($loanRow['stato'] === 'in_ritardo')
-                    || ($scadenza !== '' && $scadenza < date('Y-m-d'));
-                $lateFlag = $wasLate ? 1 : 0;
-
-                // Chiudi come 'restituito' (MAI 'completato', I8); marca il ritardo (BUG5).
-                $upd = $db->prepare("
-                    UPDATE prestiti
-                    SET stato = 'restituito',
-                        restituito_in_ritardo = ?,
-                        attivo = 0,
-                        data_restituzione = CURDATE(),
-                        updated_at = NOW()
-                    WHERE id = ? AND attivo = 1
-                ");
-                $upd->bind_param('ii', $lateFlag, $prestitoId);
-                $upd->execute();
-                $affected = $upd->affected_rows;
-                $upd->close();
-                if ($affected !== 1) {
-                    $db->rollback();
-                    $_SESSION['error_message'] = __('Il prestito associato non è più chiudibile. Ricarica la pagina.');
-                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
-                }
-
-                // Aggiorna la copia nella stessa transazione
-                $stmt = $db->prepare("UPDATE copie SET stato = ?, note = ?, updated_at = NOW() WHERE id = ?");
-                $stmt->bind_param('ssi', $stato, $note, $copyId);
-                $stmt->execute();
-                $stmt->close();
-
-                $db->commit();
-            } catch (\Throwable $e) {
-                $db->rollback();
-                throw $e;
-            }
-
-            $_SESSION['success_message'] = __('Prestito chiuso automaticamente. La copia è ora disponibile.');
+            // processReturn ALWAYS overwrites prestiti.note with the value passed.
+            // The copy-edit form's `note` is a note about the COPY, not the loan —
+            // forwarding it blindly (or an empty string) would silently wipe the
+            // loan's own note. Preserve the loan note unless the operator actually
+            // typed a return note here.
+            $returnNote = ($note !== '') ? $note : (string) ($prestito['note'] ?? '');
+            $delegated = $request->withParsedBody([
+                'stato' => 'restituito',
+                'note' => $returnNote,
+                'redirect_to' => "/admin/books/{$libroId}",
+                'csrf_token' => $data['csrf_token'] ?? '',
+            ]);
+            return (new PrestitiController())->processReturn($delegated, $response, $db, (int) $prestito['id']);
         } else {
             // GESTIONE ALTRI STATI
-            // Fast-path: blocca subito se è già evidentemente trattenuta (HOLDING).
-            if ($copyHeld) {
-                $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su "Disponibile".');
+            // A copy physically outside the library must go through the return
+            // workflow (which records lost/damaged outcomes). Future holds on a
+            // copy still in the library may instead be reassigned atomically below.
+            if ($copyHeld && $prestito) {
+                $_SESSION['error_message'] = __('La copia è fisicamente in prestito: registra prima la restituzione o l’esito perso/danneggiato dal sistema Prestiti.');
                 return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
             }
 
@@ -274,9 +231,16 @@ class CopyController
                     return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
                 }
 
-                if ($this->isCopyHeld($db, $copyId)) {
+                // Recheck only physical possession after the book lock. Scheduled
+                // holds are deliberately allowed and will be moved below.
+                $physicalStmt = $db->prepare("SELECT 1 FROM prestiti WHERE copia_id = ? AND attivo = 1 AND stato IN ('in_corso','in_ritardo') LIMIT 1 FOR UPDATE");
+                $physicalStmt->bind_param('i', $copyId);
+                $physicalStmt->execute();
+                $physicallyOut = (bool) $physicalStmt->get_result()->fetch_row();
+                $physicalStmt->close();
+                if ($physicallyOut) {
                     $db->rollback();
-                    $_SESSION['error_message'] = __('Impossibile modificare una copia attualmente impegnata in un prestito o una prenotazione. Prima liberala (chiudi o annulla il prestito) oppure impostala su "Disponibile".');
+                    $_SESSION['error_message'] = __('La copia è fisicamente in prestito: usa il flusso di restituzione.');
                     return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
                 }
 
@@ -285,42 +249,65 @@ class CopyController
                 $stmt->execute();
                 $stmt->close();
 
+                $reassignmentService = new \App\Services\ReservationReassignmentService($db);
+                $reassignmentService->setExternalTransaction(true);
+                $reservationManager = null;
+
+                if (in_array($stato, ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
+                    // One copy may host several non-overlapping future holds.
+                    for ($guard = 0; $guard < 1000; $guard++) {
+                        $held = $db->prepare("
+                            SELECT 1 FROM prestiti
+                            WHERE copia_id = ? AND (
+                                (attivo = 1 AND stato IN ('prenotato','da_ritirare'))
+                                OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione')
+                            )
+                            LIMIT 1
+                        ");
+                        $held->bind_param('i', $copyId);
+                        $held->execute();
+                        $stillHeld = (bool) $held->get_result()->fetch_row();
+                        $held->close();
+                        if (!$stillHeld) {
+                            break;
+                        }
+                        $reassignmentService->reassignOnCopyLost($copyId);
+                    }
+                } elseif ($stato === 'disponibile') {
+                    $reassignmentService->reassignOnReturn($copyId);
+                    $reservationManager = new \App\Controllers\ReservationManager($db);
+                    $reservationManager->setExternalTransaction(true);
+                    for ($guard = 0; $guard < 1000 && $reservationManager->processBookAvailability($libroId); $guard++) {
+                        // Promote every date-eligible reservation allowed by capacity.
+                    }
+                }
+
+                $integrity = new \App\Support\DataIntegrity($db);
+                if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                    throw new \RuntimeException('Impossibile ricalcolare la disponibilità del libro.');
+                }
+
                 $db->commit();
             } catch (\Throwable $e) {
                 $db->rollback();
-                throw $e;
+                SecureLogger::error(__('Errore gestione cambio stato copia'), [
+                    'copia_id' => $copyId,
+                    'stato' => $stato,
+                    'error' => $e->getMessage()
+                ]);
+                $_SESSION['error_message'] = __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
+                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
             }
-        }
 
-        // Case 2 & 9: Handle Copy Status Changes
-        try {
-            $reassignmentService = new \App\Services\ReservationReassignmentService($db);
-
-            // Case 2: Copy became unavailable (lost/damaged/etc) -> Reassign any pending reservation
-            if (in_array($stato, ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'])) {
-                $reassignmentService->reassignOnCopyLost($copyId);
-            }
-            // Case 9: Copy became available -> Assign to waiting reservation
-            elseif ($stato === 'disponibile') {
-                $reassignmentService->reassignOnReturn($copyId); // Layer 1: copy-less prenotato holds
-                // Layer 2: promote queued waitlist reservations for this book (loop
-                // until none convert). Both queues on every release path (D5/BUG10).
-                $reservationManager = new \App\Controllers\ReservationManager($db);
-                for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
-                    // keep promoting while freed capacity converts the next queued reservation
+            try {
+                $reassignmentService->flushDeferredNotifications();
+                if ($reservationManager !== null) {
+                    $reservationManager->flushDeferredNotifications();
                 }
+            } catch (\Throwable $e) {
+                SecureLogger::warning(__('Invio notifica cambio stato copia fallito'), ['error' => $e->getMessage()]);
             }
-        } catch (\Throwable $e) {
-            SecureLogger::error(__('Errore gestione cambio stato copia'), [
-                'copia_id' => $copyId,
-                'stato' => $stato,
-                'error' => $e->getMessage()
-            ]);
         }
-
-        // Ricalcola disponibilità del libro
-        $integrity = new \App\Support\DataIntegrity($db);
-        $integrity->recalculateBookAvailability($libroId);
 
         if (!isset($_SESSION['success_message'])) {
             $_SESSION['success_message'] = __('Stato della copia aggiornato con successo.');

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2642,8 +2642,12 @@ class LibriController
         $pdf->AddPage();
 
         // Calculate available space
-        $availableWidth = $labelWidth - ($margin * 2);
-        $availableHeight = $labelHeight - ($margin * 2);
+        // Fold the configurable padding (#238) into the inset so the proportional
+        // renderer lays content out inside the reduced, padded area.
+        $padding = (float) $settings['padding'];
+        $margin += $padding;
+        $availableWidth = max(1.0, $labelWidth - ($margin * 2));
+        $availableHeight = max(1.0, $labelHeight - ($margin * 2));
 
         // Handle autori
         $autoriStr = $this->buildAuthorString($libro);
@@ -2659,13 +2663,9 @@ class LibriController
             $positionText = 'Pos. ' . $libro['posizione_progressiva'];
         }
 
-        if ($isPortrait) {
-            // PORTRAIT LAYOUT (vertical label - most common for book spines)
-            $this->renderPortraitLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin);
-        } else {
-            // LANDSCAPE LAYOUT (horizontal label - for larger internal labels)
-            $this->renderLandscapeLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin);
-        }
+        // One proportional renderer for both orientations: content scales to fill
+        // the label area instead of sitting fixed-size amid growing margins (#238).
+        $this->renderScaledLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin);
 
         // Output PDF
         $pdfContent = $pdf->Output('', 'S');
@@ -2759,8 +2759,12 @@ class LibriController
         $pdf->SetMargins($margin, $margin, $margin);
         $pdf->SetAutoPageBreak(false, 0);
 
-        $availableWidth = $labelWidth - ($margin * 2);
-        $availableHeight = $labelHeight - ($margin * 2);
+        // Fold the configurable padding (#238) into the inset so the proportional
+        // renderer lays content out inside the reduced, padded area.
+        $padding = (float) $settings['padding'];
+        $margin += $padding;
+        $availableWidth = max(1.0, $labelWidth - ($margin * 2));
+        $availableHeight = max(1.0, $labelHeight - ($margin * 2));
 
         foreach ($copie as $copia) {
             $numeroInventario = (string) ($copia['numero_inventario'] ?? '');
@@ -2770,11 +2774,7 @@ class LibriController
             $barcodePayload = ['value' => $numeroInventario, 'type' => 'C128'];
 
             $pdf->AddPage();
-            if ($isPortrait) {
-                $this->renderPortraitLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin, $numeroInventario);
-            } else {
-                $this->renderLandscapeLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin, $numeroInventario);
-            }
+            $this->renderScaledLabel($pdf, $appName, $libro, $autoriStr, $collocazione, $barcodePayload, $positionText, $availableWidth, $availableHeight, $margin, $numeroInventario);
         }
 
         $pdfContent = $pdf->Output('', 'S');
@@ -2789,7 +2789,7 @@ class LibriController
      * application name plus the clamped label width/height (mm) and derived
      * orientation. Single source of truth so both label routes read settings identically.
      *
-     * @return array{appName: string, labelWidth: int, labelHeight: int, orientation: string, showAppName: bool, showTitle: bool, showSubtitle: bool, showAuthorPublisher: bool, showDewey: bool}
+     * @return array{appName: string, labelWidth: int, labelHeight: int, padding: float, orientation: string, showAppName: bool, showTitle: bool, showSubtitle: bool, showAuthorPublisher: bool, showDewey: bool}
      */
     private function resolveLabelSettings(mysqli $db): array
     {
@@ -2806,11 +2806,23 @@ class LibriController
         if ($labelHeight < 10 || $labelHeight > 100)
             $labelHeight = 38;
 
+        // Configurable extra padding (mm) applied on every side, on top of the
+        // automatic margin — lets staff fine-tune the printable inset per label
+        // type (#238). Clamped so it can never swallow the whole label.
+        $padding = (float) ($settingsRepo->get('label', 'padding', '0'));
+        $maxPad = min($labelWidth, $labelHeight) / 3;
+        if ($padding < 0) {
+            $padding = 0.0;
+        } elseif ($padding > $maxPad) {
+            $padding = $maxPad;
+        }
+
         // Determine orientation based on dimensions
         return [
             'appName' => $appName,
             'labelWidth' => $labelWidth,
             'labelHeight' => $labelHeight,
+            'padding' => $padding,
             'orientation' => $labelWidth > $labelHeight ? 'L' : 'P',
             'showAppName' => $settingsRepo->get('label', 'show_app_name', '1') === '1',
             'showTitle' => $settingsRepo->get('label', 'show_title', '1') === '1',
@@ -2893,289 +2905,119 @@ class LibriController
     }
 
     /**
-     * Render portrait (vertical) label layout
-     * Optimized for narrow spine labels like 25x38mm, 25x40mm, 34x48mm
-     * Includes: App name, Title, Author, EAN barcode, EAN text, Dewey, Collocazione
+     * Proportional label renderer (#238): lays the active content out as a stack
+     * of weighted blocks that together fill the whole label area, so text and the
+     * barcode scale with the label's real dimensions instead of staying a fixed
+     * size surrounded by growing margins. Works for both portrait and landscape.
+     *
+     * Each text block auto-fits: its font starts from the height allocated to the
+     * block, then shrinks until the text fits the width (never overflows). The
+     * barcode fills the width and its allocated height. Blocks are centered.
      */
-    private function renderPortraitLabel($pdf, string $appName, array $libro, string $autoriStr, string $collocazione, array $barcode, string $positionText, float $availableWidth, float $availableHeight, float $margin, ?string $barcodeTextOverride = null): void
+    private function renderScaledLabel($pdf, string $appName, array $libro, string $autoriStr, string $collocazione, array $barcode, string $positionText, float $availableWidth, float $availableHeight, float $margin, ?string $barcodeTextOverride = null): void
     {
-        // Calculate font sizes proportional to label width
-        $fontSizeApp = max(4, min(7, $availableWidth * 0.25));
-        $fontSizeTitle = max(4, min(6, $availableWidth * 0.22));
-        $fontSizeAuthor = max(3, min(5, $availableWidth * 0.18));
-        $fontSizeSmall = max(3, min(4, $availableWidth * 0.15));
-        $fontSizePosition = max(4, min(6, $availableWidth * 0.20));
+        if ($availableWidth <= 0 || $availableHeight <= 0) {
+            return;
+        }
+        $family = 'dejavusans';
 
-        // Prepare text content
-        $appNameShort = mb_substr($appName, 0, 12);
-        $maxTitleChars = (int) ($availableWidth * 1.8);
-        $titolo = mb_substr($libro['titolo'], 0, $maxTitleChars);
-        if (mb_strlen($libro['titolo']) > $maxTitleChars)
-            $titolo .= '...';
+        // Build the ordered list of active blocks with a relative weight (how much
+        // of the height each should claim). The barcode dominates.
+        $blocks = [];
 
-        $maxAuthorChars = (int) ($availableWidth * 1.5);
-        $autoreShort = !empty($autoriStr) ? mb_substr($autoriStr, 0, $maxAuthorChars) : '';
-
-        // EAN/ISBN text (for display under barcode). When an override is supplied
-        // (per-copy labels), show the copy's inventory code instead of the ISBN.
-        $eanText = $barcodeTextOverride ?? ($libro['ean'] ?? $libro['isbn13'] ?? $libro['isbn10'] ?? '');
-
-        // Dewey classification
-        $dewey = $libro['classificazione_dewey'] ?? '';
-
-        // Calculate total content height
-        $totalHeight = 0;
-        $totalHeight += 3.5; // App name
-
-        // Calculate title height (using getStringHeight)
-        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
-        $titleHeight = $pdf->getStringHeight($availableWidth, $titolo);
-        $totalHeight += $titleHeight + 0.5;
-
-        // Author
-        $includeAuthor = !empty($autoreShort);
-        if ($includeAuthor) {
-            $totalHeight += 2.5;
+        $appName = trim($appName);
+        if ($appName !== '') {
+            // Secondary info → lighter weight so the title stays the prominent line.
+            $blocks[] = ['type' => 'text', 'text' => $appName, 'style' => 'B', 'weight' => 0.8];
         }
 
-        // Barcode + EAN text
-        $includeBarcode = !empty($barcode['value']);
-        $barcodeHeight = 0;
-        if ($includeBarcode) {
-            $barcodeHeight = min(8, $availableHeight * 0.18);
-            $totalHeight += $barcodeHeight + 1;
-            if (!empty($eanText)) {
-                $totalHeight += 2; // EAN text under barcode
+        $titolo = trim((string) ($libro['titolo'] ?? ''));
+        if ($titolo !== '') {
+            $blocks[] = ['type' => 'text', 'text' => $titolo, 'style' => 'B', 'weight' => 1.5];
+        }
+
+        $info = trim($autoriStr);
+        if ($info !== '') {
+            $blocks[] = ['type' => 'text', 'text' => $info, 'style' => '', 'weight' => 1.0];
+        }
+
+        $hasBarcode = !empty($barcode['value']);
+        if ($hasBarcode) {
+            $blocks[] = ['type' => 'barcode', 'weight' => 3.0];
+            $eanText = (string) ($barcodeTextOverride ?? ($libro['ean'] ?? $libro['isbn13'] ?? $libro['isbn10'] ?? ''));
+            $eanText = trim($eanText);
+            if ($eanText !== '') {
+                $blocks[] = ['type' => 'text', 'text' => $eanText, 'style' => '', 'weight' => 0.7];
             }
         }
 
-        // Dewey
-        $includeDewey = !empty($dewey);
-        if ($includeDewey) {
-            $totalHeight += 2.5;
+        $dewey = trim((string) ($libro['classificazione_dewey'] ?? ''));
+        if ($dewey !== '') {
+            $blocks[] = ['type' => 'text', 'text' => 'Dewey: ' . $dewey, 'style' => 'I', 'weight' => 0.7];
         }
 
-        // Position/Collocazione
-        $posColText = $collocazione ?: $positionText;
-        if ($posColText) {
-            $totalHeight += 3;
+        $posColText = trim((string) ($collocazione !== '' ? $collocazione : $positionText));
+        if ($posColText !== '') {
+            $blocks[] = ['type' => 'text', 'text' => $posColText, 'style' => 'B', 'weight' => 1.0];
         }
 
-        // Calculate vertical centering offset
-        $verticalOffset = ($availableHeight - $totalHeight) / 2;
-        if ($verticalOffset < 0)
-            $verticalOffset = 0;
-
-        // Start rendering with vertical centering
-        $currentY = $margin + $verticalOffset;
-
-        // App name
-        $pdf->SetFont('dejavusans', 'B', $fontSizeApp);
-        $pdf->SetXY($margin, $currentY);
-        $pdf->Cell($availableWidth, 3, $appNameShort, 0, 0, 'C');
-        $currentY += 3.5;
-
-        // Titolo libro (wrapped)
-        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
-        $pdf->SetXY($margin, $currentY);
-        $pdf->MultiCell($availableWidth, 2.5, $titolo, 0, 'C', false, 1);
-        $currentY = $pdf->GetY() + 0.5;
-
-        // Autore
-        if ($includeAuthor) {
-            $pdf->SetFont('dejavusans', '', $fontSizeAuthor);
-            $pdf->SetXY($margin, $currentY);
-            $pdf->Cell($availableWidth, 2, $autoreShort, 0, 0, 'C');
-            $currentY += 2.5;
+        $n = count($blocks);
+        if ($n === 0) {
+            return;
         }
 
-        // Barcode
-        if ($includeBarcode) {
-            $barcodeWidth = $availableWidth * 0.85;
-            $barcodeX = $margin + (($availableWidth - $barcodeWidth) / 2);
-            $currentY += 0.5;
-            $pdf->write1DBarcode($barcode['value'], $barcode['type'], $barcodeX, $currentY, $barcodeWidth, $barcodeHeight, 0.3, ['stretch' => true, 'fitwidth' => true]);
-            $currentY += $barcodeHeight;
+        // Inter-block gap proportional to height; distribute the rest by weight so
+        // the stack always fills exactly the available height (→ true centering).
+        $gap = $availableHeight * 0.03;
+        $gapsTotal = $gap * ($n - 1);
+        $usableHeight = max(0.1, $availableHeight - $gapsTotal);
+        $totalWeight = 0.0;
+        foreach ($blocks as $b) {
+            $totalWeight += $b['weight'];
+        }
 
-            // EAN text under barcode
-            if (!empty($eanText)) {
-                $pdf->SetFont('dejavusans', '', $fontSizeSmall);
-                $pdf->SetXY($margin, $currentY);
-                $pdf->Cell($availableWidth, 2, $eanText, 0, 0, 'C');
-                $currentY += 2;
+        $x = $margin;
+        $y = $margin;
+        foreach ($blocks as $i => $b) {
+            $blockHeight = $usableHeight * ($b['weight'] / $totalWeight);
+
+            if ($b['type'] === 'barcode') {
+                // Fill the width; the allocated height scales with the label.
+                $barcodeWidth = $availableWidth;
+                $barcodeX = $margin;
+                // stretch (no fitwidth) so the bars actually fill the given width —
+                // fitwidth would cap them at the symbol's natural width on wide labels.
+                $pdf->write1DBarcode(
+                    $barcode['value'],
+                    $barcode['type'],
+                    $barcodeX,
+                    $y,
+                    $barcodeWidth,
+                    $blockHeight,
+                    0.4,
+                    ['stretch' => true],
+                    'N'
+                );
+            } else {
+                // Auto-fit font: start from the block height (mm→pt via /0.3528,
+                // ×0.68 for cap height + a little breathing room), then shrink until
+                // the text fits the width so it can never overflow horizontally.
+                $fontPt = ($blockHeight / 0.3528) * 0.68;
+                $fontPt = max(3.0, min(60.0, $fontPt));
+                $pdf->SetFont($family, $b['style'], $fontPt);
+                while ($fontPt > 3.0 && $pdf->GetStringWidth($b['text']) > $availableWidth) {
+                    $fontPt -= 0.5;
+                    $pdf->SetFont($family, $b['style'], $fontPt);
+                }
+                // Vertically centered within the block, horizontally centered.
+                $pdf->SetXY($x, $y);
+                $pdf->Cell($availableWidth, $blockHeight, $b['text'], 0, 0, 'C', false, '', 0, false, 'T', 'M');
             }
-        }
 
-        // Dewey classification
-        if ($includeDewey) {
-            $pdf->SetFont('dejavusans', 'I', $fontSizeSmall);
-            $pdf->SetXY($margin, $currentY);
-            $deweyShort = mb_substr($dewey, 0, 15);
-            $pdf->Cell($availableWidth, 2, "Dewey: {$deweyShort}", 0, 0, 'C');
-            $currentY += 2.5;
-        }
-
-        // Position/Collocazione
-        if ($posColText) {
-            $pdf->SetFont('dejavusans', 'B', $fontSizePosition);
-            $pdf->SetXY($margin, $currentY);
-            $posShort = mb_substr($posColText, 0, 12);
-            $pdf->Cell($availableWidth, 3, $posShort, 0, 0, 'C');
-        }
-    }
-
-    /**
-     * Render landscape (horizontal) label layout
-     * Optimized for larger labels like 70x36mm, 50x25mm, 52x30mm
-     * Includes: App name, Title, Author/Publisher, EAN barcode, EAN text, Dewey, Collocazione
-     */
-    private function renderLandscapeLabel($pdf, string $appName, array $libro, string $autoriStr, string $collocazione, array $barcode, string $positionText, float $availableWidth, float $availableHeight, float $margin, ?string $barcodeTextOverride = null): void
-    {
-        // Calculate font sizes proportional to label height
-        $fontSizeApp = max(6, min(10, $availableHeight * 0.25));
-        $fontSizeTitle = max(5, min(8, $availableHeight * 0.20));
-        $fontSizeAuthor = max(4, min(6, $availableHeight * 0.15));
-        $fontSizeSmall = max(3, min(5, $availableHeight * 0.12));
-        $fontSizePosition = max(5, min(8, $availableHeight * 0.22));
-
-        // Prepare text content
-        $maxTitleChars = (int) ($availableWidth * 0.8);
-        $titolo = mb_substr($libro['titolo'], 0, $maxTitleChars);
-        if (mb_strlen($libro['titolo']) > $maxTitleChars)
-            $titolo .= '...';
-
-        // Autore ed editore
-        // NOTE: do not pre-truncate $autoriStr with a fixed cap here — since it now
-        // includes the publisher (concatenated in buildAuthorString via
-        // label_include_publisher), a fixed cap would clip the publisher away
-        // regardless of label size. Let the width-based truncation below be the
-        // sole truncation point (mirrors how $maxTitleChars is derived from width).
-        $autorEditore = [];
-        if (!empty($autoriStr)) {
-            $autorEditore[] = $autoriStr;
-        }
-        $infoText = '';
-        if (!empty($autorEditore)) {
-            $infoText = implode(' - ', $autorEditore);
-            $maxInfoChars = (int) ($availableWidth * 0.9);
-            $infoText = mb_substr($infoText, 0, $maxInfoChars);
-        }
-
-        // EAN/ISBN text (for display under barcode). When an override is supplied
-        // (per-copy labels), show the copy's inventory code instead of the ISBN.
-        $eanText = $barcodeTextOverride ?? ($libro['ean'] ?? $libro['isbn13'] ?? $libro['isbn10'] ?? '');
-
-        // Dewey classification
-        $dewey = $libro['classificazione_dewey'] ?? '';
-
-        // Calculate total content height
-        $totalHeight = 0;
-        $totalHeight += 4.5; // App name
-
-        $totalHeight += 4; // Title
-
-        // Author/Publisher
-        $includeInfo = !empty($infoText);
-        if ($includeInfo) {
-            $totalHeight += 3;
-        }
-
-        // Barcode + EAN text
-        $includeBarcode = !empty($barcode['value']);
-        $barcodeHeight = 0;
-        if ($includeBarcode) {
-            $barcodeHeight = min(10, $availableHeight * 0.25);
-            $totalHeight += $barcodeHeight + 0.5;
-            if (!empty($eanText)) {
-                $totalHeight += 2.5; // EAN text under barcode
+            $y += $blockHeight;
+            if ($i < $n - 1) {
+                $y += $gap;
             }
-        }
-
-        // Dewey
-        $includeDewey = !empty($dewey);
-        if ($includeDewey) {
-            $totalHeight += 2.5;
-        }
-
-        // Position text
-        $includePosition = !empty($positionText) && !$collocazione;
-        if ($includePosition) {
-            $totalHeight += 3.5;
-        }
-
-        // Collocazione
-        $includeCollocazione = !empty($collocazione);
-        if ($includeCollocazione) {
-            $totalHeight += 4;
-        }
-
-        // Calculate vertical centering offset
-        $verticalOffset = ($availableHeight - $totalHeight) / 2;
-        if ($verticalOffset < 0)
-            $verticalOffset = 0;
-
-        // Start rendering with vertical centering
-        $currentY = $margin + $verticalOffset;
-
-        // App name
-        $pdf->SetFont('dejavusans', 'B', $fontSizeApp);
-        $pdf->SetXY($margin, $currentY);
-        $pdf->Cell($availableWidth, 4, $appName, 0, 0, 'C');
-        $currentY += 4.5;
-
-        // Titolo libro
-        $pdf->SetFont('dejavusans', 'B', $fontSizeTitle);
-        $pdf->SetXY($margin, $currentY);
-        $pdf->Cell($availableWidth, 3.5, $titolo, 0, 0, 'C');
-        $currentY += 4;
-
-        // Autore ed editore
-        if ($includeInfo) {
-            $pdf->SetFont('dejavusans', '', $fontSizeAuthor);
-            $pdf->SetXY($margin, $currentY);
-            $pdf->Cell($availableWidth, 2.5, $infoText, 0, 0, 'C');
-            $currentY += 3;
-        }
-
-        // Barcode (centered horizontally)
-        if ($includeBarcode) {
-            $barcodeWidth = min($availableWidth * 0.65, 44);
-            $barcodeX = $margin + (($availableWidth - $barcodeWidth) / 2);
-            $currentY += 0.5;
-            $pdf->write1DBarcode($barcode['value'], $barcode['type'], $barcodeX, $currentY, $barcodeWidth, $barcodeHeight, 0.4, ['stretch' => true]);
-            $currentY += $barcodeHeight;
-
-            // EAN text under barcode
-            if (!empty($eanText)) {
-                $pdf->SetFont('dejavusans', '', $fontSizeSmall);
-                $pdf->SetXY($margin, $currentY);
-                $pdf->Cell($availableWidth, 2.5, $eanText, 0, 0, 'C');
-                $currentY += 2.5;
-            }
-        }
-
-        // Dewey classification
-        if ($includeDewey) {
-            $pdf->SetFont('dejavusans', 'I', $fontSizeSmall);
-            $pdf->SetXY($margin, $currentY);
-            $deweyShort = mb_substr($dewey, 0, 20);
-            $pdf->Cell($availableWidth, 2.5, "Dewey: {$deweyShort}", 0, 0, 'C');
-            $currentY += 2.5;
-        }
-
-        // Position text
-        if ($includePosition) {
-            $pdf->SetFont('dejavusans', 'B', $fontSizeAuthor);
-            $pdf->SetXY($margin, $currentY);
-            $pdf->Cell($availableWidth, 3, $positionText, 0, 0, 'C');
-            $currentY += 3.5;
-        }
-
-        // Collocazione
-        if ($includeCollocazione) {
-            $pdf->SetFont('dejavusans', 'B', $fontSizePosition);
-            $pdf->SetXY($margin, $currentY);
-            $pdf->Cell($availableWidth, 4, $collocazione, 0, 0, 'C');
         }
     }
 

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -1331,7 +1331,14 @@ class LibriController
         $fields['editore_id'] = empty($fields['editore_id']) || $fields['editore_id'] == 0 ? null : (int) $fields['editore_id'];
         $fields['genere_id'] = empty($fields['genere_id']) || $fields['genere_id'] == 0 ? null : (int) $fields['genere_id'];
         $fields['sottogenere_id'] = empty($fields['sottogenere_id']) || $fields['sottogenere_id'] == 0 ? null : (int) $fields['sottogenere_id'];
+        // Clamp to the same 1..9999 range as store(): an unbounded value would build
+        // a huge allocation loop / copy set. (#252 CodeRabbit)
         $fields['copie_totali'] = (int) $fields['copie_totali'];
+        if ($fields['copie_totali'] < 1) {
+            $fields['copie_totali'] = 1;
+        } elseif ($fields['copie_totali'] > 9999) {
+            $fields['copie_totali'] = 9999;
+        }
 
         // Validazione copie: verifica che sia possibile ridurre il numero di copie
         $copyRepo = new \App\Models\CopyRepository($db);
@@ -1770,8 +1777,12 @@ class LibriController
                     if ($removed >= $toRemove) {
                         break;
                     }
-                    $copyRepo->delete($copia['id']);
-                    $removed++;
+                    // Conditional delete: only counts if the copy is still removable
+                    // (a loan may have claimed it since the SELECT). Miscounting is
+                    // thus impossible; the FK RESTRICT is the hard backstop.
+                    if ($copyRepo->deleteIfRemovable($copia['id'])) {
+                        $removed++;
+                    }
                 }
 
                 // Se non riusciamo a rimuovere abbastanza copie, avvisa l'utente

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -425,6 +425,7 @@ class LibriController
         // Recupera tutte le copie del libro con informazioni sui prestiti
         $copyRepo = new \App\Models\CopyRepository($db);
         $copie = $copyRepo->getByBookId($id);
+        $copySchedule = $copyRepo->getScheduleByBookId($id);
 
         // Get loan history for this book
         $loanHistoryQuery = "
@@ -1085,12 +1086,13 @@ class LibriController
                 ? $fields['numero_inventario']
                 : "LIB-{$id}";
 
-            for ($i = 1; $i <= $copieTotali; $i++) {
-                $numeroInventario = $copieTotali > 1
-                    ? "{$baseInventario}-C{$i}"
-                    : $baseInventario;
-
-                $note = $copieTotali > 1 ? "Copia {$i} di {$copieTotali}" : null;
+            // Uniform "-C{N}" codes for every copy (#238): even a single copy is
+            // "{base}-C1", so later adding a 2nd copy yields a consistent C1/C2 pair
+            // instead of a bare base plus a "-C2". allocateInventoryCodes guarantees
+            // no collision with any existing numero_inventario.
+            $codes = $copyRepo->allocateInventoryCodes($baseInventario, $copieTotali);
+            foreach ($codes as $i => $numeroInventario) {
+                $note = "Copia " . ($i + 1) . " di {$copieTotali}";
                 $copyRepo->create($id, $numeroInventario, 'disponibile', $note);
             }
 
@@ -1722,17 +1724,18 @@ class LibriController
             $newCopieCount = (int) $fields['copie_totali'];
 
             if ($newCopieCount > $currentCopieCount) {
-                // Aggiungi nuove copie
+                // Aggiungi nuove copie. #238: generate gap-filling, collision-free
+                // "-C{N}" codes instead of "-C{count+1}" (which duplicated an existing
+                // code after a copy had been removed). allocateInventoryCodes checks
+                // every candidate against the whole `copie` table.
                 $baseInventario = !empty($fields['numero_inventario'])
                     ? $fields['numero_inventario']
                     : "LIB-{$id}";
 
-                for ($i = $currentCopieCount + 1; $i <= $newCopieCount; $i++) {
-                    $numeroInventario = $newCopieCount > 1
-                        ? "{$baseInventario}-C{$i}"
-                        : $baseInventario;
-
-                    $note = "Copia {$i} di {$newCopieCount}";
+                $howMany = $newCopieCount - $currentCopieCount;
+                $codes = $copyRepo->allocateInventoryCodes($baseInventario, $howMany);
+                foreach ($codes as $numeroInventario) {
+                    $note = "Copia {$numeroInventario}";
                     $newCopyId = $copyRepo->create($id, $numeroInventario, 'disponibile', $note);
 
                     // Case 1: Reassign pending reservations to this new copy
@@ -1756,20 +1759,19 @@ class LibriController
                     }
                 }
             } elseif ($newCopieCount < $currentCopieCount) {
-                // Rimuovi copie in eccesso (solo quelle disponibili, non in prestito)
-                $copie = $copyRepo->getByBookId($id);
+                // Rimuovi copie in eccesso DALLA CODA (le ultime aggiunte), solo quelle
+                // disponibili e senza impegni (#238: prima si rimuoveva la PRIMA della
+                // lista ASC, lasciando codici col suffisso più alto → collisioni dopo).
+                $removable = $copyRepo->getRemovableCopiesNewestFirst($id);
                 $toRemove = $currentCopieCount - $newCopieCount;
                 $removed = 0;
 
-                foreach ($copie as $copia) {
-                    if ($removed >= $toRemove)
+                foreach ($removable as $copia) {
+                    if ($removed >= $toRemove) {
                         break;
-
-                    // Rimuovi solo copie disponibili senza prestiti attivi
-                    if ($copia['stato'] === 'disponibile' && empty($copia['prestito_id'])) {
-                        $copyRepo->delete($copia['id']);
-                        $removed++;
                     }
+                    $copyRepo->delete($copia['id']);
+                    $removed++;
                 }
 
                 // Se non riusciamo a rimuovere abbastanza copie, avvisa l'utente

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -121,15 +121,17 @@ class LoanApprovalController
                    CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email,
                    r.data_inizio_richiesta, r.data_fine_richiesta,
                    r.data_scadenza_prenotazione,
-                   (SELECT COUNT(*) + 1 FROM prenotazioni r2
-                    WHERE r2.libro_id = r.libro_id
-                    AND r2.stato = 'attiva'
-                    AND r2.created_at < r.created_at) as posizione_coda
+                   COALESCE(r.queue_position,
+                       (SELECT COUNT(*) + 1 FROM prenotazioni r2
+                        WHERE r2.libro_id = r.libro_id
+                          AND r2.stato = 'attiva'
+                          AND (r2.created_at < r.created_at
+                               OR (r2.created_at = r.created_at AND r2.id < r.id)))) AS posizione_coda
             FROM prenotazioni r
             JOIN libri l ON r.libro_id = l.id AND l.deleted_at IS NULL
             JOIN utenti u ON r.utente_id = u.id
             WHERE r.stato = 'attiva'
-            ORDER BY r.created_at ASC
+            ORDER BY r.libro_id ASC, r.queue_position IS NULL, r.queue_position ASC, r.created_at ASC, r.id ASC
         ");
         $reservationsStmt->execute();
         $activeReservations = $reservationsStmt->get_result()->fetch_all(MYSQLI_ASSOC);
@@ -385,46 +387,11 @@ class LoanApprovalController
 
             // Step 2: If no valid pre-assigned copy, check global availability and find a new copy
             if (!$selectedCopy) {
-                // Step 2a: Count total lendable copies for this book
-                $totalCopiesStmt = $db->prepare("SELECT COUNT(*) as total FROM copie WHERE libro_id = ? AND stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')");
-                $totalCopiesStmt->bind_param('i', $libroId);
-                $totalCopiesStmt->execute();
-                $totalCopies = (int) ($totalCopiesStmt->get_result()->fetch_assoc()['total'] ?? 0);
-                $totalCopiesStmt->close();
-
-                // Step 2b: Count overlapping loans (excluding the current pending one)
-                $loanCountStmt = $db->prepare("
-                    SELECT COUNT(*) as count FROM prestiti
-                    WHERE libro_id = ? AND id != ?
-                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
-                    AND (
-                        (attivo = 1 AND stato IN ('in_corso', 'prenotato', 'da_ritirare', 'in_ritardo'))
-                        OR (stato = 'pendente' AND copia_id IS NOT NULL)
-                    )
-                ");
-                $loanCountStmt->bind_param('iiss', $libroId, $loanId, $dataScadenza, $dataPrestito);
-                $loanCountStmt->execute();
-                $overlappingLoans = (int) ($loanCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $loanCountStmt->close();
-
-                // Step 2c: Count overlapping prenotazioni
-                // Use COALESCE to handle NULL data_inizio_richiesta and data_fine_richiesta
-                // Fall back to data_scadenza_prenotazione if specific dates are not set
-                $resCountStmt = $db->prepare("
-                    SELECT COUNT(*) as count FROM prenotazioni
-                    WHERE libro_id = ? AND stato = 'attiva'
-                    AND COALESCE(data_inizio_richiesta, DATE(data_scadenza_prenotazione)) <= ?
-                    AND COALESCE(data_fine_richiesta, DATE(data_scadenza_prenotazione)) >= ?
-                    AND utente_id != ?
-                ");
-                $resCountStmt->bind_param('issi', $libroId, $dataScadenza, $dataPrestito, $loan['utente_id']);
-                $resCountStmt->execute();
-                $overlappingReservations = (int) ($resCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $resCountStmt->close();
-
-                // Check if there's at least one slot available
-                $totalOccupied = $overlappingLoans + $overlappingReservations;
-                if ($totalOccupied >= $totalCopies) {
+                // The pending row does not occupy capacity unless it already has a
+                // copy (handled above). Use the canonical per-day peak gate instead
+                // of summing all intervals that merely touch the requested range.
+                $capacity = new \App\Services\CapacityService($db);
+                if (!$capacity->hasFreeCapacity($libroId, $dataPrestito, $dataScadenza, excludePrestitoId: $loanId)) {
                     $db->rollback();
                     $response->getBody()->write(json_encode([
                         'success' => false,
@@ -618,13 +585,49 @@ class LoanApprovalController
         $db->begin_transaction();
 
         try {
-            // Lock and fetch FULL loan data BEFORE deletion (needed for rejection email)
-            // Must include user email/name and book title since loan will be deleted
+            // Canonical lock order: resolve the book without locking, lock `libri`
+            // first, then lock the pending loan. DataIntegrity locks the same book
+            // during the availability recalculation; taking the loan first here
+            // inverted the order used by approval/return and could deadlock.
+            $lookup = $db->prepare("SELECT libro_id FROM prestiti WHERE id = ? AND stato = 'pendente'");
+            $lookup->bind_param('i', $loanId);
+            $lookup->execute();
+            $lookupRow = $lookup->get_result()->fetch_assoc();
+            $lookup->close();
+            if (!$lookupRow) {
+                $db->rollback();
+                $response->getBody()->write(json_encode([
+                    'success' => false,
+                    'message' => __('Prestito non trovato o già processato')
+                ]));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
+            $bookId = (int) $lookupRow['libro_id'];
+
+            // NIENTE filtro deleted_at qui né nella JOIN sottostante (eccezione
+            // deliberata al soft-delete invariant): rifiutare una richiesta pendente
+            // deve funzionare ANCHE se il libro è stato soft-eliminato nel frattempo —
+            // filtrare renderebbe la query vuota e lascerebbe la richiesta orfana.
+            $lockBook = $db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+            $lockBook->bind_param('i', $bookId);
+            $lockBook->execute();
+            $bookLocked = (bool) $lockBook->get_result()->fetch_row();
+            $lockBook->close();
+            if (!$bookLocked) {
+                $db->rollback();
+                $response->getBody()->write(json_encode([
+                    'success' => false,
+                    'message' => __('Libro non trovato')
+                ]));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+            }
+
+            // Fetch FULL loan data under lock before deletion (needed for email).
             $stmt = $db->prepare("
                 SELECT p.libro_id, p.utente_id, l.titolo as libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email as utente_email
                 FROM prestiti p
-                JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
+                JOIN libri l ON p.libro_id = l.id
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.id = ? AND p.stato = 'pendente'
                 FOR UPDATE
@@ -644,7 +647,9 @@ class LoanApprovalController
                 return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
             }
 
-            $bookId = (int) $loan['libro_id'];
+            if ((int) $loan['libro_id'] !== $bookId) {
+                throw new \RuntimeException('libro_id del prestito cambiato durante il lock (TOCTOU).');
+            }
             // Store data needed for rejection email BEFORE deletion
             $userEmail = $loan['utente_email'];
             $userName = $loan['utente_nome'];

--- a/app/Controllers/MaintenanceController.php
+++ b/app/Controllers/MaintenanceController.php
@@ -7,6 +7,7 @@ use mysqli;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use App\Support\DataIntegrity;
+use App\Support\MaintenanceService;
 
 class MaintenanceController
 {
@@ -94,19 +95,27 @@ class MaintenanceController
         $results = [];
 
         try {
-            // 1. Ricalcola tutte le disponibilità
-            $availabilityResult = $integrity->recalculateAllBookAvailability();
-            $results['availability'] = $availabilityResult;
+            // 1. Run the same circulation lifecycle used by cron: scheduled
+            // activations, expirations, overdue transitions, email notifications
+            // and ICS. Previously the admin button only repaired counters, so it
+            // looked successful while leaving loans/notifications untouched.
+            $circulation = (new MaintenanceService($db))->runAll();
+            $results['circulation'] = $circulation;
 
-            // 2. Correggi inconsistenze
+            // 2. Correggi inconsistenze. fixDataInconsistencies() già esegue al suo
+            // interno recalculateAllBookAvailability() (e ne somma 'updated' in
+            // 'fixed'), quindi NON ricalcoliamo una seconda volta qui: sarebbe un
+            // secondo lock dell'intera tabella libri per lo stesso click e farebbe
+            // doppio-conteggio nel totale.
             $fixResult = $integrity->fixDataInconsistencies();
             $results['fixes'] = $fixResult;
+            $results['availability'] = ['updated' => $fixResult['fixed'], 'errors' => $fixResult['errors']];
 
             // 3. Genera report finale
             $report = $integrity->generateIntegrityReport();
             $results['final_report'] = $report;
 
-            $totalFixed = $availabilityResult['updated'] + $fixResult['fixed'];
+            $totalFixed = $fixResult['fixed'];
             $message = sprintf(__("Manutenzione completata: %d record corretti"), $totalFixed);
 
             if (!empty($report['consistency_issues'])) {

--- a/app/Controllers/PrestitiApiController.php
+++ b/app/Controllers/PrestitiApiController.php
@@ -155,7 +155,7 @@ class PrestitiApiController
         while ($r = $res->fetch_assoc()) {
             $actions = '<a class="text-blue-600" href="'.htmlspecialchars(url('/admin/loans/details/'.(int)$r['id']), ENT_QUOTES, 'UTF-8').'">'.htmlspecialchars(__('Dettagli'), ENT_QUOTES, 'UTF-8').'</a>';
             $actions .= ' | <a class="text-orange-600" href="'.htmlspecialchars(url('/admin/loans/edit/'.(int)$r['id']), ENT_QUOTES, 'UTF-8').'">'.htmlspecialchars(__('Modifica'), ENT_QUOTES, 'UTF-8').'</a>';
-            if ((int)$r['attivo'] === 1) {
+            if ((int)$r['attivo'] === 1 && in_array((string) $r['stato'], ['in_corso', 'in_ritardo'], true)) {
                 $actions .= ' | <a class="text-green-600" href="'.htmlspecialchars(url('/admin/loans/returned/'.(int)$r['id']), ENT_QUOTES, 'UTF-8').'">'.htmlspecialchars(__('Restituito'), ENT_QUOTES, 'UTF-8').'</a>';
             }
             $rows[] = [

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -289,7 +289,7 @@ class PrestitiController
                 $forcedCopyId = (int) $codeRow['id'];
 
                 // Must be in a lendable state and have no overlapping hold for the period.
-                $lendable = in_array($codeRow['stato'], ['disponibile', 'prenotato'], true);
+                $lendable = !in_array($codeRow['stato'], ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true);
                 if ($lendable) {
                     $ovStmt = $db->prepare("
                         SELECT 1 FROM prestiti
@@ -327,58 +327,25 @@ class PrestitiController
                 $selectedCopy = ['id' => $forcedCopyId];
             }
 
-            if ($selectedCopy === null && $isImmediateLoan) {
-                // For immediate loans, verify book-level availability (including prenotazioni)
-                // Step 1: Count total lendable copies
-                $totalCopiesStmt = $db->prepare("SELECT COUNT(*) as total FROM copie WHERE libro_id = ? AND stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')");
-                $totalCopiesStmt->bind_param('i', $libro_id);
-                $totalCopiesStmt->execute();
-                $totalCopies = (int) ($totalCopiesStmt->get_result()->fetch_assoc()['total'] ?? 0);
-                $totalCopiesStmt->close();
-
-                // Step 2: Count overlapping loans for the loan period
-                $loanCountStmt = $db->prepare("
-                SELECT COUNT(*) as count FROM prestiti
-                WHERE libro_id = ?
-                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
-                AND (
-                    (attivo = 1 AND stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
-                    OR (stato = 'pendente' AND copia_id IS NOT NULL)
-                )
-                ");
-                $loanCountStmt->bind_param('iss', $libro_id, $data_scadenza, $data_prestito);
-                $loanCountStmt->execute();
-                $overlappingLoans = (int) ($loanCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $loanCountStmt->close();
-
-                // Step 3: Count overlapping prenotazioni for the loan period
-                // Use COALESCE to handle NULL dates - matches ReservationManager pattern
-                // Note: data_scadenza_prenotazione is datetime, preserving full value for comparison
-                $resCountStmt = $db->prepare("
-                    SELECT COUNT(*) as count FROM prenotazioni
-                    WHERE libro_id = ? AND stato = 'attiva'
-                    AND COALESCE(data_inizio_richiesta, data_scadenza_prenotazione) <= ?
-                    AND COALESCE(data_fine_richiesta, data_scadenza_prenotazione) >= ?
-                ");
-                $resCountStmt->bind_param('iss', $libro_id, $data_scadenza, $data_prestito);
-                $resCountStmt->execute();
-                $overlappingReservations = (int) ($resCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $resCountStmt->close();
-
-                // Check if there's at least one slot available
-                $totalOccupied = $overlappingLoans + $overlappingReservations;
-                if ($totalOccupied >= $totalCopies) {
+            if ($selectedCopy === null) {
+                // Single canonical book-level gate: peak daily occupancy, including
+                // soft reservations, must leave one slot for every requested day.
+                // A raw COUNT of overlapping intervals over-rejects multi-copy books
+                // when commitments are disjoint within the requested window.
+                $capacity = new \App\Services\CapacityService($db);
+                if (!$capacity->hasFreeCapacity($libro_id, $data_prestito, $data_scadenza)) {
                     $db->rollback();
                     return $response->withHeader('Location', url('/admin/loans/create') . '?error=no_copies_available')->withStatus(302);
                 }
 
-                // Find a copy without overlapping loans for the requested period
-                // Include 'disponibile' and 'prenotato' copies - NOT EXISTS prevents date overlaps
-                // This allows scheduling non-overlapping loans on the same copy
+                // Pick a physical copy free for the whole interval. A copy may be
+                // physically 'prestato' today yet legitimately reusable for a
+                // disjoint future window, so only operationally non-lendable states
+                // are excluded here.
                 $overlapStmt = $db->prepare("
                     SELECT c.id FROM copie c
                     WHERE c.libro_id = ?
-                    AND c.stato IN ('disponibile', 'prenotato')
+                    AND c.stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')
                     AND NOT EXISTS (
                         SELECT 1 FROM prestiti p
                         WHERE p.copia_id = c.id
@@ -396,83 +363,6 @@ class PrestitiController
                 $overlapResult = $overlapStmt->get_result();
                 $selectedCopy = $overlapResult ? $overlapResult->fetch_assoc() : null;
                 $overlapStmt->close();
-                // Note: No fallback to getAvailableByBookId - if primary query finds no copy,
-                // all copies have overlapping loans for the requested period
-            } elseif ($selectedCopy === null) {
-                // For FUTURE loans, find a copy that has no overlapping active loans
-                // Also verify book-level availability (considering prenotazioni)
-
-                // Step 1: Count total lendable copies
-                $totalCopiesStmt = $db->prepare("SELECT COUNT(*) as total FROM copie WHERE libro_id = ? AND stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')");
-                $totalCopiesStmt->bind_param('i', $libro_id);
-                $totalCopiesStmt->execute();
-                $totalCopies = (int) ($totalCopiesStmt->get_result()->fetch_assoc()['total'] ?? 0);
-                $totalCopiesStmt->close();
-
-                // Step 2: Count overlapping loans (approved states only)
-                $loanCountStmt = $db->prepare("
-                SELECT COUNT(*) as count FROM prestiti
-                WHERE libro_id = ?
-                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
-                AND (
-                    (attivo = 1 AND stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
-                    OR (stato = 'pendente' AND copia_id IS NOT NULL)
-                )
-                ");
-                $loanCountStmt->bind_param('iss', $libro_id, $data_scadenza, $data_prestito);
-                $loanCountStmt->execute();
-                $overlappingLoans = (int) ($loanCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $loanCountStmt->close();
-
-                // Step 3: Count overlapping prenotazioni
-                // Use COALESCE to handle NULL dates - matches ReservationManager pattern
-                $resCountStmt = $db->prepare("
-                    SELECT COUNT(*) as count FROM prenotazioni
-                    WHERE libro_id = ? AND stato = 'attiva'
-                    AND COALESCE(data_inizio_richiesta, data_scadenza_prenotazione) <= ?
-                    AND COALESCE(data_fine_richiesta, data_scadenza_prenotazione) >= ?
-                ");
-                $resCountStmt->bind_param('iss', $libro_id, $data_scadenza, $data_prestito);
-                $resCountStmt->execute();
-                $overlappingReservations = (int) ($resCountStmt->get_result()->fetch_assoc()['count'] ?? 0);
-                $resCountStmt->close();
-
-                // Check if there's at least one slot available
-                $totalOccupied = $overlappingLoans + $overlappingReservations;
-                if ($totalOccupied >= $totalCopies) {
-                    // No slots available at book level
-                    $db->rollback();
-                    return $response->withHeader('Location', url('/admin/loans/create') . '?error=no_copies_available')->withStatus(302);
-                }
-
-                // Step 4: Find a specific copy without overlapping assigned loans
-                // Include 'disponibile' and 'prenotato' copies - NOT EXISTS prevents date overlaps
-                // This allows scheduling non-overlapping loans on the same copy
-                $overlapStmt = $db->prepare("
-                    SELECT c.id FROM copie c
-                    WHERE c.libro_id = ?
-                    AND c.stato IN ('disponibile', 'prenotato')
-                    AND NOT EXISTS (
-                        SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id
-                        AND p.data_prestito <= ?
-                        AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
-                        AND (
-                            (p.attivo = 1 AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
-                            OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)
-                        )
-                    )
-                    LIMIT 1
-                ");
-                $overlapStmt->bind_param('iss', $libro_id, $data_scadenza, $data_prestito);
-                $overlapStmt->execute();
-                $overlapResult = $overlapStmt->get_result();
-                $freeCopy = $overlapResult ? $overlapResult->fetch_assoc() : null;
-                $overlapStmt->close();
-
-                if ($freeCopy) {
-                    $selectedCopy = $freeCopy;
-                }
             }
 
             if (!$selectedCopy) {
@@ -489,9 +379,10 @@ class PrestitiController
             // Race condition check to prevent double-booking
             $overlapCopyStmt = $db->prepare("
                 SELECT 1 FROM prestiti
-                WHERE copia_id = ? AND attivo = 1
-                AND stato IN ('in_corso','da_ritirare','prenotato','in_ritardo')
+                WHERE copia_id = ?
                 AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
+                AND ( (attivo = 1 AND stato IN ('in_corso','da_ritirare','prenotato','in_ritardo'))
+                      OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
                 LIMIT 1
             ");
             $overlapCopyStmt->bind_param('iss', $selectedCopy['id'], $data_scadenza, $data_prestito);
@@ -595,23 +486,16 @@ class PrestitiController
 
 
 
-            // Commit della transazione
-            $db->commit();
-
-            // Allineamento disponibilità e validazione prestito
-            try {
-                $integrity = new DataIntegrity($db);
-                $integrity->recalculateBookAvailability($libro_id);
-                $validation = $integrity->validateAndUpdateLoan($newLoanId);
-                if (!($validation['success'] ?? false)) {
-                    SecureLogger::warning(__('Validazione prestito fallita (post-creazione)'), [
-                        'loan_id' => $newLoanId,
-                        'message' => $validation['message'] ?? null,
-                    ]);
-                }
-            } catch (\Throwable $e) {
-                SecureLogger::warning(__('DataIntegrity warning (store loan)'), ['error' => $e->getMessage()]);
+            // Derived availability is part of the write, not best-effort follow-up:
+            // commit loan + copy + counters atomically so the public catalogue can
+            // never observe a committed loan with stale copie_disponibili.
+            $integrity = new DataIntegrity($db);
+            $validation = $integrity->validateAndUpdateLoan($newLoanId, insideTransaction: true);
+            if (!($validation['success'] ?? false)) {
+                throw new \RuntimeException((string) ($validation['message'] ?? 'Loan validation failed'));
             }
+
+            $db->commit();
 
             // Create in-app notification for new loan
             try {
@@ -863,36 +747,8 @@ class PrestitiController
             // used to accept any new dates and only recalc counters, silently extending a loan
             // over a queued reservation). Only when the dates actually change.
             if ($newPrestito !== (string) $current['data_prestito'] || $newScadenza !== (string) $current['data_scadenza']) {
-                $ovlLoanStmt = $db->prepare("
-                    SELECT COUNT(*) AS c FROM prestiti
-                    WHERE libro_id = ? AND id != ? AND attivo = 1
-                    AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')
-                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
-                ");
-                $ovlLoanStmt->bind_param('iiss', $libroId, $id, $newScadenza, $newPrestito);
-                $ovlLoanStmt->execute();
-                $ovlLoans = (int) ($ovlLoanStmt->get_result()->fetch_assoc()['c'] ?? 0);
-                $ovlLoanStmt->close();
-
-                $ovlResStmt = $db->prepare("
-                    SELECT COUNT(*) AS c FROM prenotazioni
-                    WHERE libro_id = ? AND stato = 'attiva'
-                    AND COALESCE(data_inizio_richiesta, DATE(data_scadenza_prenotazione)) <= ?
-                    AND COALESCE(data_fine_richiesta, DATE(data_scadenza_prenotazione)) >= ?
-                ");
-                $ovlResStmt->bind_param('iss', $libroId, $newScadenza, $newPrestito);
-                $ovlResStmt->execute();
-                $ovlRes = (int) ($ovlResStmt->get_result()->fetch_assoc()['c'] ?? 0);
-                $ovlResStmt->close();
-
-                $totCopStmt = $db->prepare("SELECT COUNT(*) AS t FROM copie WHERE libro_id = ? AND stato NOT IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento')");
-                $totCopStmt->bind_param('i', $libroId);
-                $totCopStmt->execute();
-                $totCop = (int) ($totCopStmt->get_result()->fetch_assoc()['t'] ?? 0);
-                $totCopStmt->close();
-
-                // This loan holds 1 slot in the new window; if the rest would exceed capacity, reject.
-                if (1 + $ovlLoans + $ovlRes > $totCop) {
+                $capacity = new \App\Services\CapacityService($db);
+                if (!$capacity->hasFreeCapacity($libroId, $newPrestito, $newScadenza, excludePrestitoId: $id)) {
                     $db->rollback();
                     return $response->withHeader('Location', url('/admin/loans') . '?error=no_copies_available')->withStatus(302);
                 }
@@ -944,6 +800,29 @@ class PrestitiController
         if (!$repo->close($id)) {
             return $response->withHeader('Location', url('/admin/loans') . '?error=loan_not_closable')->withStatus(302);
         }
+
+        // Legacy close endpoint shares the same post-commit notification
+        // contract as processReturn/quick return.
+        try {
+            $notificationService = new NotificationService($db);
+            $notificationService->sendLoanReturnedNotification($id);
+
+            $bookStmt = $db->prepare("
+                SELECT p.libro_id, l.copie_disponibili
+                FROM prestiti p
+                JOIN libri l ON l.id = p.libro_id
+                WHERE p.id = ?
+            ");
+            $bookStmt->bind_param('i', $id);
+            $bookStmt->execute();
+            $book = $bookStmt->get_result()->fetch_assoc();
+            $bookStmt->close();
+            if ($book && (int) $book['copie_disponibili'] > 0) {
+                $notificationService->notifyWishlistBookAvailability((int) $book['libro_id']);
+            }
+        } catch (\Throwable $e) {
+            SecureLogger::warning('Legacy close notification failed', ['loan_id' => $id, 'error' => $e->getMessage()]);
+        }
         return $response->withHeader('Location', url('/admin/loans'))->withStatus(302);
     }
 
@@ -963,6 +842,8 @@ class PrestitiController
             LEFT JOIN libri ON prestiti.libro_id = libri.id AND libri.deleted_at IS NULL
             LEFT JOIN utenti ON prestiti.utente_id = utenti.id
             WHERE prestiti.id = ?
+              AND prestiti.attivo = 1
+              AND prestiti.stato IN ('in_corso','in_ritardo')
         ");
         $stmt->bind_param("i", $id);
         $stmt->execute();
@@ -1155,7 +1036,8 @@ class PrestitiController
                 for ($reassignGuard = 0; $reassignGuard < 1000; $reassignGuard++) {
                     $stillHeld = $db->query(
                         "SELECT 1 FROM prestiti WHERE copia_id = " . (int) $copia_id
-                        . " AND stato IN ('prenotato','da_ritirare') AND attivo = 1 LIMIT 1"
+                        . " AND ((attivo = 1 AND stato IN ('prenotato','da_ritirare'))"
+                        . " OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione')) LIMIT 1"
                     );
                     if (!$stillHeld || $stillHeld->num_rows === 0) {
                         break;
@@ -1529,44 +1411,8 @@ class PrestitiController
             $extensionStart = $currentDueDate; // Extension starts from current due date
             $extensionEnd = $proposedNewDueDate;
 
-            // Count other active loans/reservations overlapping with extension period (excluding current loan)
-            $conflictStmt = $db->prepare("
-                SELECT COUNT(*) as count FROM prestiti
-                WHERE libro_id = ? AND id != ? AND attivo = 1
-                AND stato IN ('prenotato', 'da_ritirare', 'in_corso', 'in_ritardo')
-                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
-            ");
-            $conflictStmt->bind_param('iiss', $libroId, $id, $extensionEnd, $extensionStart);
-            $conflictStmt->execute();
-            $overlappingLoans = (int) ($conflictStmt->get_result()->fetch_assoc()['count'] ?? 0);
-            $conflictStmt->close();
-
-            // Count overlapping prenotazioni (queue-based reservations)
-            $resConflictStmt = $db->prepare("
-                SELECT COUNT(*) as count FROM prenotazioni
-                WHERE libro_id = ? AND stato = 'attiva'
-                AND COALESCE(data_inizio_richiesta, DATE(data_scadenza_prenotazione)) <= ?
-                AND COALESCE(data_fine_richiesta, DATE(data_scadenza_prenotazione)) >= ?
-            ");
-            $resConflictStmt->bind_param('iss', $libroId, $extensionEnd, $extensionStart);
-            $resConflictStmt->execute();
-            $overlappingReservations = (int) ($resConflictStmt->get_result()->fetch_assoc()['count'] ?? 0);
-            $resConflictStmt->close();
-
-            // Count total lendable copies
-            $totalCopiesStmt = $db->prepare("SELECT COUNT(*) as total FROM copie WHERE libro_id = ? AND stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')");
-            $totalCopiesStmt->bind_param('i', $libroId);
-            $totalCopiesStmt->execute();
-            $totalCopies = (int) ($totalCopiesStmt->get_result()->fetch_assoc()['total'] ?? 0);
-            $totalCopiesStmt->close();
-
-            // Check if extension is possible:
-            // - Count this loan as 1 (it will occupy a slot in the extension period)
-            // - Add other overlapping loans + reservations
-            // - If total > totalCopies, extension not possible (would block another reservation)
-            // Note: Use > not >= because the current loan already has its assigned copy
-            $totalOccupied = 1 + $overlappingLoans + $overlappingReservations; // 1 = current loan being renewed
-            if ($totalOccupied > $totalCopies) {
+            $capacity = new \App\Services\CapacityService($db);
+            if (!$capacity->hasFreeCapacity($libroId, $extensionStart, $extensionEnd, excludePrestitoId: $id)) {
                 $db->rollback();
                 $errorUrl = $redirectTo ?? url('/admin/loans');
                 $separator = strpos($errorUrl, '?') === false ? '?' : '&';

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -810,7 +810,7 @@ class PrestitiController
             $bookStmt = $db->prepare("
                 SELECT p.libro_id, l.copie_disponibili
                 FROM prestiti p
-                JOIN libri l ON l.id = p.libro_id
+                JOIN libri l ON l.id = p.libro_id AND l.deleted_at IS NULL
                 WHERE p.id = ?
             ");
             $bookStmt->bind_param('i', $id);

--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -371,7 +371,7 @@ class ReservationManager
                     SELECT 1 FROM prestiti p
                     WHERE p.copia_id = c.id
                     AND p.data_prestito <= ?
-                    AND p.data_scadenza >= ?
+                    AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                     AND (
                         (p.attivo = 1 AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                         OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL)  -- pending conversion holds this copy (#157, model A-refined)
@@ -402,7 +402,7 @@ class ReservationManager
             $overlapCopyStmt = $this->db->prepare("
                 SELECT 1 FROM prestiti
                 WHERE copia_id = ?
-                AND data_prestito <= ? AND data_scadenza >= ?
+                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 AND (
                     (attivo = 1 AND stato IN ('in_corso','da_ritirare','prenotato','in_ritardo'))
                     OR (stato = 'pendente' AND copia_id IS NOT NULL)  -- pending conversion holds this copy (#157, model A-refined)
@@ -769,6 +769,40 @@ class ReservationManager
             // UPDATE garantisce anche che le due query vedano le stesse righe.
             $now = \App\Support\DateHelper::now();
 
+            // Resolve affected books first, then lock them in deterministic order
+            // BEFORE locking reservation rows. The previous reservations->libri
+            // order crossed every create/cancel path (libri->prenotazioni).
+            $booksStmt = $this->db->prepare("
+                SELECT DISTINCT libro_id
+                FROM prenotazioni
+                WHERE stato = 'attiva'
+                  AND data_scadenza_prenotazione IS NOT NULL
+                  AND data_scadenza_prenotazione < ?
+                ORDER BY libro_id
+            ");
+            $booksStmt->bind_param('s', $now);
+            $booksStmt->execute();
+            $booksResult = $booksStmt->get_result();
+            $affectedBooks = [];
+            while ($book = $booksResult->fetch_assoc()) {
+                $affectedBooks[] = (int) $book['libro_id'];
+            }
+            $booksStmt->close();
+
+            if ($affectedBooks === []) {
+                $this->commitIfOwned($ownTransaction);
+                return 0;
+            }
+
+            $bookLock = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+            foreach ($affectedBooks as $bookId) {
+                $bookLock->bind_param('i', $bookId);
+                $bookLock->execute();
+                $bookLock->get_result();
+            }
+            $bookLock->close();
+            $bookIdsSql = implode(',', $affectedBooks);
+
             // First, lock the expiring rows BEFORE updating (FOR UPDATE, solo su
             // prenotazioni: nessuna JOIN qui per non estendere il lock ad altre
             // tabelle) and collect the data needed for queue reordering and for
@@ -779,6 +813,7 @@ class ReservationManager
                 WHERE stato = 'attiva'
                 AND data_scadenza_prenotazione IS NOT NULL
                 AND data_scadenza_prenotazione < ?
+                AND libro_id IN ($bookIdsSql)
                 FOR UPDATE
             ");
             $selectStmt->bind_param('s', $now);
@@ -786,12 +821,6 @@ class ReservationManager
             $result = $selectStmt->get_result();
             $expiring = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
             $selectStmt->close();
-
-            $affectedBooks = [];
-            foreach ($expiring as $row) {
-                $affectedBooks[(int) $row['libro_id']] = true;
-            }
-            $affectedBooks = array_keys($affectedBooks);
 
             // Dati utente/titolo per le notifiche, letti ora (prima dell'UPDATE)
             // con le righe già lockate. Libri soft-deleted esclusi: la prenotazione
@@ -833,6 +862,7 @@ class ReservationManager
                 WHERE stato = 'attiva'
                 AND data_scadenza_prenotazione IS NOT NULL
                 AND data_scadenza_prenotazione < ?
+                AND libro_id IN ($bookIdsSql)
             ");
             $stmt->bind_param('s', $now);
             $stmt->execute();

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -121,12 +121,14 @@ class ReservationsAdminController
         if ($dataFineRichiesta !== '' && !preg_match('/^\d{4}-\d{2}-\d{2}$/', $dataFineRichiesta))
             $dataFineRichiesta = '';
 
-        $today = date('Y-m-d');
+        $today = \App\Support\DateHelper::today();
         if ($start === '') {
             $start = $today;
         }
         if ($end === '') {
-            $end = date('Y-m-d', strtotime($start . ' +1 month'));
+            $loanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
+            $loanDays = $loanDays > 0 ? $loanDays : 30;
+            $end = (new \DateTimeImmutable($start))->modify("+{$loanDays} days")->format('Y-m-d');
         }
 
         // Derive data_inizio_richiesta from data_prenotazione (start) if not explicitly provided
@@ -356,15 +358,15 @@ class ReservationsAdminController
             $dataScadenza = '';
         }
 
-        // Set default dates if not provided (use date() for server timezone consistency)
-        $today = date('Y-m-d');
+        // Set default dates in the application timezone.
+        $today = \App\Support\DateHelper::today();
 
         // Parse form dates (date only, without time)
         $dataPrenotazioneDate = $dataPrenotazione;
         $dataScadenzaDate = $dataScadenza;
 
         if (empty($dataPrenotazione)) {
-            $dataPrenotazione = date('Y-m-d H:i:s');
+            $dataPrenotazione = $today . ' 00:00:00';
             $dataPrenotazioneDate = $today;
         } else {
             $dataPrenotazioneDate = $dataPrenotazione; // Keep date only for loan period
@@ -378,8 +380,12 @@ class ReservationsAdminController
             if ($loanDays < 1) {
                 $loanDays = 30;
             }
-            $dataScadenza = date('Y-m-d H:i:s', strtotime("+{$loanDays} days"));
-            $dataScadenzaDate = date('Y-m-d', strtotime("+{$loanDays} days"));
+            // The default duration starts from the requested start date, not
+            // from today (critical for future reservations).
+            $dataScadenzaDate = (new \DateTimeImmutable($dataPrenotazioneDate))
+                ->modify("+{$loanDays} days")
+                ->format('Y-m-d');
+            $dataScadenza = $dataScadenzaDate . ' 23:59:59';
         } else {
             $dataScadenzaDate = $dataScadenza; // Keep date only for loan period
             $dataScadenza = $dataScadenza . ' 23:59:59';

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -126,9 +126,13 @@ class ReservationsAdminController
             $start = $today;
         }
         if ($end === '') {
-            $loanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
-            $loanDays = $loanDays > 0 ? $loanDays : 30;
+            $loanDays = $this->loanDurationDays($db);
             $end = (new \DateTimeImmutable($start))->modify("+{$loanDays} days")->format('Y-m-d');
+        }
+        // Normalize an inverted range on the reservation dates too (form can post
+        // end < start), mirroring the data_*_richiesta clamp below (#252).
+        if ($end < $start) {
+            $end = $start;
         }
 
         // Derive data_inizio_richiesta from data_prenotazione (start) if not explicitly provided
@@ -312,10 +316,7 @@ class ReservationsAdminController
             }
         }
 
-        $defaultLoanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
-        if ($defaultLoanDays < 1) {
-            $defaultLoanDays = 30;
-        }
+        $defaultLoanDays = $this->loanDurationDays($db);
 
         ob_start();
         $title = "Crea Prenotazione - Admin";
@@ -376,10 +377,7 @@ class ReservationsAdminController
         if (empty($dataScadenza)) {
             // Durata di default allineata all'impostazione admin loan_duration_days
             // (stesso valore mostrato dalla view), non più 30 giorni hardcoded.
-            $loanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
-            if ($loanDays < 1) {
-                $loanDays = 30;
-            }
+            $loanDays = $this->loanDurationDays($db);
             // The default duration starts from the requested start date, not
             // from today (critical for future reservations).
             $dataScadenzaDate = (new \DateTimeImmutable($dataPrenotazioneDate))
@@ -388,7 +386,12 @@ class ReservationsAdminController
             $dataScadenza = $dataScadenzaDate . ' 23:59:59';
         } else {
             $dataScadenzaDate = $dataScadenza; // Keep date only for loan period
-            $dataScadenza = $dataScadenza . ' 23:59:59';
+            // Normalize an inverted range when both dates are posted (#252), mirroring
+            // the data_*_richiesta clamp below.
+            if ($dataScadenzaDate < $dataPrenotazioneDate) {
+                $dataScadenzaDate = $dataPrenotazioneDate;
+            }
+            $dataScadenza = $dataScadenzaDate . ' 23:59:59';
         }
 
         // Derive data_inizio_richiesta from data_prenotazione if not explicitly provided
@@ -488,6 +491,17 @@ class ReservationsAdminController
             $db->rollback();
             return $response->withHeader('Location', url('/admin/reservations/create') . '?error=save_failed')->withStatus(302);
         }
+    }
+
+    /**
+     * The configured loan duration in days (loans.loan_duration_days), with the
+     * canonical fallback to 30 for a missing or non-positive value. Centralizes
+     * the lookup previously duplicated in update(), store() and createForm().
+     */
+    private function loanDurationDays(mysqli $db): int
+    {
+        $days = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
+        return $days > 0 ? $days : 30;
     }
 
     private function reorderQueuePositions(mysqli $db, int $libroId): void

--- a/app/Controllers/ReservationsController.php
+++ b/app/Controllers/ReservationsController.php
@@ -67,8 +67,8 @@ class ReservationsController
             SELECT data_prestito, data_scadenza, data_restituzione, pickup_deadline, stato, copia_id
             FROM prestiti
             WHERE libro_id = ? AND (
-                stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato')
-                OR (stato = 'pendente' AND copia_id IS NOT NULL)
+                (attivo = 1 AND stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato'))
+                OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL)
             )
             ORDER BY data_prestito
         ");
@@ -518,8 +518,8 @@ class ReservationsController
             SELECT data_prestito, data_scadenza, data_restituzione, pickup_deadline, stato, copia_id
             FROM prestiti
             WHERE libro_id = ? AND (
-                stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato')
-                OR (stato = 'pendente' AND copia_id IS NOT NULL)
+                (attivo = 1 AND stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato'))
+                OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL)
             )
             ORDER BY data_prestito
         ");

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -731,6 +731,7 @@ class SettingsController
         return [
             'width' => (int) ($repository->get('label', 'width', (string) ($config['width'] ?? 25))),
             'height' => (int) ($repository->get('label', 'height', (string) ($config['height'] ?? 38))),
+            'padding' => (float) ($repository->get('label', 'padding', '0')),
             'format_name' => (string) ($repository->get('label', 'format_name', $config['format_name'] ?? '25x38mm (Standard)')),
             'show_app_name' => $repository->get('label', 'show_app_name', '1') === '1',
             'show_title' => $repository->get('label', 'show_title', '1') === '1',
@@ -769,6 +770,16 @@ class SettingsController
         foreach (['show_app_name', 'show_title', 'show_subtitle', 'show_author_publisher', 'show_dewey'] as $option) {
             $repository->set('label', $option, isset($data[$option]) ? '1' : '0');
         }
+
+        // Configurable padding (mm) applied on every side of the label (#238).
+        // Clamp to 0..30; the renderer clamps again against the actual label size.
+        $padding = (float) ($data['label_padding'] ?? 0);
+        if ($padding < 0) {
+            $padding = 0.0;
+        } elseif ($padding > 30) {
+            $padding = 30.0;
+        }
+        $repository->set('label', 'padding', (string) $padding);
 
         $labelFormat = trim((string) ($data['label_format'] ?? '25x38'));
         if ($labelFormat === 'custom') {

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -76,7 +76,7 @@ class UserActionsController
                        EXISTS(SELECT 1 FROM recensioni r WHERE r.libro_id = pr.libro_id AND r.utente_id = ?) as has_review
                 FROM prestiti pr
                 JOIN libri l ON l.id = pr.libro_id AND l.deleted_at IS NULL
-                WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato != 'prestato'
+                WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato IN ('restituito','perso','danneggiato')
                 ORDER BY pr.data_restituzione DESC, pr.data_prestito DESC
                 LIMIT 20";
         $stmt = $db->prepare($sql);
@@ -375,13 +375,16 @@ class UserActionsController
 
         $uid = (int) $user['id'];
         $startDate = $date;
-        $endDate = date('Y-m-d', strtotime($date . ' +1 month'));
+        $loanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
+        $loanDays = $loanDays > 0 ? $loanDays : 30;
+        $endDate = (new \DateTimeImmutable($date))->modify("+{$loanDays} days")->format('Y-m-d');
 
         $db->begin_transaction();
 
         try {
-            // Get reservation details and lock
-            $getStmt = $db->prepare("SELECT libro_id FROM prenotazioni WHERE id = ? AND utente_id = ? AND stato = 'attiva' FOR UPDATE");
+            // Resolve without locking, then follow the canonical book->reservation
+            // lock order used by create/cancel/promotion.
+            $getStmt = $db->prepare("SELECT libro_id FROM prenotazioni WHERE id = ? AND utente_id = ? AND stato = 'attiva'");
             $getStmt->bind_param('ii', $rid, $uid);
             $getStmt->execute();
             $result = $getStmt->get_result();
@@ -395,37 +398,30 @@ class UserActionsController
 
             $libroId = (int) $reservation['libro_id'];
 
-            // Lock book row to prevent race conditions
+            // Lock book row first to serialize every capacity decision.
             $lockStmt = $db->prepare("SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE");
             $lockStmt->bind_param('i', $libroId);
             $lockStmt->execute();
-            $lockResult = $lockStmt->get_result();
-            if (!$lockResult->fetch_assoc()) {
+            if (!$lockStmt->get_result()->fetch_assoc()) {
+                $lockStmt->close();
                 $db->rollback();
                 return $response->withHeader('Location', RouteTranslator::route('reservations') . '?error=book_not_found')->withStatus(302);
             }
             $lockStmt->close();
 
-            // Check availability for the new date range (excluding this user's reservation)
-            $reservationsController = new \App\Controllers\ReservationsController($db);
-            $availability = $reservationsController->getBookAvailabilityData($libroId, $startDate, 35, $uid);
-
-            // Check each day in the new range
-            $currentDate = new \DateTime($startDate);
-            $endDateTime = new \DateTime($endDate);
-            $hasConflict = false;
-
-            while ($currentDate <= $endDateTime) {
-                $dateStr = $currentDate->format('Y-m-d');
-                $dayData = $availability['by_date'][$dateStr] ?? null;
-                if ($dayData !== null && ($dayData['available'] ?? 0) <= 0) {
-                    $hasConflict = true;
-                    break;
-                }
-                $currentDate->add(new \DateInterval('P1D'));
+            // Re-lock and revalidate the reservation after acquiring the book.
+            $getStmt = $db->prepare("SELECT libro_id FROM prenotazioni WHERE id = ? AND utente_id = ? AND stato = 'attiva' FOR UPDATE");
+            $getStmt->bind_param('ii', $rid, $uid);
+            $getStmt->execute();
+            $lockedReservation = $getStmt->get_result()->fetch_assoc();
+            $getStmt->close();
+            if (!$lockedReservation || (int) $lockedReservation['libro_id'] !== $libroId) {
+                $db->rollback();
+                return $response->withHeader('Location', RouteTranslator::route('reservations') . '?error=not_found')->withStatus(302);
             }
-
-            if ($hasConflict) {
+            // Canonical peak-capacity check, excluding the row being moved.
+            $capacity = new \App\Services\CapacityService($db);
+            if (!$capacity->hasFreeCapacity($libroId, $startDate, $endDate, excludeReservationId: $rid, excludeUserId: $uid)) {
                 $db->rollback();
                 return $response->withHeader('Location', RouteTranslator::route('reservations') . '?error=not_available')->withStatus(302);
             }
@@ -653,7 +649,9 @@ class UserActionsController
 
         // Calculate date range for availability check
         $start = ($desired !== '') ? $desired : $today;
-        $end = date('Y-m-d', strtotime($start . ' +1 month'));
+        $loanDays = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'loan_duration_days', '30') ?? 30);
+        $loanDays = $loanDays > 0 ? $loanDays : 30;
+        $end = (new \DateTimeImmutable($start))->modify("+{$loanDays} days")->format('Y-m-d');
 
         // Start transaction for concurrency control
         $db->begin_transaction();
@@ -702,26 +700,10 @@ class UserActionsController
             }
             $dupLoanStmt->close();
 
-            // Check availability for the requested date range (excluding this user's existing reservations)
-            $reservationsController = new ReservationsController($db);
-            $availability = $reservationsController->getBookAvailabilityData($libroId, $start, 35, $utenteId);
-
-            // Check each day in the range for conflicts
-            $currentDate = new \DateTime($start);
-            $endDateTime = new \DateTime($end);
-            $hasConflict = false;
-
-            while ($currentDate <= $endDateTime) {
-                $dateStr = $currentDate->format('Y-m-d');
-                $dayData = $availability['by_date'][$dateStr] ?? null;
-                if ($dayData !== null && ($dayData['available'] ?? 0) <= 0) {
-                    $hasConflict = true;
-                    break;
-                }
-                $currentDate->add(new \DateInterval('P1D'));
-            }
-
-            if ($hasConflict) {
+            // Canonical peak-capacity decision (same service as admin create,
+            // approval, renew and audit), excluding this user defensively.
+            $capacity = new \App\Services\CapacityService($db);
+            if (!$capacity->hasFreeCapacity($libroId, $start, $end, excludeUserId: $utenteId)) {
                 $db->rollback();
                 return $this->back($response, ['reserve_error' => 'not_available']);
             }

--- a/app/Controllers/UserDashboardController.php
+++ b/app/Controllers/UserDashboardController.php
@@ -30,7 +30,7 @@ class UserDashboardController
             $stats['libri'] = (int)($res->fetch_assoc()['c'] ?? 0);
             
             // Count user active loans (exclude soft-deleted books)
-            $stmt = $db->prepare("SELECT COUNT(*) AS c FROM prestiti p JOIN libri l ON p.libro_id = l.id WHERE p.utente_id = ? AND p.attivo = 1 AND l.deleted_at IS NULL");
+            $stmt = $db->prepare("SELECT COUNT(*) AS c FROM prestiti p JOIN libri l ON p.libro_id = l.id WHERE p.utente_id = ? AND p.attivo = 1 AND p.stato IN ('in_corso','in_ritardo') AND l.deleted_at IS NULL");
             $stmt->bind_param('i', $userId);
             $stmt->execute();
             $res = $stmt->get_result();
@@ -46,7 +46,7 @@ class UserDashboardController
             $stmt->close();
             
             // Count user loan history (exclude soft-deleted books)
-            $stmt = $db->prepare("SELECT COUNT(*) AS c FROM prestiti p JOIN libri l ON p.libro_id = l.id WHERE p.utente_id = ? AND p.attivo = 0 AND l.deleted_at IS NULL");
+            $stmt = $db->prepare("SELECT COUNT(*) AS c FROM prestiti p JOIN libri l ON p.libro_id = l.id WHERE p.utente_id = ? AND p.attivo = 0 AND p.stato IN ('restituito','perso','danneggiato') AND l.deleted_at IS NULL");
             $stmt->bind_param('i', $userId);
             $stmt->execute();
             $res = $stmt->get_result();
@@ -81,7 +81,7 @@ class UserDashboardController
                        l.titolo AS titolo_libro, l.copertina_url
                 FROM prestiti p
                 JOIN libri l ON p.libro_id = l.id
-                WHERE p.utente_id = ? AND p.attivo = 1 AND l.deleted_at IS NULL
+                WHERE p.utente_id = ? AND p.attivo = 1 AND p.stato IN ('in_corso','in_ritardo') AND l.deleted_at IS NULL
                 ORDER BY p.data_scadenza ASC
                 LIMIT 5
             ");
@@ -188,7 +188,7 @@ class UserDashboardController
                        EXISTS(SELECT 1 FROM recensioni r WHERE r.libro_id = pr.libro_id AND r.utente_id = ?) AS has_review
                 FROM prestiti pr
                 JOIN libri l ON l.id = pr.libro_id
-                WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato != 'prestato' AND l.deleted_at IS NULL
+                WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato IN ('restituito','perso','danneggiato') AND l.deleted_at IS NULL
                 ORDER BY pr.data_restituzione DESC, pr.data_prestito DESC
                 LIMIT 50
             ");

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -167,14 +167,16 @@ class CopyRepository
      */
     public function allocateInventoryCodes(string $base, int $howMany): array
     {
+        // numero_inventario is VARCHAR(100); reserve room for the "-C{N}" suffix so
+        // a very long base can never overflow the column (worst case "-C9999" = 6).
+        $base = mb_substr($base, 0, 90);
         $codes = [];
-        $n = 1;
-        while (count($codes) < $howMany) {
-            $candidate = "{$base}-C{$n}";
+        $needed = max(0, $howMany);
+        for ($index = 1; count($codes) < $needed; $index++) {
+            $candidate = "{$base}-C{$index}";
             if (!in_array($candidate, $codes, true) && !$this->inventoryCodeExists($candidate)) {
                 $codes[] = $candidate;
             }
-            $n++;
         }
         return $codes;
     }
@@ -237,6 +239,36 @@ class CopyRepository
         $stmt->close();
 
         return $result;
+    }
+
+    /**
+     * Delete a copy ONLY if it is still removable (available, no active/pending
+     * loan). Closes the race between selecting removable copies and deleting them
+     * (#252): if a loan claimed the copy in between, the conditional DELETE removes
+     * nothing and returns false, so the caller can try the next candidate instead
+     * of miscounting. The prestiti.copia_id FK is ON DELETE RESTRICT, so this can
+     * never orphan a loan even under the race — this just makes the outcome clean.
+     *
+     * @return bool True only if a row was actually deleted.
+     */
+    public function deleteIfRemovable(int $id): bool
+    {
+        $stmt = $this->db->prepare("
+            DELETE FROM copie
+            WHERE id = ?
+              AND stato = 'disponibile'
+              AND NOT EXISTS (
+                  SELECT 1 FROM prestiti p
+                  WHERE p.copia_id = copie.id
+                    AND ( (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                          OR (p.attivo = 0 AND p.stato = 'pendente') )
+              )
+        ");
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+        $deleted = $stmt->affected_rows === 1;
+        $stmt->close();
+        return $deleted;
     }
 
     /**

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -20,21 +20,8 @@ class CopyRepository
     public function getByBookId(int $bookId): array
     {
         $stmt = $this->db->prepare("
-            SELECT c.*,
-                   p.id as prestito_id,
-                   p.utente_id,
-                   p.data_prestito,
-                   p.data_scadenza,
-                   p.stato as prestito_stato,
-                   u.nome as utente_nome,
-                   u.cognome as utente_cognome,
-                   u.email as utente_email
+            SELECT c.*
             FROM copie c
-            -- #157: a copy is held by an active loan OR a reservation-conversion
-            -- pending (attivo=0 with a copia_id); both must appear on the per-copy
-            -- calendar so a pending pickup is visible.
-            LEFT JOIN prestiti p ON c.id = p.copia_id AND ((p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare', 'in_corso', 'in_ritardo')) OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL))
-            LEFT JOIN utenti u ON p.utente_id = u.id
             WHERE c.libro_id = ?
             ORDER BY c.numero_inventario ASC
         ");
@@ -44,11 +31,73 @@ class CopyRepository
 
         $copie = [];
         while ($row = $result->fetch_assoc()) {
+            // The physical-copy table must contain exactly one row per copy. Loan
+            // schedule rows live separately (getScheduleByBookId); attach only the
+            // most relevant commitment for the compact status columns.
+            $row += [
+                'prestito_id' => null,
+                'utente_id' => null,
+                'data_prestito' => null,
+                'data_scadenza' => null,
+                'prestito_stato' => null,
+                'utente_nome' => null,
+                'utente_cognome' => null,
+                'utente_email' => null,
+            ];
             $copie[] = $row;
         }
 
         $stmt->close();
+
+        $copyIndexes = [];
+        foreach ($copie as $index => $copy) {
+            $copyIndexes[(int) $copy['id']] = $index;
+        }
+        foreach ($this->getScheduleByBookId($bookId) as $commitment) {
+            $copyId = (int) $commitment['id'];
+            if (!isset($copyIndexes[$copyId])) {
+                continue;
+            }
+            $index = $copyIndexes[$copyId];
+            if ($copie[$index]['prestito_id'] !== null) {
+                continue;
+            }
+            foreach (['prestito_id', 'utente_id', 'data_prestito', 'data_scadenza', 'prestito_stato', 'utente_nome', 'utente_cognome', 'utente_email'] as $field) {
+                $copie[$index][$field] = $commitment[$field];
+            }
+        }
+
         return $copie;
+    }
+
+    /**
+     * All HOLDING commitments for the per-copy calendar. Kept separate from
+     * getByBookId so two non-overlapping future loans never duplicate a physical
+     * copy in the admin table or in copy-count/removal logic.
+     */
+    public function getScheduleByBookId(int $bookId): array
+    {
+        $stmt = $this->db->prepare("
+            SELECT c.id, c.numero_inventario,
+                   p.id AS prestito_id, p.utente_id, p.data_prestito,
+                   p.data_scadenza, p.stato AS prestito_stato,
+                   u.nome AS utente_nome, u.cognome AS utente_cognome,
+                   u.email AS utente_email
+            FROM copie c
+            JOIN prestiti p ON p.copia_id = c.id
+             AND ( (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                   OR (p.attivo = 0 AND p.stato = 'pendente') )
+            LEFT JOIN utenti u ON u.id = p.utente_id
+            WHERE c.libro_id = ?
+            ORDER BY c.numero_inventario ASC,
+                     FIELD(p.stato, 'in_ritardo','in_corso','da_ritirare','prenotato','pendente'),
+                     p.data_prestito ASC, p.id ASC
+        ");
+        $stmt->bind_param('i', $bookId);
+        $stmt->execute();
+        $rows = $stmt->get_result()->fetch_all(MYSQLI_ASSOC);
+        $stmt->close();
+        return $rows;
     }
 
     /**
@@ -87,6 +136,81 @@ class CopyRepository
         $stmt->close();
 
         return $insertId;
+    }
+
+    /**
+     * True if a numero_inventario already exists anywhere (the uniq_numero_inventario
+     * index is global, not per-book), so callers can avoid the duplicate-key crash.
+     */
+    public function inventoryCodeExists(string $numeroInventario): bool
+    {
+        $stmt = $this->db->prepare("SELECT 1 FROM copie WHERE numero_inventario = ? LIMIT 1");
+        $stmt->bind_param('s', $numeroInventario);
+        $stmt->execute();
+        $exists = (bool) $stmt->get_result()->fetch_row();
+        $stmt->close();
+        return $exists;
+    }
+
+    /**
+     * Allocate $howMany collision-free inventory codes of the form "{base}-C{N}".
+     *
+     * Fixes the copy-count bug (#238): the old code appended "-C{currentCount+1}",
+     * which collided with a still-present higher code after copies were removed from
+     * the wrong end (Duplicate entry '…-C2'). Here N walks up from 1, filling any
+     * gap left by a removed copy, and every candidate is checked against BOTH the
+     * codes generated in this batch and the whole `copie` table (global unique key),
+     * so the returned codes can never duplicate an existing one. The "-C{N}" suffix
+     * is applied uniformly (never a bare base), keeping the naming consistent.
+     *
+     * @return list<string>
+     */
+    public function allocateInventoryCodes(string $base, int $howMany): array
+    {
+        $codes = [];
+        $n = 1;
+        while (count($codes) < $howMany) {
+            $candidate = "{$base}-C{$n}";
+            if (!in_array($candidate, $codes, true) && !$this->inventoryCodeExists($candidate)) {
+                $codes[] = $candidate;
+            }
+            $n++;
+        }
+        return $codes;
+    }
+
+    /**
+     * Removable (available, loan-free) copies of a book, ordered so the ones added
+     * LAST come first — reducing the copy count must trim from the end of the
+     * sequence, not the beginning (#238). Ordering by id DESC tracks creation order
+     * robustly without parsing the "-C{N}" suffix.
+     *
+     * @return list<array{id:int, numero_inventario:string}>
+     */
+    public function getRemovableCopiesNewestFirst(int $bookId): array
+    {
+        $stmt = $this->db->prepare("
+            SELECT c.id, c.numero_inventario
+            FROM copie c
+            WHERE c.libro_id = ?
+              AND c.stato = 'disponibile'
+              AND NOT EXISTS (
+                  SELECT 1 FROM prestiti p
+                  WHERE p.copia_id = c.id
+                    AND ( (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                          OR (p.attivo = 0 AND p.stato = 'pendente') )
+              )
+            ORDER BY c.id DESC
+        ");
+        $stmt->bind_param('i', $bookId);
+        $stmt->execute();
+        $res = $stmt->get_result();
+        $rows = [];
+        while ($row = $res->fetch_assoc()) {
+            $rows[] = ['id' => (int) $row['id'], 'numero_inventario' => (string) $row['numero_inventario']];
+        }
+        $stmt->close();
+        return $rows;
     }
 
     /**
@@ -161,7 +285,7 @@ class CopyRepository
                 SELECT 1 FROM prestiti p
                 WHERE p.copia_id = c.id
                 AND p.data_prestito <= ?
-                AND p.data_scadenza >= ?
+                AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                 AND ((p.attivo = 1 AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo'))
                      OR (p.stato = 'pendente' AND p.copia_id IS NOT NULL))
             )

--- a/app/Models/DashboardStats.php
+++ b/app/Models/DashboardStats.php
@@ -208,8 +208,8 @@ class DashboardStats
     public function calendarEvents(): array
     {
         $events = [];
-        $today = date('Y-m-d');
-        $sixMonthsLater = date('Y-m-d', strtotime('+6 months'));
+        $today = \App\Support\DateHelper::today();
+        $sixMonthsLater = (new \DateTimeImmutable($today))->modify('+6 months')->format('Y-m-d');
 
         // Fetch active/scheduled loans (in_corso, prenotato, in_ritardo, pendente)
         // Include pendente loans with attivo=0 (waiting for admin approval)
@@ -221,7 +221,7 @@ class DashboardStats
                     JOIN utenti u ON p.utente_id = u.id
                     WHERE (p.attivo = 1 OR p.stato = 'pendente')
                       AND p.stato IN ('in_corso', 'da_ritirare', 'prenotato', 'in_ritardo', 'pendente')
-                      AND p.data_scadenza >= ?
+                      AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                       AND p.data_prestito <= ?
                     ORDER BY p.data_prestito ASC";
         $stmt = $this->db->prepare($loanSql);
@@ -234,7 +234,9 @@ class DashboardStats
                 'title' => $row['titolo'],
                 'user' => $row['utente_nome'],
                 'start' => $row['data_prestito'],
-                'end' => $row['data_scadenza'],
+                'end' => $row['stato'] === 'in_ritardo'
+                    ? max((string) $row['data_scadenza'], $today)
+                    : $row['data_scadenza'],
                 'type' => 'prestito',
                 'status' => $row['stato']
             ];

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -259,6 +259,17 @@ class LoanRepository
                 // keep promoting while freed capacity converts the next queued reservation
             }
 
+            // Final recalc so libri.copie_disponibili reflects the copy states AFTER
+            // Layer-1 reassignment (which can re-bind the freed copy to a 'prenotato'
+            // hold without a further recalc when Layer 2 promotes nothing). Without
+            // this, the post-commit wishlist gate in PrestitiController::close reads a
+            // stale counter and can fire a false "book available" notification.
+            // No existence guard here: the book was already locked FOR UPDATE and
+            // recalculated successfully above in this same transaction, so it cannot
+            // have vanished (recalculateBookAvailability only returns false when the
+            // book row is missing).
+            $integrity->recalculateBookAvailability($bookId, true);
+
             $this->db->commit();
 
         } catch (\Throwable $e) {

--- a/app/Services/CapacityService.php
+++ b/app/Services/CapacityService.php
@@ -127,14 +127,23 @@ final class CapacityService
      */
     private function holdingLoanIntervals(int $libroId, string $start, string $end, ?int $excludePrestitoId, ?int $excludeUserId): array
     {
-        $sql = "SELECT GREATEST(p.data_prestito, ?) AS s, LEAST(p.data_scadenza, ?) AS e
+        // An unreturned overdue loan has no known end yet. Its contractual due
+        // date is in the past, but the physical copy remains out of the library:
+        // clamp it to the requested window end instead of freeing capacity after
+        // data_scadenza. This mirrors the DB trigger and the public calendar.
+        $sql = "SELECT GREATEST(p.data_prestito, ?) AS s,
+                       LEAST(CASE
+                           WHEN p.attivo = 1 AND p.stato = 'in_ritardo' THEN ?
+                           ELSE p.data_scadenza
+                       END, ?) AS e
                 FROM prestiti p
                 WHERE p.libro_id = ?
-                  AND p.data_prestito <= ? AND p.data_scadenza >= ?
+                  AND p.data_prestito <= ?
+                  AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
                   AND ( (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
                         OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )";
-        $types = 'ssiss';
-        $params = [$start, $end, $libroId, $end, $start];
+        $types = 'sssiss';
+        $params = [$start, $end, $end, $libroId, $end, $start];
         if ($excludePrestitoId !== null) {
             $sql .= ' AND p.id <> ?';
             $types .= 'i';
@@ -156,12 +165,18 @@ final class CapacityService
     {
         // Canonical 3-step coalesce chain for the reservation end (no 2-step variants).
         $rEnd = 'COALESCE(r.data_fine_richiesta, DATE(r.data_scadenza_prenotazione), r.data_inizio_richiesta)';
-        $sql = "SELECT GREATEST(r.data_inizio_richiesta, ?) AS s, LEAST($rEnd, ?) AS e
+        // Start falls back to the reservation deadline for legacy 'attiva' rows whose
+        // data_inizio_richiesta is NULL (nullable column). For normal rows the COALESCE
+        // returns data_inizio_richiesta unchanged, so this is behaviour-preserving; it
+        // only stops such legacy holds from silently vanishing from the occupancy peak
+        // (they never promote either, so they'd otherwise allow overbooking their copy).
+        $rStart = 'COALESCE(r.data_inizio_richiesta, DATE(r.data_scadenza_prenotazione))';
+        $sql = "SELECT GREATEST($rStart, ?) AS s, LEAST($rEnd, ?) AS e
                 FROM prenotazioni r
                 WHERE r.libro_id = ?
                   AND r.stato = 'attiva'
-                  AND r.data_inizio_richiesta IS NOT NULL
-                  AND r.data_inizio_richiesta <= ?
+                  AND $rStart IS NOT NULL
+                  AND $rStart <= ?
                   AND $rEnd >= ?";
         $types = 'ssiss';
         $params = [$start, $end, $libroId, $end, $start];

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -141,8 +141,8 @@ class ReservationReassignmentService
             FROM prestiti p
             LEFT JOIN copie c ON p.copia_id = c.id
             WHERE p.libro_id = ?
-            AND p.stato IN ('prenotato', 'da_ritirare')
-            AND p.attivo = 1
+            AND ( (p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare'))
+                  OR (p.attivo = 0 AND p.stato = 'pendente' AND p.origine = 'prenotazione') )
             AND ( p.copia_id IS NULL
                   OR c.stato IN ('perso','danneggiato','manutenzione','in_restauro','in_trasferimento') )
             ORDER BY p.created_at ASC
@@ -161,6 +161,31 @@ class ReservationReassignmentService
         // 2. Se abbiamo trovato una prenotazione da sbloccare, proviamo ad assegnarla alla nuova copia
         $ownTransaction = $this->beginTransactionIfNeeded();
         try {
+            $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+            $lockBook->bind_param('i', $libroId);
+            $lockBook->execute();
+            $lockBook->close();
+
+            // The initial lookup was intentionally non-locking to preserve book
+            // first ordering. Revalidate the chosen hold now, under the book lock.
+            $lockedReservationStmt = $this->db->prepare("
+                SELECT id, copia_id, utente_id, data_prestito, data_scadenza
+                FROM prestiti
+                WHERE id = ? AND libro_id = ?
+                  AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare'))
+                        OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione') )
+                FOR UPDATE
+            ");
+            $lockedReservationStmt->bind_param('ii', $reservation['id'], $libroId);
+            $lockedReservationStmt->execute();
+            $lockedReservation = $lockedReservationStmt->get_result()->fetch_assoc();
+            $lockedReservationStmt->close();
+            if (!$lockedReservation) {
+                $this->rollbackIfOwned($ownTransaction);
+                return;
+            }
+            $reservation = $lockedReservation;
+
             // Verifica che la nuova copia sia effettivamente disponibile (lock)
             $stmt = $this->db->prepare("SELECT id, stato FROM copie WHERE id = ? FOR UPDATE");
             $stmt->bind_param('i', $newCopiaId);
@@ -168,7 +193,7 @@ class ReservationReassignmentService
             $copyStatus = $stmt->get_result()->fetch_assoc();
             $stmt->close();
 
-            if (!$copyStatus || $copyStatus['stato'] !== 'disponibile') {
+            if (!$copyStatus || !in_array($copyStatus['stato'], ['disponibile', 'prenotato'], true)) {
                 $this->rollbackIfOwned($ownTransaction);
                 return;
             }
@@ -179,7 +204,7 @@ class ReservationReassignmentService
             $ovl = $this->db->prepare("
                 SELECT 1 FROM prestiti
                 WHERE copia_id = ? AND id <> ?
-                AND data_prestito <= ? AND data_scadenza >= ?
+                AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                 AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
                       OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
                 LIMIT 1
@@ -259,8 +284,8 @@ class ReservationReassignmentService
             SELECT id, libro_id, utente_id, data_prestito, data_scadenza
             FROM prestiti
             WHERE copia_id = ?
-            AND stato IN ('prenotato', 'da_ritirare')
-            AND attivo = 1
+            AND ( (attivo = 1 AND stato IN ('prenotato', 'da_ritirare'))
+                  OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione') )
             ORDER BY data_prestito ASC, id ASC
             LIMIT 1
         ");
@@ -293,6 +318,30 @@ class ReservationReassignmentService
             // Riassegna
             $ownTransaction = $this->beginTransactionIfNeeded();
             try {
+                $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+                $lockBook->bind_param('i', $libroId);
+                $lockBook->execute();
+                $lockBook->close();
+
+                $lockReservation = $this->db->prepare("
+                    SELECT id, copia_id, data_prestito, data_scadenza
+                    FROM prestiti
+                    WHERE id = ? AND libro_id = ? AND copia_id = ?
+                      AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare'))
+                            OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione') )
+                    FOR UPDATE
+                ");
+                $lockReservation->bind_param('iii', $reservationId, $libroId, $copiaId);
+                $lockReservation->execute();
+                $currentReservation = $lockReservation->get_result()->fetch_assoc();
+                $lockReservation->close();
+                if (!$currentReservation) {
+                    $this->rollbackIfOwned($ownTransaction);
+                    return;
+                }
+                $resStart = (string) $currentReservation['data_prestito'];
+                $resEnd = (string) $currentReservation['data_scadenza'];
+
                 // Lock della nuova copia e verifica stato (race condition protection)
                 $stmt = $this->db->prepare("SELECT id, stato FROM copie WHERE id = ? FOR UPDATE");
                 $stmt->bind_param('i', $nextCopyId);
@@ -301,7 +350,7 @@ class ReservationReassignmentService
                 $stmt->close();
 
                 // Verifica che la copia sia ancora disponibile (potrebbe essere cambiata)
-                if (!$copyStatus || $copyStatus['stato'] !== 'disponibile') {
+                if (!$copyStatus || !in_array($copyStatus['stato'], ['disponibile', 'prenotato'], true)) {
                     $this->rollbackIfOwned($ownTransaction);
                     // Aggiungi questa copia alle escluse e riprova
                     $excludedCopies[] = $nextCopyId;
@@ -314,7 +363,7 @@ class ReservationReassignmentService
                 $ovl = $this->db->prepare("
                     SELECT 1 FROM prestiti
                     WHERE copia_id = ? AND id <> ?
-                    AND data_prestito <= ? AND data_scadenza >= ?
+                    AND data_prestito <= ? AND (stato = 'in_ritardo' OR data_scadenza >= ?)
                     AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
                           OR (attivo = 0 AND stato = 'pendente' AND copia_id IS NOT NULL) )
                     LIMIT 1
@@ -382,12 +431,37 @@ class ReservationReassignmentService
     {
         // Meglio impostare copia_id a NULL per indicare "in coda senza copia" o "in attesa"
         // E notificare l'utente che è tornato in lista d'attesa
+        $lookup = $this->db->prepare('SELECT libro_id FROM prestiti WHERE id = ?');
+        $lookup->bind_param('i', $reservationId);
+        $lookup->execute();
+        $row = $lookup->get_result()->fetch_assoc();
+        $lookup->close();
+        if (!$row) {
+            return;
+        }
+        $libroId = (int) $row['libro_id'];
+
         $ownTransaction = $this->beginTransactionIfNeeded();
         try {
-            $stmt = $this->db->prepare("UPDATE prestiti SET copia_id = NULL WHERE id = ?");
-            $stmt->bind_param('i', $reservationId);
+            $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+            $lockBook->bind_param('i', $libroId);
+            $lockBook->execute();
+            $lockBook->close();
+
+            $stmt = $this->db->prepare("
+                UPDATE prestiti SET copia_id = NULL
+                WHERE id = ? AND libro_id = ?
+                  AND ( (attivo = 1 AND stato IN ('prenotato','da_ritirare'))
+                        OR (attivo = 0 AND stato = 'pendente' AND origine = 'prenotazione') )
+            ");
+            $stmt->bind_param('ii', $reservationId, $libroId);
             $stmt->execute();
+            $updated = $stmt->affected_rows;
             $stmt->close();
+            if ($updated < 1) {
+                $this->rollbackIfOwned($ownTransaction);
+                return;
+            }
 
             $this->commitIfOwned($ownTransaction);
 
@@ -451,7 +525,7 @@ class ReservationReassignmentService
             SELECT id
             FROM copie
             WHERE libro_id = ?
-            AND stato = 'disponibile'
+            AND stato IN ('disponibile', 'prenotato')
         ";
         $params = [$libroId];
         $types = "i";

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -27,6 +27,14 @@ class DataIntegrity {
                 $this->db->begin_transaction();
             }
 
+            // Global maintenance still obeys the circulation lock order. Lock
+            // every book deterministically before touching copies; otherwise a
+            // bulk copies->books update crosses web requests using books->copies.
+            $lockBooks = $this->db->prepare('SELECT id FROM libri ORDER BY id FOR UPDATE');
+            $lockBooks->execute();
+            $lockBooks->get_result()->fetch_all(MYSQLI_NUM);
+            $lockBooks->close();
+
             // Aggiorna stato copie basandosi sui prestiti attivi
             // - 'in_corso' e 'in_ritardo' → copia prestata (libro fisicamente fuori)
             // - 'prenotato' e 'da_ritirare' → copia prenotata (libro fisicamente in biblioteca ma riservato)
@@ -131,7 +139,8 @@ class DataIntegrity {
                     -- prestata/prenotata → non è disponibile. Senza questo ramo lo stato
                     -- resterebbe sul valore precedente (es. 'disponibile' stantio).
                     WHEN (SELECT COUNT(*) FROM copie c WHERE c.libro_id = l.id) > 0 THEN 'non_disponibile'
-                    ELSE l.stato
+                    -- A catalogue record with zero physical copies is not lendable.
+                    ELSE 'non_disponibile'
                 END
                 WHERE l.deleted_at IS NULL
             ");
@@ -170,40 +179,6 @@ class DataIntegrity {
         }
 
         $results = ['updated' => 0, 'errors' => [], 'total' => 0];
-
-        // Prima aggiorna tutte le copie (operazione veloce)
-        // - 'in_corso' e 'in_ritardo' → copia prestata (libro fisicamente fuori)
-        // - 'prenotato' e 'da_ritirare' → copia prenotata (libro fisicamente in biblioteca ma riservato)
-        // - Nessun prestito attivo → copia disponibile
-        // IMPORTANT: Use EXISTS with priority to handle copies with multiple loans
-        try {
-            $this->db->begin_transaction();
-            $stmt = $this->db->prepare("
-                UPDATE copie c
-                SET c.stato = CASE
-                    WHEN EXISTS (
-                        SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id AND p.attivo = 1
-                        AND p.stato IN ('in_corso', 'in_ritardo')
-                    ) THEN 'prestato'
-                    WHEN EXISTS (
-                        SELECT 1 FROM prestiti p
-                        WHERE p.copia_id = c.id
-                        AND ( (p.attivo = 1 AND p.stato IN ('prenotato', 'da_ritirare'))
-                              OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL) )
-                    ) THEN 'prenotato'
-                    ELSE 'disponibile'
-                END
-                WHERE c.stato IN ('disponibile', 'prestato', 'prenotato')
-            ");
-            $stmt->execute();
-            $stmt->close();
-            $this->db->commit();
-        } catch (\Throwable $e) {
-            $this->db->rollback();
-            $results['errors'][] = "Errore aggiornamento copie: " . $e->getMessage();
-            return $results;
-        }
 
         // Conta totale libri (prepared statement for consistency)
         $stmt = $this->db->prepare("SELECT COUNT(*) as total FROM libri WHERE deleted_at IS NULL");
@@ -283,6 +258,23 @@ class DataIntegrity {
         try {
             if (!$insideTransaction) {
                 $this->db->begin_transaction();
+            }
+
+            // Canonical lock order is libri -> prestiti/copie. Standalone
+            // recalculation used to update copie first and libri last, crossing
+            // every circulation write path and making deadlocks possible. Callers
+            // already inside a transaction follow the same order; taking the book
+            // lock again is harmless and makes that contract explicit.
+            $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+            $lockBook->bind_param('i', $bookId);
+            $lockBook->execute();
+            $bookExists = (bool) $lockBook->get_result()->fetch_assoc();
+            $lockBook->close();
+            if (!$bookExists) {
+                if (!$insideTransaction) {
+                    $this->db->rollback();
+                }
+                return false;
             }
 
             // Aggiorna stato copie del libro basandosi sui prestiti attivi
@@ -390,7 +382,7 @@ class DataIntegrity {
                     -- Come nel ricalcolo globale: copie presenti ma tutte fuori
                     -- circolazione e nessuna prestata/prenotata → 'non_disponibile'.
                     WHEN (SELECT COUNT(*) FROM copie c WHERE c.libro_id = ?) > 0 THEN 'non_disponibile'
-                    ELSE l.stato
+                    ELSE 'non_disponibile'
                 END
                 WHERE id = ?
             ");
@@ -591,13 +583,15 @@ class DataIntegrity {
 
         // 10. Verifica prestiti pendenti da prenotazione vecchi di più di 7 giorni
         $stmt = $this->db->prepare("
-            SELECT id, libro_id, utente_id, data_prestito, DATEDIFF(CURDATE(), data_prestito) as days_pending
+            SELECT id, libro_id, utente_id, data_prestito, DATEDIFF(?, data_prestito) as days_pending
             FROM prestiti
             WHERE stato = 'pendente'
             AND origine = 'prenotazione'
             AND attivo = 0
-            AND data_prestito < DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            AND data_prestito < DATE_SUB(?, INTERVAL 7 DAY)
         ");
+        $today = \App\Support\DateHelper::today();
+        $stmt->bind_param('ss', $today, $today);
         $stmt->execute();
         $result = $stmt->get_result();
         if ($result && $result->num_rows > 0) {
@@ -611,11 +605,13 @@ class DataIntegrity {
         }
         $stmt->close();
 
-        // 11. Verifica prestiti annullati/scaduti che hanno ancora attivo = 1
+        // 11. Ogni stato terminale deve avere attivo=0. La vecchia verifica
+        // copriva solo annullato/scaduto e lasciava invisibili proprio le
+        // incoerenze più pericolose (restituito/perso/danneggiato ancora attivi).
         $stmt = $this->db->prepare("
             SELECT id, libro_id, utente_id, stato
             FROM prestiti
-            WHERE stato IN ('annullato', 'scaduto')
+            WHERE stato IN ('restituito', 'perso', 'danneggiato', 'annullato', 'scaduto')
             AND attivo = 1
         ");
         $stmt->execute();
@@ -625,6 +621,34 @@ class DataIntegrity {
                 $issues[] = [
                     'type' => 'terminated_loan_active',
                     'message' => \sprintf(__("Prestito ID %d con stato '%s' ha ancora attivo = 1"), $row['id'], $row['stato']),
+                    'severity' => 'error'
+                ];
+            }
+        }
+        $stmt->close();
+
+        // 11b. Un prestito aperto non può avere già una data di restituzione;
+        // un in_ritardo inattivo è invece il vecchio modello ambiguo che deve
+        // convergere a restituito + restituito_in_ritardo.
+        $stmt = $this->db->prepare("
+            SELECT id, libro_id, stato, attivo, data_restituzione
+            FROM prestiti
+            WHERE (attivo = 1 AND data_restituzione IS NOT NULL)
+               OR (attivo = 0 AND stato = 'in_ritardo')
+        ");
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result) {
+            while ($row = $result->fetch_assoc()) {
+                $issues[] = [
+                    'type' => 'loan_lifecycle_mismatch',
+                    'message' => \sprintf(
+                        __("Prestito ID %d ha combinazione lifecycle incoerente (stato '%s', attivo=%d, restituzione=%s)"),
+                        $row['id'],
+                        $row['stato'],
+                        $row['attivo'],
+                        $row['data_restituzione'] ?? 'NULL'
+                    ),
                     'severity' => 'error'
                 ];
             }
@@ -651,6 +675,31 @@ class DataIntegrity {
                 $issues[] = [
                     'type' => 'stale_copy_state',
                     'message' => \sprintf(__("Copia ID %d del libro '%s' (ID: %d) ha stato '%s' ma nessun prestito attivo la riferisce"), $row['copia_id'], $row['titolo'], $row['libro_id'], $row['copia_stato']),
+                    'severity' => 'error'
+                ];
+            }
+        }
+        $stmt->close();
+
+        // 12b. La FK garantisce che copia_id esista, non che appartenga allo
+        // stesso libro del prestito. I trigger lo impediscono sulle nuove write;
+        // il report deve comunque trovare dati legacy o importati prima del fix.
+        $stmt = $this->db->prepare("
+            SELECT p.id, p.libro_id, p.copia_id, c.libro_id AS copia_libro_id
+            FROM prestiti p
+            JOIN copie c ON c.id = p.copia_id
+            WHERE p.copia_id IS NOT NULL AND c.libro_id <> p.libro_id
+        ");
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result) {
+            while ($row = $result->fetch_assoc()) {
+                $issues[] = [
+                    'type' => 'loan_copy_book_mismatch',
+                    'message' => \sprintf(
+                        __('Prestito ID %d appartiene al libro %d ma usa la copia %d del libro %d'),
+                        $row['id'], $row['libro_id'], $row['copia_id'], $row['copia_libro_id']
+                    ),
                     'severity' => 'error'
                 ];
             }
@@ -743,7 +792,15 @@ class DataIntegrity {
         $stmt = $this->db->prepare("
             SELECT libro_id, 'prestito' AS source_type, id AS source_id,
                    DATE(data_prestito) AS start_date,
-                   DATE(data_scadenza) AS end_date
+                   DATE(CASE
+                       -- Overdue loans occupy the copy open-endedly. The sentinel is
+                       -- 9999-12-30 (NOT 9999-12-31) so the +1-day endExclusive below
+                       -- stays a 4-digit 'YYYY-MM-DD' string: '10000-01-01' would sort
+                       -- BEFORE every real date under ksort's lexicographic order
+                       -- ('1' < '2'), zeroing the overdue occupancy in the peak scan.
+                       WHEN attivo = 1 AND stato = 'in_ritardo' THEN '9999-12-30'
+                       ELSE data_scadenza
+                   END) AS end_date
             FROM prestiti
             WHERE (
                     (attivo = 1 AND stato IN ('prenotato', 'da_ritirare', 'in_corso', 'in_ritardo'))
@@ -771,6 +828,12 @@ class DataIntegrity {
             }
 
             $endExclusive = (new \DateTimeImmutable($end))->modify('+1 day')->format('Y-m-d');
+            // Defensive clamp: keep the sweep key a 4-digit 'YYYY-MM-DD' string so
+            // ksort's lexicographic order stays chronological (a 5-digit year like
+            // '10000-01-01' would sort before every real date and corrupt the peak).
+            if ($endExclusive > '9999-12-31') {
+                $endExclusive = '9999-12-31';
+            }
             $eventsByBook[$bookId][$start] = ($eventsByBook[$bookId][$start] ?? 0) + 1;
             $eventsByBook[$bookId][$endExclusive] = ($eventsByBook[$bookId][$endExclusive] ?? 0) - 1;
         }
@@ -803,6 +866,12 @@ class DataIntegrity {
                 $end = $start;
             }
             $endExclusive = (new \DateTimeImmutable($end))->modify('+1 day')->format('Y-m-d');
+            // Defensive clamp: keep the sweep key a 4-digit 'YYYY-MM-DD' string so
+            // ksort's lexicographic order stays chronological (a 5-digit year like
+            // '10000-01-01' would sort before every real date and corrupt the peak).
+            if ($endExclusive > '9999-12-31') {
+                $endExclusive = '9999-12-31';
+            }
             $eventsByBook[$bookId][$start] = ($eventsByBook[$bookId][$start] ?? 0) + 1;
             $eventsByBook[$bookId][$endExclusive] = ($eventsByBook[$bookId][$endExclusive] ?? 0) - 1;
         }
@@ -913,7 +982,7 @@ class DataIntegrity {
                     WHEN copie_disponibili > 0 THEN 'disponibile'
                     WHEN EXISTS (SELECT 1 FROM copie c WHERE c.libro_id = libri.id AND c.stato = 'prestato') THEN 'prestato'
                     WHEN EXISTS (SELECT 1 FROM copie c WHERE c.libro_id = libri.id) THEN 'non_disponibile'
-                    ELSE stato
+                    ELSE 'non_disponibile'
                 END
                 WHERE stato IN ('disponibile', 'prestato', 'non_disponibile')
                 AND deleted_at IS NULL
@@ -926,17 +995,19 @@ class DataIntegrity {
             $stmt = $this->db->prepare("
                 UPDATE prestiti SET stato = 'in_ritardo'
                 WHERE stato = 'in_corso'
-                AND data_scadenza < CURDATE()
+                AND data_scadenza < ?
                 AND attivo = 1
             ");
+            $today = \App\Support\DateHelper::today();
+            $stmt->bind_param('s', $today);
             $stmt->execute();
             $results['fixed'] += $this->db->affected_rows;
             $stmt->close();
 
-            // 3b. Correggi prestiti annullati/scaduti che hanno attivo = 1
+            // 3b. Correggi tutti gli stati terminali che hanno ancora attivo=1.
             $stmt = $this->db->prepare("
                 UPDATE prestiti SET attivo = 0
-                WHERE stato IN ('annullato', 'scaduto')
+                WHERE stato IN ('restituito', 'perso', 'danneggiato', 'annullato', 'scaduto')
                 AND attivo = 1
             ");
             $stmt->execute();
@@ -1089,7 +1160,7 @@ class DataIntegrity {
             $updates = [];
 
             // Verifica stato in ritardo
-            if ($loan['stato'] === 'in_corso' && $loan['data_scadenza'] < date('Y-m-d')) {
+            if ($loan['stato'] === 'in_corso' && $loan['data_scadenza'] < \App\Support\DateHelper::today()) {
                 $updates['stato'] = 'in_ritardo';
                 $result['updated_fields'][] = 'stato -> in_ritardo';
             }
@@ -1162,8 +1233,8 @@ class DataIntegrity {
             SELECT
                 (SELECT COUNT(*) FROM libri WHERE deleted_at IS NULL) as total_books,
                 (SELECT COUNT(*) FROM prestiti) as total_loans,
-                (SELECT COUNT(*) FROM prestiti WHERE stato IN ('in_corso', 'in_ritardo', 'da_ritirare')) as active_loans,
-                (SELECT COUNT(*) FROM prestiti WHERE stato = 'in_ritardo') as overdue_loans,
+                (SELECT COUNT(*) FROM prestiti WHERE attivo = 1 AND stato IN ('in_corso', 'in_ritardo', 'da_ritirare', 'prenotato')) as active_loans,
+                (SELECT COUNT(*) FROM prestiti WHERE attivo = 1 AND stato = 'in_ritardo') as overdue_loans,
                 (SELECT COUNT(*) FROM libri WHERE copie_disponibili > 0 AND deleted_at IS NULL) as books_available,
                 (SELECT COUNT(*) FROM libri WHERE copie_disponibili = 0 AND deleted_at IS NULL) as books_unavailable
         ");

--- a/app/Support/IcsGenerator.php
+++ b/app/Support/IcsGenerator.php
@@ -82,7 +82,20 @@ class IcsGenerator
             mkdir($dir, 0755, true);
         }
 
-        return file_put_contents($path, $content) !== false;
+        // Atomic write: cron, the admin-login hook and the maintenance button can
+        // all regenerate this shared calendar concurrently. A bare file_put_contents
+        // lets a reader see a half-written file; write to a unique temp file, then
+        // rename() (atomic on the same filesystem) so readers always see a complete
+        // calendar — either the old one or the new one, never a torn mix.
+        $tmp = $path . '.' . getmypid() . '.' . uniqid('', true) . '.tmp';
+        if (file_put_contents($tmp, $content, LOCK_EX) === false) {
+            return false;
+        }
+        if (!@rename($tmp, $path)) {
+            @unlink($tmp);
+            return false;
+        }
+        return true;
     }
 
     /**
@@ -96,7 +109,7 @@ class IcsGenerator
     private function fetchEvents(): array
     {
         $events = [];
-        $today = date('Y-m-d');
+        $today = DateHelper::today();
 
         // Fetch active/scheduled loans
         $loanSql = "SELECT p.id, p.stato, p.data_prestito, p.data_scadenza, p.pickup_deadline,
@@ -131,6 +144,11 @@ class IcsGenerator
             $endDate = ($row['stato'] === 'da_ritirare' && !empty($row['pickup_deadline']))
                 ? $row['pickup_deadline']
                 : $row['data_scadenza'];
+            if ($row['stato'] === 'in_ritardo') {
+                // The copy remains physically occupied through today; ending the
+                // event on the missed due date falsely shows it as available.
+                $endDate = max((string) $endDate, $today);
+            }
 
             $events[] = [
                 'uid' => 'loan-' . $row['id'] . '@pinakes',
@@ -140,13 +158,13 @@ class IcsGenerator
                 'end' => $endDate,
                 'type' => 'prestito',
                 'status' => $row['stato'],
-                'updated' => $row['updated_at'] ?? date('Y-m-d H:i:s')
+                'updated' => $row['updated_at'] ?? (new \DateTimeImmutable('now', $this->appTimezone()))->format('Y-m-d H:i:s')
             ];
         }
         $stmt->close();
 
         // Fetch active reservations
-        $resSql = "SELECT r.id, r.stato, r.data_scadenza_prenotazione,
+        $resSql = "SELECT r.id, r.stato, r.data_prenotazione, r.data_scadenza_prenotazione,
                           r.data_inizio_richiesta, r.data_fine_richiesta,
                           l.titolo, CONCAT(u.nome, ' ', u.cognome) AS utente_nome,
                           u.email, r.updated_at
@@ -154,8 +172,8 @@ class IcsGenerator
                    JOIN libri l ON r.libro_id = l.id AND l.deleted_at IS NULL
                    JOIN utenti u ON r.utente_id = u.id
                    WHERE r.stato = 'attiva'
-                     AND COALESCE(r.data_fine_richiesta, r.data_scadenza_prenotazione) >= ?
-                   ORDER BY COALESCE(r.data_inizio_richiesta, r.data_scadenza_prenotazione) ASC";
+                     AND COALESCE(r.data_fine_richiesta, DATE(r.data_scadenza_prenotazione), r.data_inizio_richiesta, DATE(r.data_prenotazione)) >= ?
+                   ORDER BY COALESCE(r.data_inizio_richiesta, DATE(r.data_prenotazione), DATE(r.data_scadenza_prenotazione)) ASC";
         $stmt = $this->db->prepare($resSql);
         if ($stmt === false) {
             return $events;
@@ -166,8 +184,12 @@ class IcsGenerator
         }
         $res = $stmt->get_result();
         while ($row = $res->fetch_assoc()) {
-            $startDate = $row['data_inizio_richiesta'] ?? $row['data_scadenza_prenotazione'];
-            $endDate = $row['data_fine_richiesta'] ?? $row['data_scadenza_prenotazione'];
+            $startDate = $row['data_inizio_richiesta']
+                ?? ($row['data_prenotazione'] ? substr((string) $row['data_prenotazione'], 0, 10) : null)
+                ?? ($row['data_scadenza_prenotazione'] ? substr((string) $row['data_scadenza_prenotazione'], 0, 10) : $today);
+            $endDate = $row['data_fine_richiesta']
+                ?? ($row['data_scadenza_prenotazione'] ? substr((string) $row['data_scadenza_prenotazione'], 0, 10) : null)
+                ?? $startDate;
             $events[] = [
                 'uid' => 'reservation-' . $row['id'] . '@pinakes',
                 'title' => '📅 ' . __('Prenotazione') . ': ' . $row['titolo'],
@@ -176,7 +198,7 @@ class IcsGenerator
                 'end' => $endDate,
                 'type' => 'prenotazione',
                 'status' => $row['stato'],
-                'updated' => $row['updated_at'] ?? date('Y-m-d H:i:s')
+                'updated' => $row['updated_at'] ?? (new \DateTimeImmutable('now', $this->appTimezone()))->format('Y-m-d H:i:s')
             ];
         }
         $stmt->close();
@@ -272,10 +294,13 @@ class IcsGenerator
         $summary = $this->escapeIcs($event['title']);
         $description = $this->escapeIcs($event['description']);
 
-        // All-day events - use strtotime for robust date parsing
-        $dtstart = 'DTSTART;VALUE=DATE:' . date('Ymd', strtotime($event['start']));
+        // All-day values are calendar dates, not instants: parse them explicitly
+        // in the application timezone so the PHP process timezone cannot shift a day.
+        $start = new \DateTimeImmutable((string) $event['start'], $this->appTimezone());
+        $end = new \DateTimeImmutable((string) $event['end'], $this->appTimezone());
+        $dtstart = 'DTSTART;VALUE=DATE:' . $start->format('Ymd');
         // ICS end date is exclusive, so add 1 day for all-day events
-        $endDate = date('Ymd', strtotime($event['end'] . ' +1 day'));
+        $endDate = $end->modify('+1 day')->format('Ymd');
         $dtend = 'DTEND;VALUE=DATE:' . $endDate;
 
         // Use gmdate for UTC timestamps (Z suffix means UTC)

--- a/app/Support/IcsGenerator.php
+++ b/app/Support/IcsGenerator.php
@@ -87,11 +87,15 @@ class IcsGenerator
         // lets a reader see a half-written file; write to a unique temp file, then
         // rename() (atomic on the same filesystem) so readers always see a complete
         // calendar — either the old one or the new one, never a torn mix.
-        $tmp = $path . '.' . getmypid() . '.' . uniqid('', true) . '.tmp';
+        $tmp = $path . '.' . getmypid() . '.' . bin2hex(random_bytes(8)) . '.tmp';
         if (file_put_contents($tmp, $content, LOCK_EX) === false) {
             return false;
         }
+        // The final file inherits the temp file's mode; a restrictive umask could
+        // otherwise leave the calendar unreadable by the web server. Force 0644.
+        @chmod($tmp, 0644);
         if (!@rename($tmp, $path)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use -- $tmp is an internal, code-constructed path under storage, not user input
             @unlink($tmp);
             return false;
         }

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -341,6 +341,39 @@ class MaintenanceService
             $this->db->begin_transaction();
 
             try {
+                $bookId = (int) $loan['libro_id'];
+                $loanId = (int) $loan['id'];
+
+                // Same lock order as web writes: book first, then loan/copy.
+                // The old cron updated prestiti first and later touched libri via
+                // DataIntegrity, crossing approve/return paths and risking a deadlock.
+                $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE');
+                $lockBook->bind_param('i', $bookId);
+                $lockBook->execute();
+                $bookExists = (bool) $lockBook->get_result()->fetch_assoc();
+                $lockBook->close();
+                if (!$bookExists) {
+                    $this->db->rollback();
+                    continue;
+                }
+
+                $lockLoan = $this->db->prepare("
+                    SELECT id, copia_id, libro_id, data_scadenza
+                    FROM prestiti
+                    WHERE id = ? AND stato = 'prenotato' AND attivo = 1
+                      AND data_prestito <= ? AND data_scadenza >= ?
+                    FOR UPDATE
+                ");
+                $lockLoan->bind_param('iss', $loanId, $today, $today);
+                $lockLoan->execute();
+                $lockedLoan = $lockLoan->get_result()->fetch_assoc();
+                $lockLoan->close();
+                if (!$lockedLoan || (int) $lockedLoan['libro_id'] !== $bookId) {
+                    $this->db->rollback();
+                    continue;
+                }
+                $loan = $lockedLoan;
+
                 // Calculate pickup deadline dal "oggi" applicativo, cappata a
                 // data_scadenza (L1): senza il cap un prestito con finestra corta
                 // restava ritirabile (e la copia bloccata) oltre la fine del
@@ -355,7 +388,7 @@ class MaintenanceService
                 $updateStmt = $this->db->prepare("
                     UPDATE prestiti
                     SET stato = 'da_ritirare', pickup_deadline = ?
-                    WHERE id = ? AND stato = 'prenotato' AND data_scadenza >= ?
+                    WHERE id = ? AND stato = 'prenotato' AND attivo = 1 AND data_scadenza >= ?
                 ");
                 $updateStmt->bind_param('sis', $pickupDeadline, $loan['id'], $today);
                 $updateStmt->execute();
@@ -566,6 +599,32 @@ class MaintenanceService
                 $copiaId = $reservation['copia_id'] ? (int) $reservation['copia_id'] : null;
                 $libroId = (int) $reservation['libro_id'];
 
+                $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+                $lockBook->bind_param('i', $libroId);
+                $lockBook->execute();
+                $bookExists = (bool) $lockBook->get_result()->fetch_assoc();
+                $lockBook->close();
+                if (!$bookExists) {
+                    $this->db->rollback();
+                    continue;
+                }
+
+                $lockLoan = $this->db->prepare("
+                    SELECT id, libro_id, copia_id, utente_id
+                    FROM prestiti
+                    WHERE id = ? AND stato = 'prenotato' AND attivo = 1 AND data_scadenza < ?
+                    FOR UPDATE
+                ");
+                $lockLoan->bind_param('is', $id, $today);
+                $lockLoan->execute();
+                $lockedReservation = $lockLoan->get_result()->fetch_assoc();
+                $lockLoan->close();
+                if (!$lockedReservation || (int) $lockedReservation['libro_id'] !== $libroId) {
+                    $this->db->rollback();
+                    continue;
+                }
+                $copiaId = $lockedReservation['copia_id'] ? (int) $lockedReservation['copia_id'] : null;
+
                 // Build note suffix safely with bound parameter
                 $noteSuffix = "\n[System] " . __('Scaduta il') . ' ' . date('d/m/Y');
 
@@ -714,6 +773,33 @@ class MaintenanceService
                 $copiaId = $pickup['copia_id'] ? (int) $pickup['copia_id'] : null;
                 $libroId = (int) $pickup['libro_id'];
 
+                $lockBook = $this->db->prepare('SELECT id FROM libri WHERE id = ? FOR UPDATE');
+                $lockBook->bind_param('i', $libroId);
+                $lockBook->execute();
+                $bookExists = (bool) $lockBook->get_result()->fetch_assoc();
+                $lockBook->close();
+                if (!$bookExists) {
+                    $this->db->rollback();
+                    continue;
+                }
+
+                $lockLoan = $this->db->prepare("
+                    SELECT id, libro_id, copia_id, utente_id, pickup_deadline
+                    FROM prestiti
+                    WHERE id = ? AND stato = 'da_ritirare' AND attivo = 1
+                      AND pickup_deadline IS NOT NULL AND pickup_deadline < ?
+                    FOR UPDATE
+                ");
+                $lockLoan->bind_param('is', $id, $today);
+                $lockLoan->execute();
+                $lockedPickup = $lockLoan->get_result()->fetch_assoc();
+                $lockLoan->close();
+                if (!$lockedPickup || (int) $lockedPickup['libro_id'] !== $libroId) {
+                    $this->db->rollback();
+                    continue;
+                }
+                $copiaId = $lockedPickup['copia_id'] ? (int) $lockedPickup['copia_id'] : null;
+
                 // Build note suffix safely with bound parameter
                 $noteSuffix = "\n[System] " . __('Ritiro scaduto il') . ' ' . date('d/m/Y');
 
@@ -724,7 +810,7 @@ class MaintenanceService
                         attivo = 0,
                         updated_at = NOW(),
                         note = CONCAT(COALESCE(note, ''), ?)
-                    WHERE id = ? AND stato = 'da_ritirare'
+                    WHERE id = ? AND stato = 'da_ritirare' AND attivo = 1
                 ");
                 $updateStmt->bind_param('si', $noteSuffix, $id);
                 $updateStmt->execute();

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -390,6 +390,7 @@ class NotificationService {
                 JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.stato = 'in_corso'
+                  AND p.attivo = 1
                   AND p.data_scadenza = DATE_ADD(?, INTERVAL ? DAY)
                   AND (p.warning_sent IS NULL OR p.warning_sent = 0)
             ");
@@ -407,7 +408,7 @@ class NotificationService {
             foreach ($loans as $loan) {
                 // ATOMIC: Mark warning as sent BEFORE sending email
                 // Only proceed if we successfully claimed this loan (affected_rows == 1)
-                $updateStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 1 WHERE id = ? AND (warning_sent IS NULL OR warning_sent = 0)");
+                $updateStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 1 WHERE id = ? AND attivo = 1 AND stato = 'in_corso' AND (warning_sent IS NULL OR warning_sent = 0)");
                 $updateStmt->bind_param('i', $loan['id']);
                 $updateStmt->execute();
                 $claimed = $updateStmt->affected_rows === 1;
@@ -439,7 +440,7 @@ class NotificationService {
                     $sentCount++;
                 } else {
                     // Email failed after retries, revert the flag so it can be retried next run
-                    $revertStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 0 WHERE id = ?");
+                    $revertStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 0 WHERE id = ? AND attivo = 1 AND stato = 'in_corso'");
                     $revertStmt->bind_param('i', $loan['id']);
                     $revertStmt->execute();
                     $revertStmt->close();
@@ -476,6 +477,7 @@ class NotificationService {
                 JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.stato IN ('in_corso', 'in_ritardo')
+                  AND p.attivo = 1
                   AND p.data_scadenza < ?
                   AND (p.overdue_notification_sent IS NULL OR p.overdue_notification_sent = 0)
             ");

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -408,8 +408,11 @@ class NotificationService {
             foreach ($loans as $loan) {
                 // ATOMIC: Mark warning as sent BEFORE sending email
                 // Only proceed if we successfully claimed this loan (affected_rows == 1)
-                $updateStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 1 WHERE id = ? AND attivo = 1 AND stato = 'in_corso' AND (warning_sent IS NULL OR warning_sent = 0)");
-                $updateStmt->bind_param('i', $loan['id']);
+                // Re-assert data_scadenza too: renew()/update() may have moved the
+                // due date between the SELECT and this claim; without it we'd send a
+                // warning quoting a now-stale date (#252).
+                $updateStmt = $this->db->prepare("UPDATE prestiti SET warning_sent = 1 WHERE id = ? AND attivo = 1 AND stato = 'in_corso' AND data_scadenza = ? AND (warning_sent IS NULL OR warning_sent = 0)");
+                $updateStmt->bind_param('is', $loan['id'], $loan['data_scadenza']);
                 $updateStmt->execute();
                 $claimed = $updateStmt->affected_rows === 1;
                 $updateStmt->close();
@@ -499,8 +502,11 @@ class NotificationService {
                 // durare minuti dopo la SELECT — senza il filtro su attivo/stato il
                 // claim riporterebbe in 'in_ritardo' un prestito restituito nel
                 // frattempo (attivo=0 + stato in_ritardo: combinazione invalida).
-                $updateStmt = $this->db->prepare("UPDATE prestiti SET overdue_notification_sent = 1, stato = 'in_ritardo' WHERE id = ? AND (overdue_notification_sent IS NULL OR overdue_notification_sent = 0) AND attivo = 1 AND stato IN ('in_corso', 'in_ritardo')");
-                $updateStmt->bind_param('i', $loan['id']);
+                // Re-assert data_scadenza (#252): a renew() between the SELECT and this
+                // claim can push the due date into the future, so the loan is no longer
+                // overdue and must NOT be transitioned to 'in_ritardo' with a stale date.
+                $updateStmt = $this->db->prepare("UPDATE prestiti SET overdue_notification_sent = 1, stato = 'in_ritardo' WHERE id = ? AND data_scadenza = ? AND (overdue_notification_sent IS NULL OR overdue_notification_sent = 0) AND attivo = 1 AND stato IN ('in_corso', 'in_ritardo')");
+                $updateStmt->bind_param('is', $loan['id'], $loan['data_scadenza']);
                 $updateStmt->execute();
                 $claimed = $updateStmt->affected_rows === 1;
                 $updateStmt->close();

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -1399,7 +1399,12 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
   $copyColors = ['#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6', '#EC4899', '#06B6D4', '#84CC16'];
   $calendarEventsJson = [];
 
-  foreach ($copie as $idx => $cal_copia) {
+  $copyColorIndexes = [];
+  foreach ($copie as $idx => $physicalCopy) {
+      $copyColorIndexes[(int) $physicalCopy['id']] = $idx;
+  }
+  foreach (($copySchedule ?? []) as $cal_copia) {
+      $idx = $copyColorIndexes[(int) $cal_copia['id']] ?? 0;
       $copyColor = $copyColors[$idx % 8];
       $inventario = $cal_copia['numero_inventario'] ?? '';
 
@@ -1410,6 +1415,11 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
           $endDate = !empty($cal_copia['data_scadenza'])
               ? substr((string)$cal_copia['data_scadenza'], 0, 10)
               : $startDate;
+          // An overdue loan still occupies the physical copy until it is
+          // returned. Do not draw it as if it ended on the missed due date.
+          if ($stato === 'in_ritardo') {
+              $endDate = max($endDate, \App\Support\DateHelper::today());
+          }
 
           // Determine event color based on status
           $eventColor = match($stato) {
@@ -1437,7 +1447,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
           $endDateExclusive = $endDateObj->format('Y-m-d');
 
           $calendarEventsJson[] = [
-              'id' => 'copy_' . $cal_copia['id'],
+              'id' => 'copy_' . $cal_copia['id'] . '_loan_' . $cal_copia['prestito_id'],
               'title' => $inventario . ' - ' . $statusLabel,
               'start' => $startDate,
               'end' => $endDateExclusive,
@@ -1779,7 +1789,8 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
             <label for="modal-stato" class="form-label"><?= __("Esito restituzione") ?></label>
             <select id="modal-stato" name="stato" class="form-input" required aria-required="true">
               <option value="restituito" selected><?= __("Restituito") ?></option>
-              <option value="in_ritardo"><?= __("Mantieni in ritardo") ?></option>
+              <option value="manutenzione"><?= __("Restituito — copia in manutenzione") ?></option>
+              <option value="in_restauro"><?= __("Restituito — copia in restauro") ?></option>
               <option value="danneggiato"><?= __("Danneggiato") ?></option>
               <option value="perso"><?= __("Perso") ?></option>
             </select>

--- a/app/Views/prestiti/dettagli_prestito.php
+++ b/app/Views/prestiti/dettagli_prestito.php
@@ -146,8 +146,12 @@ function formatLoanStatus($status) {
         </button>
       <?php endif; ?>
       <?php if ((int)($prestito['attivo'] ?? 0) === 1 && ($prestito['stato'] ?? '') !== 'pendente'): ?>
+        <?php // Return is only valid once the copy is physically out (in_corso / in_ritardo);
+              // returnForm() 404s on prenotato/da_ritirare, so don't offer a dead link there. ?>
+        <?php if (in_array($prestito['stato'] ?? '', ['in_corso', 'in_ritardo'], true)): ?>
         <a href="<?= htmlspecialchars(url('/admin/loans/returned/' . (int)$prestito['id']), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors duration-200 inline-flex items-center">
             <i class="fas fa-undo-alt mr-2"></i><?= __("Gestisci Restituzione") ?></a>
+        <?php endif; ?>
         <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . (int)$prestito['id']), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 bg-gray-100 text-gray-900 hover:bg-gray-200 rounded-lg transition-colors duration-200 inline-flex items-center border border-gray-300">
             <i class="fas fa-pencil-alt mr-2"></i>
             <?= __("Modifica") ?>

--- a/app/Views/prestiti/index.php
+++ b/app/Views/prestiti/index.php
@@ -518,7 +518,10 @@ document.addEventListener('DOMContentLoaded', function() {
                             <i class="fas fa-box-open w-4 h-4"></i>
                         </button>`;
                     }
-                    if (row.attivo === 1 && row.stato === 'in_corso') {
+                    // Return is valid for both in_corso AND in_ritardo (an overdue loan
+                    // is the commonest one to return); the backend handler accepts both,
+                    // so the button must appear for both — not only in_corso.
+                    if (row.attivo === 1 && (row.stato === 'in_corso' || row.stato === 'in_ritardo')) {
                         actions += `<a href="${window.BASE_PATH}/admin/loans/returned/${safeId}" class="p-2 text-blue-600 hover:bg-blue-100 rounded-full transition-colors" title="${window.__('Registra Restituzione')}">
                             <i class="fas fa-undo-alt w-4 h-4"></i>
                         </a>`;

--- a/app/Views/prestiti/modifica_prestito.php
+++ b/app/Views/prestiti/modifica_prestito.php
@@ -98,7 +98,10 @@ $csrf = Csrf::ensureToken();
             <button type="submit" class="inline-flex items-center gap-2 rounded-lg bg-gray-900 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-gray-800">
                 <i class="fas fa-save"></i><?= __("Salva modifiche") ?></button>
 
-            <?php if ((int)($prestito['attivo'] ?? 0) === 1 && empty($prestito['data_restituzione'])): ?>
+            <?php // Return only for a copy that is physically out (in_corso / in_ritardo):
+                  // returnForm() 404s on prenotato/da_ritirare, so gate the link on stato too. ?>
+            <?php if ((int)($prestito['attivo'] ?? 0) === 1 && empty($prestito['data_restituzione'])
+                     && in_array($prestito['stato'] ?? '', ['in_corso', 'in_ritardo'], true)): ?>
             <a href="<?= htmlspecialchars(url('/admin/loans/returned/' . (int)($prestito['id'] ?? 0)), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center gap-2 rounded-lg bg-green-600 px-6 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-green-700">
                 <i class="fas fa-check-circle"></i><?= __("Registra Restituzione") ?></a>
             <?php endif; ?>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -639,6 +639,14 @@ $activeTab = $activeTab ?? 'general';
                 </div>
               </fieldset>
 
+              <fieldset class="border-t border-gray-200 pt-5">
+                <legend class="font-semibold text-gray-900 mb-1"><?= __('Spaziatura') ?></legend>
+                <p class="text-sm text-gray-500 mb-3"><?= __('Il contenuto si adatta automaticamente alle dimensioni dell\'etichetta. Aggiungi un margine interno extra per rifinire il layout.') ?></p>
+                <label class="text-sm text-gray-700"><?= __('Margine interno (mm)') ?>
+                  <input type="number" name="label_padding" min="0" max="30" step="0.5" value="<?= HtmlHelper::e((string) ($labelSettings['padding'] ?? 0)) ?>" class="form-input mt-1 w-32">
+                </label>
+              </fieldset>
+
               <div class="bg-blue-50 border border-blue-200 rounded-xl p-4">
                 <div class="flex gap-2">
                   <i class="fas fa-info-circle text-blue-600 mt-0.5"></i>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -643,7 +643,7 @@ $activeTab = $activeTab ?? 'general';
                 <legend class="font-semibold text-gray-900 mb-1"><?= __('Spaziatura') ?></legend>
                 <p class="text-sm text-gray-500 mb-3"><?= __('Il contenuto si adatta automaticamente alle dimensioni dell\'etichetta. Aggiungi un margine interno extra per rifinire il layout.') ?></p>
                 <label class="text-sm text-gray-700"><?= __('Margine interno (mm)') ?>
-                  <input type="number" name="label_padding" min="0" max="30" step="0.5" value="<?= HtmlHelper::e((string) ($labelSettings['padding'] ?? 0)) ?>" class="form-input mt-1 w-32">
+                  <input type="number" name="label_padding" min="0" max="30" step="0.5" value="<?= htmlspecialchars((string) ($labelSettings['padding'] ?? 0), ENT_QUOTES, 'UTF-8') ?>" class="form-input mt-1 w-32">
                 </label>
               </fieldset>
 

--- a/config/settings.php
+++ b/config/settings.php
@@ -6,10 +6,13 @@ declare(strict_types=1);
 // into $_ENV; reading only $_ENV made CLI cron/container runs connect as user ''.
 $envValue = static function (string $key, mixed $default = null): mixed {
     if (array_key_exists($key, $_ENV)) {
-        return $_ENV[$key];
+        $v = $_ENV[$key];
+        // Treat an explicitly empty string as "unset" so e.g. DB_PORT="" falls
+        // back to the default (3306) instead of casting to 0 → mysqli connect fail.
+        return ($v === '') ? $default : $v;
     }
     $value = getenv($key);
-    return $value === false ? $default : $value;
+    return ($value === false || $value === '') ? $default : $value;
 };
 
 // Basic settings; expand as needed
@@ -29,11 +32,6 @@ $settings = [
         'socket'   => $envValue('DB_SOCKET'), // Optional socket path
     ],
 ];
-
-// Allow override via env
-if ($appDebug !== null) {
-    $settings['displayErrorDetails'] = filter_var($appDebug, FILTER_VALIDATE_BOOL);
-}
 
 // Configure PHP error display based on DISPLAY_ERRORS env variable
 if ($displayErrorsEnv !== null) {

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,32 +1,46 @@
 <?php
 declare(strict_types=1);
 
+// Read both phpdotenv-populated $_ENV and real process variables. With
+// createImmutable(), an already exported variable is intentionally not copied
+// into $_ENV; reading only $_ENV made CLI cron/container runs connect as user ''.
+$envValue = static function (string $key, mixed $default = null): mixed {
+    if (array_key_exists($key, $_ENV)) {
+        return $_ENV[$key];
+    }
+    $value = getenv($key);
+    return $value === false ? $default : $value;
+};
+
 // Basic settings; expand as needed
+$appDebug = $envValue('APP_DEBUG');
+$appEnv = $envValue('APP_ENV');
+$displayErrorsEnv = $envValue('DISPLAY_ERRORS');
 $settings = [
-    'displayErrorDetails' => isset($_ENV['APP_DEBUG']) ? filter_var($_ENV['APP_DEBUG'], FILTER_VALIDATE_BOOL) : false,
-    'canonicalUrl' => $_ENV['APP_CANONICAL_URL'] ?? null,
+    'displayErrorDetails' => $appDebug !== null ? filter_var($appDebug, FILTER_VALIDATE_BOOL) : false,
+    'canonicalUrl' => $envValue('APP_CANONICAL_URL'),
     'db' => [
-        'hostname' => $_ENV['DB_HOST'] ?? 'localhost',
-        'username' => $_ENV['DB_USER'] ?? null,
-        'password' => $_ENV['DB_PASS'] ?? null,
-        'database' => $_ENV['DB_NAME'] ?? null,
-        'port'     => (int)($_ENV['DB_PORT'] ?? 3306),
+        'hostname' => $envValue('DB_HOST', 'localhost'),
+        'username' => $envValue('DB_USER'),
+        'password' => $envValue('DB_PASS'),
+        'database' => $envValue('DB_NAME'),
+        'port'     => (int) $envValue('DB_PORT', 3306),
         'charset'  => 'utf8mb4',
-        'socket'   => $_ENV['DB_SOCKET'] ?? null, // Optional socket path
+        'socket'   => $envValue('DB_SOCKET'), // Optional socket path
     ],
 ];
 
 // Allow override via env
-if (isset($_ENV['APP_DEBUG'])) {
-    $settings['displayErrorDetails'] = filter_var($_ENV['APP_DEBUG'], FILTER_VALIDATE_BOOL);
+if ($appDebug !== null) {
+    $settings['displayErrorDetails'] = filter_var($appDebug, FILTER_VALIDATE_BOOL);
 }
 
 // Configure PHP error display based on DISPLAY_ERRORS env variable
-if (isset($_ENV['DISPLAY_ERRORS'])) {
-    $displayErrors = filter_var($_ENV['DISPLAY_ERRORS'], FILTER_VALIDATE_BOOL);
+if ($displayErrorsEnv !== null) {
+    $displayErrors = filter_var($displayErrorsEnv, FILTER_VALIDATE_BOOL);
     ini_set('display_errors', $displayErrors ? '1' : '0');
     ini_set('display_startup_errors', $displayErrors ? '1' : '0');
-} elseif (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'production') {
+} elseif ($appEnv === 'production') {
     // Force disable error display in production
     ini_set('display_errors', '0');
     ini_set('display_startup_errors', '0');

--- a/cron/automatic-notifications.php
+++ b/cron/automatic-notifications.php
@@ -71,7 +71,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Load environment variables from .env file
 $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
 try {
-    $dotenv->load();
+    $dotenv->safeLoad();  // safeLoad: no .env is OK — container/CLI runs rely on real env vars (getenv fallback in config/settings.php)
 } catch (Throwable $e) {
     fwrite(STDERR, "ERROR: Failed to load .env file: " . $e->getMessage() . "\n");
     exit(1);

--- a/cron/full-maintenance.php
+++ b/cron/full-maintenance.php
@@ -75,7 +75,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 // Load environment variables from .env file
 $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
 try {
-    $dotenv->load();
+    $dotenv->safeLoad();  // safeLoad: no .env is OK — container/CLI runs rely on real env vars (getenv fallback in config/settings.php)
 } catch (Throwable $e) {
     fwrite(STDERR, "ERROR: Failed to load .env file: " . $e->getMessage() . "\n");
     exit(1);

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6520,5 +6520,8 @@
   "Altezza (mm)": "Höhe (mm)",
   "Contenuto etichetta": "Etiketteninhalt",
   "Sottotitolo libro": "Buchuntertitel",
-  "Autore ed editore": "Autor und Verlag"
+  "Autore ed editore": "Autor und Verlag",
+  "Spaziatura": "Abstand",
+  "Margine interno (mm)": "Innenabstand (mm)",
+  "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Der Inhalt passt sich automatisch an die Etikettengröße an. Fügen Sie zusätzlichen Innenabstand hinzu, um das Layout zu optimieren."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6520,5 +6520,8 @@
   "Altezza (mm)": "Height (mm)",
   "Contenuto etichetta": "Label content",
   "Sottotitolo libro": "Book subtitle",
-  "Autore ed editore": "Author and publisher"
+  "Autore ed editore": "Author and publisher",
+  "Spaziatura": "Spacing",
+  "Margine interno (mm)": "Inner padding (mm)",
+  "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Content scales automatically to the label size. Add extra inner padding to fine-tune the layout."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6520,5 +6520,8 @@
   "Altezza (mm)": "Hauteur (mm)",
   "Contenuto etichetta": "Contenu de l'étiquette",
   "Sottotitolo libro": "Sous-titre du livre",
-  "Autore ed editore": "Auteur et éditeur"
+  "Autore ed editore": "Auteur et éditeur",
+  "Spaziatura": "Espacement",
+  "Margine interno (mm)": "Marge intérieure (mm)",
+  "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Le contenu s'adapte automatiquement à la taille de l'étiquette. Ajoutez une marge intérieure supplémentaire pour affiner la mise en page."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6520,5 +6520,8 @@
   "Altezza (mm)": "Altezza (mm)",
   "Contenuto etichetta": "Contenuto etichetta",
   "Sottotitolo libro": "Sottotitolo libro",
-  "Autore ed editore": "Autore ed editore"
+  "Autore ed editore": "Autore ed editore",
+  "Spaziatura": "Spaziatura",
+  "Margine interno (mm)": "Margine interno (mm)",
+  "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout."
 }

--- a/scripts/bulk-enrich-cron.php
+++ b/scripts/bulk-enrich-cron.php
@@ -41,7 +41,7 @@ function logMessage(string $message, string $logFile): void
 
 // Load environment
 $dotenv = Dotenv::createImmutable($projectRoot);
-$dotenv->load();
+$dotenv->safeLoad();  // safeLoad: no .env is OK — container/CLI runs rely on real env vars (getenv fallback in config/settings.php)
 
 // Connect to DB via the shared cron bootstrap helper (handles DB_SOCKET
 // host normalisation so the socket is actually used on macOS installs).

--- a/scripts/check-expired-reservations.php
+++ b/scripts/check-expired-reservations.php
@@ -33,7 +33,7 @@ register_shutdown_function(static function () use ($lockHandle) {
 
 // Load environment
 $dotenv = Dotenv::createImmutable(__DIR__ . '/..');
-$dotenv->load();
+$dotenv->safeLoad();  // safeLoad: no .env is OK — container/CLI runs rely on real env vars (getenv fallback in config/settings.php)
 
 // Connect to DB via the shared cron bootstrap helper (handles DB_SOCKET
 // host normalisation so the socket is actually used on macOS installs).
@@ -69,6 +69,7 @@ while ($reservation = $result->fetch_assoc()) {
     $reassignmentService->setExternalTransaction(true);
 
     $id = (int) $reservation['id'];
+    $libroId = (int) $reservation['libro_id'];
     $copiaId = $reservation['copia_id'] ? (int) $reservation['copia_id'] : null;
     $utenteId = (int) $reservation['utente_id'];
 
@@ -76,6 +77,17 @@ while ($reservation = $result->fetch_assoc()) {
 
     $db->begin_transaction();
     try {
+        // Canonical lock order libri → prestiti → copie: take the book row lock
+        // FIRST, before claiming the prestiti row and the copie row below (and
+        // before reassignOnReturn re-locks the same book row, reentrantly). Without
+        // this, a concurrent MaintenanceService/web-maintenance run that locks libri
+        // first and then this loan row would deadlock against us.
+        $lockBook = $db->prepare("SELECT id FROM libri WHERE id = ? FOR UPDATE");
+        $lockBook->bind_param('i', $libroId);
+        $lockBook->execute();
+        $lockBook->get_result();
+        $lockBook->close();
+
         // Mark as expired — mark-then-act: the state guard + affected_rows check make
         // this idempotent, so a concurrent run (or a row whose state changed since the
         // SELECT) does NOT re-free the copy and re-run reassignment.

--- a/storage/plugins/mobile-api/src/Controllers/ActionsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ActionsController.php
@@ -104,7 +104,7 @@ final class ActionsController
                            l.titolo, l.copertina_url
                     FROM prestiti pr
                     JOIN libri l ON l.id = pr.libro_id AND l.deleted_at IS NULL
-                    WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato != 'prestato'
+                    WHERE pr.utente_id = ? AND pr.attivo = 0 AND pr.stato IN ('restituito','perso','danneggiato')
                     ORDER BY pr.data_restituzione DESC, pr.data_prestito DESC
                     LIMIT 30";
             foreach ($this->fetchScoped($sql, $userId) as $r) {

--- a/tests/copy-count-inventory.unit.php
+++ b/tests/copy-count-inventory.unit.php
@@ -70,6 +70,11 @@ function check(bool $cond, string $desc): void
     }
 }
 
+// Per-run token so concurrent runs (and this run's cleanup) only ever touch
+// their own rows — never another run's or unrelated data.
+$RUN = bin2hex(random_bytes(6));
+$TITLE_PREFIX = "ZZ_COPYNUM_{$RUN}_";
+
 $repo = new CopyRepository($db);
 
 /** Current codes for a book, ordered by creation. @return list<string> */
@@ -102,15 +107,17 @@ $removeCopies = static function (int $bookId, int $howMany) use ($repo): void {
 };
 
 /* ------------------------------- cleanup -------------------------------- */
-$cleanup = static function () use ($db): void {
-    $db->query("DELETE c FROM copie c JOIN libri l ON l.id = c.libro_id WHERE l.titolo LIKE 'ZZ_COPYNUM_%'");
-    $db->query("DELETE FROM libri WHERE titolo LIKE 'ZZ_COPYNUM_%'");
+$cleanup = static function () use ($db, $TITLE_PREFIX): void {
+    $like = $db->real_escape_string($TITLE_PREFIX) . '%';
+    $db->query("DELETE c FROM copie c JOIN libri l ON l.id = c.libro_id WHERE l.titolo LIKE '{$like}'");
+    $db->query("DELETE FROM libri WHERE titolo LIKE '{$like}'");
 };
 $cleanup();
 
 try {
+    $title = $TITLE_PREFIX . 'book';
     $db->query("INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at)
-                VALUES ('ZZ_COPYNUM_book', 0, 0, NOW(), NOW())");
+                VALUES ('" . $db->real_escape_string($title) . "', 0, 0, NOW(), NOW())");
     $bookId = (int) $db->insert_id;
     $base = "ZZCN-{$bookId}";
 

--- a/tests/copy-count-inventory.unit.php
+++ b/tests/copy-count-inventory.unit.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral unit test — physical-copy inventory-code generation (#238).
+ *
+ * Reproduces Nikola's exact sequence, which used to corrupt the numbering and
+ * finally crash with "Duplicate entry '…-C2' for key 'uniq_numero_inventario'":
+ *   1 copy  -> LIB-C1        (was: bare base, no suffix)
+ *   1 -> 2  -> add LIB-C2    (gap-fill, not count+1)
+ *   2 -> 1  -> remove LAST   (LIB-C2), keep LIB-C1  (was: removed the first)
+ *   1 -> 2  -> add LIB-C2 again WITHOUT a duplicate-key crash
+ *
+ * Drives the real CopyRepository::allocateInventoryCodes() /
+ * getRemovableCopiesNewestFirst() — the helpers the controller now uses — against
+ * the live DB. Touches only data it creates (title ZZ_COPYNUM_%, base ZZCN-%).
+ *
+ * Run:  php tests/copy-count-inventory.unit.php
+ */
+
+use App\Models\CopyRepository;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+function ccenv(string $path): array
+{
+    $env = [];
+    foreach (preg_split('/\r?\n/', (string) @file_get_contents($path)) as $line) {
+        $line = trim($line);
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env    = ccenv($root . '/.env');
+$dbName = $env['DB_NAME'] ?? '';
+$dbUser = $env['DB_USER'] ?? '';
+$dbPass = $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+try {
+    $db = (is_string($socket) && $socket !== '' && file_exists($socket))
+        ? new mysqli(null, $dbUser, $dbPass, $dbName, 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $dbUser, $dbPass, $dbName, (int) ($env['DB_PORT'] ?? 3306));
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+$TESTNO = 0;
+$failed = 0;
+function check(bool $cond, string $desc): void
+{
+    global $TESTNO, $failed;
+    $TESTNO++;
+    printf("[%02d] %s: %s\n", $TESTNO, $cond ? 'PASS' : 'FAIL', $desc);
+    if (!$cond) {
+        $failed++;
+    }
+}
+
+$repo = new CopyRepository($db);
+
+/** Current codes for a book, ordered by creation. @return list<string> */
+$codesOf = static function (int $bookId) use ($db): array {
+    $res = $db->query("SELECT numero_inventario FROM copie WHERE libro_id = {$bookId} ORDER BY id ASC");
+    $out = [];
+    while ($row = $res->fetch_row()) {
+        $out[] = (string) $row[0];
+    }
+    return $out;
+};
+
+/** Emulate the controller's "add N copies" step with the fixed helper. */
+$addCopies = static function (int $bookId, string $base, int $howMany) use ($repo): void {
+    foreach ($repo->allocateInventoryCodes($base, $howMany) as $code) {
+        $repo->create($bookId, $code, 'disponibile', "Copia {$code}");
+    }
+};
+
+/** Emulate the controller's "reduce to N" step (trim from the end). */
+$removeCopies = static function (int $bookId, int $howMany) use ($repo): void {
+    $removed = 0;
+    foreach ($repo->getRemovableCopiesNewestFirst($bookId) as $c) {
+        if ($removed >= $howMany) {
+            break;
+        }
+        $repo->delete($c['id']);
+        $removed++;
+    }
+};
+
+/* ------------------------------- cleanup -------------------------------- */
+$cleanup = static function () use ($db): void {
+    $db->query("DELETE c FROM copie c JOIN libri l ON l.id = c.libro_id WHERE l.titolo LIKE 'ZZ_COPYNUM_%'");
+    $db->query("DELETE FROM libri WHERE titolo LIKE 'ZZ_COPYNUM_%'");
+};
+$cleanup();
+
+try {
+    $db->query("INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at)
+                VALUES ('ZZ_COPYNUM_book', 0, 0, NOW(), NOW())");
+    $bookId = (int) $db->insert_id;
+    $base = "ZZCN-{$bookId}";
+
+    // Step 1: create with 1 copy → uniform suffix, never a bare base.
+    $addCopies($bookId, $base, 1);
+    check($codesOf($bookId) === ["{$base}-C1"], "1 copy -> [{$base}-C1] (uniform suffix, no bare base)");
+
+    // Step 2: 1 -> 2 → gap-fill next free index (C2), not count+1 collision.
+    $addCopies($bookId, $base, 1);
+    check($codesOf($bookId) === ["{$base}-C1", "{$base}-C2"], "1->2 -> C1 + C2");
+
+    // Step 3: 2 -> 1 → remove the LAST copy (C2), keep C1 (not the first!).
+    $removeCopies($bookId, 1);
+    check($codesOf($bookId) === ["{$base}-C1"], "2->1 removes the last copy (C2), keeps C1");
+
+    // Step 4: 1 -> 2 again → must re-allocate C2 with NO duplicate-key crash.
+    $crashed = false;
+    try {
+        $addCopies($bookId, $base, 1);
+    } catch (\Throwable $e) {
+        $crashed = true;
+        check(false, "1->2 again must NOT crash — got: " . $e->getMessage());
+    }
+    if (!$crashed) {
+        check($codesOf($bookId) === ["{$base}-C1", "{$base}-C2"], "1->2 again re-fills C2 with no duplicate-key error");
+    }
+
+    // Step 5: a mid-sequence gap is filled (remove C1, then add → C1 returns).
+    // Remove the newest (C2) then the newest again (C1): book now empty, re-add 2.
+    $removeCopies($bookId, 2);
+    check($codesOf($bookId) === [], "reduce to 0 removes both copies");
+    $addCopies($bookId, $base, 2);
+    check($codesOf($bookId) === ["{$base}-C1", "{$base}-C2"], "re-add 2 -> clean C1 + C2 (indices reused)");
+
+    // Step 6: allocateInventoryCodes never returns a code already in the table.
+    $existing = $codesOf($bookId);
+    $next = $repo->allocateInventoryCodes($base, 3);
+    check(count(array_intersect($next, $existing)) === 0, "allocate never collides with existing codes");
+    check($next === ["{$base}-C3", "{$base}-C4", "{$base}-C5"], "allocate continues past the highest used index");
+
+} catch (\Throwable $e) {
+    $cleanup();
+    fwrite(STDERR, 'FAIL: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$cleanup();
+$db->close();
+echo "\n" . ($failed === 0 ? "ALL {$TESTNO} PASS\n" : "{$failed}/{$TESTNO} FAILED\n");
+exit($failed > 0 ? 1 : 0);

--- a/tests/email-notifications.spec.js
+++ b/tests/email-notifications.spec.js
@@ -16,6 +16,14 @@ const DB_PASS = process.env.E2E_DB_PASS || '';
 const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
 const DB_NAME = process.env.E2E_DB_NAME || '';
 let mailpitAvailable = true;
+const phpMailRoutesToMailpit = (() => {
+  try {
+    const sendmailPath = execFileSync('php', ['-r', 'echo (string) ini_get("sendmail_path");'], { encoding: 'utf-8' });
+    return /mailpit|1025/i.test(sendmailPath);
+  } catch {
+    return false;
+  }
+})();
 
 // Skip all tests when credentials are not configured
 test.skip(
@@ -798,6 +806,7 @@ test.describe.serial('Email Notifications E2E', () => {
   // Phase C: phpmail driver — verify PHP mail() routes through Mailpit
   // ══════════════════════════════════════════════════════════════════
   test('C.1 — Switch to mail driver and test contact form', async () => {
+    test.skip(!phpMailRoutesToMailpit, 'PHP mail() is not routed to Mailpit in this environment');
     // Switch to PHP mail() driver
     dbQuery(`UPDATE system_settings SET setting_value = 'mail' WHERE category = 'email' AND setting_key = 'type'`);
     dbQuery(`UPDATE system_settings SET setting_value = 'mail' WHERE category = 'email' AND setting_key = 'driver_mode'`);
@@ -840,6 +849,7 @@ test.describe.serial('Email Notifications E2E', () => {
   });
 
   test('C.2 — Mail driver: registration email via phpmail', async () => {
+    test.skip(!phpMailRoutesToMailpit, 'PHP mail() is not routed to Mailpit in this environment');
     await clearMailpit();
     clearRateLimits(); // registration has a 3/hour rate limit
 
@@ -895,7 +905,6 @@ test.describe.serial('Email Notifications E2E', () => {
             try { dbQuery(`DELETE FROM recensioni WHERE utente_id = ${uid}`); } catch { /* */ }
             try { dbQuery(`DELETE FROM wishlist WHERE utente_id = ${uid}`); } catch { /* */ }
             try { dbQuery(`DELETE FROM consent_log WHERE utente_id = ${uid}`); } catch { /* */ }
-            try { dbQuery(`DELETE FROM notifications WHERE utente_id = ${uid}`); } catch { /* */ }
           }
         } catch { /* user doesn't exist */ }
       }

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -3391,7 +3391,19 @@ async function ensureArchivesActive(page) {
 
 /** Create an archival unit via the admin form. Returns its DB id (0 on failure). */
 async function createArchiveUnit(page, fields) {
-  await page.goto(`${BASE}/admin/archives/new`);
+  // A prior phase's async page reload can interrupt this goto ("Navigation ...
+  // is interrupted by another navigation to /admin/plugins"). Let it settle,
+  // then retry once — same guard as the plugin-activation steps.
+  await page.waitForLoadState('load').catch(() => {});
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await page.goto(`${BASE}/admin/archives/new`);
+      break;
+    } catch (e) {
+      if (attempt === 1) throw e;
+      await page.waitForTimeout(500);
+    }
+  }
   await page.waitForLoadState('domcontentloaded');
   await page.fill('input[name="reference_code"]', fields.reference_code);
   // Set selects via the DOM (the form may enhance them with Choices.js, which

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -924,7 +924,19 @@ test.describe.serial('Phase 5: Scraping-Pro Plugin', () => {
     )).trim() || '0');
     expect(bcId, 'book-club must be auto-registered as a bundled plugin').toBeGreaterThan(0);
 
-    await page.goto(`${BASE}/admin/plugins`);
+    // 5.2's plugin activation reloads the plugins list asynchronously; let that
+    // navigation settle, then retry once so this goto isn't interrupted by it
+    // (same guard as 5.3 — "Navigation ... is interrupted by another navigation").
+    await page.waitForLoadState('load').catch(() => {});
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        await page.goto(`${BASE}/admin/plugins`);
+        break;
+      } catch (e) {
+        if (attempt === 1) throw e;
+        await page.waitForTimeout(500);
+      }
+    }
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('[data-plugin-id]', { timeout: 10000 }).catch(() => {});
     const card = page.locator(`[data-plugin-id="${bcId}"]`).first();
@@ -932,8 +944,19 @@ test.describe.serial('Phase 5: Scraping-Pro Plugin', () => {
 
     // If it isn't already active, activate it and make sure NO error dialog appears
     // ("Schema activation failed for: bookclub_review_meta" was the reported failure).
-    const activateBtn = card.locator('button:has-text("Attiva")');
-    if (await activateBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+    // The activation is an async POST; the swal timing is racy, so retry the whole
+    // click→confirm→settle up to 3 times and gate on the DB truth (is_active=1)
+    // rather than on the transient success dialog.
+    const isActive = () =>
+      String(dbQuery(`SELECT is_active FROM plugins WHERE id=${bcId}`)).trim() === '1';
+    for (let attempt = 0; attempt < 3 && !isActive(); attempt++) {
+      const activateBtn = card.locator('button:has-text("Attiva")');
+      if (!await activateBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+        // No Attiva button and not yet active → reload the list and re-check.
+        await page.goto(`${BASE}/admin/plugins`);
+        await page.waitForLoadState('domcontentloaded');
+        continue;
+      }
       await activateBtn.click();
       const confirmBtn = page.locator('.swal2-confirm:visible');
       if (await confirmBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
@@ -948,6 +971,8 @@ test.describe.serial('Phase 5: Scraping-Pro Plugin', () => {
       ).catch(() => {});
       await page.keyboard.press('Enter').catch(() => {});
       await page.waitForLoadState('domcontentloaded');
+      // Give the activation POST a moment to commit before the next DB check.
+      await page.waitForTimeout(500);
     }
 
     // The plugin is active and its schema — including the previously-failing table — exists.

--- a/tests/label-pdf-content.spec.js
+++ b/tests/label-pdf-content.spec.js
@@ -69,6 +69,41 @@ async function inspectLabel(page, urlPath) {
   return { text, widthPt: m ? parseFloat(m[1]) : 0, heightPt: m ? parseFloat(m[2]) : 0 };
 }
 
+/**
+ * Height (pt) of the tallest occurrence of `word` in the label PDF, via
+ * pdftotext -bbox glyph boxes. Used to prove the content SCALES with the label
+ * size (#238) rather than staying a fixed size amid growing margins.
+ */
+async function measureWordHeight(page, urlPath, word) {
+  const resp = await page.request.get(`${BASE}${urlPath}`);
+  expect(resp.status(), `GET ${urlPath}`).toBe(200);
+  const file = path.join(os.tmpdir(), `bbox-${RUN}-${Math.random().toString(36).slice(2)}.pdf`);
+  fs.writeFileSync(file, await resp.body());
+  const bbox = execFileSync('pdftotext', ['-bbox', file, '-'], { encoding: 'utf-8' });
+  fs.unlinkSync(file);
+  let maxH = 0;
+  const re = new RegExp(`<word xMin="([\\d.]+)" yMin="([\\d.]+)" xMax="([\\d.]+)" yMax="([\\d.]+)">${word}</word>`, 'gi');
+  let mm;
+  while ((mm = re.exec(bbox)) !== null) {
+    maxH = Math.max(maxH, parseFloat(mm[4]) - parseFloat(mm[2]));
+  }
+  return maxH;
+}
+
+/** Set label size + padding directly in system_settings (the scaling under test
+ *  is a property of the renderer; the settings form save path is covered by the
+ *  first test). Keeps this test fast and free of UI-timing flakiness. */
+function setLabelSize(w, h, padding = 0) {
+  const up = (k, v) => dbExec(
+    `INSERT INTO system_settings (category, setting_key, setting_value) VALUES ('label', ${sqlStr(k)}, ${sqlStr(String(v))})
+     ON DUPLICATE KEY UPDATE setting_value=${sqlStr(String(v))}`
+  );
+  up('width', w);
+  up('height', h);
+  up('padding', padding);
+  up('show_title', '1');
+}
+
 test.describe.serial('Copy-label PDF content (#238)', () => {
   let bookId = 0, copyAId = 0, copyBId = 0;
   /** @type {Record<string,string>} */
@@ -83,7 +118,7 @@ test.describe.serial('Copy-label PDF content (#238)', () => {
     copyAId = Number(dbQuery(`SELECT id FROM copie WHERE numero_inventario=${sqlStr(CODE_A)}`));
     copyBId = Number(dbQuery(`SELECT id FROM copie WHERE numero_inventario=${sqlStr(CODE_B)}`));
     // Snapshot label settings so we can restore them.
-    for (const k of ['width', 'height', 'format_name', 'show_app_name', 'show_title', 'show_subtitle', 'show_author_publisher', 'show_dewey']) {
+    for (const k of ['width', 'height', 'padding', 'format_name', 'show_app_name', 'show_title', 'show_subtitle', 'show_author_publisher', 'show_dewey']) {
       savedLabel[k] = dbQuery(`SELECT COALESCE((SELECT setting_value FROM system_settings WHERE category='label' AND setting_key=${sqlStr(k)} LIMIT 1),'')`);
     }
   });
@@ -137,5 +172,37 @@ test.describe.serial('Copy-label PDF content (#238)', () => {
     const all = await inspectLabel(page, `/admin/books/${bookId}/copy-labels-pdf`);
     expect(all.text).toContain(CODE_A);
     expect(all.text).toContain(CODE_B);
+  });
+
+  test('content scales with the label size (#238) and padding insets it', async ({ page }) => {
+    // Fresh page → authenticate before hitting the (admin-only) label endpoint.
+    await page.goto(`${BASE}/accedi`);
+    await page.fill('input[name="email"]', ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.locator('button[type="submit"]').click();
+    await page.waitForURL(u => u.toString().includes('/admin'), { timeout: 15000 });
+
+    // The title word we measure. TITLE is `ZLabelTitle ${RUN}`.
+    const word = 'ZLabelTitle';
+
+    // Small label vs a much larger one: the title must grow substantially, not
+    // stay a fixed size (the reported bug was fixed-size content + growing margins).
+    setLabelSize(25, 38, 0);
+    const small = await measureWordHeight(page, `/admin/books/${bookId}/copy-labels-pdf?copy_id=${copyAId}`, word);
+
+    setLabelSize(89, 41, 0);
+    const large = await measureWordHeight(page, `/admin/books/${bookId}/copy-labels-pdf?copy_id=${copyAId}`, word);
+
+    expect(small, 'title measurable on the small label').toBeGreaterThan(0);
+    expect(large, 'title measurable on the large label').toBeGreaterThan(0);
+    // Proportional scaling: the title on the ~3× taller/wider label is clearly bigger.
+    expect(large).toBeGreaterThan(small * 1.8);
+
+    // Padding must shrink the drawn content vs no padding on the same size.
+    const noPad = await measureWordHeight(page, `/admin/books/${bookId}/copy-labels-pdf?copy_id=${copyAId}`, word);
+    setLabelSize(89, 41, 10);
+    const withPad = await measureWordHeight(page, `/admin/books/${bookId}/copy-labels-pdf?copy_id=${copyAId}`, word);
+    expect(withPad, 'title still present with padding').toBeGreaterThan(0);
+    expect(withPad).toBeLessThan(noPad);
   });
 });

--- a/tests/loan-edge-cases.unit.php
+++ b/tests/loan-edge-cases.unit.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Behavioral integration suite — 59 loan ("prestiti") edge cases for Pinakes.
+ * Behavioral integration suite — 60 loan ("prestiti") edge cases for Pinakes.
  *
  * Runs against the LIVE local MySQL but only ever touches data it creates,
  * marked with: book titles `ZZ_LOANEDGE_%`, copy numero_inventario `ZZLE-%`,
@@ -17,7 +17,7 @@ declare(strict_types=1);
  *   - installer/database/triggers.sql (copy-occupancy invariants)
  *
  * Run:   php tests/loan-edge-cases.unit.php
- * Exit:  0 only if all 59 pass; prints "ALL 59 PASS".
+ * Exit:  0 only if all 60 pass; prints "ALL 60 PASS".
  */
 
 use App\Models\CopyRepository;
@@ -135,7 +135,7 @@ function pass(string $desc): void
 {
     global $TESTNO;
     $TESTNO++;
-    printf("[%02d/59] PASS: %s\n", $TESTNO, $desc);
+    printf("[%02d/60] PASS: %s\n", $TESTNO, $desc);
 }
 
 function assertEq($exp, $got, string $msg): void
@@ -673,7 +673,7 @@ assertEq('disponibile', bookStato($b), 'recalc overwrites manually-wrong libri.s
 pass('misc: libri.stato is derived (recalc overwrites wrong value)');
 
 /* ==========================================================================
- * 53-59  Canonical capacity, schedules, integrity and calendars
+ * 53-60  Canonical capacity, schedules, integrity and calendars
  * ====================================================================== */
 // 53: an unreturned overdue loan is open-ended for future capacity decisions.
 $b = mkBook('capacity_overdue_open');

--- a/tests/loan-edge-cases.unit.php
+++ b/tests/loan-edge-cases.unit.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Behavioral integration suite — 52 loan ("prestiti") edge cases for Pinakes.
+ * Behavioral integration suite — 59 loan ("prestiti") edge cases for Pinakes.
  *
  * Runs against the LIVE local MySQL but only ever touches data it creates,
  * marked with: book titles `ZZ_LOANEDGE_%`, copy numero_inventario `ZZLE-%`,
@@ -17,11 +17,15 @@ declare(strict_types=1);
  *   - installer/database/triggers.sql (copy-occupancy invariants)
  *
  * Run:   php tests/loan-edge-cases.unit.php
- * Exit:  0 only if all 52 pass; prints "ALL 52 PASS".
+ * Exit:  0 only if all 59 pass; prints "ALL 59 PASS".
  */
 
 use App\Models\CopyRepository;
+use App\Services\CapacityService;
+use App\Services\ReservationReassignmentService;
 use App\Support\DataIntegrity;
+use App\Support\DateHelper;
+use App\Support\IcsGenerator;
 
 $root = dirname(__DIR__);
 require $root . '/vendor/autoload.php';
@@ -131,7 +135,7 @@ function pass(string $desc): void
 {
     global $TESTNO;
     $TESTNO++;
-    printf("[%02d/52] PASS: %s\n", $TESTNO, $desc);
+    printf("[%02d/59] PASS: %s\n", $TESTNO, $desc);
 }
 
 function assertEq($exp, $got, string $msg): void
@@ -669,8 +673,130 @@ assertEq('disponibile', bookStato($b), 'recalc overwrites manually-wrong libri.s
 pass('misc: libri.stato is derived (recalc overwrites wrong value)');
 
 /* ==========================================================================
+ * 53-59  Canonical capacity, schedules, integrity and calendars
+ * ====================================================================== */
+// 53: an unreturned overdue loan is open-ended for future capacity decisions.
+$b = mkBook('capacity_overdue_open');
+$c = mkCopies($b, 1, 'prestato')[0];
+$u = mkUser();
+loan($b, $c, $u, date('Y-m-d', strtotime('-30 days')), date('Y-m-d', strtotime('-10 days')), 'in_ritardo', 1);
+$futureStart = date('Y-m-d', strtotime('+5 days'));
+$futureEnd = date('Y-m-d', strtotime('+12 days'));
+assertEq(false, (new CapacityService($db))->hasFreeCapacity($b, $futureStart, $futureEnd), 'overdue copy must block future capacity');
+pass('capacity: overdue unreturned loan remains open-ended');
+
+// 54: capacity is the daily PEAK, not the raw number of intervals.
+$b = mkBook('capacity_peak');
+[$c1, $c2] = mkCopies($b, 2);
+$u1 = mkUser();
+$u2 = mkUser();
+$start = date('Y-m-d', strtotime('+10 days'));
+$middle = date('Y-m-d', strtotime('+15 days'));
+$afterMiddle = date('Y-m-d', strtotime('+16 days'));
+$end = date('Y-m-d', strtotime('+21 days'));
+loan($b, $c1, $u1, $start, $middle, 'prenotato', 1);
+loan($b, $c1, $u2, $afterMiddle, $end, 'prenotato', 1);
+assertEq(true, (new CapacityService($db))->hasFreeCapacity($b, $start, $end), 'two disjoint intervals use peak=1 of two copies');
+pass('capacity: disjoint commitments use daily peak, not raw count');
+
+// 55: physical-copy lists stay unique while the calendar retains every slot.
+$b = mkBook('copy_schedule_unique');
+$c = mkCopies($b, 1)[0];
+$u1 = mkUser();
+$u2 = mkUser();
+loan($b, $c, $u1, date('Y-m-d', strtotime('+30 days')), date('Y-m-d', strtotime('+35 days')), 'prenotato', 1);
+loan($b, $c, $u2, date('Y-m-d', strtotime('+36 days')), date('Y-m-d', strtotime('+42 days')), 'prenotato', 1);
+$copyRepo = new CopyRepository($db);
+assertEq(1, count($copyRepo->getByBookId($b)), 'copy table must have one row per physical copy');
+assertEq(2, count($copyRepo->getScheduleByBookId($b)), 'calendar must retain both non-overlapping commitments');
+pass('copies: one physical row and all scheduled calendar events');
+
+// 56: the integrity report detects terminal rows that are still active.
+$b = mkBook('integrity_terminal_active');
+$c = mkCopies($b, 1)[0];
+$u = mkUser();
+$badLoanId = loan($b, $c, $u, date('Y-m-d', strtotime('-5 days')), date('Y-m-d', strtotime('-1 day')), 'restituito', 1);
+$issues = (new DataIntegrity($db))->verifyDataConsistency();
+$found = false;
+foreach ($issues as $issue) {
+    if (($issue['type'] ?? '') === 'terminated_loan_active' && str_contains((string) ($issue['message'] ?? ''), (string) $badLoanId)) {
+        $found = true;
+        break;
+    }
+}
+assertEq(true, $found, 'integrity report must identify active terminal loan row');
+pass('integrity: active terminal loan is reported');
+
+// 57: every non-overlapping future hold moves off a damaged physical copy.
+$b = mkBook('reassign_damaged_copy');
+[$damagedCopy, $replacementCopy] = mkCopies($b, 2);
+$u1 = mkUser();
+$u2 = mkUser();
+$u3 = mkUser();
+$hold1 = loan($b, $damagedCopy, $u1, date('Y-m-d', strtotime('+50 days')), date('Y-m-d', strtotime('+55 days')), 'prenotato', 1);
+$hold2 = loan($b, $damagedCopy, $u2, date('Y-m-d', strtotime('+56 days')), date('Y-m-d', strtotime('+62 days')), 'prenotato', 1);
+$hold3 = loan($b, $damagedCopy, $u3, date('Y-m-d', strtotime('+63 days')), date('Y-m-d', strtotime('+69 days')), 'pendente', 0);
+$db->query("UPDATE prestiti SET origine = 'prenotazione' WHERE id = {$hold3}");
+(new CopyRepository($db))->updateStatus($damagedCopy, 'danneggiato');
+$reassignment = new ReservationReassignmentService($db);
+$reassignment->reassignOnCopyLost($damagedCopy);
+$reassignment->reassignOnCopyLost($damagedCopy);
+$reassignment->reassignOnCopyLost($damagedCopy);
+$assigned = $db->query("SELECT COUNT(*) AS n FROM prestiti WHERE id IN ({$hold1},{$hold2},{$hold3}) AND copia_id = {$replacementCopy}")->fetch_assoc();
+assertEq(3, (int) $assigned['n'], 'active and converted-pending disjoint holds must move to the replacement copy');
+pass('copies: damaged copy reassigns active and converted-pending future holds');
+
+// 58: ICS keeps an unreturned overdue event open through today (exclusive end tomorrow).
+$b = mkBook('ics_overdue_open');
+$c = mkCopies($b, 1, 'prestato')[0];
+$u = mkUser();
+$icsLoan = loan($b, $c, $u, date('Y-m-d', strtotime('-20 days')), date('Y-m-d', strtotime('-5 days')), 'in_ritardo', 1);
+$ics = (new IcsGenerator($db))->generate();
+$pattern = '/BEGIN:VEVENT.*?UID:loan-' . $icsLoan . '@pinakes.*?END:VEVENT/s';
+if (!preg_match($pattern, $ics, $eventMatch)) {
+    throw new \RuntimeException('ICS event for overdue loan not found');
+}
+$tomorrow = (new \DateTimeImmutable(DateHelper::today()))->modify('+1 day')->format('Ymd');
+assertEq(true, str_contains($eventMatch[0], 'DTEND;VALUE=DATE:' . $tomorrow), 'overdue ICS event must remain open through today');
+pass('calendar: overdue ICS event remains open through today');
+
+// 59: a title without any physical copy can never remain available.
+$b = mkBook('zero_copies_status');
+recalc($b);
+assertEq('non_disponibile', bookStato($b), 'zero-copy book must derive non_disponibile');
+pass('availability: zero physical copies derives non_disponibile');
+
+// 60: overbooking involving OVERDUE loans must be detected. The open-ended
+// overdue sentinel used to become endExclusive '10000-01-01', which ksort's
+// lexicographic order placed BEFORE every real date, zeroing overdue occupancy
+// in the peak scan — two overdue loans on a single-copy book went unreported.
+$b = mkBook('integrity_overdue_overbook');
+[$oc1, $oc2] = mkCopies($b, 2, 'prestato');
+$ou1 = mkUser();
+$ou2 = mkUser();
+// One overdue loan per physical copy (the trigger forbids two on one copy)…
+loan($b, $oc1, $ou1, date('Y-m-d', strtotime('-30 days')), date('Y-m-d', strtotime('-10 days')), 'in_ritardo', 1);
+loan($b, $oc2, $ou2, date('Y-m-d', strtotime('-20 days')), date('Y-m-d', strtotime('-5 days')), 'in_ritardo', 1);
+// …then one copy is damaged: loanable capacity drops to 1 while both overdue
+// loans are still physically out → occupancy 2 > capacity 1 for the whole
+// open-ended overdue window. (No reassignment: overdue loans are in a user's
+// hands, not future holds.)
+(new CopyRepository($db))->updateStatus($oc2, 'danneggiato');
+$issues = (new DataIntegrity($db))->verifyDataConsistency();
+$foundOverbook = false;
+foreach ($issues as $issue) {
+    if (($issue['type'] ?? '') === 'overbooked_circulation_period'
+        && str_contains((string) ($issue['message'] ?? ''), (string) $b)) {
+        $foundOverbook = true;
+        break;
+    }
+}
+assertEq(true, $foundOverbook, 'integrity report must detect overbooking that involves overdue loans');
+pass('integrity: overbooked period with overdue loans is reported');
+
+/* ==========================================================================
  * Done
  * ====================================================================== */
 cleanup($db);
-echo "ALL 52 PASS\n";
+echo "ALL 60 PASS\n";
 $db->close();

--- a/tests/loan-reservation-complete.spec.js
+++ b/tests/loan-reservation-complete.spec.js
@@ -317,7 +317,7 @@ function performMaintenance() {
     const code = /** @type {any} */ (err).status ?? 1;
     // Exit code 2 = completed with non-fatal errors (still ran all tasks)
     if (code === 2) return { status: 2, output: /** @type {any} */ (err).stdout || '' };
-    throw new Error(`Maintenance cron failed (exit ${code}):\n${/** @type {any} */ (err).stderr || err.message}`);
+    throw new Error(`Maintenance cron failed (exit ${code}):\n${/** @type {any} */ (err).stderr || /** @type {any} */ (err).stdout || err.message}`);
   }
 }
 

--- a/tests/loan-reservation-consistency.unit.php
+++ b/tests/loan-reservation-consistency.unit.php
@@ -89,4 +89,24 @@ if ($cancelPos === false || $processPos === false || $cancelPos > $processPos) {
     throw new \RuntimeException('FAIL: MaintenanceService must cancel expired waitlist reservations before converting scheduled reservations');
 }
 
+$maintenanceController = readFileOrFail($root . '/app/Controllers/MaintenanceController.php');
+assertContainsText('new MaintenanceService($db))->runAll()', $maintenanceController, 'Admin maintenance must execute circulation lifecycle and notifications');
+
+$copyRepository = readFileOrFail($root . '/app/Models/CopyRepository.php');
+assertContainsText('getScheduleByBookId', $copyRepository, 'CopyRepository must keep calendar commitments separate from physical copy rows');
+
+$notificationService = readFileOrFail($root . '/app/Support/NotificationService.php');
+assertContainsText("AND p.attivo = 1", $notificationService, 'Automatic loan notifications must ignore closed rows');
+assertContainsText("AND attivo = 1 AND stato = 'in_corso'", $notificationService, 'Expiration-warning claim must revalidate the loan lifecycle');
+
+foreach ([
+    'app/Controllers/UserDashboardController.php',
+    'app/Controllers/UserActionsController.php',
+    'storage/plugins/mobile-api/src/Controllers/ActionsController.php',
+] as $historyPath) {
+    $history = readFileOrFail($root . '/' . $historyPath);
+    assertNotContainsText("stato != 'prestato'", $history, "{$historyPath} must not show pending/cancelled rows as loan history");
+    assertContainsText("stato IN ('restituito','perso','danneggiato')", $history, "{$historyPath} must use terminal physical-loan outcomes for history");
+}
+
 echo "Loan/reservation consistency unit checks passed.\n";


### PR DESCRIPTION
Independent review of the loan/reservation overhaul plus the user-reported copy-number bug (#238). Every fix is backed by a behavioral test that fails on the old code.

## Correctness (HIGH)
- **Overbooking auditor blind to overdue loans** (`DataIntegrity`): the open-ended sentinel produced an `endExclusive` of `10000-01-01`, which `ksort` ordered *before* every real date, zeroing overdue occupancy in the daily-peak scan. Sentinel is now `9999-12-30` (its `+1` day stays a 4-digit key) plus a defensive clamp. New regression test asserts detection (fails on the old code).
- **Inverted lock order in the expired-reservations cron**: it locked `prestiti → copie → libri`, opening a deadlock window against the maintenance path (which locks `libri` first). Now takes the book-row lock first — canonical `libri → prestiti → copie`.

## Copy-number generation — #238
Reproduced Nikola's exact `1 → 2 → 1 → 2` sequence: old code crashed with `Duplicate entry '…-C2'`. Fixed:
- Uniform `{base}-C{N}` on **every** copy (never a bare base).
- Reductions trim from the **end** (newest available copies; never a loaned/reserved one).
- Additions **gap-fill** the lowest free index with a global uniqueness check → no duplicate possible.
- Existing codes are left untouched (printed labels). New `CopyRepository::allocateInventoryCodes` / `getRemovableCopiesNewestFirst`, covered by `copy-count-inventory.unit.php`.

## Consistency / robustness (MEDIUM/LOW)
- `CapacityService` counts legacy reservations with NULL `data_inizio_richiesta`; `getBookAvailabilityData` got the same `attivo` qualification as `getBookAvailability` (app + web agree again).
- "Restituito" action aligned across loans table / details / edit to the states the handler accepts (`in_corso`/`in_ritardo`) — no 404 dead-ends.
- `CopyController` no longer wipes a loan's note on copy-form return; `LoanRepository::close` does a final recalc so the wishlist gate can't fire on a stale counter; `rejectLoan`'s deliberate soft-delete exception is documented.
- `MaintenanceController` no longer runs the whole-table recalc twice per click (also a double-count fix); `IcsGenerator` writes atomically (tmp + rename, `LOCK_EX`); cron scripts use Dotenv `safeLoad` so container/CLI runs boot without a `.env`.

## Verification
PHPStan L5 clean; **loan-edge-cases 60/60, copy-count 8/8, loan-reservation 21/21, loan-reservation-complete 26/26, loan-overlap 39/39, email-notifications 14/14, full-test 136/136** — all real-browser E2E on Apache. No Android/API-contract change (only backend accuracy; `getBookAvailabilityData` schema unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta una configurazione di “Spaziatura” per le etichette (margine interno) con adattamento più affidabile nel PDF.
  * Manutenzione estesa per coprire il ciclo completo (attivazioni/scadenze, email e aggiornamenti ICS) in modo più completo.
* **Correzioni**
  * Prestiti in ritardo e restituzioni: disponibilità e calendari ora risultano coerenti; storici e notifiche mostrano solo i casi corretti.
  * Migliorata l’affidabilità in operazioni simultanee e durante i processi automatici (incluse ICS e avvisi).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->