### PR TITLE
Fix admin book genre hierarchy display

### DIFF
--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -223,20 +223,25 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
             <span class="font-medium"><?= __("Genere:") ?></span>
             <?php
               $genreParts = [];
-              if (!empty($libro['radice_id'])) {
-                  $genreParts[] = [(int)$libro['radice_id'], (string)$libro['radice_nome']];
-              }
-              if (!empty($libro['genere_id'])) {
-                  $genName = (string)$libro['genere_nome'];
-                  if (strpos($genName, ' - ') !== false) {
-                      $parts = explode(' - ', $genName);
-                      $genName = end($parts);
+              $addGenrePart = static function (int $id, ?string $name) use (&$genreParts): void {
+                  $name = trim((string)$name);
+                  if ($id <= 0 || $name === '') {
+                      return;
                   }
-                  $genreParts[] = [(int)$libro['genere_id'], $genName];
-              }
-              if (!empty($libro['sottogenere_id'])) {
-                  $genreParts[] = [(int)$libro['sottogenere_id'], (string)$libro['sottogenere_nome']];
-              }
+                  if (strpos($name, ' - ') !== false) {
+                      $parts = explode(' - ', $name);
+                      $name = trim((string)end($parts));
+                  }
+                  foreach ($genreParts as $part) {
+                      if ((int)$part[0] === $id) {
+                          return;
+                      }
+                  }
+                  $genreParts[] = [$id, $name];
+              };
+              $addGenrePart((int)($libro['radice_id'] ?? 0), $libro['radice_nome'] ?? null);
+              $addGenrePart((int)($libro['genere_id_cascade'] ?? $libro['genere_id'] ?? 0), $libro['genere_nome'] ?? null);
+              $addGenrePart((int)($libro['sottogenere_id_cascade'] ?? $libro['sottogenere_id'] ?? 0), $libro['sottogenere_nome'] ?? null);
             ?>
             <?php if (!empty($genreParts)): ?>
               <?php foreach ($genreParts as $i => $gp): ?>

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -2918,8 +2918,12 @@ test.describe.serial('Phase 18: Issue Regressions', () => {
     // 1) Admin book detail page
     await page.goto(`${BASE}/admin/books/${bookId}`);
     await page.waitForLoadState('domcontentloaded');
-    const genreText = await page.locator('[data-testid="genre-display"]').textContent();
+    const genreDisplay = page.locator('[data-testid="genre-display"]');
+    const genreText = await genreDisplay.textContent();
     expect(genreText).toContain(childName);
+    await expect(genreDisplay.locator('a')).toHaveCount(2);
+    await expect(genreDisplay.locator('a').nth(0)).toHaveAttribute('href', new RegExp(`/admin/books\\?genere=${rootId}$`));
+    await expect(genreDisplay.locator('a').nth(1)).toHaveAttribute('href', new RegExp(`/admin/books\\?genere=${childId}$`));
 
     // 2) Frontend (public) book detail page — uses different query path
     await page.goto(`${BASE}/libro/${bookId}`);


### PR DESCRIPTION
The admin book detail page could render a root + direct-child genre as 
`Genre: [Comic Book](id:182) → [Manga](id:182) → [](id:183)` instead of 
`Genre: [Comic Book](id:182) → [Manga](id:183)`.

<img width="1880" height="596" alt="image" src="https://github.com/user-attachments/assets/a3d22b02-fad9-42f2-b379-dc9068e79eea" />

- **Genre breadcrumb rendering**
  - Uses resolved cascade IDs (`genere_id_cascade`, `sottogenere_id_cascade`) when available. (#286, btw)
  - Skips empty genre labels.
  - Deduplicates repeated genre IDs before rendering links.

- **Regression coverage**
  - Extends the existing root + child genre scenario to assert exactly two admin genre links with the expected IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * La sezione “Genere” nelle schede libro ora mostra informazioni più coerenti, normalizzate e senza duplicati.
  * I collegamenti a radice e sottogenere vengono visualizzati correttamente, anche quando sono presenti dati incompleti o non validi.

* **Test**
  * Aggiunte verifiche sulla presenza e correttezza dei collegamenti ai filtri di genere nella scheda libro.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->