### PR TITLE
Escape social settings inputs with htmlspecialchars (CodeRabbit on #260)

### DIFF
--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -166,7 +166,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_facebook"
                            name="social_facebook"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_facebook'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_facebook'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://facebook.com/tuapagina') ?>">
                   </div>
@@ -177,7 +177,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_twitter"
                            name="social_twitter"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_twitter'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_twitter'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://twitter.com/tuoprofilo') ?>">
                   </div>
@@ -188,7 +188,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_instagram"
                            name="social_instagram"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_instagram'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_instagram'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://instagram.com/tuoprofilo') ?>">
                   </div>
@@ -199,7 +199,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_linkedin"
                            name="social_linkedin"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_linkedin'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_linkedin'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://linkedin.com/company/tuaazienda') ?>">
                   </div>
@@ -210,7 +210,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_bluesky"
                            name="social_bluesky"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_bluesky'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_bluesky'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://bsky.app/profile/tuoprofilo') ?>">
                   </div>
@@ -221,7 +221,7 @@ $activeTab = $activeTab ?? 'general';
                     <input type="url"
                            id="social_telegram"
                            name="social_telegram"
-                           value="<?php echo HtmlHelper::e((string)($appSettings['social_telegram'] ?? '')); ?>"
+                           value="<?php echo htmlspecialchars((string)($appSettings['social_telegram'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>"
                            class="block w-full rounded-lg border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-2 px-3"
                            placeholder="<?= __('https://t.me/tuocanale') ?>">
                   </div>


### PR DESCRIPTION
CodeRabbit flagged the Telegram settings input for using `HtmlHelper::e()` in a view (against the project's view-escaping rule). All six social inputs (facebook/twitter/instagram/linkedin/bluesky/telegram) shared that pattern, so I converted them all to `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')` for consistency — not just the one line CodeRabbit saw.

The other two findings on #260 are addressed by reply on the threads: the missing save-time sanitization is by design (the security boundary is output — both the footer render and the Schema.org `sameAs` already run every social through `sanitizePublicHttpUrl()`, uniformly for all six), and the re-seed concern is guarded by `.installed` (the seed only re-runs on a deliberate from-scratch reinstall, not on upgrade/recovery).