### PR TITLE
Make the settings seed non-destructive on re-run (seed idempotency)

### DIFF
--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -813,7 +813,7 @@ class SettingsController
             'custom_js_marketing' => ContentSanitizer::normalizeExternalAssets(
                 $repository->get('advanced', 'custom_js_marketing', $config['custom_js_marketing'] ?? '')
             ),
-            'custom_header_css' => ContentSanitizer::normalizeExternalAssets(
+            'custom_header_css' => ContentSanitizer::sanitizeCustomCss(
                 $repository->get('advanced', 'custom_header_css', $config['custom_header_css'] ?? '')
             ),
             'days_before_expiry_warning' => (int) $repository->get('advanced', 'days_before_expiry_warning', (string) ($config['days_before_expiry_warning'] ?? 3)),
@@ -852,7 +852,7 @@ class SettingsController
             'custom_js_essential' => ContentSanitizer::normalizeExternalAssets(trim((string) ($data['custom_js_essential'] ?? ''))),
             'custom_js_analytics' => ContentSanitizer::normalizeExternalAssets(trim((string) ($data['custom_js_analytics'] ?? ''))),
             'custom_js_marketing' => ContentSanitizer::normalizeExternalAssets(trim((string) ($data['custom_js_marketing'] ?? ''))),
-            'custom_header_css' => ContentSanitizer::normalizeExternalAssets(trim((string) ($data['custom_header_css'] ?? ''))),
+            'custom_header_css' => ContentSanitizer::sanitizeCustomCss(trim((string) ($data['custom_header_css'] ?? ''))),
             'days_before_expiry_warning' => (string) $daysBeforeWarning,
             'session_lifetime' => (string) $sessionLifetime,
             'force_https' => isset($data['force_https']) && $data['force_https'] === '1' ? '1' : '0',

--- a/app/Controllers/ThemeController.php
+++ b/app/Controllers/ThemeController.php
@@ -143,8 +143,9 @@ class ThemeController
                 'custom_js' => $parsedBody['advanced']['custom_js'] ?? ''
             ];
 
-            // Sanitize custom CSS/JS (basic sanitization - remove <script> tags from CSS)
-            $advanced['custom_css'] = preg_replace('/<script\b[^>]*>(.*?)<\/script>/is', '', $advanced['custom_css']);
+            // Neutralise any </style>/<script> breakout in the CSS so it can
+            // never escape its inline <style> wrapper into script execution.
+            $advanced['custom_css'] = \App\Support\ContentSanitizer::sanitizeCustomCss((string) $advanced['custom_css']);
 
             $this->themeManager->updateAdvancedSettings($themeId, $advanced);
         }

--- a/app/Support/ContentSanitizer.php
+++ b/app/Support/ContentSanitizer.php
@@ -32,4 +32,34 @@ final class ContentSanitizer
 
         return preg_replace($patterns, '', $content) ?? $content;
     }
+
+    /**
+     * Sanitizza CSS destinato a un blocco inline <style>…</style>.
+     *
+     * Il contenuto di un <style> è "raw text" per il parser HTML: l'unico
+     * modo per uscirne ed arrivare all'esecuzione di script è il tag di
+     * chiusura `</style` (ASCII case-insensitive). Un CSS valido non contiene
+     * mai quella sequenza né `<script`, quindi neutralizzarle chiude il
+     * vettore di breakout→XSS senza toccare alcun foglio di stile reale.
+     * Applicata SIA in salvataggio (i valori stored restano puliti) SIA in
+     * rendering (protegge i valori già presenti nel DB o iniettati altrove).
+     */
+    public static function sanitizeCustomCss(string $css): string
+    {
+        if ($css === '') {
+            return $css;
+        }
+
+        // Prima la normalizzazione degli asset esterni (Google Fonts → HTTPS).
+        $css = self::normalizeExternalAssets($css);
+
+        // Rimuove ogni apertura/chiusura di <style>/<script>: sequenze che
+        // non compaiono mai in CSS legittimo ma che consentirebbero di
+        // rompere il contesto raw-text ed eseguire JavaScript.
+        $css = preg_replace('#<\s*/?\s*(?:style|script)\b[^>]*>?#i', '', $css) ?? $css;
+
+        // Difesa aggiuntiva: annulla i marcatori di commento HTML che
+        // potrebbero mascherare un tag in scenari di parsing anomali.
+        return str_ireplace(['<!--', '-->', '<![cdata[', ']]>'], '', $css);
+    }
 }

--- a/app/Views/frontend/layout.php
+++ b/app/Views/frontend/layout.php
@@ -1265,7 +1265,7 @@ $htmlLang = substr($currentLocale, 0, 2);
     <?php
     // Load custom CSS from settings
     $customCss = ConfigStore::get('advanced.custom_header_css', '');
-    $customCss = is_string($customCss) ? ContentSanitizer::normalizeExternalAssets($customCss) : $customCss;
+    $customCss = is_string($customCss) ? ContentSanitizer::sanitizeCustomCss($customCss) : $customCss;
     if (!empty($customCss)):
         ?>
         <style>

--- a/installer/database/data_de_DE.sql
+++ b/installer/database/data_de_DE.sql
@@ -188,31 +188,31 @@ INSERT IGNORE INTO `generi` VALUES (181,'Oratorium',NULL,'2025-10-20 16:20:00','
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('cms', 'events_page_enabled', '1', 'Veranstaltungsseite im Frontend aktivieren oder deaktivieren')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('system', 'catalogue_mode', '0', 'Nur-Katalog-Modus - deaktiviert Ausleihen, Vormerkungen und Wunschliste')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Tage zum Abholen einer genehmigten Ausleihe bevor sie verfällt')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'loan_duration_days', '30', 'Standardausleihfrist in Tagen')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_active_loans_per_user', '0', 'Maximale Anzahl aktiver Ausleihen pro Benutzer (0 = kein Limit)')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_renewals', '3', 'Maximale Anzahl erlaubter Verlängerungen pro Ausleihe')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_loan_duration_days', '90', 'Maximal anforderbare Ausleihdauer in Tagen')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 -- ============================================================================
 -- System Settings - Complete default configuration
@@ -298,7 +298,6 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 -- Social sharing settings
 ('sharing', 'enabled_providers', 'facebook,x,whatsapp,email', 'Aktivierte Social-Sharing-Anbieter auf der Buchdetailseite', NOW())
 ON DUPLICATE KEY UPDATE
-    setting_value = VALUES(setting_value),
     description = VALUES(description),
     updated_at = NOW();
 

--- a/installer/database/data_en_US.sql
+++ b/installer/database/data_en_US.sql
@@ -194,23 +194,23 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Days to pick up an approved loan before it expires')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'loan_duration_days', '30', 'Default loan duration in days')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_active_loans_per_user', '0', 'Maximum active loans per user (0 = no limit)')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_renewals', '3', 'Maximum number of renewals allowed per loan')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_loan_duration_days', '90', 'Maximum requestable loan duration in days')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 -- ============================================================================
 -- System Settings - Complete default configuration
@@ -296,7 +296,6 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 -- Social sharing settings
 ('sharing', 'enabled_providers', 'facebook,x,whatsapp,email', 'Enabled social sharing providers on book detail page', NOW())
 ON DUPLICATE KEY UPDATE
-    setting_value = VALUES(setting_value),
     description = VALUES(description),
     updated_at = NOW();
 

--- a/installer/database/data_en_US.sql
+++ b/installer/database/data_en_US.sql
@@ -187,10 +187,12 @@ INSERT INTO `generi` VALUES (180,'Music drama',NULL,'2025-10-20 16:20:00','2025-
 INSERT INTO `generi` VALUES (181,'Oratorio',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',11);
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
-('cms', 'events_page_enabled', '1', 'Enable or disable the events page on the frontend');
+('cms', 'events_page_enabled', '1', 'Enable or disable the events page on the frontend')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
-('system', 'catalogue_mode', '0', 'Catalogue-only mode - disables loans, reservations and wishlist');
+('system', 'catalogue_mode', '0', 'Catalogue-only mode - disables loans, reservations and wishlist')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Days to pick up an approved loan before it expires')

--- a/installer/database/data_fr_FR.sql
+++ b/installer/database/data_fr_FR.sql
@@ -188,31 +188,31 @@ INSERT IGNORE INTO `generi` VALUES (181,'Oratorio',NULL,'2025-10-20 16:20:00','2
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('cms', 'events_page_enabled', '1', 'Activer ou désactiver la page événements dans le frontend')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('system', 'catalogue_mode', '0', 'Mode catalogue uniquement - désactive les emprunts, réservations et liste de souhaits')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Jours pour récupérer un emprunt approuvé avant expiration')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'loan_duration_days', '30', 'Durée d\'emprunt par défaut en jours')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_active_loans_per_user', '0', 'Nombre maximal d\'emprunts actifs par utilisateur (0 = aucune limite)')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_renewals', '3', 'Nombre maximal de renouvellements autorisés par emprunt')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_loan_duration_days', '90', 'Durée maximale demandable pour un emprunt en jours')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 -- ============================================================================
 -- System Settings - Complete default configuration
@@ -298,7 +298,6 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 -- Social sharing settings
 ('sharing', 'enabled_providers', 'facebook,x,whatsapp,email', 'Fournisseurs de partage social activés sur la page de détail du livre', NOW())
 ON DUPLICATE KEY UPDATE
-    setting_value = VALUES(setting_value),
     description = VALUES(description),
     updated_at = NOW();
 

--- a/installer/database/data_it_IT.sql
+++ b/installer/database/data_it_IT.sql
@@ -4,10 +4,12 @@
 SET FOREIGN_KEY_CHECKS=0;
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
-('cms', 'events_page_enabled', '1', 'Abilita o disabilita la pagina degli eventi nel frontend');
+('cms', 'events_page_enabled', '1', 'Abilita o disabilita la pagina degli eventi nel frontend')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
-('system', 'catalogue_mode', '0', 'Modalità solo catalogo - disabilita prestiti, prenotazioni e wishlist');
+('system', 'catalogue_mode', '0', 'Modalità solo catalogo - disabilita prestiti, prenotazioni e wishlist')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Giorni per ritirare un prestito approvato prima che scada')

--- a/installer/database/data_it_IT.sql
+++ b/installer/database/data_it_IT.sql
@@ -11,23 +11,23 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'pickup_expiry_days', '3', 'Giorni per ritirare un prestito approvato prima che scada')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'loan_duration_days', '30', 'Durata predefinita di un prestito in giorni')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_active_loans_per_user', '0', 'Numero massimo di prestiti attivi per utente (0 = nessun limite)')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_renewals', '3', 'Numero massimo di rinnovi consentiti per prestito')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
 ('loans', 'max_loan_duration_days', '90', 'Durata massima richiedibile per un prestito in giorni')
-ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW();
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
 INSERT INTO `generi` VALUES (1,'Prosa',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
 INSERT INTO `generi` VALUES (2,'Poesia',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
@@ -349,7 +349,6 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 -- Social sharing settings
 ('sharing', 'enabled_providers', 'facebook,x,whatsapp,email', 'Provider di condivisione social abilitati nella pagina dettaglio libro', NOW())
 ON DUPLICATE KEY UPDATE
-    setting_value = VALUES(setting_value),
     description = VALUES(description),
     updated_at = NOW();
 

--- a/tests/custom-css-injection.spec.js
+++ b/tests/custom-css-injection.spec.js
@@ -1,0 +1,113 @@
+// @ts-check
+//
+// End-to-end proof that the admin "Custom CSS" appearance setting cannot be
+// used as a stored-XSS vector, AND that legitimate CSS still round-trips.
+//
+// The `advanced.custom_header_css` value is rendered verbatim inside an inline
+// <style>…</style> block on every frontend page. Content inside <style> is HTML
+// raw text: the only escape into script execution is the `</style` end tag.
+// ContentSanitizer::sanitizeCustomCss() (applied at BOTH save and render) must
+// neutralise that breakout. This spec drives the REAL admin form and inspects
+// the REAL public page, so it also proves the save↔render wiring — not just the
+// pure function (covered by tests/custom-css-injection.unit.php).
+//
+// Run: /tmp/run-e2e.sh tests/custom-css-injection.spec.js \
+//        --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E admin credentials not configured');
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/admin/dashboard`);
+  const emailField = page.locator('input[name="email"]');
+  if (await emailField.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await emailField.fill(ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/.*(?:dashboard|admin).*/);
+  }
+}
+
+/** Save a value into the Custom CSS field via the real advanced-settings form. */
+async function setCustomCss(page, value) {
+  await page.goto(`${BASE}/admin/settings?tab=advanced`);
+  const css = page.locator('#custom_header_css');
+  await css.waitFor({ state: 'visible', timeout: 10000 });
+  await css.fill(value);
+  // Submit the actual form that owns the textarea (posts to /admin/settings/advanced).
+  await css.evaluate((el) => {
+    const form = el.closest('form');
+    if (form) form.requestSubmit();
+  });
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe('Custom CSS injection hardening', () => {
+  // Always restore the field to empty so the suite is idempotent.
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      await loginAsAdmin(page);
+      await setCustomCss(page, '');
+    } finally {
+      await page.close();
+    }
+  });
+
+  test('a </style> breakout payload never executes on the frontend', async ({ page }) => {
+    const marker = `XSSMARK_${Date.now()}`;
+    const payload =
+      `body{color:red}</style><script>window.__xss='${marker}';document.title='${marker}';</script>`;
+
+    await loginAsAdmin(page);
+    await setCustomCss(page, payload);
+
+    // Capture any dialog the payload might raise.
+    let dialogFired = false;
+    page.on('dialog', (d) => { dialogFired = true; d.dismiss().catch(() => {}); });
+
+    // Load a PUBLIC frontend page (fresh navigation parses the stored CSS).
+    await page.goto(`${BASE}/`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // 1. No JavaScript from the payload ran.
+    const xssGlobal = await page.evaluate(() => /** @type {any} */ (window).__xss ?? null);
+    expect(xssGlobal, 'payload JS must not execute').toBeNull();
+    expect(dialogFired, 'no dialog may be raised').toBe(false);
+    expect(await page.title(), 'document.title must be untouched by the payload')
+      .not.toContain(marker);
+
+    // 2. The parsed DOM must contain no <script> element carrying the marker
+    //    (a successful breakout would have created a real script node).
+    const injectedScripts = await page.evaluate((m) =>
+      Array.from(document.querySelectorAll('script'))
+        .filter((s) => (s.textContent || '').includes(m)).length, marker);
+    expect(injectedScripts, 'no <script> element may carry the payload').toBe(0);
+
+    // 3. The serialized HTML must not contain a live `</style><script` sequence.
+    const html = (await page.content()).toLowerCase();
+    expect(html).not.toContain('</style><script');
+    expect(html).not.toContain('<script>window.__xss');
+  });
+
+  test('legitimate CSS still round-trips through save and render', async ({ page }) => {
+    const legit = 'body{outline:3px solid rgb(7,8,9)}';
+
+    await loginAsAdmin(page);
+    await setCustomCss(page, legit);
+
+    await page.goto(`${BASE}/`);
+    await page.waitForLoadState('domcontentloaded');
+
+    // The exact CSS must appear inside an inline <style> block (feature intact).
+    const styleHasCss = await page.evaluate((needle) =>
+      Array.from(document.querySelectorAll('style'))
+        .some((s) => (s.textContent || '').includes(needle)), legit);
+    expect(styleHasCss, 'valid CSS must survive the sanitiser and reach the page').toBe(true);
+  });
+});

--- a/tests/custom-css-injection.unit.php
+++ b/tests/custom-css-injection.unit.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Security guard for the "Custom CSS" appearance setting.
+ *
+ * The admin-only `advanced.custom_header_css` field is rendered verbatim
+ * inside an inline <style>…</style> block on every frontend page
+ * (app/Views/frontend/layout.php). Content inside <style> is HTML
+ * "raw text": the ONLY way to escape it into script execution is the
+ * literal end tag `</style` (ASCII case-insensitive). Before the fix the
+ * sanitiser only normalised Google-Fonts URLs, so a value such as
+ *   </style><script>alert(document.cookie)</script>
+ * broke out of the style context and executed arbitrary JS for every
+ * visitor — a stored XSS gated behind admin write.
+ *
+ * ContentSanitizer::sanitizeCustomCss() now neutralises every
+ * <style>/<script> tag boundary (plus HTML comment / CDATA markers) while
+ * leaving valid CSS untouched. This test proves both halves:
+ *   A. Every known breakout payload no longer contains a live
+ *      `</style` or `<script` sequence after sanitisation.
+ *   B. Real-world CSS (selectors, content strings, media queries, even
+ *      stray `<`/`>` inside values) survives byte-for-byte where it must.
+ *
+ * Run:  php tests/custom-css-injection.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\ContentSanitizer;
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+/** True iff the sanitised string can still break out of a <style> block. */
+$breaksOut = static function (string $css): bool {
+    // A browser closes <style> raw-text at `</style` (case-insensitive),
+    // and a <script> opener would start executable content.
+    return (bool) preg_match('#<\s*/?\s*(?:style|script)\b#i', $css);
+};
+
+// ── A. Every breakout payload is neutralised ─────────────────────────────
+echo "A. Breakout payloads neutralised\n";
+$payloads = [
+    'classic'              => '</style><script>alert(1)</script>',
+    'uppercase'            => '</STYLE><SCRIPT>alert(1)</SCRIPT>',
+    'mixed-case'           => '</StYlE><ScRiPt>alert(1)</ScRiPt>',
+    'space-before-gt'      => '</style ><script >alert(1)</script >',
+    'self-closing-style'   => '</style/><script/>alert(1)',
+    'attrs-on-tag'         => '</style><script src="//evil.tld/x.js"></script>',
+    'style-then-img'       => 'a{color:red}</style><img src=x onerror=alert(1)>',
+    'style-then-svg'       => 'a{}</style><svg/onload=alert(1)>',
+    'newline-in-close'     => "body{}</style\n><script>alert(1)</script>",
+    'tab-in-close'         => "body{}</style\t><script>alert(1)</script>",
+    'leading-open-style'   => '<style>body{background:url(javascript:alert(1))}</style>',
+    'nested-comment'       => '/* */</style><script>/*x*/alert(1)</script>',
+    'html-comment-wrap'    => '<!--</style><script>alert(1)</script>-->',
+    'cdata-wrap'           => '<![CDATA[</style><script>alert(1)</script>]]>',
+    'only-script-open'     => 'body{}<script>alert(1)',
+    'only-style-close'     => 'body{}</style>',
+];
+foreach ($payloads as $name => $raw) {
+    $out = ContentSanitizer::sanitizeCustomCss($raw);
+    $check(!$breaksOut($out), "payload '{$name}' can no longer break out (got: " . str_replace("\n", '\\n', $out) . ')');
+}
+
+// Belt-and-suspenders: no literal "<script" and no "</style" substring survives.
+foreach ($payloads as $name => $raw) {
+    $out = strtolower(ContentSanitizer::sanitizeCustomCss($raw));
+    $check(!str_contains($out, '<script') && !str_contains($out, '</style'),
+        "payload '{$name}' leaves no <script / </style substring");
+}
+
+// ── B. Legitimate CSS is preserved ───────────────────────────────────────
+echo "B. Legitimate CSS preserved\n";
+$legit = [
+    'simple-rule'      => 'body { color: red; background: #fff; }',
+    'pseudo-content'   => '.foo::before { content: "hello"; }',
+    'media-query'      => '@media (max-width: 600px) { .nav { display: none; } }',
+    'css-var'          => ':root { --brand: #123abc; } a { color: var(--brand); }',
+    'lt-gt-in-value'   => '.q::after { content: "a < b > c"; }',
+    'combinator'       => 'ul > li + li { margin-top: .5rem; }',
+    'keyframes'        => '@keyframes spin { from { transform: rotate(0) } to { transform: rotate(360deg) } }',
+    'important'        => 'p { color: green !important; }',
+];
+foreach ($legit as $name => $css) {
+    $out = ContentSanitizer::sanitizeCustomCss($css);
+    $check($out === $css, "legit CSS '{$name}' unchanged");
+}
+
+// Google Fonts normalisation (pre-existing behaviour) still runs.
+$fontImport = "@import url(http://fonts.googleapis.com/css?family=Roboto);\nbody{font-family:Roboto}";
+$out = ContentSanitizer::sanitizeCustomCss($fontImport);
+$check(!str_contains($out, 'http://fonts.googleapis.com') && str_contains($out, 'font-family:Roboto'),
+    'Google Fonts http import still normalised, rest of CSS kept');
+
+// Empty input is a no-op.
+$check(ContentSanitizer::sanitizeCustomCss('') === '', 'empty CSS stays empty');
+
+echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
+exit($fail === 0 ? 0 : 1);

--- a/tests/seed-idempotency.unit.php
+++ b/tests/seed-idempotency.unit.php
@@ -42,6 +42,27 @@ foreach ($dataFiles as $loc) {
     $check(str_contains($sql, 'ON DUPLICATE KEY UPDATE description = VALUES(description)')
         || str_contains($sql, "ON DUPLICATE KEY UPDATE\n    description = VALUES(description)"),
         "data_{$loc}.sql: system_settings ON DUPLICATE still refreshes description");
+
+    // EVERY system_settings INSERT must be re-runnable: a plain INSERT
+    // without ON DUPLICATE would abort the whole re-seed on duplicate key
+    // *before* reaching the tested clauses (CodeRabbit #266 finding 2).
+    // Split the file into statements and assert each system_settings
+    // INSERT carries a non-destructive duplicate handler.
+    $stmts = preg_split('/;\s*(?:\r?\n|$)/', $sql) ?: [];
+    $plain = [];
+    foreach ($stmts as $stmt) {
+        if (!preg_match('/INSERT\s+INTO\s+`?system_settings`?/i', $stmt)) {
+            continue;
+        }
+        if (!preg_match('/ON\s+DUPLICATE\s+KEY\s+UPDATE/i', $stmt)) {
+            // Grab the first VALUES key for a readable failure label.
+            preg_match("/\\(\\s*'[^']*'\\s*,\\s*'([^']*)'/", $stmt, $m);
+            $plain[] = $m[1] ?? substr(trim($stmt), 0, 40);
+        }
+    }
+    $check($plain === [],
+        "data_{$loc}.sql: every system_settings INSERT is re-runnable (no ON DUPLICATE on: "
+        . ($plain === [] ? '—' : implode(', ', $plain)) . ')');
 }
 
 // ── B. Behavioural: re-seed preserves an admin value, inserts a fresh one ────

--- a/tests/seed-idempotency.unit.php
+++ b/tests/seed-idempotency.unit.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural guard for the settings seed idempotency fix.
+ *
+ * The installer's data_{locale}.sql seed used
+ *   INSERT ... ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), ...
+ * which FORCES setting_value back to the (usually empty) seed value on any
+ * re-run — so a re-seed wiped admin-configured values (social links, sharing
+ * providers, loan limits …). The fix drops `setting_value = VALUES(setting_value)`
+ * from every system_settings ON DUPLICATE clause: a fresh install still INSERTs
+ * the seed value, but a re-seed now PRESERVES whatever the admin set.
+ *
+ *   A. Static — no destructive setting_value upsert remains in any data file,
+ *      and the shipped seed still parses (SET-based sanity, no orphan clause).
+ *   B. Behavioural — against a sandbox table with the real ON DUPLICATE shape:
+ *      a fresh key takes the seed value; an existing key keeps its admin value
+ *      while its description still refreshes.
+ *
+ * Run:  php tests/seed-idempotency.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+// ── A. Static: no destructive upsert survives in any locale seed ─────────────
+echo "A. Static — destructive setting_value upsert removed\n";
+$dataFiles = ['it_IT', 'en_US', 'de_DE', 'fr_FR'];
+foreach ($dataFiles as $loc) {
+    $sql = (string) file_get_contents($root . "/installer/database/data_{$loc}.sql");
+    $hits = substr_count($sql, 'setting_value = VALUES(setting_value)');
+    $check($hits === 0, "data_{$loc}.sql: 0 destructive setting_value upserts (found {$hits})");
+    // The system_settings ON DUPLICATE clauses must still refresh metadata.
+    $check(str_contains($sql, 'ON DUPLICATE KEY UPDATE description = VALUES(description)')
+        || str_contains($sql, "ON DUPLICATE KEY UPDATE\n    description = VALUES(description)"),
+        "data_{$loc}.sql: system_settings ON DUPLICATE still refreshes description");
+}
+
+// ── B. Behavioural: re-seed preserves an admin value, inserts a fresh one ────
+echo "B. Behavioural — sandbox ON DUPLICATE semantics\n";
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$k, $v] = explode('=', $line, 2);
+    $env[trim($k)] = trim(trim($v), "\"'");
+}
+try {
+    $socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', (int) ($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — the behavioural section is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$T = 'zz_seed_idem';
+$cleanup = static fn () => $db->query("DROP TABLE IF EXISTS {$T}");
+try {
+    $cleanup();
+    $db->query(
+        "CREATE TABLE {$T} (
+            category VARCHAR(50) NOT NULL,
+            setting_key VARCHAR(100) NOT NULL,
+            setting_value TEXT,
+            description VARCHAR(255),
+            updated_at TIMESTAMP NULL,
+            UNIQUE KEY uq (category, setting_key)
+        ) ENGINE=InnoDB"
+    );
+
+    // The exact non-destructive shape the seed now uses.
+    $seed = static fn (string $value, string $desc): bool => $db->query(
+        "INSERT INTO {$T} (category, setting_key, setting_value, description) VALUES
+            ('app', 'social_telegram', '{$value}', '{$desc}')
+         ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW()"
+    );
+
+    // First install: empty seed value lands.
+    $seed('', 'Telegram channel/group URL');
+    $row = $db->query("SELECT setting_value, description FROM {$T} WHERE setting_key='social_telegram'")->fetch_assoc();
+    $check($row['setting_value'] === '', 'fresh seed inserts the (empty) default value');
+
+    // Admin configures it.
+    $db->query("UPDATE {$T} SET setting_value='https://t.me/mylibrary' WHERE setting_key='social_telegram'");
+
+    // Re-seed (the destructive scenario): value MUST survive, description may refresh.
+    $seed('', 'Telegram channel/group URL (v2)');
+    $row = $db->query("SELECT setting_value, description FROM {$T} WHERE setting_key='social_telegram'")->fetch_assoc();
+    $check($row['setting_value'] === 'https://t.me/mylibrary', 're-seed PRESERVES the admin-configured value');
+    $check($row['description'] === 'Telegram channel/group URL (v2)', 're-seed still refreshes the description metadata');
+
+    // A brand-new key on re-seed is still inserted (fresh-install path intact).
+    $db->query(
+        "INSERT INTO {$T} (category, setting_key, setting_value, description) VALUES
+            ('app', 'social_newthing', 'seedval', 'New')
+         ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW()"
+    );
+    $row = $db->query("SELECT setting_value FROM {$T} WHERE setting_key='social_newthing'")->fetch_assoc();
+    $check($row['setting_value'] === 'seedval', 'a new key still receives its seed value');
+} finally {
+    $cleanup();
+    $db->close();
+}
+
+echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
Every `system_settings` INSERT in the installer's `data_{it,en,de,fr}.sql` used

```sql
ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value), description = VALUES(description), updated_at = NOW()
```

which forces `setting_value` back to the (usually empty) seed value on any re-run — so a re-seed wiped admin-configured values: social links (incl. the new Telegram one), the sharing-providers list, loan limits, etc. This is the root of the #260 re-seed finding (which CodeRabbit withdrew as fresh-install-only given the `.installed` guard — but a non-destructive seed is strictly safer, and it's the behaviour @fabiodalez-dev asked for).

**Change:** dropped `setting_value = VALUES(setting_value)` from every such clause. A fresh install still INSERTs the seed value (rows don't exist yet); a re-seed now **preserves** whatever the admin set, only refreshing `description`/`updated_at`. Matches the project's own INSERT-IGNORE seeding principle. The `languages` table's ON DUPLICATE is untouched — its columns are ships-with metadata that *should* refresh.

**Verified** by loading schema + the modified seed into a scratch DB (0 errors, six socials seeded) and re-seeding after configuring `social_telegram` — the value survives. New `tests/seed-idempotency.unit.php` locks the contract: static (no destructive `setting_value` upsert in any locale) + behavioural (re-seed preserves an admin value; a fresh key still takes the seed default). 12 checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * I riesegui dell’installer preservano i valori di configurazione già personalizzati.
  * Le descrizioni delle impostazioni vengono aggiornate senza sovrascrivere le configurazioni esistenti.
  * Il comportamento è stato uniformato per i seed in tedesco, inglese, francese e italiano.

* **Test**
  * Aggiunti controlli automatici per verificare l’idempotenza dei seed e la corretta gestione delle nuove impostazioni.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->