### PR TITLE
Add Telegram as a configurable social link

### DIFF
--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -128,6 +128,7 @@ class SettingsController
             'social_instagram' => trim((string) ($data['social_instagram'] ?? '')),
             'social_linkedin' => trim((string) ($data['social_linkedin'] ?? '')),
             'social_bluesky' => trim((string) ($data['social_bluesky'] ?? '')),
+            'social_telegram' => trim((string) ($data['social_telegram'] ?? '')),
         ];
 
         foreach ($socialLinks as $key => $value) {
@@ -254,6 +255,7 @@ class SettingsController
             'social_instagram' => $repository->get('app', 'social_instagram', $config['social_instagram'] ?? ''),
             'social_linkedin' => $repository->get('app', 'social_linkedin', $config['social_linkedin'] ?? ''),
             'social_bluesky' => $repository->get('app', 'social_bluesky', $config['social_bluesky'] ?? ''),
+            'social_telegram' => $repository->get('app', 'social_telegram', $config['social_telegram'] ?? ''),
         ];
     }
 

--- a/app/Support/ConfigStore.php
+++ b/app/Support/ConfigStore.php
@@ -25,6 +25,7 @@ final class ConfigStore
                 'social_instagram' => '',
                 'social_linkedin' => '',
                 'social_bluesky' => '',
+                'social_telegram' => '',
             ],
             'mail' => [
                 'driver' => 'mail', // mail|smtp|phpmailer
@@ -411,7 +412,7 @@ final class ConfigStore
                     self::$dbSettingsCache['app']['locale'] = (string) $raw['app']['locale'];
                 }
                 // Load social links
-                $socialKeys = ['social_facebook', 'social_twitter', 'social_instagram', 'social_linkedin', 'social_bluesky'];
+                $socialKeys = ['social_facebook', 'social_twitter', 'social_instagram', 'social_linkedin', 'social_bluesky', 'social_telegram'];
                 foreach ($socialKeys as $socialKey) {
                     if (isset($raw['app'][$socialKey])) {
                         self::$dbSettingsCache['app'][$socialKey] = (string) $raw['app'][$socialKey];

--- a/app/Views/frontend/layout.php
+++ b/app/Views/frontend/layout.php
@@ -21,6 +21,7 @@ $socialTwitter = (string) ConfigStore::get('app.social_twitter', '');
 $socialInstagram = (string) ConfigStore::get('app.social_instagram', '');
 $socialLinkedin = (string) ConfigStore::get('app.social_linkedin', '');
 $socialBluesky = (string) ConfigStore::get('app.social_bluesky', '');
+$socialTelegram = (string) ConfigStore::get('app.social_telegram', '');
 $catalogRoute = route_path('catalog');
 $reservationsRoute = route_path('reservations');
 $wishlistRoute = route_path('wishlist');
@@ -1673,6 +1674,10 @@ $htmlLang = substr($currentLocale, 0, 2);
                         <?php if ($socialBluesky !== ''): ?>
                             <a href="<?= HtmlHelper::e($socialBluesky) ?>" target="_blank" rel="noopener noreferrer"><i
                                     class="fa-brands fa-bluesky"></i></a>
+                        <?php endif; ?>
+                        <?php if ($socialTelegram !== ''): ?>
+                            <a href="<?= HtmlHelper::e($socialTelegram) ?>" target="_blank" rel="noopener noreferrer"><i
+                                    class="fa-brands fa-telegram"></i></a>
                         <?php endif; ?>
                     </div>
                 </div>

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -210,6 +210,17 @@ $activeTab = $activeTab ?? 'general';
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://bsky.app/profile/tuoprofilo') ?>">
                   </div>
+                  <div>
+                    <label for="social_telegram" class="block text-xs text-gray-600 mb-1">
+                      <i class="fa-brands fa-telegram mr-1"></i> Telegram
+                    </label>
+                    <input type="url"
+                           id="social_telegram"
+                           name="social_telegram"
+                           value="<?php echo HtmlHelper::e((string)($appSettings['social_telegram'] ?? '')); ?>"
+                           class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
+                           placeholder="<?= __('https://t.me/tuocanale') ?>">
+                  </div>
                 </div>
                 <p class="text-xs text-gray-500 mt-2">
                   <i class="fas fa-info-circle"></i> <?= __("Lascia vuoto per nascondere il social dal footer") ?>

--- a/app/Views/user_layout.php
+++ b/app/Views/user_layout.php
@@ -40,6 +40,7 @@ $socialTwitter = (string) ConfigStore::get('app.social_twitter', '');
 $socialInstagram = (string) ConfigStore::get('app.social_instagram', '');
 $socialLinkedin = (string) ConfigStore::get('app.social_linkedin', '');
 $socialBluesky = (string) ConfigStore::get('app.social_bluesky', '');
+$socialTelegram = (string) ConfigStore::get('app.social_telegram', '');
 $catalogRoute = route_path('catalog');
 $reservationsRoute = route_path('reservations');
 $wishlistRoute = route_path('wishlist');
@@ -1062,6 +1063,10 @@ $htmlLang = substr($currentLocale, 0, 2);
                         <?php if ($socialBluesky !== ''): ?>
                             <a href="<?= HtmlHelper::e($socialBluesky) ?>" target="_blank" rel="noopener noreferrer"><i
                                     class="fa-brands fa-bluesky"></i></a>
+                        <?php endif; ?>
+                        <?php if ($socialTelegram !== ''): ?>
+                            <a href="<?= HtmlHelper::e($socialTelegram) ?>" target="_blank" rel="noopener noreferrer"><i
+                                    class="fa-brands fa-telegram"></i></a>
                         <?php endif; ?>
                     </div>
                 </div>

--- a/docs/settings.MD
+++ b/docs/settings.MD
@@ -37,7 +37,7 @@ La pagina Impostazioni (`/admin/settings`) è organizzata in **11 tab**. Il tab 
 
 | Tab (`?tab=`) | Contenuto |
 |---|---|
-| `general` | Identità: nome, logo, descrizione footer, link social (Facebook, Twitter/X, Instagram, LinkedIn, Bluesky) |
+| `general` | Identità: nome, logo, descrizione footer, link social (Facebook, Twitter/X, Instagram, LinkedIn, Bluesky, Telegram) |
 | `email` | Provider/SMTP + toggle "richiedi approvazione admin" alla registrazione |
 | `templates` | Template email (19 tipi) |
 | `cms` | Contenuti homepage / pagine + layout immagine eventi |

--- a/installer/database/data_de_DE.sql
+++ b/installer/database/data_de_DE.sql
@@ -230,6 +230,7 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('app', 'social_instagram', '', 'Instagram-Profil-URL', NOW()),
 ('app', 'social_linkedin', '', 'LinkedIn-Profil-URL', NOW()),
 ('app', 'social_bluesky', '', 'Bluesky-Profil-URL', NOW()),
+('app', 'social_telegram', '', 'Telegram-Profil-URL', NOW()),
 
 -- Email settings are configured by user in installer step 6
 -- No default values here to avoid overwriting user choices

--- a/installer/database/data_en_US.sql
+++ b/installer/database/data_en_US.sql
@@ -228,6 +228,7 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('app', 'social_instagram', '', 'Instagram profile URL', NOW()),
 ('app', 'social_linkedin', '', 'LinkedIn profile URL', NOW()),
 ('app', 'social_bluesky', '', 'Bluesky profile URL', NOW()),
+('app', 'social_telegram', '', 'Telegram profile URL', NOW()),
 
 -- Email settings are configured by user in installer step 6
 -- No default values here to avoid overwriting user choices

--- a/installer/database/data_fr_FR.sql
+++ b/installer/database/data_fr_FR.sql
@@ -230,6 +230,7 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('app', 'social_instagram', '', 'URL du profil Instagram', NOW()),
 ('app', 'social_linkedin', '', 'URL du profil LinkedIn', NOW()),
 ('app', 'social_bluesky', '', 'URL du profil Bluesky', NOW()),
+('app', 'social_telegram', '', 'URL du profil Telegram', NOW()),
 
 -- Email settings are configured by user in installer step 6
 -- No default values here to avoid overwriting user choices

--- a/installer/database/data_it_IT.sql
+++ b/installer/database/data_it_IT.sql
@@ -281,6 +281,7 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('app', 'social_instagram', '', 'Instagram profile URL', NOW()),
 ('app', 'social_linkedin', '', 'LinkedIn profile URL', NOW()),
 ('app', 'social_bluesky', '', 'Bluesky profile URL', NOW()),
+('app', 'social_telegram', '', 'Telegram profile URL', NOW()),
 
 -- Le impostazioni email sono configurate dall'utente nello step 6 dell'installer
 -- Nessun valore predefinito qui per evitare di sovrascrivere le scelte dell'utente

--- a/installer/database/migrations/migrate_0.7.35.sql
+++ b/installer/database/migrations/migrate_0.7.35.sql
@@ -1,0 +1,9 @@
+-- Migration 0.7.35 — add Telegram social link setting.
+--
+-- Existing installations upgraded to 0.7.35 must get app.social_telegram
+-- in system_settings so the new admin/footer integration can persist/read it.
+-- INSERT IGNORE keeps this idempotent on reruns and on fresh installs seeded
+-- from installer/database/data_*.sql.
+
+INSERT IGNORE INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('app', 'social_telegram', '', 'Telegram profile URL');

--- a/tests/issue-257-telegram-social-links.unit.php
+++ b/tests/issue-257-telegram-social-links.unit.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Static coverage for issue #257 (Telegram social link).
+ *
+ * Run:
+ *   php tests/issue-257-telegram-social-links.unit.php
+ */
+
+$root = dirname(__DIR__);
+$failed = 0;
+$passed = 0;
+
+$check = static function (bool $cond, string $label) use (&$failed, &$passed): void {
+    if ($cond) {
+        $passed++;
+        echo "  OK   {$label}\n";
+        return;
+    }
+    $failed++;
+    echo "  FAIL {$label}\n";
+};
+
+$read = static function (string $rel) use ($root): string {
+    $path = $root . '/' . $rel;
+    if (!is_file($path)) {
+        throw new RuntimeException("Missing file: {$rel}");
+    }
+    $content = file_get_contents($path);
+    if ($content === false) {
+        throw new RuntimeException("Unreadable file: {$rel}");
+    }
+    return $content;
+};
+
+try {
+    $configStore = $read('app/Support/ConfigStore.php');
+    $settingsController = $read('app/Controllers/SettingsController.php');
+    $settingsView = $read('app/Views/settings/index.php');
+    $frontendLayout = $read('app/Views/frontend/layout.php');
+    $userLayout = $read('app/Views/user_layout.php');
+    $migration = $read('installer/database/migrations/migrate_0.7.35.sql');
+    $seedEn = $read('installer/database/data_en_US.sql');
+    $seedDe = $read('installer/database/data_de_DE.sql');
+    $seedFr = $read('installer/database/data_fr_FR.sql');
+    $seedIt = $read('installer/database/data_it_IT.sql');
+
+    $check(str_contains($configStore, "'social_telegram' => ''"), 'ConfigStore default includes social_telegram');
+    $check(str_contains($settingsController, "'social_telegram' => trim((string) (\$data['social_telegram'] ?? ''))"), 'SettingsController saves social_telegram');
+    $check(str_contains($settingsController, "'social_telegram' => \$repository->get('app', 'social_telegram', \$config['social_telegram'] ?? '')"), 'SettingsController resolves social_telegram');
+    $check(str_contains($settingsView, 'id="social_telegram"'), 'Settings view has social_telegram input');
+    $check(str_contains($settingsView, 'class="fa-brands fa-telegram mr-1"'), 'Settings view uses Telegram icon');
+    $check(str_contains($frontendLayout, "ConfigStore::get('app.social_telegram', '')"), 'Frontend layout loads social_telegram');
+    $check(str_contains($frontendLayout, 'class="fa-brands fa-telegram"'), 'Frontend layout renders Telegram icon');
+    $check(str_contains($userLayout, "ConfigStore::get('app.social_telegram', '')"), 'User layout loads social_telegram');
+    $check(str_contains($userLayout, 'class="fa-brands fa-telegram"'), 'User layout renders Telegram icon');
+    $check(str_contains($migration, "'app', 'social_telegram', '', 'Telegram profile URL'"), 'Migration inserts social_telegram');
+    $check(str_contains($seedEn, "('app', 'social_telegram', '', 'Telegram profile URL', NOW())"), 'en_US seed includes social_telegram');
+    $check(str_contains($seedDe, "('app', 'social_telegram', '', 'Telegram-Profil-URL', NOW())"), 'de_DE seed includes social_telegram');
+    $check(str_contains($seedFr, "('app', 'social_telegram', '', 'URL du profil Telegram', NOW())"), 'fr_FR seed includes social_telegram');
+    $check(str_contains($seedIt, "('app', 'social_telegram', '', 'Telegram profile URL', NOW())"), 'it_IT seed includes social_telegram');
+} catch (Throwable $e) {
+    $failed++;
+    echo "  FAIL exception: " . $e->getMessage() . "\n";
+}
+
+echo "\n  {$passed} passed, {$failed} failed\n";
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
Implements #257

# AI Description

This PR adds `social_telegram` across the same paths currently used by other app social links, so Telegram can be configured in admin settings and rendered in public/user footers. It also adds DB coverage for both fresh installs (seed data) and upgrades (migration).

- **Config + persistence wiring**
  - Added `social_telegram` to app defaults and DB-loaded social key set in `ConfigStore`.
  - Added `social_telegram` to general settings save/load flow in `SettingsController`.

- **Admin settings UI**
  - Added Telegram URL input in General → Social Links (`social_telegram`), with Font Awesome brand icon and Telegram placeholder URL.
  - Uses project-consistent icon class style: `fa-brands fa-telegram`.

- **Frontend rendering**
  - Added `app.social_telegram` read in both layout templates:
    - `app/Views/frontend/layout.php`
    - `app/Views/user_layout.php`
  - Renders Telegram icon/link only when configured (same conditional pattern as existing social links).

- **Database install/upgrade coverage**
  - Added `app.social_telegram` seed row to:
    - `installer/database/data_en_US.sql`
    - `installer/database/data_de_DE.sql`
    - `installer/database/data_fr_FR.sql`
    - `installer/database/data_it_IT.sql`
  - Added idempotent migration `installer/database/migrations/migrate_0.7.35.sql` inserting the new setting for existing installations.

- **Docs + focused regression guard**
  - Updated social links list in `docs/settings.MD`.
  - Added focused static unit check: `tests/issue-257-telegram-social-links.unit.php`.

```php
// app/Support/ConfigStore.php
$socialKeys = [
    'social_facebook',
    'social_twitter',
    'social_instagram',
    'social_linkedin',
    'social_bluesky',
    'social_telegram',
];
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto il supporto per configurare il link al profilo Telegram nelle impostazioni generali.
  * Il link Telegram viene visualizzato nel footer pubblico quando configurato.
  * Inclusa l’inizializzazione dell’impostazione nelle nuove installazioni e negli aggiornamenti.

* **Documentazione**
  * Aggiornate le informazioni sulle impostazioni del footer per includere Telegram.

* **Test**
  * Aggiunti controlli automatici per verificare la configurazione e visualizzazione del link Telegram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->