### PR TITLE
security: fix stored XSS in per-copy fields + harden two open redirects

### DIFF
--- a/app/Controllers/AutoriController.php
+++ b/app/Controllers/AutoriController.php
@@ -392,8 +392,19 @@ class AutoriController
                 session_start();
             }
             $_SESSION['error_message'] = __('Impossibile eliminare l\'autore: sono presenti libri associati.');
+            // Only bounce back to the referring authors page when it is a
+            // same-host /admin/authors URL — a bare substring check would let
+            // https://evil.tld/admin/authors through as an open redirect.
             $referer = $request->getHeaderLine('Referer');
-            $target = str_contains($referer, '/admin/authors') ? $referer : '/admin/authors';
+            $target = url('/admin/authors');
+            if ($referer !== '' && strpbrk($referer, "\r\n") === false && !str_starts_with($referer, '//')) {
+                $parsed = parse_url($referer);
+                $host = $parsed['host'] ?? null;
+                $sameHost = $host === null || $host === ($_SERVER['HTTP_HOST'] ?? '');
+                if ($sameHost && str_contains((string) ($parsed['path'] ?? ''), '/admin/authors')) {
+                    $target = $referer;
+                }
+            }
             return $response->withHeader('Location', $target)->withStatus(302);
         }
 

--- a/app/Controllers/AutoriController.php
+++ b/app/Controllers/AutoriController.php
@@ -392,19 +392,14 @@ class AutoriController
                 session_start();
             }
             $_SESSION['error_message'] = __('Impossibile eliminare l\'autore: sono presenti libri associati.');
-            // Only bounce back to the referring authors page when it is a
-            // same-host /admin/authors URL — a bare substring check would let
-            // https://evil.tld/admin/authors through as an open redirect.
-            $referer = $request->getHeaderLine('Referer');
-            $target = url('/admin/authors');
-            if ($referer !== '' && strpbrk($referer, "\r\n") === false && !str_starts_with($referer, '//')) {
-                $parsed = parse_url($referer);
-                $host = $parsed['host'] ?? null;
-                $sameHost = $host === null || $host === ($_SERVER['HTTP_HOST'] ?? '');
-                if ($sameHost && str_contains((string) ($parsed['path'] ?? ''), '/admin/authors')) {
-                    $target = $referer;
-                }
-            }
+            // Bounce back to the referring authors page, but derive the redirect
+            // from the referer's PATH only (scheme/host discarded) so a spoofed
+            // Host/Referer can never make this an open redirect. See RefererGuard.
+            $target = \App\Support\RefererGuard::localPath(
+                $request->getHeaderLine('Referer'),
+                '/admin/authors',
+                '/admin/authors'
+            );
             return $response->withHeader('Location', $target)->withStatus(302);
         }
 

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -15,35 +15,10 @@ class CopyController
      */
     private function safeReferer(string $default = '/admin/books'): string
     {
-        $default = url($default);
-        $referer = $_SERVER['HTTP_REFERER'] ?? $default;
-
-        // Block CRLF injection
-        if (strpos($referer, "\r") !== false || strpos($referer, "\n") !== false) {
-            return $default;
-        }
-
-        // Allow relative internal URLs
-        if (str_starts_with($referer, '/') && !str_starts_with($referer, '//')) {
-            return $referer;
-        }
-
-        // For absolute URLs, only allow same host
-        $parsed = parse_url($referer);
-        if (!$parsed || empty($parsed['host'])) {
-            return $default;
-        }
-
-        $currentHost = $_SERVER['HTTP_HOST'] ?? '';
-        if ($parsed['host'] === $currentHost) {
-            $path = $parsed['path'] ?? '/';
-            if (!empty($parsed['query'])) {
-                $path .= '?' . $parsed['query'];
-            }
-            return $path;
-        }
-
-        return $default;
+        // Delegate to the single audited implementation. localPath() uses only
+        // the referer's path (never its scheme/host), which is strictly safer
+        // than the previous same-host comparison and port-agnostic.
+        return \App\Support\RefererGuard::localPath((string) ($_SERVER['HTTP_REFERER'] ?? ''), $default);
     }
 
     /**

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -377,10 +377,11 @@ class FrontendController
                 $orgSchema['sameAs'] = $sameAs;
             }
 
-            // Combine schemas
-            $seoSchema = json_encode([$schemaOrg, $orgSchema], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            // Combine schemas. JSON_HEX_TAG neutralises any </script> that could
+            // reach the value (defence in depth on top of the strip_tags at save).
+            $seoSchema = json_encode([$schemaOrg, $orgSchema], JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG);
         } else {
-            $seoSchema = json_encode($schemaOrg, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            $seoSchema = json_encode($schemaOrg, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT | JSON_HEX_TAG);
         }
 
         // Render template

--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -437,6 +437,64 @@ class HtmlHelper
     }
 
     /**
+     * Resolve a redirect host that is OPERATOR-CONFIGURED, never the raw request
+     * Host header (which an attacker controls on a catch-all vhost).
+     *
+     * Priority: APP_CANONICAL_URL, then the first APP_TRUSTED_HOSTS entry. Both
+     * are set by the operator — the installer writes APP_CANONICAL_URL at setup.
+     * Returns null when neither is configured, so security-sensitive callers can
+     * fail safe instead of trusting the request Host.
+     *
+     * @return string|null host (with :port when the canonical URL carried one)
+     */
+    public static function configuredTrustedHost(): ?string
+    {
+        $canonical = $_ENV['APP_CANONICAL_URL'] ?? getenv('APP_CANONICAL_URL') ?: '';
+        if (is_string($canonical) && $canonical !== '') {
+            $parts = parse_url($canonical);
+            if (is_array($parts) && !empty($parts['host'])) {
+                return $parts['host']
+                    . (isset($parts['port']) ? ':' . (int) $parts['port'] : '');
+            }
+        }
+
+        $whitelist = $_ENV['APP_TRUSTED_HOSTS'] ?? getenv('APP_TRUSTED_HOSTS') ?: '';
+        if (is_string($whitelist) && trim($whitelist) !== '') {
+            $first = trim(explode(',', $whitelist)[0]);
+            if ($first !== '') {
+                return $first;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the target for the force-HTTPS bootstrap redirect from a configured
+     * trusted host + the (sanitised) request path. Returns null when no trusted
+     * host is configured — the caller must then NOT redirect (avoids an open
+     * redirect built from the attacker-controllable Host header).
+     *
+     * @return string|null absolute https:// URL, or null to skip the redirect
+     */
+    public static function forceHttpsRedirectTarget(): ?string
+    {
+        $host = self::configuredTrustedHost();
+        if ($host === null) {
+            return null;
+        }
+
+        // Strip control characters (CR/LF etc.) so the Location stays a single
+        // header line; normalise to a leading-'/' path.
+        $uri = preg_replace('/[^\x20-\x7E]/', '', (string) ($_SERVER['REQUEST_URI'] ?? '/')) ?? '/';
+        if ($uri === '' || $uri[0] !== '/') {
+            $uri = '/' . $uri;
+        }
+
+        return 'https://' . $host . $uri;
+    }
+
+    /**
      * Costruisce un URL assoluto sicuro da un path relativo
      *
      * @param string $path Path relativo

--- a/app/Support/RefererGuard.php
+++ b/app/Support/RefererGuard.php
@@ -1,0 +1,62 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Safe same-origin redirect derivation from an untrusted Referer header.
+ *
+ * The one audited implementation reused by every "bounce the user back to
+ * where they came from" redirect (authors/copies/… admin lists). Only the
+ * referer's PATH (+ query) is ever used — its scheme and host are ALWAYS
+ * discarded — so a spoofed Host or Referer can never turn the redirect into
+ * an open redirect, and there is no host/port comparison to get wrong on
+ * non-standard-port or reverse-proxied deployments.
+ */
+final class RefererGuard
+{
+    /**
+     * Return a safe local redirect derived from $referer, or url($default)
+     * when the referer has no usable local path (or its path does not contain
+     * $mustContain, when that gate is supplied).
+     *
+     * @param string $referer     Raw Referer header value (untrusted).
+     * @param string $default     App-relative fallback route (run through url()).
+     * @param string $mustContain When non-empty, the referer path must contain
+     *                            this substring to be accepted (e.g. '/admin/authors').
+     */
+    public static function localPath(string $referer, string $default, string $mustContain = ''): string
+    {
+        $fallback = url($default);
+
+        // Reject empties and CRLF (header-injection) outright.
+        if ($referer === '' || strpbrk($referer, "\r\n") !== false) {
+            return $fallback;
+        }
+
+        $parsed = parse_url($referer);
+        if ($parsed === false) {
+            return $fallback;
+        }
+
+        $path = (string) ($parsed['path'] ?? '');
+
+        // Must be a clean root-relative path: a single leading '/', and NOT a
+        // protocol-relative ('//') or backslash-tricked ('/\') form that a
+        // browser would normalise into an off-site redirect. A scheme-relative
+        // referer like "https:evil.tld/admin/authors" parses to a host-less,
+        // non-leading-'/' path and is rejected here too.
+        if ($path === ''
+            || !str_starts_with($path, '/')
+            || str_starts_with($path, '//')
+            || str_starts_with($path, '/\\')) {
+            return $fallback;
+        }
+
+        if ($mustContain !== '' && !str_contains($path, $mustContain)) {
+            return $fallback;
+        }
+
+        return $path . (isset($parsed['query']) && $parsed['query'] !== '' ? '?' . $parsed['query'] : '');
+    }
+}

--- a/app/Views/events/index.php
+++ b/app/Views/events/index.php
@@ -249,7 +249,7 @@ $formatEventTime = static function (?string $value) use ($timeFormatter, $create
                       <?= __("Visualizza") ?>
                     </a>
                     <button
-                      onclick="confirmDelete(<?= (int)$event['id'] ?>, <?= htmlspecialchars(json_encode($event['title']), ENT_QUOTES, 'UTF-8') ?>)"
+                      onclick="confirmDelete(<?= (int)$event['id'] ?>, <?= htmlspecialchars((string) json_encode($event['title'], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8') ?>)"
                       class="inline-flex items-center gap-2 px-4 py-2 bg-white border border-red-300 text-red-700 rounded-lg hover:bg-red-50 transition-colors text-sm font-semibold">
                       <i class="fas fa-trash"></i>
                       <?= __("Elimina") ?>

--- a/app/Views/frontend/home-sections/latest_books_title.php
+++ b/app/Views/frontend/home-sections/latest_books_title.php
@@ -27,7 +27,7 @@ $legacyCatalogRoute = $legacyCatalogRoute ?? route_path('catalog_legacy');
                 <i class="fas fa-plus"></i>
                 <?= __("Carica Altri") ?>
             </button>
-            <a href="<?= $legacyCatalogRoute ?>" class="btn-cta">
+            <a href="<?= htmlspecialchars($legacyCatalogRoute, ENT_QUOTES, 'UTF-8') ?>" class="btn-cta">
                 <i class="fas fa-th-large"></i>
                 <?= __("Visualizza Tutto il Catalogo") ?>
             </a>

--- a/app/Views/layout.php
+++ b/app/Views/layout.php
@@ -1318,7 +1318,7 @@ $htmlLang = substr($currentLocale, 0, 2);
                     </p>
                     <p class="text-xs text-gray-600 mt-1 group-hover:text-gray-700 transition-colors">${escapeHtml(notif.message || '')}</p>
             ${hasLink ? `
-              <?php $openLabel = json_encode(__('Apri'), JSON_UNESCAPED_UNICODE); ?>
+              <?php $openLabel = json_encode(__('Apri'), JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>
               <div class="mt-3">
                 <button type="button" class="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-white bg-gray-900 rounded-lg shadow-sm hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-500/40" data-open-link="${escapedLink}">
                   <i class="fas fa-external-link-alt text-[11px]"></i>

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -1062,7 +1062,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                     ?>
                     <?php if ($canEdit): ?>
                     <button type="button"
-                            onclick="openEditCopyModal(<?php echo (int)$copia['id']; ?>, '<?php echo htmlspecialchars($copia['stato'] ?? '', ENT_QUOTES); ?>', '<?php echo htmlspecialchars($copia['note'] ?? '', ENT_QUOTES); ?>')"
+                            onclick="openEditCopyModal(<?php echo (int)$copia['id']; ?>, <?php echo htmlspecialchars((string) json_encode($copia['stato'] ?? '', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8'); ?>, <?php echo htmlspecialchars((string) json_encode($copia['note'] ?? '', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8'); ?>)"
                             class="text-blue-600 hover:text-blue-900 transition-colors"
                             title="<?= __("Modifica stato") ?>">
                       <i class="fas fa-edit"></i>
@@ -1070,7 +1070,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                     <?php endif; ?>
                     <?php if ($canDelete): ?>
                     <button type="button"
-                            onclick="confirmDeleteCopy(<?php echo (int)$copia['id']; ?>, '<?php echo htmlspecialchars($copia['numero_inventario'], ENT_QUOTES); ?>')"
+                            onclick="confirmDeleteCopy(<?php echo (int)$copia['id']; ?>, <?php echo htmlspecialchars((string) json_encode($copia['numero_inventario'] ?? '', JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8'); ?>)"
                             class="text-red-600 hover:text-red-900 transition-colors"
                             title="<?= __("Elimina copia") ?>">
                       <i class="fas fa-trash"></i>
@@ -1978,7 +1978,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
       if (window.Swal) {
         Swal.fire({
           title: __('Elimina copia'),
-          html: `${__('Sei sicuro di voler eliminare la copia')} <strong>${numeroInventario}</strong>?<br><span class="text-sm text-gray-600">${__('Questa azione non può essere annullata.')}</span>`,
+          html: `${__('Sei sicuro di voler eliminare la copia')} <strong>${escapeHtml(numeroInventario)}</strong>?<br><span class="text-sm text-gray-600">${__('Questa azione non può essere annullata.')}</span>`,
           icon: 'warning',
           showCancelButton: true,
           confirmButtonText: __('Sì, elimina'),

--- a/public/index.php
+++ b/public/index.php
@@ -277,17 +277,21 @@ if (!$isCli && !$httpsDetected) {
     $forceHttps = $forceHttpsFromDb || (getenv('APP_ENV') === 'production' && $forceHttpsFromEnv);
 
     if ($forceHttps) {
-        // Build the redirect target through the app's single audited host
-        // resolver (HtmlHelper::getCurrentUrl) rather than the raw Host header:
-        // it prefers APP_CANONICAL_URL, enforces the APP_TRUSTED_HOSTS whitelist,
-        // RFC-1123-validates the Host (falling back to localhost on a bad value),
-        // and strips control characters from the request URI. So an attacker-
-        // supplied Host on a catch-all vhost cannot steer the HTTPS upgrade to an
-        // off-site host. Then force the scheme to https for the upgrade itself.
-        $target = \App\Support\HtmlHelper::getCurrentUrl();
-        $target = preg_replace('#^http://#i', 'https://', $target, 1) ?? $target;
-        header('Location: ' . $target, true, 301);
-        exit;
+        // Build the redirect target ONLY from an operator-configured trusted
+        // host (APP_CANONICAL_URL, else APP_TRUSTED_HOSTS) — never the raw Host
+        // header, which an attacker controls on a catch-all vhost. The installer
+        // always writes APP_CANONICAL_URL, so real installs hit the redirect path.
+        $target = \App\Support\HtmlHelper::forceHttpsRedirectTarget();
+        if ($target !== null) {
+            header('Location: ' . $target, true, 301);
+            exit;
+        }
+        // No trusted host configured: refuse to build a redirect from the
+        // attacker-controllable Host header. Fail safe — skip the HTTPS upgrade
+        // (serve over HTTP this request) and tell the operator how to enforce it.
+        error_log('[Pinakes] force_https is enabled but no trusted host is configured '
+            . '(set APP_CANONICAL_URL or APP_TRUSTED_HOSTS); skipping the HTTPS redirect '
+            . 'to avoid an open redirect via the Host header.');
     }
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -277,9 +277,12 @@ if (!$isCli && !$httpsDetected) {
     $forceHttps = $forceHttpsFromDb || (getenv('APP_ENV') === 'production' && $forceHttpsFromEnv);
 
     if ($forceHttps) {
-        // Prefer the configured canonical host over the raw Host header so an
-        // attacker-supplied Host on a catch-all vhost cannot turn the HTTPS
-        // upgrade into an open redirect (https://evil.tld/…).
+        // When APP_CANONICAL_URL is configured, redirect to that canonical host
+        // instead of the raw Host header, so an attacker-supplied Host on a
+        // catch-all vhost cannot turn the HTTPS upgrade into an open redirect.
+        // Without a canonical URL set there is no trusted host at this bootstrap
+        // stage, so we fall back to the request Host (best effort) — operators
+        // on a shared/catch-all vhost should set APP_CANONICAL_URL.
         $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
         $canonicalUrl = getenv('APP_CANONICAL_URL') ?: ($_ENV['APP_CANONICAL_URL'] ?? '');
         if ($canonicalUrl !== '') {

--- a/public/index.php
+++ b/public/index.php
@@ -277,7 +277,18 @@ if (!$isCli && !$httpsDetected) {
     $forceHttps = $forceHttpsFromDb || (getenv('APP_ENV') === 'production' && $forceHttpsFromEnv);
 
     if ($forceHttps) {
+        // Prefer the configured canonical host over the raw Host header so an
+        // attacker-supplied Host on a catch-all vhost cannot turn the HTTPS
+        // upgrade into an open redirect (https://evil.tld/…).
         $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $canonicalUrl = getenv('APP_CANONICAL_URL') ?: ($_ENV['APP_CANONICAL_URL'] ?? '');
+        if ($canonicalUrl !== '') {
+            $canonicalParts = parse_url($canonicalUrl);
+            if (!empty($canonicalParts['host'])) {
+                $host = $canonicalParts['host']
+                    . (isset($canonicalParts['port']) ? ':' . (int) $canonicalParts['port'] : '');
+            }
+        }
         $requestUri = $_SERVER['REQUEST_URI'] ?? '/';
         header('Location: https://' . $host . $requestUri, true, 301);
         exit;

--- a/public/index.php
+++ b/public/index.php
@@ -277,23 +277,16 @@ if (!$isCli && !$httpsDetected) {
     $forceHttps = $forceHttpsFromDb || (getenv('APP_ENV') === 'production' && $forceHttpsFromEnv);
 
     if ($forceHttps) {
-        // When APP_CANONICAL_URL is configured, redirect to that canonical host
-        // instead of the raw Host header, so an attacker-supplied Host on a
-        // catch-all vhost cannot turn the HTTPS upgrade into an open redirect.
-        // Without a canonical URL set there is no trusted host at this bootstrap
-        // stage, so we fall back to the request Host (best effort) — operators
-        // on a shared/catch-all vhost should set APP_CANONICAL_URL.
-        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
-        $canonicalUrl = getenv('APP_CANONICAL_URL') ?: ($_ENV['APP_CANONICAL_URL'] ?? '');
-        if ($canonicalUrl !== '') {
-            $canonicalParts = parse_url($canonicalUrl);
-            if (!empty($canonicalParts['host'])) {
-                $host = $canonicalParts['host']
-                    . (isset($canonicalParts['port']) ? ':' . (int) $canonicalParts['port'] : '');
-            }
-        }
-        $requestUri = $_SERVER['REQUEST_URI'] ?? '/';
-        header('Location: https://' . $host . $requestUri, true, 301);
+        // Build the redirect target through the app's single audited host
+        // resolver (HtmlHelper::getCurrentUrl) rather than the raw Host header:
+        // it prefers APP_CANONICAL_URL, enforces the APP_TRUSTED_HOSTS whitelist,
+        // RFC-1123-validates the Host (falling back to localhost on a bad value),
+        // and strips control characters from the request URI. So an attacker-
+        // supplied Host on a catch-all vhost cannot steer the HTTPS upgrade to an
+        // off-site host. Then force the scheme to https for the upgrade itself.
+        $target = \App\Support\HtmlHelper::getCurrentUrl();
+        $target = preg_replace('#^http://#i', 'https://', $target, 1) ?? $target;
+        header('Location: ' . $target, true, 301);
         exit;
     }
 }

--- a/tests/force-https-redirect.unit.php
+++ b/tests/force-https-redirect.unit.php
@@ -5,27 +5,28 @@ declare(strict_types=1);
  * Security guard for the force-HTTPS bootstrap redirect in public/index.php.
  *
  * When `advanced.force_https` (or APP_ENV=production + FORCE_HTTPS) is on and a
- * request arrives over HTTP, public/index.php issues a 301 to the HTTPS URL.
- * The redirect target is built via the app's single audited host resolver:
+ * request arrives over HTTP, public/index.php issues a 301 to the HTTPS URL —
+ * but ONLY to an operator-configured trusted host, never the raw Host header:
  *
- *     $target = HtmlHelper::getCurrentUrl();
- *     $target = preg_replace('#^http://#i', 'https://', $target, 1);
+ *     $target = HtmlHelper::forceHttpsRedirectTarget();   // null = don't redirect
+ *     if ($target !== null) { header('Location: ' . $target, true, 301); exit; }
  *
- * This replaced an earlier hand-rolled block that trusted the raw Host header,
- * which was an open-redirect on catch-all vhosts (CodeRabbit). These tests pin
- * the security-relevant properties of that resolution so a future refactor
- * can't silently reintroduce Host-header trust.
+ * forceHttpsRedirectTarget() derives the host from APP_CANONICAL_URL (else the
+ * first APP_TRUSTED_HOSTS entry) and returns null when neither is set, so the
+ * bootstrap fails safe instead of redirecting to an attacker-chosen domain on a
+ * catch-all vhost (CodeRabbit). The installer always writes APP_CANONICAL_URL,
+ * so real installs still get the HTTPS upgrade.
  *
- * Each scenario runs in a FRESH subprocess (`php <this-file> --child`) so
- * per-request $_SERVER / $_ENV state and getBasePath()'s static cache never
- * bleed across cases. No DB — getCurrentUrl() reads only env + $_SERVER.
+ * These tests pin those properties. Each scenario runs in a FRESH subprocess
+ * (`php <this-file> --child`) so env / $_SERVER state never bleeds across cases.
+ * No DB — the resolver reads only env + $_SERVER.
  *
  * Run:  php tests/force-https-redirect.unit.php   (exit 0 iff all pass)
  */
 
 $root = dirname(__DIR__);
 
-// ── Child mode: apply one scenario, print the exact index.php redirect target ─
+// ── Child mode: apply one scenario, print the resolved target (or "NULL") ─────
 if (($argv[1] ?? '') === '--child') {
     require $root . '/vendor/autoload.php';
     /** @var array{server?:array<string,string>,env?:array<string,string>} $s */
@@ -37,10 +38,8 @@ if (($argv[1] ?? '') === '--child') {
     foreach (($s['server'] ?? []) as $k => $v) {
         $_SERVER[$k] = $v;
     }
-    // The exact expression public/index.php uses for the force-HTTPS upgrade.
-    $target = \App\Support\HtmlHelper::getCurrentUrl();
-    $target = preg_replace('#^http://#i', 'https://', $target, 1) ?? $target;
-    echo $target;
+    $target = \App\Support\HtmlHelper::forceHttpsRedirectTarget();
+    echo $target === null ? 'NULL' : $target;
     exit(0);
 }
 
@@ -54,13 +53,14 @@ $check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
 };
 
 /**
- * Compute the redirect target for a scenario in an isolated subprocess.
+ * Resolve the redirect target for a scenario in an isolated subprocess.
+ * Returns the literal string "NULL" when the resolver declines to redirect.
  *
- * @param array<string,string> $server $_SERVER overrides (HTTP_HOST, REQUEST_URI, …)
- * @param array<string,string> $env    env overrides (APP_CANONICAL_URL, APP_TRUSTED_HOSTS, TRUSTED_PROXIES)
+ * @param array<string,string> $server $_SERVER overrides
+ * @param array<string,string> $env    env overrides (APP_CANONICAL_URL, APP_TRUSTED_HOSTS)
  */
 $target = static function (array $server, array $env = []) use ($self): string {
-    // json_encode escapes any raw CR/LF as \r\n TEXT, so the env var carries no
+    // json_encode escapes raw CR/LF as \r\n TEXT, so the env var carries no
     // control bytes; the child's json_decode restores the real bytes.
     $payload = (string) json_encode(['server' => $server, 'env' => $env]);
     $cmd = 'RT_SCENARIO=' . escapeshellarg($payload)
@@ -69,57 +69,64 @@ $target = static function (array $server, array $env = []) use ($self): string {
     return trim((string) shell_exec($cmd));
 };
 
-echo "A. Legit host — correct HTTPS upgrade\n";
+echo "A. Configured canonical host — correct, Host-independent upgrade\n";
 
-$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/admin/dashboard']);
-$check($out === 'https://mysite.com/admin/dashboard', "legit host preserves host + path (got: {$out})");
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/admin/dashboard'],
+    ['APP_CANONICAL_URL' => 'https://mysite.com']);
+$check($out === 'https://mysite.com/admin/dashboard', "canonical host + request path (got: {$out})");
 
-$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/x']);
-$check(str_starts_with($out, 'https://'), "scheme is forced to https (got: {$out})");
-
-$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/catalogo?page=3&q=rossi']);
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/catalogo?page=3&q=rossi'],
+    ['APP_CANONICAL_URL' => 'https://mysite.com']);
 $check($out === 'https://mysite.com/catalogo?page=3&q=rossi', "path + query preserved (got: {$out})");
 
-$out = $target(['HTTP_HOST' => 'mysite.com:8080', 'REQUEST_URI' => '/x']);
-$check($out === 'https://mysite.com:8080/x', "non-standard port preserved (got: {$out})");
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/x'],
+    ['APP_CANONICAL_URL' => 'https://mysite.com:8443']);
+$check($out === 'https://mysite.com:8443/x', "canonical port preserved (got: {$out})");
 
-echo "B. Host-header attacks — never redirect off-site\n";
+echo "B. Host-header attacks — target is the trusted host, never the attacker\n";
 
-$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'], ['APP_TRUSTED_HOSTS' => 'mysite.com']);
+// THE core fix: an attacker Host is ignored entirely — the target is the canonical host.
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'],
+    ['APP_CANONICAL_URL' => 'https://mysite.com']);
 $check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
-    "spoofed Host neutralised by APP_TRUSTED_HOSTS whitelist (got: {$out})");
+    "spoofed Host ignored; redirect goes to the canonical host (got: {$out})");
 
-$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'], ['APP_CANONICAL_URL' => 'https://mysite.com']);
-$check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
-    "spoofed Host overridden by APP_CANONICAL_URL (got: {$out})");
+// With no canonical but a whitelist, the first whitelisted host is used (not the Host).
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'],
+    ['APP_TRUSTED_HOSTS' => 'good.example, other.example']);
+$check($out === 'https://good.example/x' && !str_contains($out, 'evil.tld'),
+    "no canonical → first APP_TRUSTED_HOSTS entry used, Host ignored (got: {$out})");
 
-$out = $target(['HTTP_HOST' => 'e<vil>.tld', 'REQUEST_URI' => '/x']);
-$check(str_starts_with($out, 'https://localhost') && !str_contains($out, 'vil'),
-    "malformed Host falls back to localhost, never the attacker (got: {$out})");
+echo "C. Fail-safe when no trusted host is configured (the reported vector)\n";
 
-$out = $target(
-    ['HTTP_HOST' => 'mysite.com', 'HTTP_X_FORWARDED_HOST' => 'evil.tld', 'REMOTE_ADDR' => '203.0.113.9', 'REQUEST_URI' => '/x'],
-    [] // no TRUSTED_PROXIES → X-Forwarded-Host must be ignored
-);
-$check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
-    "X-Forwarded-Host ignored when the client is not a trusted proxy (got: {$out})");
+// The vulnerability CodeRabbit flagged: zero config + attacker Host must NOT redirect.
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'], []);
+$check($out === 'NULL', "no trusted config + attacker Host → NO redirect (fail safe) (got: {$out})");
 
-echo "C. Whitelist + header-injection hardening\n";
+// Even a plausible-looking Host is refused without configuration.
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/x'], []);
+$check($out === 'NULL', "no trusted config → NO redirect even for a benign Host (got: {$out})");
 
-// A non-first whitelisted host must be accepted as-is (not forced to entry 0).
-$out = $target(['HTTP_HOST' => 'second.example', 'REQUEST_URI' => '/x'],
-    ['APP_TRUSTED_HOSTS' => 'first.example, second.example']);
-$check($out === 'https://second.example/x', "a matching non-first whitelisted host is accepted (got: {$out})");
+// A malformed APP_CANONICAL_URL (no host) must not fall back to the Host header.
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'],
+    ['APP_CANONICAL_URL' => 'not-a-valid-url']);
+$check($out === 'NULL', "malformed APP_CANONICAL_URL → NO redirect, not the Host (got: {$out})");
 
-// Raw CR/LF in the request URI must be stripped so the Location stays a SINGLE
-// header line and the host is not hijacked. The injected payload survives only
-// as inert text glued to the path (no control bytes → header() cannot split it).
-$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => "/x\r\nSet-Cookie: pwned=1"]);
+echo "D. Request-path hardening\n";
+
+// Raw CR/LF in the request URI is stripped so the Location stays a single header.
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => "/x\r\nSet-Cookie: pwned=1"],
+    ['APP_CANONICAL_URL' => 'https://mysite.com']);
 $noCrlf = !str_contains($out, "\r") && !str_contains($out, "\n");
-$hostIntact = preg_match('#^https://mysite\.com/#', $out) === 1;
+$hostIntact = str_starts_with($out, 'https://mysite.com/');
 $check($noCrlf && $hostIntact,
-    "raw CRLF in REQUEST_URI stripped → single header, host intact (got: "
+    "raw CRLF in REQUEST_URI stripped → single header, canonical host intact (got: "
     . str_replace(["\r", "\n"], ['\\r', '\\n'], $out) . ")");
+
+// An empty / non-leading-slash REQUEST_URI is normalised to a rooted path.
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => ''],
+    ['APP_CANONICAL_URL' => 'https://mysite.com']);
+$check($out === 'https://mysite.com/', "empty REQUEST_URI normalised to '/' (got: {$out})");
 
 echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
 exit($fail === 0 ? 0 : 1);

--- a/tests/force-https-redirect.unit.php
+++ b/tests/force-https-redirect.unit.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Security guard for the force-HTTPS bootstrap redirect in public/index.php.
+ *
+ * When `advanced.force_https` (or APP_ENV=production + FORCE_HTTPS) is on and a
+ * request arrives over HTTP, public/index.php issues a 301 to the HTTPS URL.
+ * The redirect target is built via the app's single audited host resolver:
+ *
+ *     $target = HtmlHelper::getCurrentUrl();
+ *     $target = preg_replace('#^http://#i', 'https://', $target, 1);
+ *
+ * This replaced an earlier hand-rolled block that trusted the raw Host header,
+ * which was an open-redirect on catch-all vhosts (CodeRabbit). These tests pin
+ * the security-relevant properties of that resolution so a future refactor
+ * can't silently reintroduce Host-header trust.
+ *
+ * Each scenario runs in a FRESH subprocess (`php <this-file> --child`) so
+ * per-request $_SERVER / $_ENV state and getBasePath()'s static cache never
+ * bleed across cases. No DB — getCurrentUrl() reads only env + $_SERVER.
+ *
+ * Run:  php tests/force-https-redirect.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+
+// ── Child mode: apply one scenario, print the exact index.php redirect target ─
+if (($argv[1] ?? '') === '--child') {
+    require $root . '/vendor/autoload.php';
+    /** @var array{server?:array<string,string>,env?:array<string,string>} $s */
+    $s = json_decode((string) getenv('RT_SCENARIO'), true) ?: [];
+    foreach (($s['env'] ?? []) as $k => $v) {
+        putenv("{$k}={$v}");
+        $_ENV[$k] = $v;
+    }
+    foreach (($s['server'] ?? []) as $k => $v) {
+        $_SERVER[$k] = $v;
+    }
+    // The exact expression public/index.php uses for the force-HTTPS upgrade.
+    $target = \App\Support\HtmlHelper::getCurrentUrl();
+    $target = preg_replace('#^http://#i', 'https://', $target, 1) ?? $target;
+    echo $target;
+    exit(0);
+}
+
+// ── Parent mode: drive the scenarios ─────────────────────────────────────────
+$self = __FILE__;
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+/**
+ * Compute the redirect target for a scenario in an isolated subprocess.
+ *
+ * @param array<string,string> $server $_SERVER overrides (HTTP_HOST, REQUEST_URI, …)
+ * @param array<string,string> $env    env overrides (APP_CANONICAL_URL, APP_TRUSTED_HOSTS, TRUSTED_PROXIES)
+ */
+$target = static function (array $server, array $env = []) use ($self): string {
+    // json_encode escapes any raw CR/LF as \r\n TEXT, so the env var carries no
+    // control bytes; the child's json_decode restores the real bytes.
+    $payload = (string) json_encode(['server' => $server, 'env' => $env]);
+    $cmd = 'RT_SCENARIO=' . escapeshellarg($payload)
+        . ' ' . escapeshellarg(PHP_BINARY)
+        . ' ' . escapeshellarg($self) . ' --child';
+    return trim((string) shell_exec($cmd));
+};
+
+echo "A. Legit host — correct HTTPS upgrade\n";
+
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/admin/dashboard']);
+$check($out === 'https://mysite.com/admin/dashboard', "legit host preserves host + path (got: {$out})");
+
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/x']);
+$check(str_starts_with($out, 'https://'), "scheme is forced to https (got: {$out})");
+
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => '/catalogo?page=3&q=rossi']);
+$check($out === 'https://mysite.com/catalogo?page=3&q=rossi', "path + query preserved (got: {$out})");
+
+$out = $target(['HTTP_HOST' => 'mysite.com:8080', 'REQUEST_URI' => '/x']);
+$check($out === 'https://mysite.com:8080/x', "non-standard port preserved (got: {$out})");
+
+echo "B. Host-header attacks — never redirect off-site\n";
+
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'], ['APP_TRUSTED_HOSTS' => 'mysite.com']);
+$check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
+    "spoofed Host neutralised by APP_TRUSTED_HOSTS whitelist (got: {$out})");
+
+$out = $target(['HTTP_HOST' => 'evil.tld', 'REQUEST_URI' => '/x'], ['APP_CANONICAL_URL' => 'https://mysite.com']);
+$check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
+    "spoofed Host overridden by APP_CANONICAL_URL (got: {$out})");
+
+$out = $target(['HTTP_HOST' => 'e<vil>.tld', 'REQUEST_URI' => '/x']);
+$check(str_starts_with($out, 'https://localhost') && !str_contains($out, 'vil'),
+    "malformed Host falls back to localhost, never the attacker (got: {$out})");
+
+$out = $target(
+    ['HTTP_HOST' => 'mysite.com', 'HTTP_X_FORWARDED_HOST' => 'evil.tld', 'REMOTE_ADDR' => '203.0.113.9', 'REQUEST_URI' => '/x'],
+    [] // no TRUSTED_PROXIES → X-Forwarded-Host must be ignored
+);
+$check($out === 'https://mysite.com/x' && !str_contains($out, 'evil.tld'),
+    "X-Forwarded-Host ignored when the client is not a trusted proxy (got: {$out})");
+
+echo "C. Whitelist + header-injection hardening\n";
+
+// A non-first whitelisted host must be accepted as-is (not forced to entry 0).
+$out = $target(['HTTP_HOST' => 'second.example', 'REQUEST_URI' => '/x'],
+    ['APP_TRUSTED_HOSTS' => 'first.example, second.example']);
+$check($out === 'https://second.example/x', "a matching non-first whitelisted host is accepted (got: {$out})");
+
+// Raw CR/LF in the request URI must be stripped so the Location stays a SINGLE
+// header line and the host is not hijacked. The injected payload survives only
+// as inert text glued to the path (no control bytes → header() cannot split it).
+$out = $target(['HTTP_HOST' => 'mysite.com', 'REQUEST_URI' => "/x\r\nSet-Cookie: pwned=1"]);
+$noCrlf = !str_contains($out, "\r") && !str_contains($out, "\n");
+$hostIntact = preg_match('#^https://mysite\.com/#', $out) === 1;
+$check($noCrlf && $hostIntact,
+    "raw CRLF in REQUEST_URI stripped → single header, host intact (got: "
+    . str_replace(["\r", "\n"], ['\\r', '\\n'], $out) . ")");
+
+echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
+exit($fail === 0 ? 0 : 1);

--- a/tests/referer-guard.unit.php
+++ b/tests/referer-guard.unit.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Security guard for RefererGuard::localPath() — the single audited
+ * implementation now reused by AutoriController::delete and
+ * CopyController::safeReferer for "bounce back to the referring page".
+ *
+ * It derives the redirect from the referer's PATH only (scheme/host always
+ * discarded), so it is immune to the open-redirect vectors that the earlier
+ * inline host-comparison guard was vulnerable to (adamsreview F001/F003 +
+ * CodeRabbit): non-standard-port blind spot, host-null bypass
+ * ('https:evil.tld/…'), backslash trick ('/\evil.tld/…'), and Host-header
+ * spoofing — while preserving the local path + query (pagination/filters).
+ *
+ * Run:  php tests/referer-guard.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\RefererGuard;
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+$DEFAULT = '/admin/authors';
+$fallback = url($DEFAULT);
+
+// ── A. Open-redirect vectors are neutralised (never leave the origin) ────────
+echo "A. Bypass vectors → safe local fallback (or local path)\n";
+
+// scheme-relative-without-slashes: parse_url gives a host-less, non-'/' path.
+$check(RefererGuard::localPath('https:evil.tld/admin/authors', $DEFAULT, '/admin/authors') === $fallback,
+    "scheme-relative 'https:evil.tld/…' rejected → fallback");
+
+// backslash trick: browsers normalise '/\' into '//' (protocol-relative).
+$check(RefererGuard::localPath('/\\evil.tld/admin/authors', $DEFAULT, '/admin/authors') === $fallback,
+    "backslash '/\\evil.tld/…' rejected → fallback");
+
+// CRLF header injection.
+$check(RefererGuard::localPath("https://host/admin/authors\r\nSet-Cookie: x=1", $DEFAULT, '/admin/authors') === $fallback,
+    "CRLF referer rejected → fallback");
+
+// Cross-host absolute referer: only its LOCAL path is reused — never evil.tld.
+$out = RefererGuard::localPath('https://evil.tld/admin/authors?page=9', $DEFAULT, '/admin/authors');
+$check($out === '/admin/authors?page=9',
+    "cross-host absolute referer reuses only the local path (got: {$out})");
+$check(!str_contains($out, 'evil.tld'), "result never contains the attacker host");
+
+// protocol-relative referer: the clean path is extracted, host dropped.
+$out = RefererGuard::localPath('//evil.tld/admin/authors?x=1', $DEFAULT, '/admin/authors');
+$check($out === '/admin/authors?x=1' && !str_contains($out, 'evil.tld'),
+    "protocol-relative '//evil.tld/…' → local path only (got: {$out})");
+
+// empty referer.
+$check(RefererGuard::localPath('', $DEFAULT, '/admin/authors') === $fallback, "empty referer → fallback");
+
+// ── B. Legitimate same-origin referers preserve path + query (F001) ──────────
+echo "B. Legit referers preserve path + query (port-agnostic)\n";
+
+// Non-standard port (this project's :8081): the old host-vs-HTTP_HOST check
+// bounced these; path-only preserves the referring page + its query.
+$out = RefererGuard::localPath('http://localhost:8081/admin/authors?page=2&q=rossi', $DEFAULT, '/admin/authors');
+$check($out === '/admin/authors?page=2&q=rossi',
+    "non-standard-port referer preserves path+query (got: {$out})");
+
+// relative internal referer with query.
+$out = RefererGuard::localPath('/admin/authors?letter=B', $DEFAULT, '/admin/authors');
+$check($out === '/admin/authors?letter=B', "relative referer preserves query (got: {$out})");
+
+// ── C. mustContain gate ──────────────────────────────────────────────────────
+echo "C. mustContain gate\n";
+
+$check(RefererGuard::localPath('https://myhost/admin/books/5', $DEFAULT, '/admin/authors') === $fallback,
+    "same-app but wrong section (/admin/books) → fallback when gated on /admin/authors");
+
+// Without a gate (CopyController usage) any local path is accepted.
+$out = RefererGuard::localPath('https://myhost/admin/books?page=3', '/admin/books');
+$check($out === '/admin/books?page=3', "no mustContain → any local path reused (got: {$out})");
+
+echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
+exit($fail === 0 ? 0 : 1);

--- a/tests/xss-copy-fields-encoding.unit.php
+++ b/tests/xss-copy-fields-encoding.unit.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Security guard for the per-copy fields rendered into inline onclick handlers
+ * on the admin book-detail page (app/Views/libri/scheda_libro.php).
+ *
+ * numero_inventario / stato / note are staff-writable free text (copy-tracking
+ * #238). They were emitted into `onclick="fn(id, '<value>')"` with only
+ * htmlspecialchars(ENT_QUOTES). That is the WRONG encoding for a JS string
+ * inside an HTML attribute: the browser HTML-decodes the attribute (`&#039;`→`'`)
+ * BEFORE the JS parser runs, so a value like `');alert(1)//` breaks out of the
+ * string and executes — a stored XSS that fires in another admin's browser when
+ * they click the copy edit/delete button.
+ *
+ * The fix wraps the value in json_encode() with the JSON_HEX_* flags (so the JS
+ * string cannot be broken) and then htmlspecialchars() (so the JSON's delimiting
+ * quotes cannot terminate the HTML attribute). This test reproduces that exact
+ * expression and asserts the rendered handler is inert for every payload.
+ *
+ * Run:  php tests/xss-copy-fields-encoding.unit.php   (exit 0 iff all pass)
+ */
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+/** The exact PHP expression scheda_libro.php now uses for a copy field. */
+$encode = static fn (string $value): string => htmlspecialchars(
+    (string) json_encode($value, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE),
+    ENT_QUOTES,
+    'UTF-8'
+);
+
+/**
+ * Emulate a browser: the HTML attribute value is HTML-decoded, then the JS
+ * argument is parsed. We assert the decoded-then-evaluated argument equals the
+ * original string exactly (no breakout), and that neither the raw nor the
+ * HTML-decoded attribute can terminate the attribute or the JS string early.
+ */
+echo "A. onclick JS-string context — no breakout\n";
+$payloads = [
+    'string-break-alert'  => "');alert(document.domain)//",
+    'double-quote-break'  => '");alert(1)//',
+    'tag-inject'          => '</script><script>alert(1)</script>',
+    'img-onerror'         => '<img src=x onerror=alert(1)>',
+    'attr-break'          => '"><svg onload=alert(1)>',
+    'backslash'           => "\\');alert(1)//",
+    'newline'             => "a\n');alert(1)//",
+    'unicode-quote'       => "\u{2028}');alert(1)//",
+    'plain-code'          => 'INV-001',
+    'quotes-mix'          => 'O\'Brien "the" <b>bold</b>',
+];
+
+foreach ($payloads as $name => $raw) {
+    $attr = $encode($raw);
+
+    // 1. The rendered attribute value must not contain a raw " that would end
+    //    the double-quoted onclick="…" attribute early.
+    $check(!str_contains($attr, '"'), "payload '{$name}': no raw double-quote in attribute");
+
+    // 2. HTML-decode the attribute the way a browser does before running the JS.
+    $decoded = html_entity_decode($attr, ENT_QUOTES, 'UTF-8');
+
+    // 3. The decoded text is a JS expression argument: `"<escaped>"`. It must be
+    //    a single well-formed JS string literal — i.e. exactly one opening and
+    //    one closing unescaped double quote, with nothing after it. json_decode
+    //    parses JS/JSON string escapes identically, so it recovers the original.
+    $recovered = json_decode($decoded, true);
+    $check($recovered === $raw,
+        "payload '{$name}': JS string literal round-trips to the original (no breakout)");
+
+    // 4. Belt-and-suspenders: the decoded literal has no unescaped `'`/`"`/`<`
+    //    that could break the string or the surrounding markup, apart from the
+    //    two delimiting quotes.
+    $inner = substr($decoded, 1, -1); // strip the delimiting quotes
+    $check(!preg_match('/(?<!\\\\)["\']/', $inner) && !str_contains($inner, '<') && !str_contains($inner, '>'),
+        "payload '{$name}': inner JS string has no live quote/angle-bracket");
+}
+
+echo "\n" . ($fail === 0 ? "ALL {$pass} PASS\n" : "{$pass} PASS, {$fail} FAIL\n");
+exit($fail === 0 ? 0 : 1);

--- a/tests/xss-copy-fields.spec.js
+++ b/tests/xss-copy-fields.spec.js
@@ -71,11 +71,13 @@ test.describe('Per-copy field XSS hardening', () => {
     bookId = parseInt(dbQuery('SELECT id FROM libri WHERE deleted_at IS NULL ORDER BY id LIMIT 1'), 10);
     if (!bookId) return;
     // 'danneggiato' → the book-detail view shows BOTH the edit and delete buttons.
-    dbQuery(
+    // Grab the inserted row id in the SAME connection (LAST_INSERT_ID is
+    // connection-scoped) so afterAll always has an id to clean up.
+    copyId = parseInt(dbQuery(
       `INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES ` +
-      `(${bookId}, ${sqlStr(invPayload)}, 'danneggiato', ${sqlStr(notePayload)})`
-    );
-    copyId = parseInt(dbQuery(`SELECT id FROM copie WHERE numero_inventario = ${sqlStr(invPayload)}`), 10);
+      `(${bookId}, ${sqlStr(invPayload)}, 'danneggiato', ${sqlStr(notePayload)}); ` +
+      `SELECT LAST_INSERT_ID()`
+    ), 10);
   });
 
   test.afterAll(() => {
@@ -107,15 +109,19 @@ test.describe('Per-copy field XSS hardening', () => {
     // body must escape the code (no injected <img> onerror).
     await delBtn.click();
     await page.locator('.swal2-popup').waitFor({ state: 'visible', timeout: 8000 });
-    // The payload must appear as inert TEXT, not as a live <img> element.
+    // The payload must appear as inert, escaped TEXT (the serialization contract:
+    // present and readable, not stripped) and NOT as a live <img> element.
+    await expect(page.locator('.swal2-html-container')).toContainText(invPayload);
     const liveImg = await page.evaluate(() =>
       document.querySelectorAll('.swal2-html-container img[src="x"]').length);
     expect(liveImg, 'the SweetAlert body must not contain a live injected <img>').toBe(0);
     await page.locator('.swal2-cancel').click();
     await page.locator('.swal2-popup').waitFor({ state: 'hidden', timeout: 5000 });
 
-    // Behavioural — EDIT path: onclick must not break out.
+    // Behavioural — EDIT path: onclick must not break out, and the note must
+    // round-trip verbatim into the edit textarea (not stripped by the encoding).
     await editBtn.click();
+    await expect(page.locator('#edit-copy-note')).toHaveValue(notePayload);
     await page.waitForTimeout(300); // let the modal + any (non-)injected code settle
 
     // Nothing the payloads would have set may exist, and no dialog may have fired.

--- a/tests/xss-copy-fields.spec.js
+++ b/tests/xss-copy-fields.spec.js
@@ -1,0 +1,132 @@
+// @ts-check
+//
+// End-to-end proof that staff-writable per-copy fields (numero_inventario, note)
+// cannot execute script on the admin book-detail page. These fields (copy
+// tracking #238) were emitted into inline onclick handlers with only
+// htmlspecialchars(ENT_QUOTES) — the wrong encoding for a JS string inside an
+// HTML attribute — and numero_inventario was also dropped raw into a SweetAlert
+// `html:` template. A copy code like `');window.x=1//<img src=x onerror=…>` then
+// ran in another admin's browser on click of the copy edit/delete button.
+//
+// The fix json_encode()s the values for the onclick handlers and escapeHtml()s
+// the SweetAlert body. This spec seeds a copy carrying a live payload straight
+// into the DB, opens the REAL book-detail page, clicks the buttons, and asserts
+// nothing executes — while the pure-PHP encoding is covered by
+// tests/xss-copy-fields-encoding.unit.php.
+//
+// Run: /tmp/run-e2e.sh tests/xss-copy-fields.spec.js \
+//        --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_USER = process.env.E2E_DB_USER || '';
+const DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_NAME = process.env.E2E_DB_NAME || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const DB_HOST = process.env.E2E_DB_HOST || '';
+const DB_PORT = process.env.E2E_DB_PORT || '';
+
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME, 'Missing E2E env (admin/DB)');
+
+function mysqlArgs(sql) {
+  const args = [];
+  if (DB_HOST) { args.push('-h', DB_HOST); if (DB_PORT) args.push('-P', DB_PORT); }
+  else if (DB_SOCKET) { args.push('-S', DB_SOCKET); }
+  args.push('-u', DB_USER, DB_NAME, '-N', '-B', '-e', sql);
+  return args;
+}
+function dbQuery(sql) {
+  return execFileSync('mysql', mysqlArgs(sql), {
+    encoding: 'utf-8', timeout: 10000, env: { ...process.env, MYSQL_PWD: DB_PASS },
+  }).trim();
+}
+const sqlStr = (s) => "'" + String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'";
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/admin/dashboard`);
+  const emailField = page.locator('input[name="email"]');
+  if (await emailField.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await emailField.fill(ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/.*(?:dashboard|admin).*/);
+  }
+}
+
+test.describe('Per-copy field XSS hardening', () => {
+  const uniq = Date.now();
+  // numero_inventario feeds BOTH the confirmDeleteCopy onclick AND the SweetAlert
+  // html; note feeds the openEditCopyModal onclick. Each payload flips a distinct
+  // window flag iff it executes.
+  const invPayload = `');window.__xssInvJs=true;//<img src=x onerror="window.__xssInvHtml=true">_${uniq}`;
+  const notePayload = `');window.__xssNoteJs=true;//_${uniq}`;
+  let bookId = 0;
+  let copyId = 0;
+
+  test.beforeAll(() => {
+    bookId = parseInt(dbQuery('SELECT id FROM libri WHERE deleted_at IS NULL ORDER BY id LIMIT 1'), 10);
+    if (!bookId) return;
+    // 'danneggiato' → the book-detail view shows BOTH the edit and delete buttons.
+    dbQuery(
+      `INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES ` +
+      `(${bookId}, ${sqlStr(invPayload)}, 'danneggiato', ${sqlStr(notePayload)})`
+    );
+    copyId = parseInt(dbQuery(`SELECT id FROM copie WHERE numero_inventario = ${sqlStr(invPayload)}`), 10);
+  });
+
+  test.afterAll(() => {
+    if (copyId) dbQuery(`DELETE FROM copie WHERE id = ${copyId}`);
+  });
+
+  test('malicious copy code/note never execute on the book-detail page', async ({ page }) => {
+    test.skip(!bookId || !copyId, 'could not seed a copy (no book in DB)');
+
+    let dialogFired = false;
+    page.on('dialog', (d) => { dialogFired = true; d.dismiss().catch(() => {}); });
+
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const delBtn = page.locator(`button[onclick^="confirmDeleteCopy(${copyId},"]`);
+    const editBtn = page.locator(`button[onclick^="openEditCopyModal(${copyId},"]`);
+    await expect(delBtn).toHaveCount(1);
+
+    // Structural: the fix emits a json-encoded string (double-quote delimited),
+    // never the old single-quoted `confirmDeleteCopy(id, '…')` breakout form.
+    const delOnclick = await delBtn.getAttribute('onclick');
+    expect(delOnclick).toMatch(new RegExp(`^confirmDeleteCopy\\(${copyId},\\s*"`));
+    const editOnclick = await editBtn.getAttribute('onclick');
+    expect(editOnclick).toMatch(new RegExp(`^openEditCopyModal\\(${copyId},`));
+
+    // Behavioural — DELETE path: onclick must not break out, and the SweetAlert
+    // body must escape the code (no injected <img> onerror).
+    await delBtn.click();
+    await page.locator('.swal2-popup').waitFor({ state: 'visible', timeout: 8000 });
+    // The payload must appear as inert TEXT, not as a live <img> element.
+    const liveImg = await page.evaluate(() =>
+      document.querySelectorAll('.swal2-html-container img[src="x"]').length);
+    expect(liveImg, 'the SweetAlert body must not contain a live injected <img>').toBe(0);
+    await page.locator('.swal2-cancel').click();
+    await page.locator('.swal2-popup').waitFor({ state: 'hidden', timeout: 5000 });
+
+    // Behavioural — EDIT path: onclick must not break out.
+    await editBtn.click();
+    await page.waitForTimeout(300); // let the modal + any (non-)injected code settle
+
+    // Nothing the payloads would have set may exist, and no dialog may have fired.
+    const flags = await page.evaluate(() => ({
+      invJs: /** @type {any} */ (window).__xssInvJs ?? null,
+      invHtml: /** @type {any} */ (window).__xssInvHtml ?? null,
+      noteJs: /** @type {any} */ (window).__xssNoteJs ?? null,
+    }));
+    expect(flags.invJs, 'confirmDeleteCopy onclick must not break out').toBeNull();
+    expect(flags.invHtml, 'SweetAlert html must escape the copy code').toBeNull();
+    expect(flags.noteJs, 'openEditCopyModal onclick must not break out').toBeNull();
+    expect(dialogFired, 'no dialog may be raised by the payloads').toBe(false);
+  });
+});


### PR DESCRIPTION
Full-app XSS review (server views · client JS/DOM · controllers/headers). One real stored XSS, two low-severity open redirects, and three defence-in-depth encoding gaps. The rest of the output surface was verified safe.

## 🔴 High — Stored XSS in per-copy fields (`app/Views/libri/scheda_libro.php`)
The staff-writable per-copy fields `numero_inventario` / `note` / `stato` (copy tracking #238) were rendered into inline `onclick` handlers with only `htmlspecialchars(ENT_QUOTES)`. That is the wrong encoding for a JS string inside an HTML attribute: the browser HTML-decodes the attribute (`&#039;`→`'`) **before** the JS parser runs, so a copy code like `');alert(document.domain)//` broke out of the string and executed in another admin's browser when they clicked the copy edit/delete button — a staff→admin persistence/escalation vector (issue #27). `numero_inventario` was additionally dropped raw into a SweetAlert `html:` template.

**Fix:** `json_encode()` the values with `JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT|JSON_HEX_AMP` for the two `onclick` handlers, and `escapeHtml()` the SweetAlert body. The same value was already escaped correctly elsewhere in the file — this was a localized oversight, not a systemic gap.

## 🟡 Low — Open redirects (no header injection — PSR-7 blocks CRLF)
- `AutoriController::delete` used `str_contains($referer, '/admin/authors')`, which accepts `https://evil.tld/admin/authors`. Now validates same-host + path before bouncing back, else falls back to `url('/admin/authors')`.
- `public/index.php` force-HTTPS redirect reflected the raw `Host` header (and exited before the canonical-host enforcement). Now prefers the `APP_CANONICAL_URL` host when configured.

## 🔵 Defence in depth (low, not currently reachable)
- Home JSON-LD (`FrontendController`) and the notification "Apri" label (`layout.php`) now include `JSON_HEX_TAG`.
- The bare `route_path()` in the latest-books CTA href is now `htmlspecialchars()`-wrapped (convention).

## Tests
- `tests/xss-copy-fields-encoding.unit.php` — 30 assertions: the exact view encoding renders inert for every breakout payload (quote/tag/attr/backslash/unicode).
- `tests/xss-copy-fields.spec.js` — E2E: seeds a copy carrying a live payload into the DB, opens the real book-detail page, clicks delete (SweetAlert) and edit — no `onclick` breakout, no injected `<img>`, no dialog; structural check confirms the json-encoded handler.

Verification: PHPStan level 5 full-tree clean, unit 30/30, E2E 1/1.

## Verified safe (broad coverage)
Header injection structurally impossible (PSR-7 rejects `\r\n`); RSS/Atom/sitemap/ICS/OAI all escaped; JSON always `application/json`; `Content-Disposition` filenames sanitized; file serving realpath-contained + `nosniff`. Views: all other `onX=`/JSON-LD/script contexts use `(int)` or `json_encode(JSON_HEX_TAG)`+`htmlspecialchars`; rich text sanitized at save via `HtmlHelper::sanitizeHtml()`; meta/OG tags `htmlspecialchars`. Client JS: unified search, DataTables, autocomplete, file preview, other SweetAlert `html:` all escape via `escapeHtml`/`textContent`/`createElement`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correzioni di sicurezza**
  * Rafforzata la protezione XSS nei flussi admin (copie fisiche: modifica/eliminazione), nelle card notifiche e nelle conferme di eliminazione eventi, con encoding/escaping più robusti dei contenuti iniettati in HTML/JS.
  * Migliorata la sicurezza dei redirect basati su Referer: ora vengono costruiti percorsi locali “safe” tramite guard dedicata e, durante l’enforcement HTTPS, si usa una URL canonica verificata.
* **Test**
  * Aggiornata la copertura con nuovi test unitari e end-to-end per XSS e per la validazione del Referer (inclusa la logica “mustContain”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->