### PR TITLE
Home 'Disponibili' real count + responsive related-books

### DIFF
--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -581,12 +581,28 @@ class FrontendController
         // Get hierarchical genre display for correct sidebar rendering
         $genre_display = $this->getDisplayGenres($filter_options['generi'], (int)($filters['genere_id'] ?? 0));
 
+        // Available-books count (same filter set, restricted to loanable copies)
+        // so the home hero "Disponibili" stat can show a real number instead of
+        // a placeholder emoji. Reuses the same bound params as the total count.
+        $available_books = 0;
+        $available_stmt = $db->prepare("SELECT COUNT(DISTINCT l.id) as total " . $base_query . " AND l.copie_disponibili > 0");
+        if ($available_stmt !== false) {
+            if (!empty($query_params)) {
+                $available_stmt->bind_param($param_types, ...$query_params);
+            }
+            $available_stmt->execute();
+            $available_row = $available_stmt->get_result()->fetch_assoc();
+            $available_books = (int) ($available_row['total'] ?? 0);
+            $available_stmt->close();
+        }
+
         $data = [
             'html' => $html,
             'pagination' => [
                 'current_page' => $page,
                 'total_pages' => $total_pages,
                 'total_books' => $total_books,
+                'available_books' => $available_books,
                 'start' => $offset + 1,
                 'end' => min($offset + $limit, $total_books)
             ],
@@ -1967,7 +1983,10 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
     private function getRelatedBooks(mysqli $db, int $book_id, array $book, array $authors, array $seriesBooks = []): array
     {
         $related_books = [];
-        $limit = 3;
+        // Fetch a superset so the book page can show as many related books as
+        // fit the viewport width (the grid shows one row and hides the overflow
+        // on narrower screens) instead of a fixed 3. #279-adjacent UX request.
+        $limit = 6;
         $allCreatorsSelect = "
             (SELECT GROUP_CONCAT(DISTINCT " . \App\Support\AuthorName::displaySql('a_all') . "
                      ORDER BY (la_all.ruolo = 'principale') DESC,

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -584,15 +584,28 @@ class FrontendController
         // Available-books count (same filter set, restricted to loanable copies)
         // so the home hero "Disponibili" stat can show a real number instead of
         // a placeholder emoji. Reuses the same bound params as the total count.
-        $available_books = 0;
+        // On any query failure it stays null (never a misleading 0): the field
+        // is emitted as null and the home JS falls back to total_books, while
+        // the failure is logged instead of silently masked.
+        $available_books = null;
         $available_stmt = $db->prepare("SELECT COUNT(DISTINCT l.id) as total " . $base_query . " AND l.copie_disponibili > 0");
-        if ($available_stmt !== false) {
+        if ($available_stmt === false) {
+            \App\Support\SecureLogger::error('Available-books count prepare failed', ['db_error' => $db->error]);
+        } else {
             if (!empty($query_params)) {
                 $available_stmt->bind_param($param_types, ...$query_params);
             }
-            $available_stmt->execute();
-            $available_row = $available_stmt->get_result()->fetch_assoc();
-            $available_books = (int) ($available_row['total'] ?? 0);
+            if (!$available_stmt->execute()) {
+                \App\Support\SecureLogger::error('Available-books count execute failed', ['db_error' => $available_stmt->error]);
+            } else {
+                $available_result = $available_stmt->get_result();
+                if ($available_result === false) {
+                    \App\Support\SecureLogger::error('Available-books count get_result failed', ['db_error' => $available_stmt->error]);
+                } else {
+                    $available_row = $available_result->fetch_assoc();
+                    $available_books = (int) ($available_row['total'] ?? 0);
+                }
+            }
             $available_stmt->close();
         }
 

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -584,29 +584,41 @@ class FrontendController
         // Available-books count (same filter set, restricted to loanable copies)
         // so the home hero "Disponibili" stat can show a real number instead of
         // a placeholder emoji. Reuses the same bound params as the total count.
-        // On any query failure it stays null (never a misleading 0): the field
-        // is emitted as null and the home JS falls back to total_books, while
+        //
+        // FIX F001: this adds a sixth aggregate scan (5 LEFT JOINs) on top of the
+        // total-count and books queries, yet ONLY the home hero consumes it (a
+        // single loadStats() fetch). The live catalog search/filter path — which
+        // hits this endpoint on every keystroke — used to pay for it and throw
+        // the value away. Gate it behind an explicit `with_stats=1` flag so the
+        // aggregate runs only when the caller actually needs the number.
+        //
+        // When the flag is absent the field stays null; home.php's JS falls back
+        // to total_books, but only the search path (which never requests stats)
+        // ever sees that fallback. When the flag IS passed the value is the real
+        // count, or null only on a genuine DB failure (never a misleading 0):
         // the failure is logged instead of silently masked.
         $available_books = null;
-        $available_stmt = $db->prepare("SELECT COUNT(DISTINCT l.id) as total " . $base_query . " AND l.copie_disponibili > 0");
-        if ($available_stmt === false) {
-            \App\Support\SecureLogger::error('Available-books count prepare failed', ['db_error' => $db->error]);
-        } else {
-            if (!empty($query_params)) {
-                $available_stmt->bind_param($param_types, ...$query_params);
-            }
-            if (!$available_stmt->execute()) {
-                \App\Support\SecureLogger::error('Available-books count execute failed', ['db_error' => $available_stmt->error]);
+        if (($params['with_stats'] ?? '') === '1') {
+            $available_stmt = $db->prepare("SELECT COUNT(DISTINCT l.id) as total " . $base_query . " AND l.copie_disponibili > 0");
+            if ($available_stmt === false) {
+                \App\Support\SecureLogger::error('Available-books count prepare failed', ['db_error' => $db->error]);
             } else {
-                $available_result = $available_stmt->get_result();
-                if ($available_result === false) {
-                    \App\Support\SecureLogger::error('Available-books count get_result failed', ['db_error' => $available_stmt->error]);
-                } else {
-                    $available_row = $available_result->fetch_assoc();
-                    $available_books = (int) ($available_row['total'] ?? 0);
+                if (!empty($query_params)) {
+                    $available_stmt->bind_param($param_types, ...$query_params);
                 }
+                if (!$available_stmt->execute()) {
+                    \App\Support\SecureLogger::error('Available-books count execute failed', ['db_error' => $available_stmt->error]);
+                } else {
+                    $available_result = $available_stmt->get_result();
+                    if ($available_result === false) {
+                        \App\Support\SecureLogger::error('Available-books count get_result failed', ['db_error' => $available_stmt->error]);
+                    } else {
+                        $available_row = $available_result->fetch_assoc();
+                        $available_books = (int) ($available_row['total'] ?? 0);
+                    }
+                }
+                $available_stmt->close();
             }
-            $available_stmt->close();
         }
 
         $data = [

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1478,9 +1478,30 @@ $additional_css = "
        plain wrapper div (not the Bootstrap .row) so it doesn't fight .row's
        negative gutter margins — no !important needed. */
     .related-books-wrap {
-        max-width: 960px;
+        /* Widened from the old ~3-card (960px) cap so wide screens can show up
+           to 6 related books in one row; the grid below decides how many
+           actually fit at any given width. */
+        max-width: 1320px;
         margin-left: auto;
         margin-right: auto;
+    }
+
+    /* Responsive related-books grid: one row of as many cards as fit the
+       viewport (≈6 desktop, 4 laptop, 3 tablet, 2 phone), overflow hidden — so
+       the COUNT shown adapts to screen size instead of being a fixed 3.
+       grid-auto-rows:0 + overflow:hidden collapse every row after the first. */
+    .related-books-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+        gap: 1.5rem;
+        justify-content: center;
+        grid-template-rows: auto;
+        grid-auto-rows: 0;
+        overflow: hidden;
+    }
+
+    .related-book-cell {
+        min-width: 0;
     }
 
     .related-book-card {
@@ -2346,9 +2367,9 @@ ob_start();
             <?= __("Potrebbero interessarti") ?>
         </h2>
         <div class="related-books-wrap">
-        <div class="row g-4 justify-content-center">
+        <div class="related-books-grid">
             <?php foreach($related_books as $related): ?>
-            <div class="col-12 col-sm-6 col-lg-4">
+            <div class="related-book-cell">
                 <div class="related-book-card">
                     <div class="related-book-image-container">
                         <?php
@@ -2409,7 +2430,7 @@ ob_start();
                 </div>
             </div>
             <?php endforeach; ?>
-        </div><!-- /.row -->
+        </div><!-- /.related-books-grid -->
         </div><!-- /.related-books-wrap -->
     </div>
 </section>

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1493,7 +1493,11 @@ $additional_css = "
     .related-books-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
-        gap: 1.5rem;
+        /* row-gap:0 so the zero-height clipped rows don't add trailing
+           whitespace below the single visible row (F002). Horizontal spacing
+           between cards in the visible row is preserved via column-gap. */
+        column-gap: 1.5rem;
+        row-gap: 0;
         justify-content: center;
         grid-template-rows: auto;
         grid-auto-rows: 0;
@@ -1502,6 +1506,37 @@ $additional_css = "
 
     .related-book-cell {
         min-width: 0;
+    }
+
+    /* Narrow phones (~360-390px): the grid collapses to a single visible column
+       so only one related book shows. Switch to a horizontal snap-scroll strip
+       instead, so all related books are reachable by swiping. The 80% flex-basis
+       leaves a ~20% peek of the next card as the scroll affordance (F003). */
+    @media (max-width: 480px) {
+        .related-books-grid {
+            display: flex;
+            flex-wrap: nowrap;
+            overflow-x: auto;
+            overflow-y: hidden;
+            scroll-snap-type: x mandatory;
+            -webkit-overflow-scrolling: touch;
+            /* neutralize the desktop grid props so they don't interfere */
+            grid-template-columns: none;
+            grid-template-rows: none;
+            grid-auto-rows: auto;
+            column-gap: 1rem;
+            row-gap: 0;
+            /* hide the scrollbar aesthetically while keeping scrollability */
+            scrollbar-width: none;
+            -ms-overflow-style: none;
+        }
+        .related-books-grid::-webkit-scrollbar {
+            display: none;
+        }
+        .related-book-cell {
+            flex: 0 0 80%;
+            scroll-snap-align: start;
+        }
     }
 
     .related-book-card {
@@ -2431,6 +2466,19 @@ ob_start();
             </div>
             <?php endforeach; ?>
         </div><!-- /.related-books-grid -->
+        <noscript>
+            <style>
+                /* With JS off the inert script can't clip cards, so show them all
+                   stacked — matching what assistive tech can reach. row-gap is
+                   restored here because the base rule sets it to 0 for the
+                   JS-driven single-row layout (F005). */
+                .related-books-grid {
+                    overflow: visible !important;
+                    grid-auto-rows: auto !important;
+                    row-gap: 1.5rem !important;
+                }
+            </style>
+        </noscript>
         </div><!-- /.related-books-wrap -->
     </div>
 </section>
@@ -2447,6 +2495,22 @@ ob_start();
   var cells = Array.prototype.slice.call(grid.querySelectorAll('.related-book-cell'));
   if (!cells.length) { return; }
   function sync() {
+    // Phone scroll mode (F003): the @media(max-width:480px) rule turns the grid
+    // into a horizontal snap-scroll strip (overflow-x:auto), where every card is
+    // reachable by swiping — nothing is clipped. Clear any inert/aria-hidden/
+    // tabindex the desktop path may have set and bail out. The desktop clip mode
+    // uses overflow:hidden (overflow-x:hidden), so overflowX==='auto' unambiguously
+    // means scroll mode.
+    if (window.getComputedStyle(grid).overflowX === 'auto') {
+      cells.forEach(function (c) {
+        c.removeAttribute('inert');
+        c.removeAttribute('aria-hidden');
+        Array.prototype.forEach.call(c.querySelectorAll('a'), function (a) {
+          a.removeAttribute('tabindex');
+        });
+      });
+      return;
+    }
     var firstTop = Math.min.apply(null, cells.map(function (c) { return c.offsetTop; }));
     cells.forEach(function (c) {
       var clipped = c.offsetTop > firstTop + 1;

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -2434,6 +2434,44 @@ ob_start();
         </div><!-- /.related-books-wrap -->
     </div>
 </section>
+<script>
+// Accessibility: the grid clips every row after the first with overflow:hidden
+// + grid-auto-rows:0, but clipped cards stay in the DOM. Take them out of the
+// tab order and the accessibility tree so keyboard/screen-reader users can't
+// reach cards they cannot see. A clipped cell sits below the first row, so its
+// offsetTop is greater than the first row's. Recomputed on resize. `inert` does
+// not change layout, so reading offsetTop stays accurate without oscillation.
+(function () {
+  var grid = document.querySelector('.related-books-grid');
+  if (!grid) { return; }
+  var cells = Array.prototype.slice.call(grid.querySelectorAll('.related-book-cell'));
+  if (!cells.length) { return; }
+  function sync() {
+    var firstTop = Math.min.apply(null, cells.map(function (c) { return c.offsetTop; }));
+    cells.forEach(function (c) {
+      var clipped = c.offsetTop > firstTop + 1;
+      if (clipped) {
+        c.setAttribute('inert', '');
+        c.setAttribute('aria-hidden', 'true');
+      } else {
+        c.removeAttribute('inert');
+        c.removeAttribute('aria-hidden');
+      }
+      // Fallback for browsers without `inert`: keep the links off the tab order.
+      Array.prototype.forEach.call(c.querySelectorAll('a'), function (a) {
+        if (clipped) { a.setAttribute('tabindex', '-1'); }
+        else { a.removeAttribute('tabindex'); }
+      });
+    });
+  }
+  sync();
+  var t;
+  window.addEventListener('resize', function () {
+    clearTimeout(t);
+    t = setTimeout(sync, 150);
+  });
+})();
+</script>
 <?php endif; ?>
 
 <?php

--- a/app/Views/frontend/home.php
+++ b/app/Views/frontend/home.php
@@ -911,7 +911,12 @@ function loadStats() {
     // Only load stats if elements exist
     if (!totalBooksEl || !availableBooksEl) return;
 
-    fetch(API_CATALOG_ROUTE)
+    // Ask the catalog API for the available-books aggregate. The endpoint only
+    // computes that extra COUNT when with_stats=1 is present, so the live
+    // search/filter path (which omits the flag) never pays for it.
+    const statsUrl = API_CATALOG_ROUTE + (API_CATALOG_ROUTE.indexOf('?') === -1 ? '?' : '&') + 'with_stats=1';
+
+    fetch(statsUrl)
         .then(response => response.json())
         .then(data => {
             totalBooksEl.textContent = data.pagination.total_books;

--- a/app/Views/frontend/home.php
+++ b/app/Views/frontend/home.php
@@ -915,12 +915,14 @@ function loadStats() {
         .then(response => response.json())
         .then(data => {
             totalBooksEl.textContent = data.pagination.total_books;
-            availableBooksEl.textContent = '\uD83D\uDCDA';
+            // Real available-books count from the API (falls back to the total
+            // if the field is missing on an older backend).
+            availableBooksEl.textContent = (data.pagination.available_books ?? data.pagination.total_books);
         })
         .catch(error => {
             console.error('Error loading stats:', error);
-            totalBooksEl.textContent = '\uD83D\uDCDA';
-            availableBooksEl.textContent = '\u2713';
+            totalBooksEl.textContent = '\u2014';
+            availableBooksEl.textContent = '\u2014';
         });
 }
 

--- a/tests/home-available-count-288.unit.php
+++ b/tests/home-available-count-288.unit.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression for the home "Disponibili" stat (finding F001, PR #288).
+ *
+ * FrontendController::catalogAPI() runs an extra available-books aggregate
+ * (COUNT over 5 LEFT JOINs restricted to loanable copies). Only the home hero
+ * consumes it, so the aggregate is now gated behind an explicit `with_stats=1`
+ * flag and home.php appends that flag to its loadStats() fetch.
+ *
+ * This test proves the contract the `?? total_books` fallback in home.php could
+ * otherwise silently mask (a mistyped flag name would make available_books
+ * always null yet the page would still render total_books):
+ *   1. WITH with_stats=1  -> pagination.available_books is an integer <= total
+ *   2. WITHOUT the flag   -> pagination.available_books is null
+ *   3. seeded set of one loanable + one zero-copy book under a unique publisher
+ *      yields total=2, available=1 (coherent: available < total).
+ *
+ * Runs transactionally and rolls back, so no data survives (soft-delete safe:
+ * nothing is ever committed).
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Controllers\FrontendController;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+    } else {
+        $failed++;
+        echo "  FAIL {$label}\n";
+    }
+};
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string)@file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $value = trim($value);
+    if (strlen($value) >= 2 && ($value[0] === '"' || $value[0] === "'") && $value[-1] === $value[0]) {
+        $value = substr($value, 1, -1);
+    }
+    $env[trim($key)] = $value;
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+try {
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', (int)($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+
+$controller = new FrontendController();
+$requestFactory = new ServerRequestFactory();
+
+/** Invoke catalogAPI with the given query params and return the decoded JSON. */
+$callCatalog = static function (array $params) use ($controller, $requestFactory, $db): array {
+    $request = $requestFactory->createServerRequest('GET', '/api/catalogo')->withQueryParams($params);
+    $response = $controller->catalogAPI($request, new Response(), $db);
+    $decoded = json_decode((string)$response->getBody(), true);
+    return is_array($decoded) ? $decoded : [];
+};
+
+$token = bin2hex(random_bytes(5));
+$publisher = "ZZ F001 Publisher {$token}";
+
+$db->begin_transaction();
+try {
+    // Unique publisher so the catalog `editore` filter matches exactly the two
+    // seeded books (exact `e.nome = ?` match, no FULLTEXT indexing needed).
+    $stmt = $db->prepare('INSERT INTO editori (nome) VALUES (?)');
+    $stmt->bind_param('s', $publisher);
+    $stmt->execute();
+    $publisherId = (int)$db->insert_id;
+    $stmt->close();
+
+    // One loanable copy, one with zero available copies. deleted_at defaults NULL.
+    $insertBook = static function (mysqli $db, string $titolo, int $publisherId, int $copie): void {
+        $stmt = $db->prepare('INSERT INTO libri (titolo, editore_id, copie_totali, copie_disponibili) VALUES (?, ?, ?, ?)');
+        $totali = max(1, $copie);
+        $stmt->bind_param('siii', $titolo, $publisherId, $totali, $copie);
+        $stmt->execute();
+        $stmt->close();
+    };
+    $insertBook($db, "ZZ F001 Available {$token}", $publisherId, 1);
+    $insertBook($db, "ZZ F001 Unavailable {$token}", $publisherId, 0);
+
+    // 1 + 3. WITH the flag: real available count, coherent with total.
+    $withStats = $callCatalog(['editore' => $publisher, 'with_stats' => '1']);
+    $pagWith = $withStats['pagination'] ?? [];
+    $totalWith = (int)($pagWith['total_books'] ?? -1);
+    $availWith = $pagWith['available_books'] ?? 'MISSING';
+
+    $check($totalWith === 2, "with_stats: total_books counts both seeded books (got {$totalWith})");
+    $check(is_int($availWith), 'with_stats: available_books is an integer, not null/missing');
+    $check(is_int($availWith) && $availWith <= $totalWith, 'with_stats: available_books <= total_books');
+    $check(is_int($availWith) && $availWith === 1, "with_stats: available_books excludes the zero-copy book (got " . var_export($availWith, true) . ")");
+    $check(is_int($availWith) && $availWith < $totalWith, 'with_stats: available < total when a zero-copy book is in the filtered set');
+
+    // 2. WITHOUT the flag: aggregate is skipped, field is null.
+    $withoutStats = $callCatalog(['editore' => $publisher]);
+    $pagWithout = $withoutStats['pagination'] ?? [];
+    $totalWithout = (int)($pagWithout['total_books'] ?? -1);
+    $availWithout = array_key_exists('available_books', $pagWithout) ? $pagWithout['available_books'] : 'MISSING';
+
+    $check($totalWithout === 2, "no flag: total_books is still returned (got {$totalWithout})");
+    $check($availWithout === null, 'no flag: available_books is null (aggregate not computed)');
+} finally {
+    $db->rollback();
+    $db->close();
+}
+
+echo "\n" . ($failed === 0 ? "ALL {$passed} PASS\n" : "{$passed} passed, {$failed} FAILED\n");
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
Two reported frontend bugs, both fixed and deployed to bibliotecafemminista.

### 1. 🐛 Home hero "Disponibili" showed 📚 instead of a number
`loadStats()` explicitly set the element to the emoji because the catalog API had no available-books figure. `catalogAPI()` now returns `pagination.available_books` (COUNT of the same filter set restricted to `copie_disponibili > 0`), and the JS renders it (falling back to the total on an older backend; the error path shows an em-dash).
**Verified in prod:** `/api/catalogo` → `total_books: 157, available_books: 150`; the live home hero shows **Disponibili 150**.

### 2. 🐛 Related books ("Potrebbero interessarti") were hard-capped at 3
Fixed `$limit = 3` + a Bootstrap `col-lg-4` row. Now fetches up to 6 and renders them in a responsive one-row grid (`repeat(auto-fill, minmax(170px, 1fr))` + `grid-auto-rows: 0` + `overflow: hidden`), so the **number shown adapts to the viewport** instead of a fixed 3.
**Verified locally:** 6 cards at 1400px, 3 at 768px, 1 at 380px, with the overflow rows clipped.

php -l + PHPStan clean. Deployed (with backup) to the production install; opcache reset.

_Note: on the local PHP 8.5 dev box the catalog API response is polluted by a `ReflectionProperty::setAccessible()` deprecation (a no-op since 8.1) from `PluginManager.php:1723`, which breaks the home fetch locally only — prod runs 8.3 with display_errors off, so the JSON is clean. Worth removing that call separately for forward-compat._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto il conteggio dei libri disponibili nella paginazione del catalogo.
  * La sezione dei libri correlati può ora mostrare fino a 6 suggerimenti.
  * Introdotta una griglia responsive per visualizzare meglio i libri correlati su schermi di diverse dimensioni.

* **Correzioni**
  * Le statistiche della home page mostrano correttamente i libri disponibili.
  * In caso di errore nel caricamento, le statistiche vengono sostituite da un indicatore neutro invece di messaggi poco chiari.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->