### PR TITLE
Collapse REICAT/SBN and MAG digital-assets sections on the book form (#274)

### DIFF
--- a/storage/plugins/oai-pmh-server/views/book-digital-assets.php
+++ b/storage/plugins/oai-pmh-server/views/book-digital-assets.php
@@ -21,14 +21,27 @@ if (!function_exists('oaiFormatBytes')) {
         return $bytes . ' B';
     }
 }
+
+// Accordion (#274): collapsed by default to keep the book form uncluttered;
+// opens automatically when the book already has digital assets (editing a
+// digitised record) or when the user expands it. JS opens it on add too.
+$oaiHasData = !empty($assets);
 ?>
 
 <div class="mt-6 bg-gradient-to-br from-teal-50 to-cyan-50 border-2 border-teal-200 rounded-2xl p-6 dark:from-teal-900/20 dark:to-cyan-900/20 dark:border-teal-800"
      id="oai-digital-assets-section">
-    <h3 class="text-lg font-bold text-teal-900 dark:text-teal-100 mb-1 flex items-center gap-2">
-        <i class="fas fa-file-image text-teal-600"></i>
-        <?= __("Copie Digitalizzate (MAG/ICCU)") ?>
-    </h3>
+    <button type="button" id="oai-digital-assets-toggle"
+            class="w-full flex items-center justify-between gap-2 text-left"
+            aria-expanded="<?= $oaiHasData ? 'true' : 'false' ?>" aria-controls="oai-digital-assets-body">
+        <span class="text-lg font-bold text-teal-900 dark:text-teal-100 flex items-center gap-2">
+            <i class="fas fa-file-image text-teal-600"></i>
+            <?= __("Copie Digitalizzate (MAG/ICCU)") ?>
+        </span>
+        <i class="fas fa-chevron-down text-teal-600 transition-transform duration-200 <?= $oaiHasData ? 'rotate-180' : '' ?>"
+           id="oai-digital-assets-chevron"></i>
+    </button>
+
+    <div id="oai-digital-assets-body" class="<?= $oaiHasData ? 'mt-4' : 'hidden' ?>">
     <p class="text-sm text-teal-700 dark:text-teal-300 mb-4">
         <i class="fas fa-info-circle mr-1"></i>
         <?= __("Metadati delle copie digitali usati nell'esportazione OAI-PMH formato MAG per ICCU/Internet Culturale.") ?>
@@ -179,6 +192,7 @@ if (!function_exists('oaiFormatBytes')) {
             <p id="oai-add-error" class="text-red-600 dark:text-red-400 text-xs mt-2 hidden"></p>
         </div>
     </div>
+    </div><!-- /#oai-digital-assets-body -->
 </div>
 
 <script>
@@ -210,6 +224,30 @@ if (!function_exists('oaiFormatBytes')) {
 
     function hasSwal() {
         return typeof window !== 'undefined' && typeof window.Swal !== 'undefined' && typeof window.Swal.fire === 'function';
+    }
+
+    // Accordion (#274): toggle the section body; open on demand or when data lands.
+    var acToggle = document.getElementById('oai-digital-assets-toggle');
+    var acBody = document.getElementById('oai-digital-assets-body');
+    var acChevron = document.getElementById('oai-digital-assets-chevron');
+    function openOai() {
+        if (!acBody || !acBody.classList.contains('hidden')) { return; }
+        acBody.classList.remove('hidden');
+        acBody.classList.add('mt-4');
+        if (acToggle) { acToggle.setAttribute('aria-expanded', 'true'); }
+        if (acChevron) { acChevron.classList.add('rotate-180'); }
+    }
+    if (acToggle && acBody) {
+        acToggle.addEventListener('click', function () {
+            if (acBody.classList.contains('hidden')) {
+                openOai();
+            } else {
+                acBody.classList.add('hidden');
+                acBody.classList.remove('mt-4');
+                acToggle.setAttribute('aria-expanded', 'false');
+                if (acChevron) { acChevron.classList.remove('rotate-180'); }
+            }
+        });
     }
 
     document.getElementById('oai-toggle-add-form').addEventListener('click', function () {
@@ -337,6 +375,7 @@ if (!function_exists('oaiFormatBytes')) {
             if (!d.success) { setError(d.error || MSG_ERR); return; }
             appendRow(d.asset);
             clearForm();
+            openOai();
             document.getElementById('oai-add-form').classList.add('hidden');
         })
         .catch(function () { setError(MSG_ERR_NET); })

--- a/storage/plugins/z39-server/views/reicat/book-fields.php
+++ b/storage/plugins/z39-server/views/reicat/book-fields.php
@@ -17,6 +17,11 @@ $soggettiJson = json_encode(array_map(static function (array $s): array {
     return ['termine' => $s['termine'], 'bncf_id' => $s['bncf_id'], 'uri' => $s['uri']];
 }, $reicat['soggetti']), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE);
 $soggettiJson = $soggettiJson !== false ? $soggettiJson : '[]';
+
+// Accordion (#274): collapsed by default so the cataloguing section doesn't
+// crowd the book form. Opens automatically when the book already carries SBN
+// data (editing a catalogued record) or when an SBN import lands (see JS).
+$reicatHasData = $reicat['sbn_bid'] !== '' || !empty($reicat['soggetti']);
 ?>
 
 <div id="reicat-sbn-panel"
@@ -24,10 +29,18 @@ $soggettiJson = $soggettiJson !== false ? $soggettiJson : '[]';
      data-csrf="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>"
      data-book-id="<?php echo (int) $id; ?>">
 
-    <h3 class="text-lg font-bold text-emerald-900 mb-1 flex items-center gap-2">
-        <i class="fas fa-landmark text-emerald-600"></i>
-        <?= __("Catalogazione REICAT / SBN") ?>
-    </h3>
+    <button type="button" id="reicat-sbn-toggle"
+            class="w-full flex items-center justify-between gap-2 text-left"
+            aria-expanded="<?= $reicatHasData ? 'true' : 'false' ?>" aria-controls="reicat-sbn-body">
+        <span class="text-lg font-bold text-emerald-900 flex items-center gap-2">
+            <i class="fas fa-landmark text-emerald-600"></i>
+            <?= __("Catalogazione REICAT / SBN") ?>
+        </span>
+        <i class="fas fa-chevron-down text-emerald-600 transition-transform duration-200 <?= $reicatHasData ? 'rotate-180' : '' ?>"
+           id="reicat-sbn-chevron"></i>
+    </button>
+
+    <div id="reicat-sbn-body" class="<?= $reicatHasData ? 'mt-4' : 'hidden' ?>">
     <p class="text-sm text-emerald-700 mb-4">
         <i class="fas fa-info-circle mr-1"></i>
         <?= __("Importa da SBN (OPAC Nazionale), gestisci l'identificativo BID e i soggetti del Nuovo Soggettario BNCF, esporta in UNIMARC.") ?>
@@ -111,6 +124,7 @@ $soggettiJson = $soggettiJson !== false ? $soggettiJson : '[]';
         </a>
     </div>
     <?php endif; ?>
+    </div><!-- /#reicat-sbn-body -->
 </div>
 
 <script>
@@ -122,6 +136,32 @@ $soggettiJson = $soggettiJson !== false ? $soggettiJson : '[]';
     const csrf = panel.dataset.csrf || '';
     const bookId = panel.dataset.bookId || '0';
     const base = (window.BASE_PATH || '');
+
+    // Accordion (#274): toggle the body; open on demand or when SBN data lands.
+    const acToggle = document.getElementById('reicat-sbn-toggle');
+    const acBody = document.getElementById('reicat-sbn-body');
+    const acChevron = document.getElementById('reicat-sbn-chevron');
+    function openReicat() {
+        if (!acBody) { return; }
+        if (!acBody.classList.contains('hidden')) { return; }
+        acBody.classList.remove('hidden');
+        acBody.classList.add('mt-4');
+        if (acToggle) { acToggle.setAttribute('aria-expanded', 'true'); }
+        if (acChevron) { acChevron.classList.add('rotate-180'); }
+    }
+    if (acToggle && acBody) {
+        acToggle.addEventListener('click', function () {
+            const isHidden = acBody.classList.contains('hidden');
+            if (isHidden) {
+                openReicat();
+            } else {
+                acBody.classList.add('hidden');
+                acBody.classList.remove('mt-4');
+                acToggle.setAttribute('aria-expanded', 'false');
+                if (acChevron) { acChevron.classList.remove('rotate-180'); }
+            }
+        });
+    }
 
     const T = {
         importing: <?= json_encode(__('Importazione in corso…'), JSON_HEX_TAG) ?>,
@@ -283,6 +323,7 @@ $soggettiJson = $soggettiJson !== false ? $soggettiJson : '[]';
             setField('collana', b.series || b.collana);
             if (d.sbn_bid) { setField('sbn_bid', d.sbn_bid); setField('sbn_bid_display', d.sbn_bid); }
             if (d.sbn_polo) { setField('sbn_polo', d.sbn_polo); }
+            openReicat();
             status(T.imported + (b.author ? ' — ' + b.author : ''), 'ok');
         })
         .catch(function () { status(T.error, 'err'); })


### PR DESCRIPTION
Closes #274.

Both plugin-injected sections on the book form — z39-server's **REICAT/SBN cataloguing** panel and oai-pmh-server's **MAG digital-copies** panel — rendered fully expanded, crowding the form for the majority of users who don't catalogue against SBN or manage digitised copies.

Each is now a collapsible accordion:
- **Collapsed by default** on a fresh create (no data).
- **Auto-opens** when the book already carries data — REICAT: `sbn_bid` or subjects; MAG: existing digital assets — so editing a catalogued/digitised record still shows it expanded.
- Header is a clickable toggle (`type="button"`, chevron rotates, `aria-expanded`).
- Opens on demand, and stays open when an SBN import / asset-add lands.

For anyone who wants REICAT/SBN gone entirely rather than just collapsed, the whole section can still be removed by **deactivating the z39-server plugin** (Admin → Plugins) — this PR just makes it unobtrusive while keeping the plugin active.

The collapsed body stays in the DOM, so all fields still submit — I verified a save with the section collapsed persists the book and preserves `sbn_bid`. No new user-facing strings (headers reuse existing `__()` keys).

Verified live on create + edit for both sections: default state, toggle open/close, auto-open on pre-existing data, save with section collapsed; zero console errors. PHPStan level 5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Le sezioni “Copie Digitalizzate (MAG/ICCU)” e “Catalogazione REICAT / SBN” sono ora organizzate in pannelli a fisarmonica.
  * I pannelli si aprono automaticamente quando contengono dati esistenti o appena aggiunti/importati.
  * È possibile espandere e richiudere le sezioni tramite intestazioni interattive e indicatori visivi.

* **Accessibilità**
  * Aggiunti stati ARIA e controlli aggiornati per comunicare correttamente l’apertura e la chiusura dei pannelli.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->