### PR TITLE
Email/SMTP test button + loan due-date visibility & notifications (#238)

### DIFF
--- a/app/Controllers/PrestitiApiController.php
+++ b/app/Controllers/PrestitiApiController.php
@@ -135,7 +135,7 @@ class PrestitiApiController
         $param_types .= 'ii';
 
         $sql_prepared = "SELECT p.id, l.titolo AS libro, CONCAT(u.nome,' ',u.cognome) AS utente,
-                       p.data_prestito, p.data_restituzione, p.attivo, p.stato,
+                       p.data_prestito, p.data_scadenza, p.data_restituzione, p.attivo, p.stato,
                        CONCAT(staff.nome,' ',staff.cognome) AS processed_by
                 $base $where_prepared
                 ORDER BY $orderColumn $orderDir LIMIT ?, ?";
@@ -163,6 +163,7 @@ class PrestitiApiController
                 'libro' => $r['libro'] ?? '',
                 'utente' => $r['utente'] ?? '',
                 'data_prestito' => $r['data_prestito'] ?? '',
+                'data_scadenza' => $r['data_scadenza'] ?? '',
                 'data_restituzione' => $r['data_restituzione'] ?? '',
                 'processed_by' => $r['processed_by'] ?? '',
                 'attivo' => (int)$r['attivo'],

--- a/app/Controllers/PrestitiApiController.php
+++ b/app/Controllers/PrestitiApiController.php
@@ -109,13 +109,14 @@ class PrestitiApiController
         $orderDir = 'DESC';
 
         // Map column index to database column
-        // 0: libro, 1: utente, 2: data_prestito, 3: stato, 4: actions
+        // 0: libro, 1: utente, 2: data_prestito, 3: data_scadenza,
+        // 4: stato; columns 5 (PDF) and 6 (actions) are not orderable.
         $columnMap = [
             0 => 'l.titolo',       // Libro
             1 => 'utente',         // Utente (computed column)
             2 => 'p.data_prestito',// Data Prestito
-            3 => 'p.stato',        // Stato
-            4 => 'p.id'            // Actions (fallback to id)
+            3 => 'p.data_scadenza',// Scadenza
+            4 => 'p.stato'         // Stato
         ];
 
         // Parse order parameter from DataTables

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -139,6 +139,49 @@ class SettingsController
         return $this->redirect($response, '/admin/settings?tab=general');
     }
 
+    /**
+     * Send a test email with the current mail settings and return a JSON result
+     * with the real outcome — the specific SMTP error on failure — so the admin
+     * can diagnose an email configuration without guessing (Nikola #238).
+     */
+    public function sendTestEmail(Request $request, Response $response, mysqli $db): Response
+    {
+        $data = (array) $request->getParsedBody();
+
+        // Recipient: an explicit address from the form, else the logged-in admin's.
+        $to = trim((string) ($data['test_email'] ?? ''));
+        if ($to === '') {
+            $adminId = (int) ($_SESSION['user']['id'] ?? 0);
+            if ($adminId > 0) {
+                $stmt = $db->prepare('SELECT email FROM utenti WHERE id = ? LIMIT 1');
+                $stmt->bind_param('i', $adminId);
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                $to = (string) ($row['email'] ?? '');
+            }
+        }
+
+        if ($to === '') {
+            $response->getBody()->write((string) json_encode([
+                'success' => false,
+                'message' => __('Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.'),
+            ]));
+            return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
+        }
+
+        $result = \App\Support\Mailer::sendTest($to);
+        $response->getBody()->write((string) json_encode([
+            'success' => $result['ok'],
+            'message' => $result['ok']
+                ? sprintf(__('Email di prova inviata a %s. Controlla la casella (anche lo spam).'), $to)
+                : sprintf(__('Invio fallito: %s'), $result['error']),
+        ]));
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withStatus($result['ok'] ? 200 : 502);
+    }
+
     public function updateEmailSettings(Request $request, Response $response, mysqli $db): Response
     {
         $data = (array) $request->getParsedBody();

--- a/app/Models/SettingsRepository.php
+++ b/app/Models/SettingsRepository.php
@@ -72,6 +72,17 @@ class SettingsRepository
     }
 
     /**
+     * Days-before-expiry warning horizon (Settings → Advanced). Zero is a valid
+     * value meaning "today only"; negative/corrupt values clamp to 0. Shared by the
+     * web reminders (NotificationService) and the mobile-api due-soon feed/push so
+     * the two can never diverge on the setting key, fallback or clamp.
+     */
+    public function daysBeforeExpiryWarning(): int
+    {
+        return max(0, (int)($this->get('advanced', 'days_before_expiry_warning', '3') ?? 3));
+    }
+
+    /**
      * @return array<string,string>
      */
     public function getCategory(string $category): array

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -575,7 +575,9 @@ return function (App $app): void {
         $db = $app->getContainer()->get('db');
         $controller = new SettingsController();
         return $controller->sendTestEmail($request, $response, $db);
-    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+    })->add(new \App\Middleware\RateLimitMiddleware(5, 60, 'email_test')) // triggers an external SMTP handshake — throttle like the other costly admin routes
+      ->add(new CsrfMiddleware())
+      ->add(new AdminAuthMiddleware());
 
     $app->post('/admin/settings/contacts', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -571,6 +571,12 @@ return function (App $app): void {
         return $controller->updateEmailSettings($request, $response, $db);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
+    $app->post('/admin/settings/email/test', function ($request, $response) use ($app) {
+        $db = $app->getContainer()->get('db');
+        $controller = new SettingsController();
+        return $controller->sendTestEmail($request, $response, $db);
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+
     $app->post('/admin/settings/contacts', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');
         $controller = new SettingsController();

--- a/app/Support/Mailer.php
+++ b/app/Support/Mailer.php
@@ -117,6 +117,23 @@ final class Mailer
             // Fallback to mail()
             return self::sendMail($to, $subject, $htmlBody, $fromEmail, $fromName);
         }
+        $result = self::dispatchPHPMailer($to, $subject, $htmlBody, $textBody, $fromEmail, $fromName);
+        if (!$result['ok']) {
+            SecureLogger::warning('Email send failed: ' . $result['error']);
+        }
+        return $result['ok'];
+    }
+
+    /**
+     * Build and send one PHPMailer message. Single source of truth for the real
+     * send path, so the diagnostic sendTest() exercises exactly what production
+     * uses — if CC/BCC/AltBody/etc. change here they can't silently drift apart.
+     * Returns the real outcome (the specific error on failure), never throws.
+     *
+     * @return array{ok: bool, error: string}
+     */
+    private static function dispatchPHPMailer(string $to, string $subject, string $htmlBody, ?string $textBody, string $fromEmail, string $fromName): array
+    {
         try {
             $mailer = new \PHPMailer\PHPMailer\PHPMailer(true);
             self::configureMailer($mailer, $fromEmail, $fromName);
@@ -124,10 +141,10 @@ final class Mailer
             $mailer->Subject = $subject;
             $mailer->Body = $htmlBody;
             $mailer->AltBody = $textBody ?: strip_tags($htmlBody);
-            return $mailer->send();
+            $mailer->send();
+            return ['ok' => true, 'error' => ''];
         } catch (\Throwable $e) {
-            SecureLogger::warning('Email send failed: ' . $e->getMessage());
-            return false;
+            return ['ok' => false, 'error' => $e->getMessage()];
         }
     }
 
@@ -152,20 +169,10 @@ final class Mailer
         $subject = __('Email di prova da Pinakes');
         $html = '<p>' . __('Questa è un\'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.') . '</p>';
 
-        // SMTP / PHPMailer path: capture the real handshake/auth/recipient error.
+        // SMTP / PHPMailer path: reuse the exact real send path so the test is a
+        // faithful diagnostic, and capture its real handshake/auth/recipient error.
         if (($driver === 'smtp' || $driver === 'phpmailer') && class_exists('PHPMailer\\PHPMailer\\PHPMailer')) {
-            try {
-                $mailer = new \PHPMailer\PHPMailer\PHPMailer(true);
-                self::configureMailer($mailer, $fromEmail, $fromName);
-                $mailer->addAddress($to);
-                $mailer->Subject = $subject;
-                $mailer->Body = $html;
-                $mailer->AltBody = strip_tags($html);
-                $mailer->send();
-                return ['ok' => true, 'error' => ''];
-            } catch (\Throwable $e) {
-                return ['ok' => false, 'error' => $e->getMessage()];
-            }
+            return self::dispatchPHPMailer($to, $subject, $html, null, $fromEmail, $fromName);
         }
 
         // Plain mail() path: no detailed error is available, only success/failure.

--- a/app/Support/Mailer.php
+++ b/app/Support/Mailer.php
@@ -44,10 +44,12 @@ final class Mailer
         $fromName  = (string)ConfigStore::get('mail.from_name', 'Biblioteca');
         $driver    = (string)ConfigStore::get('mail.driver', 'mail');
 
-        if ($driver === 'smtp') {
-            return self::sendSmtp($to, $subject, $htmlBody, $textBody, $fromEmail, $fromName);
-        }
-        if ($driver === 'phpmailer') {
+        // Both 'smtp' and 'phpmailer' go through PHPMailer. It verifies the SMTP
+        // handshake, AUTH and recipient and fails loudly — unlike the old hand-
+        // rolled SMTP path, which never checked server replies and could report
+        // success on a silently-rejected message (the "SMTP looks fine but no mail
+        // arrives" class of bug).
+        if ($driver === 'smtp' || $driver === 'phpmailer') {
             return self::sendPHPMailer($to, $subject, $htmlBody, $textBody, $fromEmail, $fromName);
         }
         return self::sendMail($to, $subject, $htmlBody, $fromEmail, $fromName);
@@ -72,83 +74,41 @@ final class Mailer
         return @mail($to, self::encodeHeader($subject), $body, implode("\r\n", $headers));
     }
 
-    private static function sendSmtp(string $to, string $subject, string $htmlBody, ?string $textBody, string $fromEmail, string $fromName): bool
-    {
-        $host = (string)ConfigStore::get('mail.smtp.host', 'localhost');
-        $port = (int)ConfigStore::get('mail.smtp.port', 587);
-        $enc  = (string)ConfigStore::get('mail.smtp.encryption', 'tls');
-        $user = (string)ConfigStore::get('mail.smtp.username', '');
-        $pass = (string)ConfigStore::get('mail.smtp.password', '');
-
-        $transport = ($enc === 'ssl') ? 'ssl://' . $host : $host;
-        $remote = ($enc === 'tls') ? 'tcp://' . $host . ':' . $port : $transport . ':' . $port;
-
-        $errno = 0; $errstr = '';
-        $fp = @stream_socket_client($remote, $errno, $errstr, 10, STREAM_CLIENT_CONNECT);
-        if (!$fp) return false;
-        stream_set_timeout($fp, 10);
-
-        $send = function(string $cmd) use ($fp) {
-            fwrite($fp, $cmd . "\r\n");
-            return fgets($fp, 512);
-        };
-
-        $read = function() use ($fp) {
-            return fgets($fp, 512);
-        };
-
-        $read();
-        $send('EHLO localhost');
-        if ($enc === 'tls') {
-            $send('STARTTLS');
-            if (!stream_socket_enable_crypto($fp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
-                fclose($fp); return false;
-            }
-            $send('EHLO localhost');
-        }
-        if ($user !== '') {
-            $send('AUTH LOGIN');
-            $send(base64_encode($user));
-            $send(base64_encode($pass));
-        }
-        // Validate email addresses to prevent CRLF injection
-        if (!filter_var($fromEmail, FILTER_VALIDATE_EMAIL) || strpos($fromEmail, "\r") !== false || strpos($fromEmail, "\n") !== false) {
-            throw new \Exception('Invalid from email address');
-        }
-        $send('MAIL FROM: <' . $fromEmail . '>');
-        if (!filter_var($to, FILTER_VALIDATE_EMAIL) || strpos($to, "\r") !== false || strpos($to, "\n") !== false) {
-            throw new \Exception('Invalid recipient email address');
-        }
-        $send('RCPT TO: <' . $to . '>');
-        $send('DATA');
-
-        // Use more secure boundary generation
-        $boundary = uniqid('mail_boundary_', true);
-        $headers = [];
-        $headers[] = 'From: ' . self::encodeHeader($fromName) . " <{$fromEmail}>";
-        $headers[] = 'To: <' . $to . '>';
-        $headers[] = 'Subject: ' . self::encodeHeader($subject);
-        $headers[] = 'MIME-Version: 1.0';
-        $headers[] = 'Content-Type: multipart/alternative; boundary="' . $boundary . '"';
-
-        $text = $textBody ?: strip_tags($htmlBody);
-        $msg  = implode("\r\n", $headers) . "\r\n\r\n";
-        $msg .= "--{$boundary}\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n{$text}\r\n";
-        $msg .= "--{$boundary}\r\nContent-Type: text/html; charset=utf-8\r\n\r\n{$htmlBody}\r\n";
-        $msg .= "--{$boundary}--\r\n.";
-
-        $send($msg);
-        $send('QUIT');
-        fclose($fp);
-        return true;
-    }
-
     private static function encodeHeader(string $s): string
     {
         if (!preg_match('/^[\x20-\x7E]*$/', $s)) {
             return '=?UTF-8?B?' . base64_encode($s) . '?=';
         }
         return $s;
+    }
+
+    /**
+     * Configure a PHPMailer instance from the stored mail settings (SMTP when a
+     * host is set, otherwise PHP mail()). Shared by sendPHPMailer() and sendTest().
+     */
+    private static function configureMailer(\PHPMailer\PHPMailer\PHPMailer $mailer, string $fromEmail, string $fromName): void
+    {
+        $mailer->CharSet = 'UTF-8';
+        $mailer->setFrom($fromEmail, $fromName);
+        $mailer->isHTML(true);
+
+        $host = (string) ConfigStore::get('mail.smtp.host', '');
+        if ($host !== '') {
+            $mailer->isSMTP();
+            // PHPMailer's default Timeout is 300s: if the SMTP host accepts the TCP
+            // connection but then stalls, a single send would block the (cron) request
+            // for 5 minutes. Cap it.
+            $mailer->Timeout = (int) ConfigStore::get('mail.smtp.timeout', 10);
+            $mailer->Host = $host;
+            $mailer->Port = (int) ConfigStore::get('mail.smtp.port', 587);
+            $enc = (string) ConfigStore::get('mail.smtp.encryption', 'tls');
+            if ($enc === 'ssl') { $mailer->SMTPSecure = \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS; }
+            elseif ($enc === 'tls') { $mailer->SMTPSecure = \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_STARTTLS; }
+            else { $mailer->SMTPSecure = ''; $mailer->SMTPAutoTLS = false; }
+            $user = (string) ConfigStore::get('mail.smtp.username', '');
+            $pass = (string) ConfigStore::get('mail.smtp.password', '');
+            if ($user !== '') { $mailer->SMTPAuth = true; $mailer->Username = $user; $mailer->Password = $pass; }
+        }
     }
 
     private static function sendPHPMailer(string $to, string $subject, string $htmlBody, ?string $textBody, string $fromEmail, string $fromName): bool
@@ -159,35 +119,60 @@ final class Mailer
         }
         try {
             $mailer = new \PHPMailer\PHPMailer\PHPMailer(true);
-            $mailer->CharSet = 'UTF-8';
-            $mailer->setFrom($fromEmail, $fromName);
+            self::configureMailer($mailer, $fromEmail, $fromName);
             $mailer->addAddress($to);
             $mailer->Subject = $subject;
-            $mailer->isHTML(true);
             $mailer->Body = $htmlBody;
             $mailer->AltBody = $textBody ?: strip_tags($htmlBody);
-
-            // Use SMTP if configured
-            $host = (string)ConfigStore::get('mail.smtp.host', '');
-            if ($host !== '') {
-                $mailer->isSMTP();
-                // PHPMailer's default Timeout is 300s: if the SMTP host accepts the TCP
-                // connection but then stalls, a single send would block the (cron) request
-                // for 5 minutes. Cap it — the raw-socket path already uses 10s.
-                $mailer->Timeout = (int)ConfigStore::get('mail.smtp.timeout', 10);
-                $mailer->Host = $host;
-                $mailer->Port = (int)ConfigStore::get('mail.smtp.port', 587);
-                $enc  = (string)ConfigStore::get('mail.smtp.encryption', 'tls');
-                if ($enc === 'ssl') { $mailer->SMTPSecure = \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_SMTPS; }
-                elseif ($enc === 'tls') { $mailer->SMTPSecure = \PHPMailer\PHPMailer\PHPMailer::ENCRYPTION_STARTTLS; }
-                else { $mailer->SMTPSecure = ''; $mailer->SMTPAutoTLS = false; }
-                $user = (string)ConfigStore::get('mail.smtp.username', '');
-                $pass = (string)ConfigStore::get('mail.smtp.password', '');
-                if ($user !== '') { $mailer->SMTPAuth = true; $mailer->Username = $user; $mailer->Password = $pass; }
-            }
             return $mailer->send();
         } catch (\Throwable $e) {
+            SecureLogger::warning('Email send failed: ' . $e->getMessage());
             return false;
         }
     }
+
+    /**
+     * Send a diagnostic test email with the CURRENT mail settings and return the
+     * real outcome — the specific error on failure, not just a boolean — so the
+     * admin can tell a bad SMTP config from a working one. Verifies the SMTP
+     * handshake/auth/recipient via PHPMailer.
+     *
+     * @return array{ok: bool, error: string}
+     */
+    public static function sendTest(string $to): array
+    {
+        $fromEmail = (string) ConfigStore::get('mail.from_email', 'no-reply@localhost');
+        $fromName  = (string) ConfigStore::get('mail.from_name', 'Biblioteca');
+        $driver    = (string) ConfigStore::get('mail.driver', 'mail');
+
+        if (!filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            return ['ok' => false, 'error' => __('Indirizzo email del destinatario non valido.')];
+        }
+
+        $subject = __('Email di prova da Pinakes');
+        $html = '<p>' . __('Questa è un\'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.') . '</p>';
+
+        // SMTP / PHPMailer path: capture the real handshake/auth/recipient error.
+        if (($driver === 'smtp' || $driver === 'phpmailer') && class_exists('PHPMailer\\PHPMailer\\PHPMailer')) {
+            try {
+                $mailer = new \PHPMailer\PHPMailer\PHPMailer(true);
+                self::configureMailer($mailer, $fromEmail, $fromName);
+                $mailer->addAddress($to);
+                $mailer->Subject = $subject;
+                $mailer->Body = $html;
+                $mailer->AltBody = strip_tags($html);
+                $mailer->send();
+                return ['ok' => true, 'error' => ''];
+            } catch (\Throwable $e) {
+                return ['ok' => false, 'error' => $e->getMessage()];
+            }
+        }
+
+        // Plain mail() path: no detailed error is available, only success/failure.
+        $ok = self::send($to, $subject, $html);
+        return $ok
+            ? ['ok' => true, 'error' => '']
+            : ['ok' => false, 'error' => __('La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.')];
+    }
+
 }

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -408,6 +408,16 @@ class NotificationService {
             }
             $stmt->close();
 
+            // The email template renders in the installation locale (see
+            // sendWithRetry), so resolve the "oggi" label in that locale too — not
+            // the caller's session locale (this runs from the admin-login
+            // maintenance path as well as cron). Computed once for the whole batch.
+            $installLocale = \App\Support\I18n::getInstallationLocale();
+            $sessionLocale = \App\Support\I18n::getLocale();
+            \App\Support\I18n::setLocale($installLocale);
+            $todayLabel = __('oggi');
+            \App\Support\I18n::setLocale($sessionLocale);
+
             foreach ($loans as $loan) {
                 // ATOMIC: Mark warning as sent BEFORE sending email
                 // Only proceed if we successfully claimed this loan (affected_rows == 1)
@@ -433,7 +443,7 @@ class NotificationService {
                     'utente_nome' => $loan['utente_nome'],
                     'libro_titolo' => $loan['libro_titolo'],
                     'data_scadenza' => $this->formatEmailDate($loan['data_scadenza']),
-                    'giorni_rimasti' => $daysRemaining === 0 ? __('oggi') : (string)$daysRemaining
+                    'giorni_rimasti' => $daysRemaining === 0 ? $todayLabel : (string)$daysRemaining
                 ];
 
                 $emailSent = $this->sendWithRetry($loan['utente_email'], 'loan_expiring_warning', $variables);

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -425,18 +425,21 @@ class NotificationService {
                     continue;
                 }
 
+                // "Giorni rimasti: 0" reads wrong in the email — show "oggi" for a
+                // due-today loan, the number of days otherwise (matches the in-app
+                // notification wording below).
+                $daysRemaining = (int)$loan['giorni_rimasti'];
                 $variables = [
                     'utente_nome' => $loan['utente_nome'],
                     'libro_titolo' => $loan['libro_titolo'],
                     'data_scadenza' => $this->formatEmailDate($loan['data_scadenza']),
-                    'giorni_rimasti' => $loan['giorni_rimasti']
+                    'giorni_rimasti' => $daysRemaining === 0 ? __('oggi') : (string)$daysRemaining
                 ];
 
                 $emailSent = $this->sendWithRetry($loan['utente_email'], 'loan_expiring_warning', $variables);
 
                 if ($emailSent) {
                     // Create in-app notification for expiring loan
-                    $daysRemaining = (int)$loan['giorni_rimasti'];
                     $notificationMessage = $daysRemaining === 0
                         ? sprintf(__('"%s" prestato a %s scade oggi'), $loan['libro_titolo'], $loan['utente_nome'])
                         : sprintf(__('"%s" prestato a %s scade fra %d giorni'), $loan['libro_titolo'], $loan['utente_nome'], $daysRemaining);

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -366,7 +366,7 @@ class NotificationService {
     }
 
     /**
-     * Invia avvisi di scadenza prestiti (3 giorni prima)
+     * Invia avvisi per prestiti in scadenza entro la finestra configurata.
      * Uses atomic mark-then-send pattern to prevent duplicate notifications
      */
     public function sendLoanExpirationWarnings(): int {
@@ -374,14 +374,17 @@ class NotificationService {
 
         try {
             // Get configured days before expiry warning (default: 3)
-            $daysBeforeWarning = (int)ConfigStore::get('advanced.days_before_expiry_warning', 3);
+            $daysBeforeWarning = max(0, (int)ConfigStore::get('advanced.days_before_expiry_warning', 3));
 
             // "Oggi" nel timezone applicativo come parametro bound (M9): CURDATE()
             // dipende dalla session timezone del client DB, che differiva tra cron
             // (UTC forzato) e web (nessuna impostazione).
             $today = DateHelper::today();
 
-            // Get loans expiring in X days
+            // Include every still-unnotified loan from today through the configured
+            // warning horizon. An exact "today + X" match misses short loans created
+            // inside that horizon (especially loans created with due date today).
+            // Overdue loans remain handled separately below by the overdue workflow.
             $stmt = $this->db->prepare("
                 SELECT p.id, p.data_scadenza, l.titolo as libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email as utente_email,
@@ -391,10 +394,10 @@ class NotificationService {
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.stato = 'in_corso'
                   AND p.attivo = 1
-                  AND p.data_scadenza = DATE_ADD(?, INTERVAL ? DAY)
+                  AND p.data_scadenza BETWEEN ? AND DATE_ADD(?, INTERVAL ? DAY)
                   AND (p.warning_sent IS NULL OR p.warning_sent = 0)
             ");
-            $stmt->bind_param('ssi', $today, $today, $daysBeforeWarning);
+            $stmt->bind_param('sssi', $today, $today, $today, $daysBeforeWarning);
             $stmt->execute();
             $result = $stmt->get_result();
 
@@ -433,10 +436,14 @@ class NotificationService {
 
                 if ($emailSent) {
                     // Create in-app notification for expiring loan
+                    $daysRemaining = (int)$loan['giorni_rimasti'];
+                    $notificationMessage = $daysRemaining === 0
+                        ? sprintf(__('"%s" prestato a %s scade oggi'), $loan['libro_titolo'], $loan['utente_nome'])
+                        : sprintf(__('"%s" prestato a %s scade fra %d giorni'), $loan['libro_titolo'], $loan['utente_nome'], $daysRemaining);
                     $this->createNotification(
                         'general',
                         __('Prestito in scadenza'),
-                        sprintf(__('"%s" prestato a %s scade fra %d giorni'), $loan['libro_titolo'], $loan['utente_nome'], (int)$loan['giorni_rimasti']),
+                        $notificationMessage,
                         '/admin/loans',
                         (int)$loan['id']
                     );

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -657,7 +657,9 @@ $applicationToday = \App\Support\DateHelper::today();
                     // The date turning red is a visibility signal; it does NOT mean the
                     // loan is formally late (a loan due today is still on time).
                     $dueSoonOrOverdue = !empty($p['data_scadenza'])
-                        && (string)$p['data_scadenza'] <= $applicationToday;
+                        && (string)$p['data_scadenza'] <= $applicationToday
+                        && (int)($p['attivo'] ?? 0) === 1
+                        && in_array($p['stato'] ?? '', ['in_corso', 'in_ritardo'], true);
                     // The status badge reflects the REAL loan state (in_ritardo is set
                     // by the maintenance overdue-updater), so a due-today loan still
                     // reads "In corso" while a genuinely late one reads "In Ritardo".

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -650,14 +650,33 @@ $isCatalogueMode = ConfigStore::isCatalogueMode();
                   <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     <?php echo $p['data_prestito'] ? format_date($p['data_prestito']) : ''; ?>
                   </td>
-                  <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <?php
+                    // Red-highlight the due date when it is today or past — the "act
+                    // now" cue Nikola asked for, matching the Physical Copies list.
+                    // The date turning red is a visibility signal; it does NOT mean the
+                    // loan is formally late (a loan due today is still on time).
+                    $dueSoonOrOverdue = !empty($p['data_scadenza'])
+                        && strtotime((string)$p['data_scadenza']) <= strtotime(date('Y-m-d'));
+                    // The status badge reflects the REAL loan state (in_ritardo is set
+                    // by the maintenance overdue-updater), so a due-today loan still
+                    // reads "In corso" while a genuinely late one reads "In Ritardo".
+                    $isLate = ($p['stato'] ?? '') === 'in_ritardo';
+                  ?>
+                  <td class="px-6 py-4 whitespace-nowrap text-sm <?= $dueSoonOrOverdue ? 'text-red-600 font-semibold' : 'text-gray-500' ?>">
                     <?php echo $p['data_scadenza'] ? format_date($p['data_scadenza']) : ''; ?>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap">
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                      <i class="fas fa-clock mr-1"></i>
-                      <?= __("In corso") ?>
-                    </span>
+                    <?php if ($isLate): ?>
+                      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                        <i class="fas fa-exclamation-triangle mr-1"></i>
+                        <?= __("In Ritardo") ?>
+                      </span>
+                    <?php else: ?>
+                      <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                        <i class="fas fa-clock mr-1"></i>
+                        <?= __("In corso") ?>
+                      </span>
+                    <?php endif; ?>
                   </td>
                 </tr>
               <?php endforeach; ?>

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -3,6 +3,7 @@
 /** @var array $calendarEvents */
 use App\Support\ConfigStore;
 $isCatalogueMode = ConfigStore::isCatalogueMode();
+$applicationToday = \App\Support\DateHelper::today();
 ?>
 <!-- Minimal White Dashboard Interface -->
 <div class="min-h-screen bg-gray-50 py-6">
@@ -212,7 +213,7 @@ $isCatalogueMode = ConfigStore::isCatalogueMode();
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
           <?php foreach ($pickupLoans as $loan): ?>
             <?php
-            $isExpired = !empty($loan['pickup_deadline']) && $loan['pickup_deadline'] < date('Y-m-d');
+            $isExpired = !empty($loan['pickup_deadline']) && $loan['pickup_deadline'] < $applicationToday;
             $cardBg = $isExpired ? 'bg-red-50 border-red-200' : 'bg-white border-gray-200';
             ?>
             <div class="flex flex-col <?= $cardBg ?> border rounded-xl overflow-hidden hover:shadow-md transition-shadow" data-pickup-card>
@@ -656,7 +657,7 @@ $isCatalogueMode = ConfigStore::isCatalogueMode();
                     // The date turning red is a visibility signal; it does NOT mean the
                     // loan is formally late (a loan due today is still on time).
                     $dueSoonOrOverdue = !empty($p['data_scadenza'])
-                        && strtotime((string)$p['data_scadenza']) <= strtotime(date('Y-m-d'));
+                        && (string)$p['data_scadenza'] <= $applicationToday;
                     // The status badge reflects the REAL loan state (in_ritardo is set
                     // by the maintenance overdue-updater), so a due-today loan still
                     // reads "In corso" while a genuinely late one reads "In Ritardo".

--- a/app/Views/prestiti/index.php
+++ b/app/Views/prestiti/index.php
@@ -28,6 +28,7 @@ function getStatusBadge($status) {
             return "<span class='$baseClasses bg-gray-100 text-gray-800'><i class='fas fa-question-circle mr-2'></i>" . __("Sconosciuto") . "</span>";
     }
 }
+$applicationToday = \App\Support\DateHelper::today();
 ?>
 
 <!-- Modern Loans Management Interface -->
@@ -352,12 +353,13 @@ function getStatusBadge($status) {
                                     <?= format_date($prestito['data_prestito'], false, '/') ?>
                                 </td>
                                 <?php
-                                    $isLoanOverdue = !empty($prestito['data_scadenza'])
-                                        && strtotime((string)$prestito['data_scadenza']) <= strtotime(date('Y-m-d'))
+                                    $isDueNowOrOverdue = !empty($prestito['data_scadenza'])
+                                        && (string)$prestito['data_scadenza'] <= $applicationToday
+                                        && (int)($prestito['attivo'] ?? 0) === 1
                                         && in_array($prestito['stato'] ?? '', ['in_corso', 'in_ritardo'], true);
                                 ?>
                                 <td class="px-6 py-4 whitespace-nowrap">
-                                    <span class="<?= $isLoanOverdue ? 'text-red-600 font-semibold' : 'text-gray-700' ?>">
+                                    <span class="<?= $isDueNowOrOverdue ? 'text-red-600 font-semibold' : 'text-gray-700' ?>">
                                         <?= format_date($prestito['data_scadenza'], false, '/') ?>
                                     </span>
                                 </td>
@@ -427,6 +429,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     let currentStatusFilter = '';
+    const applicationToday = <?= json_encode($applicationToday, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 
     // Initialize DataTable
     const table = new DataTable('#prestiti-table', {
@@ -472,14 +475,11 @@ document.addEventListener('DOMContentLoaded', function() {
                     }
                     // Same red-highlight rule as the Physical Copies list: an active
                     // loan (in_corso/in_ritardo) whose due date is today or past.
-                    // Compare on local date to match the server's stored dates.
-                    const now = new Date();
-                    const today = now.getFullYear() + '-' +
-                        String(now.getMonth() + 1).padStart(2, '0') + '-' +
-                        String(now.getDate()).padStart(2, '0');
-                    const isOverdue = data <= today &&
+                    // Compare against the application's configured timezone, not
+                    // the browser or PHP process timezone.
+                    const isDueNowOrOverdue = data <= applicationToday && Number(row.attivo) === 1 &&
                         (row.stato === 'in_corso' || row.stato === 'in_ritardo');
-                    const cls = isOverdue ? 'text-red-600 font-semibold' : 'text-gray-700';
+                    const cls = isDueNowOrOverdue ? 'text-red-600 font-semibold' : 'text-gray-700';
                     return `<span class="${cls}">${formatDateLocale(data)}</span>`;
                 }
             },
@@ -531,13 +531,8 @@ document.addEventListener('DOMContentLoaded', function() {
                             <i class="fas fa-eye w-4 h-4"></i>
                         </a>`;
                     // Show "Conferma Ritiro" button for da_ritirare OR prenotato with today's date
-                    // Use local date (not UTC) to correctly compare with server dates
-                    const now = new Date();
-                    const today = now.getFullYear() + '-' +
-                        String(now.getMonth() + 1).padStart(2, '0') + '-' +
-                        String(now.getDate()).padStart(2, '0');
                     const isReadyForPickup = row.stato === 'da_ritirare' ||
-                        (row.stato === 'prenotato' && row.data_prestito && row.data_prestito <= today);
+                        (row.stato === 'prenotato' && row.data_prestito && row.data_prestito <= applicationToday);
                     if (isReadyForPickup) {
                         actions += `<button type="button" onclick="confirmPickup(${safeId})" class="p-2 text-amber-600 hover:bg-amber-100 rounded-full transition-colors" title="${window.__('Conferma Ritiro')}">
                             <i class="fas fa-box-open w-4 h-4"></i>

--- a/app/Views/prestiti/index.php
+++ b/app/Views/prestiti/index.php
@@ -323,6 +323,7 @@ function getStatusBadge($status) {
                         <th scope="col" class="px-6 py-3 text-left font-medium"><?= __('Libro') ?></th>
                         <th scope="col" class="px-6 py-3 text-left font-medium"><?= __('Utente') ?></th>
                         <th scope="col" class="px-6 py-3 text-left font-medium"><?= __('Date') ?></th>
+                        <th scope="col" class="px-6 py-3 text-left font-medium"><?= __('Scadenza') ?></th>
                         <th scope="col" class="px-6 py-3 text-center font-medium"><?= __('Stato') ?></th>
                         <th scope="col" class="px-6 py-3 text-center font-medium"><?= __('PDF') ?></th>
                         <th scope="col" class="px-6 py-3 text-right font-medium"><?= __('Azioni') ?></th>
@@ -331,7 +332,7 @@ function getStatusBadge($status) {
                 <tbody class="divide-y divide-slate-200">
                     <?php if (empty($prestiti)): ?>
                         <tr>
-                            <td colspan="6" class="text-center py-10 text-gray-500">
+                            <td colspan="7" class="text-center py-10 text-gray-500">
                                 <i class="fas fa-folder-open fa-2x mb-2"></i>
                                 <p><?= __("Nessun prestito trovato.") ?></p>
                             </td>
@@ -348,12 +349,17 @@ function getStatusBadge($status) {
                                     <div class="text-gray-500"><?php echo htmlspecialchars($prestito['utente_email'] ?? 'N/D'); ?></div>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-gray-700">
-                                    <div>
-                                        <span class="font-semibold"><?= __("Prestito:") ?></span> <?= format_date($prestito['data_prestito'], false, '/') ?>
-                                    </div>
-                                    <div>
-                                        <span class="font-semibold"><?= __("Scadenza:") ?></span> <?= format_date($prestito['data_scadenza'], false, '/') ?>
-                                    </div>
+                                    <?= format_date($prestito['data_prestito'], false, '/') ?>
+                                </td>
+                                <?php
+                                    $isLoanOverdue = !empty($prestito['data_scadenza'])
+                                        && strtotime((string)$prestito['data_scadenza']) <= strtotime(date('Y-m-d'))
+                                        && in_array($prestito['stato'] ?? '', ['in_corso', 'in_ritardo'], true);
+                                ?>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    <span class="<?= $isLoanOverdue ? 'text-red-600 font-semibold' : 'text-gray-700' ?>">
+                                        <?= format_date($prestito['data_scadenza'], false, '/') ?>
+                                    </span>
                                 </td>
                                 <td class="px-6 py-4 whitespace-nowrap text-center">
                                     <?php echo getStatusBadge($prestito['stato']); ?>
@@ -456,6 +462,25 @@ document.addEventListener('DOMContentLoaded', function() {
                 render: function(data, type, row) {
                     const dataPrestito = data ? formatDateLocale(data) : window.__('N/D');
                     return `<div class="text-gray-700">${dataPrestito}</div>`;
+                }
+            },
+            {
+                data: 'data_scadenza',
+                render: function(data, type, row) {
+                    if (!data) {
+                        return `<span class="text-gray-400">${window.__('N/D')}</span>`;
+                    }
+                    // Same red-highlight rule as the Physical Copies list: an active
+                    // loan (in_corso/in_ritardo) whose due date is today or past.
+                    // Compare on local date to match the server's stored dates.
+                    const now = new Date();
+                    const today = now.getFullYear() + '-' +
+                        String(now.getMonth() + 1).padStart(2, '0') + '-' +
+                        String(now.getDate()).padStart(2, '0');
+                    const isOverdue = data <= today &&
+                        (row.stato === 'in_corso' || row.stato === 'in_ritardo');
+                    const cls = isOverdue ? 'text-red-600 font-semibold' : 'text-gray-700';
+                    return `<span class="${cls}">${formatDateLocale(data)}</span>`;
                 }
             },
             {

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -320,6 +320,19 @@ $activeTab = $activeTab ?? 'general';
             </label>
           </div>
 
+          <div class="border-t border-gray-200 pt-5">
+            <h3 class="text-sm font-semibold text-gray-900 uppercase tracking-wide"><?= __("Prova invio") ?></h3>
+            <p class="text-sm text-gray-500 mt-1 mb-3"><?= __("Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.") ?></p>
+            <div class="flex flex-col sm:flex-row sm:items-center gap-3">
+              <input type="email" id="test_email" placeholder="<?= __('Destinatario (vuoto = la tua email admin)') ?>" class="flex-1 rounded-xl border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-3 px-4">
+              <button type="button" id="btn-test-email" class="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-gray-100 text-gray-900 text-sm font-semibold hover:bg-gray-200 transition-colors whitespace-nowrap">
+                <i class="fas fa-paper-plane"></i>
+                <?= __("Invia email di prova") ?>
+              </button>
+            </div>
+            <p id="test-email-result" class="mt-3 text-sm hidden"></p>
+          </div>
+
           <div class="flex justify-end">
             <button type="submit" class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-gray-700 transition-colors">
               <i class="fas fa-save"></i>
@@ -327,6 +340,38 @@ $activeTab = $activeTab ?? 'general';
             </button>
           </div>
         </form>
+        <script>
+          (function () {
+            var btn = document.getElementById('btn-test-email');
+            if (!btn) { return; }
+            var out = document.getElementById('test-email-result');
+            var csrf = document.querySelector('section[data-settings-panel="email"] input[name="csrf_token"]');
+            btn.addEventListener('click', function () {
+              var to = (document.getElementById('test_email') || {}).value || '';
+              btn.disabled = true;
+              var original = btn.innerHTML;
+              btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> <?= __("Invio in corso…") ?>';
+              out.className = 'mt-3 text-sm text-gray-500';
+              out.textContent = '';
+              var body = 'test_email=' + encodeURIComponent(to);
+              if (csrf) { body += '&csrf_token=' + encodeURIComponent(csrf.value); }
+              fetch('<?= htmlspecialchars(url('/admin/settings/email/test'), ENT_QUOTES, 'UTF-8') ?>', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest' },
+                body: body
+              }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
+                .then(function (res) {
+                  out.className = 'mt-3 text-sm ' + (res.j.success ? 'text-green-700' : 'text-red-700');
+                  out.textContent = res.j.message || (res.j.success ? 'OK' : 'Error');
+                })
+                .catch(function () {
+                  out.className = 'mt-3 text-sm text-red-700';
+                  out.textContent = '<?= __("Richiesta non riuscita. Riprova.") ?>';
+                })
+                .finally(function () { btn.disabled = false; btn.innerHTML = original; });
+            });
+          })();
+        </script>
       </section>
 
       <!-- Email Templates -->

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -362,7 +362,7 @@ $activeTab = $activeTab ?? 'general';
               }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
                 .then(function (res) {
                   out.className = 'mt-3 text-sm ' + (res.j.success ? 'text-green-700' : 'text-red-700');
-                  out.textContent = res.j.message || (res.j.success ? 'OK' : 'Error');
+                  out.textContent = res.j.message || (res.j.success ? <?= json_encode(__('Operazione completata'), JSON_HEX_TAG) ?> : <?= json_encode(__('Errore'), JSON_HEX_TAG) ?>);
                 })
                 .catch(function () {
                   out.className = 'mt-3 text-sm text-red-700';

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -350,7 +350,7 @@ $activeTab = $activeTab ?? 'general';
               var to = (document.getElementById('test_email') || {}).value || '';
               btn.disabled = true;
               var original = btn.innerHTML;
-              btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> <?= __("Invio in corso…") ?>';
+              btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> ' + <?= json_encode(__("Invio in corso…"), JSON_HEX_TAG) ?>;
               out.className = 'mt-3 text-sm text-gray-500';
               out.textContent = '';
               var body = 'test_email=' + encodeURIComponent(to);
@@ -366,7 +366,7 @@ $activeTab = $activeTab ?? 'general';
                 })
                 .catch(function () {
                   out.className = 'mt-3 text-sm text-red-700';
-                  out.textContent = '<?= __("Richiesta non riuscita. Riprova.") ?>';
+                  out.textContent = <?= json_encode(__("Richiesta non riuscita. Riprova."), JSON_HEX_TAG) ?>;
                 })
                 .finally(function () { btn.disabled = false; btn.innerHTML = original; });
             });

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -355,10 +355,16 @@ $activeTab = $activeTab ?? 'general';
               out.textContent = '';
               var body = 'test_email=' + encodeURIComponent(to);
               if (csrf) { body += '&csrf_token=' + encodeURIComponent(csrf.value); }
+              // Client-side timeout: if the SMTP handshake stalls the request never
+              // settles, so without this the button would stay disabled with the
+              // spinner forever. AbortController rejects the fetch -> catch -> finally.
+              var controller = new AbortController();
+              var timeoutId = window.setTimeout(function () { controller.abort(); }, 30000);
               fetch(<?= json_encode(url('/admin/settings/email/test'), JSON_HEX_TAG) ?>, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest' },
-                body: body
+                body: body,
+                signal: controller.signal
               }).then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
                 .then(function (res) {
                   out.className = 'mt-3 text-sm ' + (res.j.success ? 'text-green-700' : 'text-red-700');
@@ -368,7 +374,7 @@ $activeTab = $activeTab ?? 'general';
                   out.className = 'mt-3 text-sm text-red-700';
                   out.textContent = <?= json_encode(__("Richiesta non riuscita. Riprova."), JSON_HEX_TAG) ?>;
                 })
-                .finally(function () { btn.disabled = false; btn.innerHTML = original; });
+                .finally(function () { window.clearTimeout(timeoutId); btn.disabled = false; btn.innerHTML = original; });
             });
           })();
         </script>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -355,7 +355,7 @@ $activeTab = $activeTab ?? 'general';
               out.textContent = '';
               var body = 'test_email=' + encodeURIComponent(to);
               if (csrf) { body += '&csrf_token=' + encodeURIComponent(csrf.value); }
-              fetch('<?= htmlspecialchars(url('/admin/settings/email/test'), ENT_QUOTES, 'UTF-8') ?>', {
+              fetch(<?= json_encode(url('/admin/settings/email/test'), JSON_HEX_TAG) ?>, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest' },
                 body: body

--- a/cron/automatic-notifications.php
+++ b/cron/automatic-notifications.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 use Dotenv\Dotenv;
 use App\Support\NotificationService;
 use App\Controllers\ReservationManager;
+use App\Support\HookManager;
 
 // ============================================================
 // PROCESS LOCK - Prevent concurrent cron executions
@@ -158,6 +159,18 @@ try {
 
     $totalSent = $results['expiration_warnings'] + $results['overdue_notifications'] + $results['wishlist_notifications'] + $retriedNotifications;
     logMessage("Total emails sent: {$totalSent}");
+
+    // Dispatch native mobile push on the same hourly pass as email reminders.
+    // The daily full-maintenance job also fires this hook, but relying on 06:00
+    // alone misses loans created later in the day and may always land inside a
+    // user's quiet-hours window. PushDispatcher deduplicates event keys, so the
+    // daily + hourly invocations are safe together.
+    try {
+        (new HookManager($db))->doAction('mobile_api.dispatch_push');
+        logMessage("Mobile push dispatch completed");
+    } catch (Throwable $e) {
+        logMessage("WARNING: mobile push dispatch failed: " . $e->getMessage());
+    }
 
     // NOTE: Daily maintenance tasks (loan state transitions, expiry handling) are now
     // handled exclusively by full-maintenance.php via MaintenanceService::runAll()

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6525,5 +6525,18 @@
   "Spaziatura": "Abstand",
   "Margine interno (mm)": "Innenabstand (mm)",
   "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Der Inhalt passt sich automatisch an die Etikettengröße an. Fügen Sie zusätzlichen Innenabstand hinzu, um das Layout zu optimieren.",
-  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Es sieht so aus, als würden Sie das Docker-Image verwenden: Die Anwendungsdateien gehören zum Image und können über diese Schaltfläche nicht geändert werden. Aktualisieren Sie, indem Sie den Container auf das neue Image umstellen: „docker compose pull && docker compose up -d“ (Ihre Daten in der Datenbank und in den storage/uploads-Volumes bleiben sicher). Die Update-Schaltfläche ist für klassische Installationen/Shared Hosting gedacht, bei denen der Webserver-Benutzer Eigentümer der Dateien ist."
+  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Es sieht so aus, als würden Sie das Docker-Image verwenden: Die Anwendungsdateien gehören zum Image und können über diese Schaltfläche nicht geändert werden. Aktualisieren Sie, indem Sie den Container auf das neue Image umstellen: „docker compose pull && docker compose up -d“ (Ihre Daten in der Datenbank und in den storage/uploads-Volumes bleiben sicher). Die Update-Schaltfläche ist für klassische Installationen/Shared Hosting gedacht, bei denen der Webserver-Benutzer Eigentümer der Dateien ist.",
+  "Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.": "Kein Empfänger: Geben Sie eine E-Mail-Adresse ein oder stellen Sie sicher, dass Ihr Admin-Konto eine hat.",
+  "Email di prova inviata a %s. Controlla la casella (anche lo spam).": "Test-E-Mail an %s gesendet. Prüfen Sie den Posteingang (und den Spam-Ordner).",
+  "Invio fallito: %s": "Senden fehlgeschlagen: %s",
+  "Indirizzo email del destinatario non valido.": "Ungültige Empfänger-E-Mail-Adresse.",
+  "Email di prova da Pinakes": "Test-E-Mail von Pinakes",
+  "Questa è un'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.": "Dies ist eine Test-E-Mail aus den Pinakes-Einstellungen. Wenn Sie sie erhalten, funktioniert Ihre E-Mail-Konfiguration.",
+  "La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.": "Die PHP-Funktion mail() hat einen Fehler zurückgegeben. Prüfen Sie die Konfiguration des Mailservers.",
+  "Prova invio": "Sendetest",
+  "Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.": "Senden Sie eine Test-E-Mail mit den aktuellen Einstellungen und sehen Sie sofort, ob es funktioniert oder was der Fehler ist. Speichern Sie zuerst die Einstellungen.",
+  "Destinatario (vuoto = la tua email admin)": "Empfänger (leer = Ihre Admin-E-Mail)",
+  "Invia email di prova": "Test-E-Mail senden",
+  "Invio in corso…": "Wird gesendet…",
+  "Richiesta non riuscita. Riprova.": "Anfrage fehlgeschlagen. Bitte erneut versuchen."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -5430,6 +5430,7 @@
   "Prenotazione annullata": "Reservierung storniert",
   "Inviata all'utente quando una prenotazione viene annullata dall'amministrazione.": "Wird an den Benutzer gesendet, wenn eine Reservierung von der Verwaltung storniert wird.",
   "\"%s\" prestato a %s scade fra %d giorni": "\"%s\" ausgeliehen an %s ist in %d Tagen fällig",
+  "\"%s\" prestato a %s scade oggi": "\"%s\" ausgeliehen an %s ist heute fällig",
   "MaintenanceService claim cooldown fallito": "MaintenanceService Claim des Cooldowns fehlgeschlagen",
   "MaintenanceService errore recupero notifiche prenotazione": "MaintenanceService Fehler beim Abrufen der Reservierungsbenachrichtigungen",
   "La data di inizio non può essere nel passato": "Das Startdatum darf nicht in der Vergangenheit liegen",

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6539,5 +6539,6 @@
   "Destinatario (vuoto = la tua email admin)": "Empfänger (leer = Ihre Admin-E-Mail)",
   "Invia email di prova": "Test-E-Mail senden",
   "Invio in corso…": "Wird gesendet…",
-  "Richiesta non riuscita. Riprova.": "Anfrage fehlgeschlagen. Bitte erneut versuchen."
+  "Richiesta non riuscita. Riprova.": "Anfrage fehlgeschlagen. Bitte erneut versuchen.",
+  "oggi": "heute"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6525,5 +6525,18 @@
   "Spaziatura": "Spacing",
   "Margine interno (mm)": "Inner padding (mm)",
   "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Content scales automatically to the label size. Add extra inner padding to fine-tune the layout.",
-  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "It looks like you're running the Docker image: the application files belong to the image and can't be modified from this button. Update by moving the container to the new image with “docker compose pull && docker compose up -d” (your data in the database and the storage/uploads volumes stays safe). The update button is meant for classic/shared-hosting installs where the web-server user owns the files."
+  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "It looks like you're running the Docker image: the application files belong to the image and can't be modified from this button. Update by moving the container to the new image with “docker compose pull && docker compose up -d” (your data in the database and the storage/uploads volumes stays safe). The update button is meant for classic/shared-hosting installs where the web-server user owns the files.",
+  "Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.": "No recipient: enter an email address or make sure your admin account has one.",
+  "Email di prova inviata a %s. Controlla la casella (anche lo spam).": "Test email sent to %s. Check the inbox (and spam).",
+  "Invio fallito: %s": "Send failed: %s",
+  "Indirizzo email del destinatario non valido.": "Invalid recipient email address.",
+  "Email di prova da Pinakes": "Test email from Pinakes",
+  "Questa è un'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.": "This is a test email sent from the Pinakes settings. If you received it, your email configuration works.",
+  "La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.": "PHP's mail() function returned an error. Check your mail-server configuration.",
+  "Prova invio": "Test send",
+  "Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.": "Send a test email with the current settings and see right away whether it works or what the error is. Save the settings first.",
+  "Destinatario (vuoto = la tua email admin)": "Recipient (empty = your admin email)",
+  "Invia email di prova": "Send test email",
+  "Invio in corso…": "Sending…",
+  "Richiesta non riuscita. Riprova.": "Request failed. Try again."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -5430,6 +5430,7 @@
   "Prenotazione annullata": "Reservation cancelled",
   "Inviata all'utente quando una prenotazione viene annullata dall'amministrazione.": "Sent to the user when a reservation is cancelled by the administration.",
   "\"%s\" prestato a %s scade fra %d giorni": "\"%s\" loaned to %s is due in %d days",
+  "\"%s\" prestato a %s scade oggi": "\"%s\" loaned to %s is due today",
   "MaintenanceService claim cooldown fallito": "MaintenanceService claim cooldown failed",
   "MaintenanceService errore recupero notifiche prenotazione": "MaintenanceService error retrieving reservation notifications",
   "La data di inizio non può essere nel passato": "The start date cannot be in the past",

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6539,5 +6539,6 @@
   "Destinatario (vuoto = la tua email admin)": "Recipient (empty = your admin email)",
   "Invia email di prova": "Send test email",
   "Invio in corso…": "Sending…",
-  "Richiesta non riuscita. Riprova.": "Request failed. Try again."
+  "Richiesta non riuscita. Riprova.": "Request failed. Try again.",
+  "oggi": "today"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6539,5 +6539,6 @@
   "Destinatario (vuoto = la tua email admin)": "Destinataire (vide = votre e-mail admin)",
   "Invia email di prova": "Envoyer un e-mail de test",
   "Invio in corso…": "Envoi en cours…",
-  "Richiesta non riuscita. Riprova.": "La requête a échoué. Réessayez."
+  "Richiesta non riuscita. Riprova.": "La requête a échoué. Réessayez.",
+  "oggi": "aujourd'hui"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6525,5 +6525,18 @@
   "Spaziatura": "Espacement",
   "Margine interno (mm)": "Marge intérieure (mm)",
   "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Le contenu s'adapte automatiquement à la taille de l'étiquette. Ajoutez une marge intérieure supplémentaire pour affiner la mise en page.",
-  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Il semble que vous utilisiez l'image Docker : les fichiers de l'application appartiennent à l'image et ne peuvent pas être modifiés depuis ce bouton. Mettez à jour en déplaçant le conteneur vers la nouvelle image avec « docker compose pull && docker compose up -d » (vos données dans la base et dans les volumes storage/uploads restent en sécurité). Le bouton de mise à jour est prévu pour les installations classiques/hébergement mutualisé où l'utilisateur du serveur web est propriétaire des fichiers."
+  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Il semble que vous utilisiez l'image Docker : les fichiers de l'application appartiennent à l'image et ne peuvent pas être modifiés depuis ce bouton. Mettez à jour en déplaçant le conteneur vers la nouvelle image avec « docker compose pull && docker compose up -d » (vos données dans la base et dans les volumes storage/uploads restent en sécurité). Le bouton de mise à jour est prévu pour les installations classiques/hébergement mutualisé où l'utilisateur du serveur web est propriétaire des fichiers.",
+  "Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.": "Aucun destinataire : saisissez une adresse e-mail ou assurez-vous que votre compte admin en possède une.",
+  "Email di prova inviata a %s. Controlla la casella (anche lo spam).": "E-mail de test envoyé à %s. Vérifiez la boîte de réception (et les spams).",
+  "Invio fallito: %s": "Échec de l'envoi : %s",
+  "Indirizzo email del destinatario non valido.": "Adresse e-mail du destinataire non valide.",
+  "Email di prova da Pinakes": "E-mail de test de Pinakes",
+  "Questa è un'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.": "Ceci est un e-mail de test envoyé depuis les paramètres de Pinakes. Si vous le recevez, votre configuration e-mail fonctionne.",
+  "La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.": "La fonction mail() de PHP a renvoyé une erreur. Vérifiez la configuration du serveur de messagerie.",
+  "Prova invio": "Test d'envoi",
+  "Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.": "Envoyez un e-mail de test avec les paramètres actuels et voyez immédiatement si cela fonctionne ou quelle est l'erreur. Enregistrez d'abord les paramètres.",
+  "Destinatario (vuoto = la tua email admin)": "Destinataire (vide = votre e-mail admin)",
+  "Invia email di prova": "Envoyer un e-mail de test",
+  "Invio in corso…": "Envoi en cours…",
+  "Richiesta non riuscita. Riprova.": "La requête a échoué. Réessayez."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -5430,6 +5430,7 @@
   "Prenotazione annullata": "Réservation annulée",
   "Inviata all'utente quando una prenotazione viene annullata dall'amministrazione.": "Envoyée à l'utilisateur lorsqu'une réservation est annulée par l'administration.",
   "\"%s\" prestato a %s scade fra %d giorni": "\"%s\" emprunté par %s arrive à échéance dans %d jours",
+  "\"%s\" prestato a %s scade oggi": "\"%s\" emprunté par %s arrive à échéance aujourd'hui",
   "MaintenanceService claim cooldown fallito": "MaintenanceService échec du claim du cooldown",
   "MaintenanceService errore recupero notifiche prenotazione": "MaintenanceService erreur lors de la récupération des notifications de réservation",
   "La data di inizio non può essere nel passato": "La date de début ne peut pas être dans le passé",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6539,5 +6539,6 @@
   "Destinatario (vuoto = la tua email admin)": "Destinatario (vuoto = la tua email admin)",
   "Invia email di prova": "Invia email di prova",
   "Invio in corso…": "Invio in corso…",
-  "Richiesta non riuscita. Riprova.": "Richiesta non riuscita. Riprova."
+  "Richiesta non riuscita. Riprova.": "Richiesta non riuscita. Riprova.",
+  "oggi": "oggi"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -5430,6 +5430,7 @@
   "Prenotazione annullata": "Prenotazione annullata",
   "Inviata all'utente quando una prenotazione viene annullata dall'amministrazione.": "Inviata all'utente quando una prenotazione viene annullata dall'amministrazione.",
   "\"%s\" prestato a %s scade fra %d giorni": "\"%s\" prestato a %s scade fra %d giorni",
+  "\"%s\" prestato a %s scade oggi": "\"%s\" prestato a %s scade oggi",
   "MaintenanceService claim cooldown fallito": "MaintenanceService claim cooldown fallito",
   "MaintenanceService errore recupero notifiche prenotazione": "MaintenanceService errore recupero notifiche prenotazione",
   "La data di inizio non può essere nel passato": "La data di inizio non può essere nel passato",

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6525,5 +6525,18 @@
   "Spaziatura": "Spaziatura",
   "Margine interno (mm)": "Margine interno (mm)",
   "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.": "Il contenuto si adatta automaticamente alle dimensioni dell'etichetta. Aggiungi un margine interno extra per rifinire il layout.",
-  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file."
+  "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.": "Sembra che tu stia eseguendo l'immagine Docker: i file dell'applicazione appartengono all'immagine e non sono modificabili da questo pulsante. Aggiorna spostando il container alla nuova immagine con «docker compose pull && docker compose up -d» (i tuoi dati nel database e nei volumi storage/uploads restano al sicuro). Il pulsante di aggiornamento è pensato per installazioni classiche/hosting condiviso dove l'utente del web server è proprietario dei file.",
+  "Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.": "Nessun destinatario: inserisci un indirizzo email o assicurati che il tuo account admin ne abbia uno.",
+  "Email di prova inviata a %s. Controlla la casella (anche lo spam).": "Email di prova inviata a %s. Controlla la casella (anche lo spam).",
+  "Invio fallito: %s": "Invio fallito: %s",
+  "Indirizzo email del destinatario non valido.": "Indirizzo email del destinatario non valido.",
+  "Email di prova da Pinakes": "Email di prova da Pinakes",
+  "Questa è un'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.": "Questa è un'email di prova inviata dalle impostazioni di Pinakes. Se la ricevi, la configurazione email funziona.",
+  "La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.": "La funzione mail() di PHP ha restituito un errore. Verifica la configurazione del server di posta.",
+  "Prova invio": "Prova invio",
+  "Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.": "Invia un'email di prova con le impostazioni attuali e vedi subito se funziona o qual è l'errore. Salva prima le impostazioni.",
+  "Destinatario (vuoto = la tua email admin)": "Destinatario (vuoto = la tua email admin)",
+  "Invia email di prova": "Invia email di prova",
+  "Invio in corso…": "Invio in corso…",
+  "Richiesta non riuscita. Riprova.": "Richiesta non riuscita. Riprova."
 }

--- a/storage/plugins/mobile-api/src/Controllers/ActionsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ActionsController.php
@@ -708,11 +708,10 @@ final class ActionsController
             // Domain "today" from DateHelper::today() (app timezone), so the
             // due/overdue day boundary matches the web/cron pipeline.
             $today = DateHelper::today();
-            // Due-soon window from settings (fallback 3 days), same idea as the web reminders.
-            $dueSoonDays = (int) ((new \App\Models\SettingsRepository($this->db))->get('loans', 'reminder_days_before', '3') ?? 3);
-            if ($dueSoonDays < 1) {
-                $dueSoonDays = 3;
-            }
+            // Use the exact same setting as NotificationService / Settings → Advanced.
+            // The former loans.reminder_days_before key never existed, so the mobile
+            // feed silently stayed at its fallback even when an admin changed the UI.
+            $dueSoonDays = max(0, (int) ((new \App\Models\SettingsRepository($this->db))->get('advanced', 'days_before_expiry_warning', '3') ?? 3));
             $dueSoonLimit = date('Y-m-d', strtotime($today . " +{$dueSoonDays} days"));
 
             // Loans due soon (active, in-progress, not yet overdue).
@@ -912,14 +911,23 @@ final class ActionsController
      */
     private function mapLoan(array $r): array
     {
+        $status = (string) ($r['stato'] ?? '');
+        $dueAt = $this->nullableString($r['data_scadenza'] ?? null);
+
         return [
             'id'           => (int) $r['id'],
             'book_id'      => (int) $r['libro_id'],
             'title'        => (string) ($r['titolo'] ?? ''),
             'cover_url'    => absoluteUrl($this->coverPath($r['copertina_url'] ?? null)),
-            'status'       => (string) ($r['stato'] ?? ''),
+            'status'       => $status,
             'loaned_at'    => $this->nullableString($r['data_prestito'] ?? null),
-            'due_at'       => $this->nullableString($r['data_scadenza'] ?? null),
+            'due_at'       => $dueAt,
+            // Server-authoritative visibility cue: the Android device may be in a
+            // different timezone from the library, so it must not derive "today"
+            // from LocalDate.now(). The badge still uses the raw status above.
+            'due_attention' => $dueAt !== null
+                && in_array($status, ['in_corso', 'in_ritardo'], true)
+                && $dueAt <= DateHelper::today(),
             'returned_at'  => $this->nullableString($r['data_restituzione'] ?? null),
             'renewals'     => isset($r['renewals']) ? (int) $r['renewals'] : null,
         ];

--- a/storage/plugins/mobile-api/src/Controllers/ActionsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ActionsController.php
@@ -708,10 +708,11 @@ final class ActionsController
             // Domain "today" from DateHelper::today() (app timezone), so the
             // due/overdue day boundary matches the web/cron pipeline.
             $today = DateHelper::today();
-            // Use the exact same setting as NotificationService / Settings → Advanced.
-            // The former loans.reminder_days_before key never existed, so the mobile
-            // feed silently stayed at its fallback even when an admin changed the UI.
-            $dueSoonDays = max(0, (int) ((new \App\Models\SettingsRepository($this->db))->get('advanced', 'days_before_expiry_warning', '3') ?? 3));
+            // Single source of truth for the horizon (key + fallback + clamp), shared
+            // with the web reminders and the push dispatcher. The former
+            // loans.reminder_days_before key never existed, so the mobile feed used to
+            // stay pinned to its fallback even after an admin changed the UI.
+            $dueSoonDays = (new \App\Models\SettingsRepository($this->db))->daysBeforeExpiryWarning();
             $dueSoonLimit = date('Y-m-d', strtotime($today . " +{$dueSoonDays} days"));
 
             // Loans due soon (active, in-progress, not yet overdue).

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -1112,6 +1112,10 @@ final class OpenApiController
                 'status'      => ['type' => 'string', 'description' => 'Raw prestiti.stato value.'],
                 'loaned_at'   => ['type' => 'string', 'format' => 'date', 'nullable' => true],
                 'due_at'      => ['type' => 'string', 'format' => 'date', 'nullable' => true],
+                'due_attention' => [
+                    'type' => 'boolean',
+                    'description' => 'True when an active in-progress/overdue loan is due today or earlier in the application timezone.',
+                ],
                 'returned_at' => ['type' => 'string', 'format' => 'date', 'nullable' => true],
                 'renewals'    => ['type' => 'integer', 'nullable' => true],
             ],

--- a/storage/plugins/mobile-api/src/Push/PushDispatcher.php
+++ b/storage/plugins/mobile-api/src/Push/PushDispatcher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\MobileApi\Push;
 
+use App\Support\DateHelper;
 use App\Support\SecureLogger;
 use mysqli;
 
@@ -66,11 +67,13 @@ final class PushDispatcher
         ];
 
         try {
-            // UTC so quiet-hours and "today" comparisons are deterministic.
-            $this->db->query("SET SESSION time_zone = '+00:00'");
+            // Bind the application-domain date explicitly. CURDATE() would follow
+            // the DB session timezone (this class used to force UTC), disagreeing
+            // with the web/email pipeline around the library's midnight.
+            $today = DateHelper::today();
 
-            $counters['loan_due']          = $this->sweepLoanDue($counters);
-            $counters['loan_overdue']      = $this->sweepLoanOverdue($counters);
+            $counters['loan_due']          = $this->sweepLoanDue($counters, $today);
+            $counters['loan_overdue']      = $this->sweepLoanOverdue($counters, $today);
             $counters['reservation_ready'] = $this->sweepReservationReady($counters);
             $counters['book_available']    = $this->sweepBookAvailable($counters);
         } catch (\Throwable $e) {
@@ -89,7 +92,7 @@ final class PushDispatcher
      *
      * @param array{loan_due:int,loan_overdue:int,reservation_ready:int,book_available:int,sent:int,skipped:int} $counters
      */
-    private function sweepLoanDue(array &$counters): int
+    private function sweepLoanDue(array &$counters, string $today): int
     {
         $days = $this->dueSoonDays();
         $events = 0;
@@ -98,13 +101,13 @@ final class PushDispatcher
                 FROM prestiti pr
                 JOIN libri l ON l.id = pr.libro_id AND l.deleted_at IS NULL
                 WHERE pr.attivo = 1 AND pr.stato = 'in_corso'
-                  AND pr.data_scadenza >= CURDATE()
-                  AND pr.data_scadenza <= DATE_ADD(CURDATE(), INTERVAL ? DAY)";
+                  AND pr.data_scadenza >= ?
+                  AND pr.data_scadenza <= DATE_ADD(?, INTERVAL ? DAY)";
         $stmt = $this->db->prepare($sql);
         if ($stmt === false) {
             return 0;
         }
-        $stmt->bind_param('i', $days);
+        $stmt->bind_param('ssi', $today, $today, $days);
         $stmt->execute();
         $res = $stmt->get_result();
         $rows = ($res instanceof \mysqli_result) ? $res->fetch_all(MYSQLI_ASSOC) : [];
@@ -142,7 +145,7 @@ final class PushDispatcher
     /**
      * @param array{loan_due:int,loan_overdue:int,reservation_ready:int,book_available:int,sent:int,skipped:int} $counters
      */
-    private function sweepLoanOverdue(array &$counters): int
+    private function sweepLoanOverdue(array &$counters, string $today): int
     {
         $events = 0;
 
@@ -150,9 +153,16 @@ final class PushDispatcher
                 FROM prestiti pr
                 JOIN libri l ON l.id = pr.libro_id AND l.deleted_at IS NULL
                 WHERE pr.attivo = 1
-                  AND (pr.stato = 'in_ritardo' OR (pr.stato = 'in_corso' AND pr.data_scadenza < CURDATE()))";
-        $res  = $this->db->query($sql);
+                  AND (pr.stato = 'in_ritardo' OR (pr.stato = 'in_corso' AND pr.data_scadenza < ?))";
+        $stmt = $this->db->prepare($sql);
+        if ($stmt === false) {
+            return 0;
+        }
+        $stmt->bind_param('s', $today);
+        $stmt->execute();
+        $res  = $stmt->get_result();
         $rows = ($res instanceof \mysqli_result) ? $res->fetch_all(MYSQLI_ASSOC) : [];
+        $stmt->close();
 
         foreach ($rows as $r) {
             $userId = (int) $r['utente_id'];
@@ -565,11 +575,13 @@ final class PushDispatcher
     private function dueSoonDays(): int
     {
         try {
-            $days = (int) ((new \App\Models\SettingsRepository($this->db))->get('loans', 'reminder_days_before', '3') ?? 3);
+            $days = (int) ((new \App\Models\SettingsRepository($this->db))->get('advanced', 'days_before_expiry_warning', '3') ?? 3);
         } catch (\Throwable $e) {
             $days = 3;
         }
 
-        return $days >= 1 ? $days : 3;
+        // Match NotificationService exactly: zero is valid and means "today only";
+        // negative/corrupt values are clamped rather than silently reset to three.
+        return max(0, $days);
     }
 }

--- a/storage/plugins/mobile-api/src/Push/PushDispatcher.php
+++ b/storage/plugins/mobile-api/src/Push/PushDispatcher.php
@@ -575,13 +575,11 @@ final class PushDispatcher
     private function dueSoonDays(): int
     {
         try {
-            $days = (int) ((new \App\Models\SettingsRepository($this->db))->get('advanced', 'days_before_expiry_warning', '3') ?? 3);
+            // Single source of truth for the horizon (key + fallback + clamp), shared
+            // with the web reminders and the mobile-api loan feed.
+            return (new \App\Models\SettingsRepository($this->db))->daysBeforeExpiryWarning();
         } catch (\Throwable $e) {
-            $days = 3;
+            return 3;
         }
-
-        // Match NotificationService exactly: zero is valid and means "today only";
-        // negative/corrupt values are clamped rather than silently reset to three.
-        return max(0, $days);
     }
 }

--- a/tests/email-notifications.spec.js
+++ b/tests/email-notifications.spec.js
@@ -623,6 +623,34 @@ test.describe.serial('Email Notifications E2E', () => {
     dbQuery(`DELETE FROM prestiti WHERE id = ${loanId}`);
   });
 
+  test('B.9b — Loan due today receives the expiration warning', async () => {
+    await clearMailpit();
+
+    const userId = dbQuery(`SELECT id FROM utenti WHERE email = '${TEST_USER_EMAIL}' LIMIT 1`);
+    const bookId = dbQuery("SELECT id FROM libri WHERE deleted_at IS NULL LIMIT 1");
+    const today = todayISO();
+    const startDate = dateOffset(-1);
+    const loanId = dbQuery(`INSERT INTO prestiti (libro_id, utente_id, stato, data_prestito, data_scadenza, attivo, warning_sent, overdue_notification_sent, created_at)
+             VALUES (${bookId}, ${userId}, 'in_corso', '${startDate}', '${today}', 1, 0, 0, NOW()); SELECT LAST_INSERT_ID()`);
+
+    await withAdminPage(browserRef, async (page) => {
+      await page.goto(`${BASE}/admin/integrity`, { waitUntil: 'domcontentloaded' });
+      const csrfToken = await getCsrfToken(page);
+      const maintenanceRes = await page.request.post(`${BASE}/admin/maintenance/perform`, {
+        form: { csrf_token: csrfToken || '' },
+      });
+      expect(maintenanceRes.status()).toBeLessThan(500);
+    });
+
+    const warningMail = await waitForMail(`to:${TEST_USER_EMAIL}`);
+    expect(warningMail).toBeTruthy();
+    const msg = await getMessage(warningMail.ID);
+    expect(msg.Subject.toLowerCase()).toMatch(/scad|expir|promemoria|warning/);
+    expect(dbQuery(`SELECT warning_sent FROM prestiti WHERE id = ${loanId}`)).toBe('1');
+
+    dbQuery(`DELETE FROM prestiti WHERE id = ${loanId}`);
+  });
+
   // ── B.10 + B.11: Loan overdue (user + admin) ──────────────────
   test('B.10+B.11 — Overdue loan notifications (user + admin)', async () => {
     await clearMailpit();

--- a/tests/loan-due-visibility-email.unit.php
+++ b/tests/loan-due-visibility-email.unit.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+/** Static regression guards for due-date visibility and warning selection. */
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+        return;
+    }
+
+    $failed++;
+    echo "  FAIL {$label}\n";
+};
+
+$root = dirname(__DIR__);
+$notifications = (string)file_get_contents($root . '/app/Support/NotificationService.php');
+$api = (string)file_get_contents($root . '/app/Controllers/PrestitiApiController.php');
+$loansView = (string)file_get_contents($root . '/app/Views/prestiti/index.php');
+$dashboardView = (string)file_get_contents($root . '/app/Views/dashboard/index.php');
+
+$check(
+    str_contains($notifications, 'p.data_scadenza BETWEEN ? AND DATE_ADD(?, INTERVAL ? DAY)')
+        && str_contains($notifications, "bind_param('sssi', \$today, \$today, \$today, \$daysBeforeWarning)"),
+    'expiration warnings include due-today loans through the configured horizon'
+);
+$check(
+    str_contains($notifications, 'scade oggi') && str_contains($notifications, '$daysRemaining === 0'),
+    'due-today in-app notification has accurate wording'
+);
+$check(
+    preg_match("/3\s*=>\s*'p\\.data_scadenza'/", $api) === 1
+        && preg_match("/4\s*=>\s*'p\\.stato'/", $api) === 1,
+    'DataTables due-date and status columns map to their real SQL fields'
+);
+$check(
+    str_contains($loansView, 'DateHelper::today()')
+        && str_contains($loansView, 'data <= applicationToday')
+        && !str_contains($loansView, "strtotime(date('Y-m-d'))"),
+    'loan list highlighting uses the application date in PHP and JavaScript'
+);
+$check(
+    str_contains($dashboardView, 'DateHelper::today()')
+        && !str_contains($dashboardView, "strtotime(date('Y-m-d'))"),
+    'dashboard due-date highlighting uses the application timezone'
+);
+
+foreach (['it_IT', 'en_US', 'fr_FR', 'de_DE'] as $locale) {
+    $catalogue = json_decode((string)file_get_contents($root . "/locale/{$locale}.json"), true);
+    $check(
+        is_array($catalogue) && isset($catalogue['"%s" prestato a %s scade oggi']),
+        "{$locale} translates the due-today notification"
+    );
+}
+
+echo "\nPassed: {$passed}   Failed: {$failed}\n";
+exit($failed > 0 ? 1 : 0);

--- a/tests/mobile-api-behaviors.spec.js
+++ b/tests/mobile-api-behaviors.spec.js
@@ -499,8 +499,51 @@ test.describe('Loans envelope', () => {
             expect(mine, 'seeded loan present in active[]').toBeTruthy();
             expect(mine.status).toBe('in_corso');
             expect(mine.due_at, 'due_at present on active loan').toBeTruthy();
+            expect(mine.due_attention, 'future due date needs no urgent styling').toBe(false);
         } finally {
             dbExec(`DELETE FROM prestiti WHERE id = ${loanId}`);
+        }
+    });
+
+    test('20b) a loan due today keeps status=in_corso but exposes due_attention=true', async ({ request }) => {
+        const book = pickAvailableBook();
+        dbExec(`
+            INSERT INTO prestiti (libro_id, utente_id, copia_id, data_prestito, data_scadenza, stato, attivo, origine, renewals)
+            VALUES (${book}, ${ctx.adminId}, NULL, ${sqlStr(todayYmd())}, ${sqlStr(todayYmd())}, 'in_corso', 1, 'diretto', 0)`);
+        const loanId = dbInt(`SELECT id FROM prestiti WHERE libro_id = ${book} AND utente_id = ${ctx.adminId} ORDER BY id DESC LIMIT 1`);
+        try {
+            const active = (await jsonOf(await call(request, 'GET', '/me/loans', { token: ctx.adminToken }))).data.active;
+            const mine = active.find((l) => l.id === loanId);
+            expect(mine, 'due-today loan present in active[]').toBeTruthy();
+            expect(mine.status).toBe('in_corso');
+            expect(mine.due_attention).toBe(true);
+        } finally {
+            dbExec(`DELETE FROM prestiti WHERE id = ${loanId}`);
+        }
+    });
+
+    test('20c) notification feed honors advanced.days_before_expiry_warning', async ({ request }) => {
+        const oldValue = dbScalar("SELECT setting_value FROM system_settings WHERE category='advanced' AND setting_key='days_before_expiry_warning' LIMIT 1");
+        const hadValue = dbInt("SELECT COUNT(*) FROM system_settings WHERE category='advanced' AND setting_key='days_before_expiry_warning'") > 0;
+        const book = pickAvailableBook();
+        dbExec(`
+            INSERT INTO system_settings (category, setting_key, setting_value)
+            VALUES ('advanced', 'days_before_expiry_warning', '0')
+            ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`);
+        dbExec(`
+            INSERT INTO prestiti (libro_id, utente_id, copia_id, data_prestito, data_scadenza, stato, attivo, origine, renewals)
+            VALUES (${book}, ${ctx.adminId}, NULL, ${sqlStr(todayYmd())}, ${sqlStr(plusDays(1))}, 'in_corso', 1, 'diretto', 0)`);
+        const loanId = dbInt(`SELECT id FROM prestiti WHERE libro_id = ${book} AND utente_id = ${ctx.adminId} ORDER BY id DESC LIMIT 1`);
+        try {
+            const feed = (await jsonOf(await call(request, 'GET', '/me/notifications', { token: ctx.adminToken }))).data;
+            expect(feed.some((n) => n.id === `loan:${loanId}`), 'zero-day horizon includes today only').toBe(false);
+        } finally {
+            dbExec(`DELETE FROM prestiti WHERE id = ${loanId}`);
+            if (hadValue) {
+                dbExec(`UPDATE system_settings SET setting_value = ${sqlStr(oldValue)} WHERE category='advanced' AND setting_key='days_before_expiry_warning'`);
+            } else {
+                dbExec("DELETE FROM system_settings WHERE category='advanced' AND setting_key='days_before_expiry_warning'");
+            }
         }
     });
 

--- a/tests/mobile-due-push-alignment.unit.php
+++ b/tests/mobile-due-push-alignment.unit.php
@@ -18,14 +18,19 @@ $root = dirname(__DIR__);
 $actions = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/ActionsController.php');
 $openApi = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/OpenApiController.php');
 $dispatcher = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Push/PushDispatcher.php');
+$settingsRepo = (string)file_get_contents($root . '/app/Models/SettingsRepository.php');
 $hourlyCron = (string)file_get_contents($root . '/cron/automatic-notifications.php');
 
 $check(
-    substr_count($actions . $dispatcher, "get('advanced', 'days_before_expiry_warning'") === 2
-        && !str_contains($actions . $dispatcher, "get('loans', 'reminder_days_before'")
-        && str_contains($actions, '$dueSoonDays = max(0,')
-        && str_contains($dispatcher, 'return max(0, $days);'),
-    'mobile feed and push use the core expiration-warning setting'
+    // The horizon (key + fallback + clamp) lives in one shared method; both mobile
+    // callers delegate to it and neither reads the setting inline or via the old key.
+    str_contains($settingsRepo, 'public function daysBeforeExpiryWarning(): int')
+        && str_contains($settingsRepo, "get('advanced', 'days_before_expiry_warning', '3')")
+        && str_contains($settingsRepo, 'max(0,')
+        && substr_count($actions . $dispatcher, '->daysBeforeExpiryWarning()') === 2
+        && !str_contains($actions . $dispatcher, "get('advanced', 'days_before_expiry_warning'")
+        && !str_contains($actions . $dispatcher, "get('loans', 'reminder_days_before'"),
+    'mobile feed and push share the core expiration-warning horizon helper'
 );
 $check(
     str_contains($dispatcher, '$today = DateHelper::today()')

--- a/tests/mobile-due-push-alignment.unit.php
+++ b/tests/mobile-due-push-alignment.unit.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+/** Regression guards for Android due-date parity and hourly mobile push dispatch. */
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+        return;
+    }
+    $failed++;
+    echo "  FAIL {$label}\n";
+};
+
+$root = dirname(__DIR__);
+$actions = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/ActionsController.php');
+$openApi = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/OpenApiController.php');
+$dispatcher = (string)file_get_contents($root . '/storage/plugins/mobile-api/src/Push/PushDispatcher.php');
+$hourlyCron = (string)file_get_contents($root . '/cron/automatic-notifications.php');
+
+$check(
+    substr_count($actions . $dispatcher, "get('advanced', 'days_before_expiry_warning'") === 2
+        && !str_contains($actions . $dispatcher, "get('loans', 'reminder_days_before'")
+        && str_contains($actions, '$dueSoonDays = max(0,')
+        && str_contains($dispatcher, 'return max(0, $days);'),
+    'mobile feed and push use the core expiration-warning setting'
+);
+$check(
+    str_contains($dispatcher, '$today = DateHelper::today()')
+        && !str_contains($dispatcher, '>= CURDATE()')
+        && !str_contains($dispatcher, '< CURDATE()')
+        && !str_contains($dispatcher, "SET SESSION time_zone = '+00:00'"),
+    'push date boundaries use the application timezone'
+);
+$check(
+    str_contains($dispatcher, "bind_param('ssi', \$today, \$today, \$days)")
+        && str_contains($dispatcher, "bind_param('s', \$today)"),
+    'due and overdue push queries bind the authoritative application date'
+);
+$check(
+    str_contains($actions, "'due_attention'") && str_contains($openApi, "'due_attention'"),
+    'loan API and OpenAPI expose the server-authoritative due-date cue'
+);
+$check(
+    str_contains($hourlyCron, "doAction('mobile_api.dispatch_push')"),
+    'hourly notification cron dispatches native mobile push'
+);
+
+echo "\nPassed: {$passed}   Failed: {$failed}\n";
+exit($failed > 0 ? 1 : 0);


### PR DESCRIPTION
Addresses the [Email/SMTP Testing and Due Date Visibility feedback](https://github.com/fabiodalez-dev/Pinakes/discussions/238#discussioncomment-17621300) in discussion #238.

Three related gaps: no way to tell whether SMTP works, no due-date visibility in the loans list/dashboard, and no notification for loans due today.

## 1. Send test email + robust SMTP
- New **"Send test email"** button in **Settings → Email**: sends a test message with the current config to a given address (or the logged-in admin) and reports success or the **specific** error.
- Fixed a latent bug: the `smtp` driver used a hand-rolled SMTP client that never checked server replies and returned success even when the message was rejected (the classic "SMTP looks fine but no mail arrives"). Both `smtp` and `phpmailer` now go through PHPMailer, which verifies the handshake/auth/recipient and surfaces the real error.

## 2. Due-date visibility
- **Loans List** gains a dedicated **Due date** column; the date turns red (`text-red-600 font-semibold`) when an active loan is due today or overdue — the same rule the Physical Copies list uses.
- **Dashboard "Active Loans"** applies the same red date highlight. The status badge stays faithful to the real loan state: a loan due today reads *In corso* with a red date (act-now cue), a genuinely late one reads *In Ritardo*.
- Fixed a column-map bug this introduced: after inserting the Due-date column at index 3, the DataTables server-side sort map still assumed index 3 = status, so sorting by "Scadenza"/"Stato" used the wrong SQL column. Remapped correctly.
- All highlight logic now computes "today" from `DateHelper::today()` (application timezone), consistent with the rest of the loan pipeline, instead of the browser/PHP-process local date.

## 3. Notifications for due-today / overdue
- The expiration-warning query matched `data_scadenza` exactly at `today + N`, which silently skipped a loan due **today** (the exact repro). Widened to `BETWEEN today AND today + N`; the in-app notification reads *"scade oggi"* at zero days.
- **Mobile API** aligned to the same pipeline: native push now dispatches on the hourly cron pass (not only 06:00), reads the due-soon horizon from the real `advanced.days_before_expiry_warning` setting (it previously read a key that never existed and stayed pinned to the 3-day fallback), derives "today" from the application timezone, and the loan payload exposes a server-authoritative `due_attention` flag so the Android client doesn't compute "today" from its own device timezone.

## Verification
- PHPStan level 5 clean across all changed files.
- Send-test verified end-to-end against Mailpit: valid SMTP → delivered; bad host → `success:false` with the connection error.
- Due-today and overdue red highlight verified in the browser in both the loans list and the dashboard.
- New behavioral E2E: loan due today receives the warning email (`B.9b`); mobile-api `due_attention` for future vs due-today, and the zero-day notification horizon.
- New static regression unit tests for the query shape, column map, timezone source, mobile setting alignment, and locale parity (all four locales, 6541 keys).

Docker deployments also need an in-container scheduler for the automatic jobs to run at all — that lives in the companion `pinakes-docker` PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta la funzione “Email di prova” nelle impostazioni, con feedback sull’esito dell’invio.
  * Nell’app mobile compare l’indicatore `due_attention` per prestiti che scadono “oggi” o sono già scaduti.
* **Correzioni**
  * Avvisi di scadenza estesi a una finestra (oggi→soglia configurata) e testo “scade oggi” quando applicabile.
  * Aggiornata la visibilità di “Scadenza” e l’evidenziazione in dashboard/lista; migliorato anche l’ordinamento e l’esposizione del campo.
  * Allineate le notifiche/push mobile alla stessa logica “oggi”.
* **Localizzazione**
  * Aggiornate le traduzioni per “scade oggi” e per il flusso di email di prova.
* **Test**
  * Nuovi test per scadenza “oggi” e allineamento mobile/push.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->