### PR TITLE
Drop no-op ReflectionProperty::setAccessible() (PHP 8.5 forward-compat)

### DIFF
--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -1720,7 +1720,8 @@ class PluginManager
             try {
                 $reflection = new \ReflectionClass($pluginInstance);
                 $instanceProperty = $reflection->getProperty('instance');
-                $instanceProperty->setAccessible(true);
+                // No setAccessible(): it is a no-op since PHP 8.1 and emits a
+                // deprecation notice under PHP 8.5 that pollutes page output.
                 $wrappedInstance = $instanceProperty->getValue($pluginInstance);
 
                 if (is_object($wrappedInstance) && method_exists($wrappedInstance, $method)) {


### PR DESCRIPTION
`PluginManager::pluginHasMethod()` calls `setAccessible(true)` before reading a wrapper object's `instance` property. Since PHP 8.1 that call is a no-op — reflection reads non-public members without it — and under **PHP 8.5** it emits a deprecation notice.

With `display_errors` on (dev), that notice is printed *before* the page HTML, corrupting every rendered admin/frontend page (broken DataTables init, missing action bars, `<html lang>` shifted, etc.). Production (PHP 8.3) is unaffected, but it makes local PHP 8.5 unusable for browser testing.

Removing the call is behaviour-preserving on 8.1–8.4 and clears the deprecation on 8.5; `getValue()` already reads the property without it. PHPStan level 5 clean.