### PR TITLE
Mobile API: public GET /auth/registration-fields for configurable/custom signup fields (#255)

### DIFF
--- a/storage/plugins/mobile-api/MobileApiPlugin.php
+++ b/storage/plugins/mobile-api/MobileApiPlugin.php
@@ -428,6 +428,17 @@ class MobileApiPlugin
                 return (new AuthController($db))->register($request, $response);
             })->add(new RateLimitMiddleware(5, 3600, 'mobile_register'));
 
+            // Public registration discovery — no token. Advertises whether
+            // self-registration is enabled and which fields (config-driven
+            // built-ins + admin-defined custom) the signup form should render.
+            // Light rate-limit to keep it from being scraped in a loop.
+            $group->get('/auth/registration-fields', function (
+                ServerRequestInterface $request,
+                ResponseInterface $response
+            ) use ($db): ResponseInterface {
+                return (new AuthController($db))->registrationFields($request, $response);
+            })->add(new RateLimitMiddleware(30, 300, 'mobile_registration_fields'));
+
             $group->post('/auth/forgot-password', function (
                 ServerRequestInterface $request,
                 ResponseInterface $response

--- a/storage/plugins/mobile-api/plugin.json
+++ b/storage/plugins/mobile-api/plugin.json
@@ -2,7 +2,7 @@
   "name": "mobile-api",
   "display_name": "Mobile API",
   "description": "API REST/JSON versionata (/api/v1) per l'app companion mobile di Pinakes: discovery, autenticazione a token per dispositivo, ricerca catalogo, prestiti/prenotazioni, wishlist, profilo, messaggi e notifiche push. Disattivata per default finché non viene abilitata.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "",

--- a/storage/plugins/mobile-api/src/Controllers/AuthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/AuthController.php
@@ -322,13 +322,23 @@ final class AuthController
      * Public registration discovery (issue #255).
      *
      * Advertises whether self-registration is enabled and which fields the
-     * signup form should render: the config-driven built-ins plus the
-     * admin-defined custom fields. No token — it only reveals field
-     * labels/required flags the registration form shows anyway and leaks no
-     * user data. Gated on the same app-access flag as the other public auth
-     * endpoints; the registration toggle is surfaced as `registration_enabled`
-     * in the payload (not a 403) so the client can distinguish "app disabled"
-     * from "registration closed" and still learn the field shape.
+     * signup form should render: the always-required core fields, the
+     * config-driven built-in toggles, and the admin-defined custom fields.
+     * No token — it only reveals field labels/required flags the registration
+     * form shows anyway and leaks no user data. Gated on the same app-access
+     * flag as the other public auth endpoints; the registration toggle is
+     * surfaced as `registration_enabled` in the payload (not a 403) so the
+     * client can distinguish "app disabled" from "registration closed" and
+     * still learn the field shape.
+     *
+     * Relationship to GET /health: `/health` also carries a lightweight
+     * `registration` summary (require_cognome/telefono/indirizzo + custom_fields)
+     * for a quick liveness/config peek. This endpoint is the CANONICAL,
+     * form-render contract (per-field {required, configurable} shape + the
+     * always-required core fields). Both derive from the same
+     * App\Support\RegistrationFields source, so their values cannot drift — the
+     * two are intentional views, not two sources of truth. A client rendering
+     * the signup form should read THIS endpoint.
      */
     public function registrationFields(Request $request, ResponseInterface $response): ResponseInterface
     {
@@ -337,13 +347,25 @@ final class AuthController
         }
 
         try {
-            // ONLY the three config-driven built-ins (BUILTIN_TOGGLES) belong
-            // here. data_nascita/cod_fiscale/sesso are profile-only fields:
+            // The always-required core fields register() enforces unconditionally
+            // (see register(): empty nome/email/password -> 422). They carry
+            // configurable:false so a client rendering purely from this contract
+            // knows they are mandatory and cannot be toggled off — closing the
+            // gap where a contract-driven form could omit `nome` (which is not
+            // one of the configurable toggles below). `password_confirm` is a
+            // client-side echo of `password`, not advertised as its own field.
+            $builtin = [
+                'nome'     => ['required' => true, 'configurable' => false],
+                'email'    => ['required' => true, 'configurable' => false],
+                'password' => ['required' => true, 'configurable' => false],
+            ];
+
+            // The three config-driven built-in toggles (BUILTIN_TOGGLES).
+            // data_nascita/cod_fiscale/sesso are profile-only fields:
             // register() never reads them and isRequired() returns a hardcoded
             // true for them (they are absent from BUILTIN_TOGGLES), so they must
             // NOT leak into the signup contract — they are always optional at
             // registration and editable only through GET/PATCH /me.
-            $builtin = [];
             foreach (array_keys(RegistrationFields::BUILTIN_TOGGLES) as $field) {
                 $builtin[$field] = [
                     'required'     => RegistrationFields::isRequired($field),

--- a/storage/plugins/mobile-api/src/Controllers/AuthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/AuthController.php
@@ -316,6 +316,57 @@ final class AuthController
         }
     }
 
+    // ─── GET /auth/registration-fields ──────────────────────────────────────
+
+    /**
+     * Public registration discovery (issue #255).
+     *
+     * Advertises whether self-registration is enabled and which fields the
+     * signup form should render: the config-driven built-ins plus the
+     * admin-defined custom fields. No token — it only reveals field
+     * labels/required flags the registration form shows anyway and leaks no
+     * user data. Gated on the same app-access flag as the other public auth
+     * endpoints; the registration toggle is surfaced as `registration_enabled`
+     * in the payload (not a 403) so the client can distinguish "app disabled"
+     * from "registration closed" and still learn the field shape.
+     */
+    public function registrationFields(Request $request, ResponseInterface $response): ResponseInterface
+    {
+        if (!$this->appAccessEnabled()) {
+            return ResponseEnvelope::error($response, 'app_access_disabled', __('L\'accesso da app non è abilitato su questa istanza.'), 403);
+        }
+
+        try {
+            // ONLY the three config-driven built-ins (BUILTIN_TOGGLES) belong
+            // here. data_nascita/cod_fiscale/sesso are profile-only fields:
+            // register() never reads them and isRequired() returns a hardcoded
+            // true for them (they are absent from BUILTIN_TOGGLES), so they must
+            // NOT leak into the signup contract — they are always optional at
+            // registration and editable only through GET/PATCH /me.
+            $builtin = [];
+            foreach (array_keys(RegistrationFields::BUILTIN_TOGGLES) as $field) {
+                $builtin[$field] = [
+                    'required'     => RegistrationFields::isRequired($field),
+                    'configurable' => true,
+                ];
+            }
+
+            $data = [
+                'registration_enabled' => $this->registrationEnabled(),
+                'builtin_fields'       => $builtin,
+                // apiDefinitions() already returns the public-safe
+                // {id,label,type,required} shape (active only, ordered by
+                // ordine/id), hiding attivo/ordine. Do not re-query.
+                'custom_fields'        => RegistrationFields::apiDefinitions($this->db),
+            ];
+
+            return ResponseEnvelope::success($response, $data, [], 200);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[MobileApi] registration-fields failed: ' . $e->getMessage());
+            return ResponseEnvelope::error($response, 'internal_error', __('Errore del server.'), 500);
+        }
+    }
+
     // ─── POST /auth/forgot-password ─────────────────────────────────────────
 
     public function forgotPassword(Request $request, ResponseInterface $response): ResponseInterface

--- a/storage/plugins/mobile-api/src/Controllers/HealthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/HealthController.php
@@ -90,6 +90,12 @@ final class HealthController
                 'catalogue_mode'       => $catalogueMode,
                 'app_access_enabled'   => $appAccessEnabled,
                 'registration_enabled' => $registrationEnabled,
+                // Lightweight registration summary (a convenience mirror). The
+                // CANONICAL signup form-render contract is GET
+                // /auth/registration-fields — both derive from the same
+                // App\Support\RegistrationFields source so their values cannot
+                // drift; a client rendering the signup form should read the
+                // dedicated endpoint (richer per-field shape + core fields).
                 'registration'         => [
                     'require_cognome'   => RegistrationFields::isRequired('cognome'),
                     'require_telefono'  => RegistrationFields::isRequired('telefono'),

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -1039,13 +1039,16 @@ final class OpenApiController
 
         return [
             'type'        => 'object',
-            'description' => 'Registration discovery payload. builtin_fields carries ONLY the three config-driven built-ins (cognome / telefono / indirizzo); the profile-only fields (data_nascita / cod_fiscale / sesso) are always optional at signup and are not advertised here.',
+            'description' => 'Canonical signup form-render contract. builtin_fields carries the always-required core fields (nome / email / password, configurable=false) plus the three config-driven toggles (cognome / telefono / indirizzo, configurable=true). Profile-only fields (data_nascita / cod_fiscale / sesso) are always optional at signup and are not advertised here. GET /health carries a lightweight mirror of the same RegistrationFields source; the two cannot drift.',
             'required'    => ['registration_enabled', 'builtin_fields', 'custom_fields'],
             'properties'  => [
                 'registration_enabled' => ['type' => 'boolean'],
                 'builtin_fields'       => [
                     'type'       => 'object',
                     'properties' => [
+                        'nome'      => $builtinRule,
+                        'email'     => $builtinRule,
+                        'password'  => $builtinRule,
                         'cognome'   => $builtinRule,
                         'telefono'  => $builtinRule,
                         'indirizzo' => $builtinRule,

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -126,6 +126,7 @@ final class OpenApiController
                     'LoginResponse'     => $this->loginResponseSchema(),
                     'RegisterRequest'   => $this->registerRequestSchema(),
                     'RegistrationConfig'=> $this->registrationConfigSchema(),
+                    'RegistrationFieldsPayload' => $this->registrationFieldsPayloadSchema(),
                     'CustomFieldDefinition' => $this->customFieldDefinitionSchema(),
                     'CustomProfileField'=> $this->customProfileFieldSchema(),
                     'ForgotRequest'     => $this->forgotRequestSchema(),
@@ -288,6 +289,27 @@ final class OpenApiController
                         '400' => ['$ref' => '#/components/responses/UnprocessableEntity'],
                         '403' => ['$ref' => '#/components/responses/Forbidden'],
                         '409' => ['description' => 'Email already registered.', 'content' => $json],
+                        '429' => ['$ref' => '#/components/responses/TooManyRequests'],
+                        '500' => ['$ref' => '#/components/responses/InternalError'],
+                    ],
+                ],
+            ],
+
+            '/auth/registration-fields' => [
+                'get' => [
+                    'tags'        => ['auth'],
+                    'summary'     => 'Registration field discovery',
+                    'description' => 'Public, no token. Advertises whether self-registration is enabled (registration_enabled) plus the fields the signup form should render: the config-driven built-ins (cognome / telefono / indirizzo, each with required + configurable flags) and the admin-defined custom_fields ({id, label, type, required}). The native app calls this before showing the registration form so it can render the right inputs and required markers. Gated on app access (403 app_access_disabled) like the other public auth endpoints.',
+                    'operationId' => 'getAuthRegistrationFields',
+                    'responses'   => [
+                        '200' => [
+                            'description' => 'Registration discovery payload.',
+                            'content'     => ['application/json' => ['schema' => [
+                                'allOf'      => [['$ref' => '#/components/schemas/Envelope']],
+                                'properties' => ['data' => ['$ref' => '#/components/schemas/RegistrationFieldsPayload']],
+                            ]]],
+                        ],
+                        '403' => ['$ref' => '#/components/responses/Forbidden'],
                         '429' => ['$ref' => '#/components/responses/TooManyRequests'],
                         '500' => ['$ref' => '#/components/responses/InternalError'],
                     ],
@@ -996,6 +1018,40 @@ final class OpenApiController
                 'require_telefono'  => ['type' => 'boolean'],
                 'require_indirizzo' => ['type' => 'boolean'],
                 'custom_fields'     => [
+                    'type'  => 'array',
+                    'items' => ['$ref' => '#/components/schemas/CustomFieldDefinition'],
+                ],
+            ],
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function registrationFieldsPayloadSchema(): array
+    {
+        $builtinRule = [
+            'type'       => 'object',
+            'required'   => ['required', 'configurable'],
+            'properties' => [
+                'required'     => ['type' => 'boolean', 'description' => 'Whether this built-in field is required at signup (admin-configurable).'],
+                'configurable' => ['type' => 'boolean', 'description' => 'Always true — these built-ins can be toggled required/optional by the admin.'],
+            ],
+        ];
+
+        return [
+            'type'        => 'object',
+            'description' => 'Registration discovery payload. builtin_fields carries ONLY the three config-driven built-ins (cognome / telefono / indirizzo); the profile-only fields (data_nascita / cod_fiscale / sesso) are always optional at signup and are not advertised here.',
+            'required'    => ['registration_enabled', 'builtin_fields', 'custom_fields'],
+            'properties'  => [
+                'registration_enabled' => ['type' => 'boolean'],
+                'builtin_fields'       => [
+                    'type'       => 'object',
+                    'properties' => [
+                        'cognome'   => $builtinRule,
+                        'telefono'  => $builtinRule,
+                        'indirizzo' => $builtinRule,
+                    ],
+                ],
+                'custom_fields'        => [
                     'type'  => 'array',
                     'items' => ['$ref' => '#/components/schemas/CustomFieldDefinition'],
                 ],

--- a/tests/mobile-api-idempotency.spec.js
+++ b/tests/mobile-api-idempotency.spec.js
@@ -144,6 +144,7 @@ const ENDPOINTS = [
     { name: 'POST /auth/register',               method: 'POST',   path: '/auth/register',                auth: false, kind: 'conflict2',
         body: () => ({ email: USER_EMAIL, password: USER_PASS, password_confirm: USER_PASS, nome: 'Idem', cognome: 'Test', telefono: '0', indirizzo: 'x', privacy_acceptance: '1' }),
         firstAny: true /* registration may be disabled → 1st is 4xx; still asserts 2nd >= 400 */ },
+    { name: 'GET /auth/registration-fields',     method: 'GET',    path: '/auth/registration-fields',     auth: false, kind: 'doc' },
     { name: 'POST /auth/logout',                 method: 'POST',   path: '/auth/logout',                  auth: 'throwaway', kind: 'revoked2' },
     { name: 'GET /me',                           method: 'GET',    path: '/me',                           auth: true,  kind: 'safeGet' },
     { name: 'PATCH /me',                         method: 'PATCH',  path: '/me',                           auth: true,  kind: 'write2xx',

--- a/tests/mobile-api.spec.js
+++ b/tests/mobile-api.spec.js
@@ -483,6 +483,66 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
         expect(d.features.push).toBe(true);                     // push available once keyed
     });
 
+    // ── GET /auth/registration-fields — the canonical signup form contract (#255,
+    //    hardened per the #277 review: core fields + no profile-field leak) ──────
+    test('9d. /auth/registration-fields → 200 envelope with the three top-level keys', async ({ request }) => {
+        const res  = await apiGet(request, '/auth/registration-fields');
+        const body = await envelope(res, 200);
+        expect(body.error).toBeNull();
+        const d = body.data;
+        expect(d).toHaveProperty('registration_enabled');
+        expect(d).toHaveProperty('builtin_fields');
+        expect(d).toHaveProperty('custom_fields');
+    });
+
+    test('9e. builtin_fields advertises the always-required core fields (nome/email/password, configurable=false)', async ({ request }) => {
+        // #277 review fix: a client rendering purely from the contract must know
+        // nome/email/password are mandatory-and-fixed, not just the toggles.
+        const res  = await apiGet(request, '/auth/registration-fields');
+        const d    = (await res.json()).data;
+        for (const key of ['nome', 'email', 'password']) {
+            expect(d.builtin_fields[key]).toMatchObject({ required: true, configurable: false });
+        }
+    });
+
+    test('9f. builtin_fields carries the three config-driven toggles with configurable=true reflecting settings', async ({ request }) => {
+        // beforeAll set require_cognome/telefono/indirizzo = '0' → required:false here.
+        const res  = await apiGet(request, '/auth/registration-fields');
+        const d    = (await res.json()).data;
+        for (const key of ['cognome', 'telefono', 'indirizzo']) {
+            expect(d.builtin_fields[key]).toMatchObject({ required: false, configurable: true });
+        }
+    });
+
+    test('9g. builtin_fields does NOT leak profile-only fields into the signup contract', async ({ request }) => {
+        // data_nascita/cod_fiscale/sesso are profile-only (editable via /me), never
+        // part of registration — they must not appear in builtin_fields.
+        const res  = await apiGet(request, '/auth/registration-fields');
+        const d    = (await res.json()).data;
+        for (const key of ['data_nascita', 'cod_fiscale', 'sesso']) {
+            expect(d.builtin_fields).not.toHaveProperty(key);
+        }
+    });
+
+    test('9h. custom_fields are the public-safe {id,label,type,required} shape (active only, no italian/internal keys)', async ({ request }) => {
+        const res  = await apiGet(request, '/auth/registration-fields');
+        const d    = (await res.json()).data;
+        expect(Array.isArray(d.custom_fields)).toBe(true);
+        const seeded = d.custom_fields.find((f) => f.id === customFieldId);
+        expect(seeded).toBeTruthy();
+        expect(Object.keys(seeded).sort()).toEqual(['id', 'label', 'required', 'type']);
+        // Internal columns must never leak to a public client.
+        expect(seeded).not.toHaveProperty('attivo');
+        expect(seeded).not.toHaveProperty('ordine');
+        expect(seeded).not.toHaveProperty('etichetta');
+    });
+
+    test('9i. registration-fields is public (no token) and gated only on app-access', async ({ request }) => {
+        // No Authorization header — must still return 200 (public discovery).
+        const res = await apiGet(request, '/auth/registration-fields');
+        expect(res.status()).toBe(200);
+    });
+
     test('9c. POST /auth/register follows optional built-ins and stores custom fields', async ({ request }) => {
         dbExec(`DELETE FROM utenti WHERE email='${REGISTRATION_EMAIL}'`);
         const res = await apiPost(request, '/auth/register', {


### PR DESCRIPTION
Adds the missing **discovery endpoint** so the Android app (and any client) can render the registration form for #255's configurable + custom fields.

### Why
`POST /auth/register` already validates custom fields and `GET /me` returns them for logged-in users, but there was **no public endpoint** exposing the field schema *before* signup — so a client couldn't know which built-in fields are required on this instance or which admin-defined custom fields to show.

### Endpoint
`GET /api/v1/auth/registration-fields` — public (no token), gated on the same app-access flag as the other auth endpoints. Returns:
- `registration_enabled` — lets the client distinguish "app disabled" from "signup closed"
- `builtin_fields` — the three config-driven toggles (`cognome`/`telefono`/`indirizzo`), each `{ required: isRequired(key), configurable: true }`
- `custom_fields` — `RegistrationFields::apiDefinitions()`: active fields only, `{ id, label, type, required }`, ordered, leaking no `attivo`/`ordine`

`data_nascita`/`cod_fiscale`/`sesso` are intentionally **not** in the signup contract (register() never reads them; profile-only, via `GET`/`PATCH /me`).

### Implementation
Reuses existing `RegistrationFields::{BUILTIN_TOGGLES, isRequired, apiDefinitions}` — no new controller file. OpenAPI spec + `mobile-api-idempotency` manifest test updated; mobile-api plugin `1.3.0 → 1.4.0`.

### Verified (live, on the dev install)
- `GET` returns **200** with the correct `{data, meta, error}` envelope.
- `builtin_fields` reflects the real `isRequired()` config.
- `custom_fields` reflects `apiDefinitions()` dynamically — seeded a field → it appeared, deleted it → gone.
- `php -l` + **PHPStan level 5** clean; route ↔ OpenAPI ↔ manifest consistent.

The matching **Android client** work (models, `PinakesApi`, dynamic register/profile fields) is in a separate PR on the `Pinakes-Android` repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto un endpoint pubblico per scoprire i campi disponibili durante la registrazione.
  * Ora sono indicati campi integrati, campi personalizzati, obbligatorietà e stato della registrazione.
  * L’endpoint è documentato nell’API ed è soggetto a limitazione delle richieste.

* **Correzioni**
  * Gestiti gli errori di accesso, le richieste eccessive e gli errori interni con risposte appropriate.

* **Manutenzione**
  * Aggiornata la versione del componente Mobile API alla 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->