### PR TITLE
Mark the registration Nome field as required in its label (#255)

### DIFF
--- a/app/Views/auth/register.php
+++ b/app/Views/auth/register.php
@@ -107,7 +107,7 @@ $registerRoute = route_path('register');
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label for="nome" class="block text-sm font-medium text-gray-700 mb-2">
-              <?= __('Nome') ?>
+              <?= __('Nome') ?> *
             </label>
             <input
               type="text"


### PR DESCRIPTION
The public registration form enforces `nome` as required (the HTML `required` attribute and the server-side check both do), but its label was missing the `*` indicator that Email and the toggle-driven Cognome/Telefono/Indirizzo already show — so the field looked optional while it wasn't.

Added the asterisk to match the profile and admin user forms, which already mark it. One-line view change; verified the `/registrati` form now renders "Nome *".

Reported by @Himura2la on #255.