### PR TITLE
Change translation for 'Active' to 'Activate'

### DIFF
--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -364,7 +364,7 @@
   "Attenzione: %d prestito in ritardo": "Warning: %d overdue loan",
   "Attenzione: Azione Manuale Richiesta": "Warning: Manual Action Required",
   "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Warning: Could not remove all requested copies. Some copies are currently on loan.",
-  "Attiva": "Active",
+  "Attiva": "Activate",
   "Attiva Direttamente": "Activate Directly",
   "Attiva HTTP Strict Transport Security (max-age: 1 anno, include sottodomini)": "Enable HTTP Strict Transport Security (max-age: 1 year, includes subdomains)",
   "Attiva HTTPS solo se hai un certificato SSL valido installato. Attivare HSTS rende permanente il reindirizzamento HTTPS nel browser.": "Enable HTTPS only if you have a valid SSL certificate installed. Enabling HSTS makes HTTPS redirection permanent in the browser.",


### PR DESCRIPTION
In Plugins page, the button text is misleading, it seems like all inactive plugins are already active, because the word "Active" means the current state, not the verb "transition to Active state".

Maybe it breaks some other places, but looks like the Italian word for a verb and an adjective should be different...

<img width="867" height="934" alt="image" src="https://github.com/user-attachments/assets/ff4236da-00bd-4f86-a4ab-52cfeeb85e5a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Aggiornata la traduzione inglese dell’etichetta “Attiva” da “Active” a “Activate”, rendendola più coerente con un’azione.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->