### PR TITLE
Security hardening + OPAC fixes (v0.7.42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,34 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 ---
 
+## What's New in v0.7.42
+
+A security-hardening and bug-fix release. It closes a set of access-control,
+SSRF, open-redirect and data-exposure issues found in a full security audit,
+and fixes three OPAC/CMS regressions.
+
+### Security
+- **Access control on the internal APIs** — `GET /api/editori` and `GET /api/libri` were reachable without a session and returned every column, exposing publisher PII (email, phone, tax code, referent contacts) and internal book fields (purchase price, private notes, inventory numbers). They now require the admin session middleware, matching how they are already documented.
+- **Borrower privacy on the book page** — a non-admin patron could open `/admin/books/{id}` and read every borrower's name, email and loan history. Borrower identity is now gated to admin/staff only (the reservations block already was).
+- **Privilege boundary on updates** — a `staff` user could upload and install an update package, or trigger a full update/downgrade, over the application files (a route to code execution). Those actions now require an explicit `admin` role, like the backup/restore actions.
+- **Public search API** no longer leaks the current borrower's name/email; it returns availability and due dates only.
+- **Session-role enforcement** — admin routes now re-validate the user against the database each request, so demoting or suspending a user takes effect immediately instead of at session expiry.
+- **Secrets** — the settings page no longer shows API keys or the reCAPTCHA secret to the `staff` role; API keys are accepted only via the `X-API-Key` / `Authorization: Bearer` header (never a `?api_key=` query string, which leaks into access logs).
+- **Hardening** — fixed an open redirect after login and on the language switch (`/\` backslash bypass), a path-traversal on language-file upload, SSRF in the image proxy (redirect + DNS-rebinding) and the installer DB test, plaintext SMTP password storage in the installer, CSV/formula injection in two exports, reset-link Host-header poisoning, a login timing side channel, and rate-limit bypass via forged forwarding headers.
+
+### Fixes
+- **Book subtitle now shows on the public book page** ([#293](https://github.com/fabiodalez-dev/Pinakes/issues/293)) — the `sottotitolo` was never rendered in the OPAC; it now appears under the title.
+- **Hero background image upload under a strict CSP** ([#292](https://github.com/fabiodalez-dev/Pinakes/issues/292)) — the uploader fetched a `blob:` URL that a strict `connect-src` policy blocks, so the image never reached the form. It now uses the file object directly and works regardless of the site's CSP.
+- **Related-books count on high-resolution screens** — the related strip packed 6+ cards on high-res laptops; it now caps at 4 and adapts down to 3/2/1 as the viewport narrows, with the mobile swipe carousel unchanged.
+
+### Database Changes
+- `migrate_0.7.42.sql` — bumps the `da_DK` translation key count (6607 → 6611) for installs already on 0.7.41, after this release added 4 UI strings. Idempotent.
+
+### Upgrade Notes
+- Back up your database before updating (the in-app updater does this automatically).
+
+---
+
 ## What's New in v0.7.41
 
 A maintenance release bundling seven merged pull requests: a new interface

--- a/app/Controllers/Admin/LanguagesController.php
+++ b/app/Controllers/Admin/LanguagesController.php
@@ -99,6 +99,16 @@ class LanguagesController
             $errors[] = __("Il nome nativo è obbligatorio (es. Italiano, English)");
         }
 
+        // Bail on an invalid locale code BEFORE reaching the upload handler:
+        // the code becomes part of the target file path, so an invalid code
+        // must never be used to build/write a translation file (path traversal).
+        if (empty($data['code']) || !I18n::isValidLocaleCode($data['code'])) {
+            $_SESSION['flash_error'] = implode('<br>', $errors);
+            return $response
+                ->withHeader('Location', '/admin/languages/create')
+                ->withStatus(302);
+        }
+
         // Handle translation file upload
         $translationFile = null;
         if (isset($_FILES['translation_json']) && $_FILES['translation_json']['error'] === UPLOAD_ERR_OK) {
@@ -559,6 +569,13 @@ class LanguagesController
             return ['success' => false, 'error' => __("Errore nel caricamento del file JSON")];
         }
 
+        // The locale code becomes part of the target file path — reject any
+        // code that is not a strict xx_YY locale BEFORE touching the filesystem
+        // (prevents arbitrary .json write via "../" traversal).
+        if (!I18n::isValidLocaleCode($code)) {
+            return ['success' => false, 'error' => __("Codice lingua non valido")];
+        }
+
         $extension = strtolower(pathinfo($uploadedFile['name'] ?? '', PATHINFO_EXTENSION));
         $mimeType = strtolower($uploadedFile['type'] ?? '');
 
@@ -579,6 +596,17 @@ class LanguagesController
 
         $sanitized = $this->sanitizeTranslations($decoded);
         $targetPath = $this->getLocaleFilePath($code);
+
+        // Defense in depth: the resolved file must live directly inside the
+        // locale directory. realpath() can't resolve a not-yet-created file, so
+        // validate the DIRNAME against the locale base and the basename shape.
+        $localeDir = realpath(__DIR__ . '/../../../locale');
+        $targetDir = realpath(dirname($targetPath));
+        if ($localeDir === false || $targetDir === false
+            || $targetDir !== $localeDir
+            || basename($targetPath) !== $code . '.json') {
+            return ['success' => false, 'error' => __("Percorso file non valido")];
+        }
 
         if ($backupExisting && file_exists($targetPath)) {
             copy($targetPath, $targetPath . '.backup.' . time());

--- a/app/Controllers/AuthController.php
+++ b/app/Controllers/AuthController.php
@@ -92,7 +92,15 @@ class AuthController
             // security measure. By always running password_verify() even for non-existent users,
             // attackers cannot enumerate valid emails by measuring response times.
             // See OWASP: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
-            $dummyHash = '$2y$12$PXZb520pM93TmNGnoJy2TuhssLxu4XversvqtKZ4B7xrm0sAldZE6'; // @codingStandardsIgnoreLine
+            //
+            // The dummy MUST use the SAME algorithm+cost as real passwords
+            // (PASSWORD_DEFAULT), otherwise password_verify() against it takes a
+            // measurably different time than against a real hash and leaks
+            // account existence via timing (CWE-208). Computed once per process.
+            static $dummyHash = null;
+            if ($dummyHash === null) {
+                $dummyHash = password_hash('', PASSWORD_DEFAULT);
+            }
             $hashToCheck = (string) ($row['password'] ?? $dummyHash);
 
             // Plugin hook: Custom login validation (e.g., reCAPTCHA, 2FA)
@@ -175,9 +183,11 @@ class AuthController
 
                 return $response->withHeader('Location', $redirectUrl)->withStatus(302);
             }
-
-            // Ensure hash verification still happens when credentials invalid
-            password_verify($password, $dummyHash);
+            // NOTE: exactly ONE password_verify() runs above on every path — the
+            // real hash on a hit, $dummyHash on a miss — so both paths do
+            // identical work. Do NOT add a second password_verify() here: it
+            // would make the miss/wrong-password path slower than a valid-hash
+            // check and reintroduce the timing oracle (CWE-208).
         }
 
         // Failed: redirect back with invalid credentials error
@@ -220,7 +230,13 @@ class AuthController
         if ($clean === '' || !str_starts_with($clean, '/')) {
             return null;
         }
-        if (str_starts_with($clean, '//')) {
+        // Reject protocol-relative ('//') and backslash-authority ('/\') forms:
+        // a browser normalises the '\' to '/', turning '/\evil.com' into
+        // '//evil.com' → a cross-origin open redirect (CWE-601). Query params
+        // are already URL-decoded here, so a '%5C' payload arrives as a raw '\'
+        // and is caught too. This is the single choke point for the post-login
+        // redirect (both loginForm() and login() route return_url through here).
+        if (preg_match('#^/[\\\\/]#', $clean)) {
             return null;
         }
         return $clean;

--- a/app/Controllers/CollocazioneController.php
+++ b/app/Controllers/CollocazioneController.php
@@ -405,7 +405,7 @@ class CollocazioneController
 
         // Generate CSV output
         $output = fopen('php://temp', 'r+');
-        $writer = Csv::writerToStream($output, ';');
+        $writer = Csv::writerToStream($output, ';', "'");
         $writer->insertAll($csv);
         rewind($output);
         $csvContent = stream_get_contents($output);

--- a/app/Controllers/LanguageController.php
+++ b/app/Controllers/LanguageController.php
@@ -69,6 +69,16 @@ class LanguageController
             return '/';
         }
 
-        return $redirect[0] === '/' ? $redirect : '/';
+        if ($redirect[0] !== '/') {
+            return '/';
+        }
+
+        // Reject backslash- or double-slash-prefixed paths (e.g. "/\evil.com")
+        // that browsers normalise into a cross-origin redirect.
+        if (preg_match('#^/[\\\\/]#', $redirect)) {
+            return '/';
+        }
+
+        return $redirect;
     }
 }

--- a/app/Controllers/LibraryThingImportController.php
+++ b/app/Controllers/LibraryThingImportController.php
@@ -2141,7 +2141,7 @@ class LibraryThingImportController
 
         // LibraryThing headers (TSV format). Field encoding (RFC 4180 quoting
         // of tab/newline/quote, doubled quotes) is handled by league/csv.
-        $writer = Csv::writerToStream($stream, "\t");
+        $writer = Csv::writerToStream($stream, "\t", "'");
         $headers = $this->getLibraryThingHeaders();
         $writer->insertOne($headers);
 

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -427,42 +427,66 @@ class LibriController
         $copie = $copyRepo->getByBookId($id);
         $copySchedule = $copyRepo->getScheduleByBookId($id);
 
-        // Get loan history for this book
-        $loanHistoryQuery = "
-            SELECT
-                p.id,
-                p.data_prestito,
-                p.data_scadenza,
-                p.data_restituzione,
-                p.stato,
-                p.renewals,
-                p.note,
-                u.nome as utente_nome,
-                u.cognome as utente_cognome,
-                u.email as utente_email,
-                u.id as utente_id,
-                staff.nome as staff_nome,
-                staff.cognome as staff_cognome
-            FROM prestiti p
-            LEFT JOIN utenti u ON p.utente_id = u.id
-            LEFT JOIN utenti staff ON p.processed_by = staff.id
-            WHERE p.libro_id = ?
-            ORDER BY p.data_prestito DESC
-        ";
-        $stmt = $db->prepare($loanHistoryQuery);
-        $stmt->bind_param('i', $id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-        $loanHistory = [];
-        while ($row = $result->fetch_assoc()) {
-            $loanHistory[] = $row;
+        // Borrower identity (name/email/reading history) is GDPR-sensitive and must
+        // only be exposed to admin/staff. Standard/premium patrons can reach this
+        // page (route allows them) but must see availability WITHOUT any borrower PII.
+        $currentUserRole = $_SESSION['user']['tipo_utente'] ?? '';
+        $isAdminOrStaff = \in_array($currentUserRole, ['admin', 'staff'], true);
+
+        // Redact borrower PII from the active loan for non-admin/staff viewers,
+        // preserving the loan-existence/date fields needed for availability display.
+        if (!$isAdminOrStaff && !empty($activeLoan)) {
+            foreach (['utente_nome', 'utente_cognome', 'utente_email', 'utente_id'] as $piiField) {
+                unset($activeLoan[$piiField]);
+            }
         }
-        $stmt->close();
+
+        // Redact per-copy current-borrower PII for non-admin/staff viewers.
+        if (!$isAdminOrStaff) {
+            foreach ($copie as $ci => $copia) {
+                foreach (['utente_nome', 'utente_cognome', 'utente_email', 'utente_id'] as $piiField) {
+                    unset($copie[$ci][$piiField]);
+                }
+            }
+        }
+
+        // Get loan history for this book — contains borrower PII, so only fetch it
+        // for admin/staff. Non-admin viewers get an empty history (block hidden).
+        $loanHistory = [];
+        if ($isAdminOrStaff) {
+            $loanHistoryQuery = "
+                SELECT
+                    p.id,
+                    p.data_prestito,
+                    p.data_scadenza,
+                    p.data_restituzione,
+                    p.stato,
+                    p.renewals,
+                    p.note,
+                    u.nome as utente_nome,
+                    u.cognome as utente_cognome,
+                    u.email as utente_email,
+                    u.id as utente_id,
+                    staff.nome as staff_nome,
+                    staff.cognome as staff_cognome
+                FROM prestiti p
+                LEFT JOIN utenti u ON p.utente_id = u.id
+                LEFT JOIN utenti staff ON p.processed_by = staff.id
+                WHERE p.libro_id = ?
+                ORDER BY p.data_prestito DESC
+            ";
+            $stmt = $db->prepare($loanHistoryQuery);
+            $stmt->bind_param('i', $id);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            while ($row = $result->fetch_assoc()) {
+                $loanHistory[] = $row;
+            }
+            $stmt->close();
+        }
 
         // Active reservations for this book (admin/staff only - contains PII)
         $activeReservations = [];
-        $currentUserRole = $_SESSION['user']['tipo_utente'] ?? '';
-        $isAdminOrStaff = \in_array($currentUserRole, ['admin', 'staff'], true);
 
         if ($isAdminOrStaff) {
             $resStmt = $db->prepare("

--- a/app/Controllers/PasswordController.php
+++ b/app/Controllers/PasswordController.php
@@ -102,7 +102,10 @@ class PasswordController
                     $emailService = new EmailService($db);
                     $emailService->sendEmail($email, $subject, $html, $name);
                 } catch (\Throwable $e) {
-                    error_log('EmailService failed, falling back to Mailer: ' . $e->getMessage());
+                    // Use SecureLogger (not error_log): the PHPMailer exception
+                    // message can embed the recipient address, and SecureLogger
+                    // applies the centralised redaction/retention.
+                    \App\Support\SecureLogger::error('EmailService failed, falling back to Mailer', ['error' => $e->getMessage()]);
                     Mailer::send($email, $subject, $html);
                 }
             }

--- a/app/Controllers/PasswordController.php
+++ b/app/Controllers/PasswordController.php
@@ -59,32 +59,52 @@ class PasswordController
             $stmt->execute();
             $stmt->close();
 
+            // Build the reset link ONLY from an operator-configured canonical /
+            // trusted host, NEVER from the request Host header (which an attacker
+            // controls on a catch-all vhost → reset-link poisoning, CWE-20).
+            $resetPath = RouteTranslator::route('reset_password') . '?token=' . urlencode($resetToken);
             $envUrl = getenv('APP_CANONICAL_URL') ?: ($_ENV['APP_CANONICAL_URL'] ?? '');
+            $resetUrl = null;
             if (is_string($envUrl) && $envUrl !== '') {
-                $resetUrl = rtrim($envUrl, '/') . RouteTranslator::route('reset_password') . '?token=' . urlencode($resetToken);
+                // Full canonical URL preserves scheme and any base path.
+                $resetUrl = rtrim($envUrl, '/') . $resetPath;
             } else {
-                SecureLogger::warning('Password reset URL generated without APP_CANONICAL_URL — relies on Host header');
-                $resetUrl = absoluteUrl(RouteTranslator::route('reset_password')) . '?token=' . urlencode($resetToken);
+                // No canonical URL: fall back ONLY to a configured trusted host.
+                $trustedHost = \App\Support\HtmlHelper::configuredTrustedHost();
+                if ($trustedHost !== null) {
+                    $resetUrl = 'https://' . $trustedHost . $resetPath;
+                }
             }
-            $name = trim((string) ($row['nome'] ?? '') . ' ' . (string) ($row['cognome'] ?? ''));
-            $subject = __('Recupera la tua password');
-            $html = '<h2>' . __('Recupera la tua password') . '</h2>' .
-                '<p>' . __('Ciao') . ' ' . htmlspecialchars($name !== '' ? $name : $email, ENT_QUOTES, 'UTF-8') . ',</p>' .
-                '<p>' . __('Abbiamo ricevuto una richiesta di reset della password per il tuo account.') . '</p>' .
-                '<p>' . __('Clicca sul pulsante qui sotto per resettare la tua password:') . '</p>' .
-                '<p style="margin: 20px 0;"><a href="' . htmlspecialchars($resetUrl, ENT_QUOTES, 'UTF-8') . '" style="background-color: #111827; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px;">' . __('Resetta Password') . '</a></p>' .
-                '<p>' . __('Oppure copia e incolla questo link nel tuo browser:') . '</p>' .
-                '<p><code style="background-color: #f3f4f6; padding: 10px; display: block; word-break: break-all;">' . htmlspecialchars($resetUrl, ENT_QUOTES, 'UTF-8') . '</code></p>' .
-                '<p><strong>' . __('Nota:') . '</strong> ' . __('Questo link scadrà tra 2 ore.') . '</p>' .
-                '<p>' . __('Se non hai richiesto il reset della password, puoi ignorare questa email. Il tuo account rimane sicuro.') . '</p>';
 
-            // Use EmailService if available, fall back to Mailer
-            try {
-                $emailService = new EmailService($db);
-                $emailService->sendEmail($email, $subject, $html, $name);
-            } catch (\Throwable $e) {
-                error_log('EmailService failed, falling back to Mailer: ' . $e->getMessage());
-                Mailer::send($email, $subject, $html);
+            if ($resetUrl === null) {
+                // Fail closed: no trustworthy host is configured, so refuse to
+                // emit a link derived from the raw Host header. Suppress this
+                // email but still fall through to the generic 'sent' response
+                // below so account existence is not disclosed (anti-enumeration).
+                SecureLogger::error('Password reset email suppressed: neither APP_CANONICAL_URL nor APP_TRUSTED_HOSTS is configured; refusing to build the reset link from the request Host header', [
+                    'user_id' => $row['id'],
+                ]);
+            } else {
+                $name = trim((string) ($row['nome'] ?? '') . ' ' . (string) ($row['cognome'] ?? ''));
+                $subject = __('Recupera la tua password');
+                $html = '<h2>' . __('Recupera la tua password') . '</h2>' .
+                    '<p>' . __('Ciao') . ' ' . htmlspecialchars($name !== '' ? $name : $email, ENT_QUOTES, 'UTF-8') . ',</p>' .
+                    '<p>' . __('Abbiamo ricevuto una richiesta di reset della password per il tuo account.') . '</p>' .
+                    '<p>' . __('Clicca sul pulsante qui sotto per resettare la tua password:') . '</p>' .
+                    '<p style="margin: 20px 0;"><a href="' . htmlspecialchars($resetUrl, ENT_QUOTES, 'UTF-8') . '" style="background-color: #111827; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px;">' . __('Resetta Password') . '</a></p>' .
+                    '<p>' . __('Oppure copia e incolla questo link nel tuo browser:') . '</p>' .
+                    '<p><code style="background-color: #f3f4f6; padding: 10px; display: block; word-break: break-all;">' . htmlspecialchars($resetUrl, ENT_QUOTES, 'UTF-8') . '</code></p>' .
+                    '<p><strong>' . __('Nota:') . '</strong> ' . __('Questo link scadrà tra 2 ore.') . '</p>' .
+                    '<p>' . __('Se non hai richiesto il reset della password, puoi ignorare questa email. Il tuo account rimane sicuro.') . '</p>';
+
+                // Use EmailService if available, fall back to Mailer
+                try {
+                    $emailService = new EmailService($db);
+                    $emailService->sendEmail($email, $subject, $html, $name);
+                } catch (\Throwable $e) {
+                    error_log('EmailService failed, falling back to Mailer: ' . $e->getMessage());
+                    Mailer::send($email, $subject, $html);
+                }
             }
         } else {
             $stmt->close();

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -1747,7 +1747,11 @@ class PrestitiController
             return null;
         }
 
-        if (str_starts_with($trimmed, '//')) {
+        // Reject protocol-relative (`//host`) and backslash-authority (`/\host`,
+        // which browsers normalise to `//host`) targets — a second char of `/`
+        // or `\` after the leading slash is an open-redirect vector. Aligned
+        // with AuthController/LanguageController sanitizers (findings F4/F10).
+        if (preg_match('#^/[\\\\/]#', $trimmed)) {
             return null;
         }
 

--- a/app/Controllers/PublicApiController.php
+++ b/app/Controllers/PublicApiController.php
@@ -290,6 +290,10 @@ class PublicApiController
      */
     private function getBookLoanStatus(mysqli $db, int $bookId): ?array
     {
+        // Public payload: expose only availability / due-date, never the
+        // borrower's identity. This endpoint is reachable by any API key
+        // holder, so returning the patron's name/email would leak PII
+        // (CWE-863). The JOIN on utenti is therefore intentionally dropped.
         $sql = "
             SELECT
                 p.id,
@@ -297,13 +301,8 @@ class PublicApiController
                 p.data_scadenza,
                 p.data_restituzione,
                 p.stato,
-                p.attivo,
-                u.id AS utente_id,
-                u.nome AS utente_nome,
-                u.cognome AS utente_cognome,
-                u.email AS utente_email
+                p.attivo
             FROM prestiti p
-            JOIN utenti u ON p.utente_id = u.id
             WHERE p.libro_id = ? AND p.attivo = 1
             ORDER BY p.data_prestito DESC
             LIMIT 1
@@ -330,13 +329,7 @@ class PublicApiController
             'data_scadenza' => $row['data_scadenza'],
             'data_restituzione' => $row['data_restituzione'],
             'stato' => $row['stato'],
-            'attivo' => (bool)$row['attivo'],
-            'utente' => [
-                'id' => (int)$row['utente_id'],
-                'nome' => $row['utente_nome'],
-                'cognome' => $row['utente_cognome'],
-                'email' => $row['utente_email']
-            ]
+            'attivo' => (bool)$row['attivo']
         ];
     }
 

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -655,6 +655,17 @@ class SettingsController
             'notification_email' => trim(strip_tags((string) ($data['notification_email'] ?? ''))),
         ];
 
+        // F11 follow-up: the reCAPTCHA secret is admin-only. Its input is
+        // rendered disabled for staff (so it isn't submitted), which means a
+        // staff save would otherwise persist an empty string and silently wipe
+        // the admin-configured secret — disabling spam protection on the public
+        // contact form (fail-open). Drop the key entirely for non-admins so
+        // neither a normal save nor a forged POST can overwrite it; the stored
+        // value is preserved. Admins keep full edit (including clearing it).
+        if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
+            unset($settings['recaptcha_secret_key']);
+        }
+
         // Validate and sanitize Maps embed code (Google Maps or OpenStreetMap)
         if (!empty($settings['google_maps_embed'])) {
             $embedCode = trim($settings['google_maps_embed']);

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -46,6 +46,12 @@ class SettingsController
         $queryParams = $request->getQueryParams();
         $activeTab = $queryParams['tab'] ?? 'general';
 
+        // Security scan F11 (CWE-522): the settings page is reachable by 'staff'
+        // (AdminAuthMiddleware admits them), but the advanced/contacts tabs echo
+        // admin secrets (API keys, reCAPTCHA secret) verbatim. Only real admins
+        // may see those values; the partials gate secret output on $isAdmin.
+        $isAdmin = (($_SESSION['user']['tipo_utente'] ?? '') === 'admin');
+
         ob_start();
         $data = compact(
             'appSettings',
@@ -60,7 +66,8 @@ class SettingsController
             'contactMessages',
             'activeTab',
             'db',
-            'cookieBannerTexts'
+            'cookieBannerTexts',
+            'isAdmin'
         );
         require __DIR__ . '/../Views/settings/index.php';
         $content = ob_get_clean();

--- a/app/Controllers/UpdateController.php
+++ b/app/Controllers/UpdateController.php
@@ -72,8 +72,11 @@ class UpdateController
      */
     public function performUpdate(Request $request, Response $response, mysqli $db): Response
     {
-        // Admin-only access check removed
-
+        // Applies a downloaded release over the app → admin-only (AdminAuthMiddleware
+        // also lets staff through, so re-check here, like createBackup/restoreBackup).
+        if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
+            return $this->jsonResponse($response, ['error' => __('Operazione riservata agli amministratori')], 403);
+        }
 
         // Verify CSRF token
         $data = (array) $request->getParsedBody();
@@ -492,6 +495,12 @@ class UpdateController
      */
     public function uploadUpdate(Request $request, Response $response, mysqli $db): Response
     {
+        // Accepts an uploaded update ZIP → admin-only (AdminAuthMiddleware also lets
+        // staff through, so re-check here, like createBackup/restoreBackup).
+        if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
+            return $this->jsonResponse($response, ['error' => __('Operazione riservata agli amministratori')], 403);
+        }
+
         // Verify CSRF token
         $data = (array) $request->getParsedBody();
         $csrfToken = $data['csrf_token'] ?? '';
@@ -579,6 +588,12 @@ class UpdateController
      */
     public function installManualUpdate(Request $request, Response $response, mysqli $db): Response
     {
+        // Applies an uploaded update ZIP over the app → admin-only (AdminAuthMiddleware
+        // also lets staff through, so re-check here, like createBackup/restoreBackup).
+        if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
+            return $this->jsonResponse($response, ['error' => __('Operazione riservata agli amministratori')], 403);
+        }
+
         // Verify CSRF token
         $data = (array) $request->getParsedBody();
         $csrfToken = $data['csrf_token'] ?? '';

--- a/app/Controllers/UpdateController.php
+++ b/app/Controllers/UpdateController.php
@@ -657,6 +657,13 @@ class UpdateController
      */
     public function saveToken(Request $request, Response $response, mysqli $db): Response
     {
+        // Persists the GitHub token used by the update-download chain → admin-only
+        // (AdminAuthMiddleware also lets staff through, so re-check here, like the
+        // other update actions).
+        if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
+            return $this->jsonResponse($response, ['error' => __('Operazione riservata agli amministratori')], 403);
+        }
+
         $data = (array) $request->getParsedBody();
         $csrfToken = $data['csrf_token'] ?? '';
 

--- a/app/Middleware/AdminAuthMiddleware.php
+++ b/app/Middleware/AdminAuthMiddleware.php
@@ -16,6 +16,36 @@ use Slim\Psr7\Response as SlimResponse;
  */
 class AdminAuthMiddleware implements MiddlewareInterface
 {
+    /** Roles this middleware admits. */
+    private const ALLOWED_ROLES = ['admin', 'staff'];
+
+    /**
+     * Per-request cache of DB re-validation results, keyed by user id.
+     * PHP resets static state between requests (shared-nothing, incl. PHP-FPM),
+     * so this never leaks a stale verdict across requests.
+     *
+     * @var array<int,bool>
+     */
+    private static array $revalidationCache = [];
+
+    /** Lazily-opened shared mysqli handle for this request (see getDb()). */
+    private static ?\mysqli $sharedDb = null;
+
+    /** True once we've attempted to open the shared connection this request. */
+    private static bool $dbInitAttempted = false;
+
+    private ?\mysqli $db;
+
+    /**
+     * $db is optional: the app instantiates this middleware without arguments
+     * (see app/Routes/web.php), so when none is injected we lazily open a
+     * connection from the app's own DB config (see getDb()).
+     */
+    public function __construct(?\mysqli $db = null)
+    {
+        $this->db = $db;
+    }
+
     public function process(Request $request, RequestHandler $handler): Response
     {
         $user = $_SESSION['user'] ?? null;
@@ -42,25 +72,193 @@ class AdminAuthMiddleware implements MiddlewareInterface
             return $res->withHeader('Location', $loginUrl);
         }
 
-        // Check for admin or staff role
+        // Check for admin or staff role (from the session snapshot set at login)
         $tipo_utente = $user['tipo_utente'] ?? null;
-        if ($tipo_utente !== 'admin' && $tipo_utente !== 'staff') {
-            if ($isApiRequest) {
-                // Return JSON error for API requests
-                $res = new SlimResponse(403);
-                $res->getBody()->write(json_encode([
-                    'error' => true,
-                    'message' => __('Accesso negato. Permessi insufficienti.')
-                ], JSON_UNESCAPED_UNICODE));
-                return $res->withHeader('Content-Type', 'application/json');
-            }
+        if (!in_array($tipo_utente, self::ALLOWED_ROLES, true)) {
+            return $this->denyRole($isApiRequest);
+        }
 
-            // Regular user trying to access admin area - redirect to profile
-            $profileUrl = RouteTranslator::route('profile');
-            return (new SlimResponse(302))->withHeader('Location', $profileUrl);
+        // Security scan F8 (CWE-613): the session role above is a stale snapshot
+        // captured at login. Re-validate the user against the DB once per request
+        // so demotions/suspensions take effect immediately instead of lingering
+        // until the session expires. Fails CLOSED on any DB/lookup failure.
+        if (!$this->revalidateRole($user)) {
+            return $this->denyRole($isApiRequest);
         }
 
         // Admin/staff user - allow access
         return $handler->handle($request);
+    }
+
+    /**
+     * Deny response for an insufficient/void admin role.
+     * Mirrors the existing role-gate behaviour: JSON 403 for API requests,
+     * a 302 redirect to the profile page for browser requests.
+     */
+    private function denyRole(bool $isApiRequest): Response
+    {
+        if ($isApiRequest) {
+            $res = new SlimResponse(403);
+            $res->getBody()->write(json_encode([
+                'error' => true,
+                'message' => __('Accesso negato. Permessi insufficienti.')
+            ], JSON_UNESCAPED_UNICODE));
+            return $res->withHeader('Content-Type', 'application/json');
+        }
+
+        $profileUrl = RouteTranslator::route('profile');
+        return (new SlimResponse(302))->withHeader('Location', $profileUrl);
+    }
+
+    /**
+     * Re-validate the session user against the DB (fail-closed).
+     *
+     * Returns true only when the user still exists, is `stato = 'attivo'`, and
+     * still holds an allowed role. The verdict is cached per-request per user id
+     * so multiple admin-guarded middleware hits in one request issue one query.
+     *
+     * @param array<string,mixed> $user
+     */
+    private function revalidateRole(array $user): bool
+    {
+        $userId = isset($user['id']) ? (int) $user['id'] : 0;
+        if ($userId <= 0) {
+            // No usable id in the session → cannot re-validate → fail closed.
+            \App\Support\SecureLogger::error('[AdminAuthMiddleware] Missing user id in session during admin re-validation');
+            return false;
+        }
+
+        if (isset(self::$revalidationCache[$userId])) {
+            return self::$revalidationCache[$userId];
+        }
+
+        $db = $this->getDb();
+        if (!$db instanceof \mysqli) {
+            // DB unreachable → fail closed (do NOT cache: a later hit may recover).
+            \App\Support\SecureLogger::error('[AdminAuthMiddleware] Database unreachable during admin re-validation; denying access');
+            return false;
+        }
+
+        try {
+            $stmt = $db->prepare('SELECT tipo_utente, stato FROM utenti WHERE id = ? LIMIT 1');
+            $stmt->bind_param('i', $userId);
+            $stmt->execute();
+            $result = $stmt->get_result();
+            $row = $result ? $result->fetch_assoc() : null;
+            $stmt->close();
+        } catch (\Throwable $e) {
+            \App\Support\SecureLogger::error('[AdminAuthMiddleware] Admin re-validation query failed; denying access', ['exception' => $e->getMessage()]);
+            return false;
+        }
+
+        $valid = is_array($row)
+            && (($row['stato'] ?? '') === 'attivo')
+            && in_array($row['tipo_utente'] ?? null, self::ALLOWED_ROLES, true);
+
+        self::$revalidationCache[$userId] = $valid;
+        return $valid;
+    }
+
+    /**
+     * Obtain a mysqli handle: the injected one if present, otherwise a shared
+     * connection lazily built from the app's own DB config (config/settings.php),
+     * the same source config/container.php uses. Returns null on failure so the
+     * caller can fail closed.
+     */
+    private function getDb(): ?\mysqli
+    {
+        if ($this->db instanceof \mysqli) {
+            return $this->db;
+        }
+
+        if (self::$sharedDb instanceof \mysqli) {
+            return self::$sharedDb;
+        }
+
+        if (self::$dbInitAttempted) {
+            return null; // Already tried and failed this request.
+        }
+        self::$dbInitAttempted = true;
+
+        $settingsPath = __DIR__ . '/../../config/settings.php';
+        if (!is_file($settingsPath)) {
+            return null;
+        }
+
+        try {
+            $settings = require $settingsPath;
+            $cfg = is_array($settings) ? ($settings['db'] ?? null) : null;
+            if (!is_array($cfg)) {
+                return null;
+            }
+
+            $hostname = (string) ($cfg['hostname'] ?? 'localhost');
+            $username = (string) ($cfg['username'] ?? '');
+            $password = (string) ($cfg['password'] ?? '');
+            $database = (string) ($cfg['database'] ?? '');
+            $port     = (int) ($cfg['port'] ?? 3306);
+            $charset  = (string) ($cfg['charset'] ?? 'utf8mb4');
+            $socket   = $cfg['socket'] ?? null;
+
+            if ($database === '' || $username === '') {
+                return null;
+            }
+
+            // Auto-detect a socket for localhost installs without an explicit one
+            // (mirrors config/container.php).
+            if (empty($socket) && $hostname === 'localhost') {
+                foreach ([
+                    '/tmp/mysql.sock',
+                    '/var/run/mysqld/mysqld.sock',
+                    '/var/lib/mysql/mysql.sock',
+                    '/opt/homebrew/var/mysql/mysql.sock',
+                    '/usr/local/var/mysql/mysql.sock',
+                    '/Applications/MAMP/tmp/mysql/mysql.sock',
+                    '/Applications/XAMPP/xamppfiles/var/mysql/mysql.sock',
+                ] as $candidate) {
+                    if (file_exists($candidate)) {
+                        $socket = $candidate;
+                        break;
+                    }
+                }
+            }
+
+            // Ordered connection attempts: explicit/detected socket first, then TCP.
+            $attempts = [];
+            if (!empty($socket)) {
+                $sock = (string) $socket;
+                $attempts[] = static function () use ($username, $password, $database, $port, $sock): \mysqli {
+                    return new \mysqli('localhost', $username, $password, $database, $port, $sock);
+                };
+            }
+            $hostCandidates = ($hostname === 'localhost') ? ['127.0.0.1', 'localhost'] : [$hostname];
+            foreach ($hostCandidates as $host) {
+                $attempts[] = static function () use ($host, $username, $password, $database, $port): \mysqli {
+                    return new \mysqli($host, $username, $password, $database, $port);
+                };
+            }
+
+            $mysqli = null;
+            foreach ($attempts as $attempt) {
+                try {
+                    $mysqli = $attempt();
+                    break;
+                } catch (\Throwable $connErr) {
+                    $mysqli = null;
+                    continue;
+                }
+            }
+
+            if (!$mysqli instanceof \mysqli || $mysqli->connect_errno) {
+                return null;
+            }
+
+            $mysqli->set_charset($charset);
+            self::$sharedDb = $mysqli;
+            return self::$sharedDb;
+        } catch (\Throwable $e) {
+            \App\Support\SecureLogger::error('[AdminAuthMiddleware] Failed to open DB connection for admin re-validation', ['exception' => $e->getMessage()]);
+            return null;
+        }
     }
 }

--- a/app/Middleware/AdminAuthMiddleware.php
+++ b/app/Middleware/AdminAuthMiddleware.php
@@ -155,6 +155,19 @@ class AdminAuthMiddleware implements MiddlewareInterface
             && (($row['stato'] ?? '') === 'attivo')
             && in_array($row['tipo_utente'] ?? null, self::ALLOWED_ROLES, true);
 
+        // Propagate the fresh DB role/status into the session snapshot. This
+        // middleware admits BOTH admin and staff, so a demoted admin (admin →
+        // staff) still passes the set-membership check above; without writing
+        // the current role back, every downstream inline `tipo_utente ===
+        // 'admin'` guard (update install/perform, saveToken, reCAPTCHA secret)
+        // would keep reading the stale login-time 'admin' and grant the
+        // destructive operation. Realigning the session closes that gap.
+        if ($valid) {
+            // $valid implies $row is an array with these keys.
+            $_SESSION['user']['tipo_utente'] = $row['tipo_utente'];
+            $_SESSION['user']['stato'] = $row['stato'];
+        }
+
         self::$revalidationCache[$userId] = $valid;
         return $valid;
     }

--- a/app/Middleware/ApiKeyMiddleware.php
+++ b/app/Middleware/ApiKeyMiddleware.php
@@ -35,7 +35,7 @@ class ApiKeyMiddleware implements MiddlewareInterface
         $apiKey = $this->extractApiKey($request);
 
         if ($apiKey === null) {
-            return $this->jsonError('API key is required. Provide it via X-API-Key header or api_key query parameter', 401);
+            return $this->jsonError('API key is required. Provide it via the X-API-Key header or an Authorization: Bearer token', 401);
         }
 
         // Validate API key
@@ -64,16 +64,26 @@ class ApiKeyMiddleware implements MiddlewareInterface
 
     private function extractApiKey(Request $request): ?string
     {
-        // Try header first (preferred method)
+        // Security scan F12 (CWE-598): the API key must NEVER travel in the query
+        // string — it would be captured verbatim in Apache access logs, proxy
+        // logs and browser history. Accept it only via request headers.
+
+        // Preferred: dedicated X-API-Key header.
         $headers = $request->getHeader('X-API-Key');
         if (!empty($headers)) {
-            return trim($headers[0]);
+            $key = trim($headers[0]);
+            if ($key !== '') {
+                return $key;
+            }
         }
 
-        // Fallback to query parameter
-        $queryParams = $request->getQueryParams();
-        if (isset($queryParams['api_key']) && is_string($queryParams['api_key'])) {
-            return trim($queryParams['api_key']);
+        // Also accept a standard Authorization: Bearer <key> header.
+        $authHeaders = $request->getHeader('Authorization');
+        if (!empty($authHeaders) && preg_match('/^\s*Bearer\s+(.+)$/i', $authHeaders[0], $m)) {
+            $key = trim($m[1]);
+            if ($key !== '') {
+                return $key;
+            }
         }
 
         return null;

--- a/app/Middleware/PrivateModeMiddleware.php
+++ b/app/Middleware/PrivateModeMiddleware.php
@@ -48,7 +48,13 @@ class PrivateModeMiddleware implements MiddlewareInterface
         '/assets/', '/css/', '/js/', '/img/', '/images/', '/fonts/',
         '/uploads/settings/',
         '/installer', '/language/', '/health', '/favicon', '/robots.txt',
-        '/sitemap', '/feed.xml', '/llms.txt', '/.well-known/',
+        '/.well-known/',
+        // Security scan F3 (CWE-862): /feed.xml, /sitemap(.xml) and /llms.txt
+        // are content-bearing — they leak book titles, authors, descriptions and
+        // enumerate every catalog URL to unauthenticated visitors. In private
+        // mode the whole catalog must be behind the login wall, so they are NOT
+        // allow-listed here (they stay fully public when private mode is off,
+        // since isAllowed() only runs once advanced.private_mode === '1').
     ];
 
     /**

--- a/app/Middleware/RateLimitMiddleware.php
+++ b/app/Middleware/RateLimitMiddleware.php
@@ -84,7 +84,20 @@ class RateLimitMiddleware implements MiddlewareInterface
     private function getClientIP(Request $request): string
     {
         $serverParams = $request->getServerParams();
-        
+        $remoteAddr = $serverParams['REMOTE_ADDR'] ?? 'unknown';
+
+        // Security scan F1 (CWE-807): client-controlled forwarding headers are
+        // the rate-limiter's identity, and the limiter is the ONLY brute-force
+        // control on login/forgot-password/reset (no per-account lockout). Only
+        // honor those headers when the direct peer (REMOTE_ADDR) is a configured
+        // trusted reverse proxy — otherwise an unauthenticated client rotates
+        // X-Forwarded-For to mint an unlimited number of fresh buckets and
+        // defeats the throttle entirely. Default (Apache-direct, TRUSTED_PROXIES
+        // unset) → always key on the real peer address.
+        if (!\App\Support\HtmlHelper::isRemoteAddrTrustedProxy()) {
+            return $remoteAddr;
+        }
+
         // Check various headers that might contain the real IP
         $headers = [
             'X-Forwarded-For',
@@ -108,7 +121,7 @@ class RateLimitMiddleware implements MiddlewareInterface
         }
 
         // Fallback to REMOTE_ADDR
-        return $serverParams['REMOTE_ADDR'] ?? 'unknown';
+        return $remoteAddr;
     }
 
     /**

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2057,11 +2057,16 @@ return function (App $app): void {
         ->add(new \App\Middleware\RateLimitMiddleware(10, 60))
         ->add(new CsrfMiddleware())
         ->add(new AdminAuthMiddleware());
+    // Admin-only: this DataTables feed runs SELECT l.* and exposes internal
+    // fields (prezzo, note_varie, numero_inventario, tipo_acquisizione,
+    // collocazione) never shown on the public catalog. Guard it like its
+    // sibling /api/libri/bulk-* routes so anonymous visitors can't page
+    // through internal book data (CWE-862).
     $app->get('/api/libri', function ($request, $response) use ($app) {
         $controller = new \App\Controllers\LibriApiController();
         $db = $app->getContainer()->get('db');
         return $controller->list($request, $response, $db);
-    });
+    })->add(new AdminAuthMiddleware());
     // API Autori (server-side DataTables)
     $app->get('/api/autori', function ($request, $response) use ($app) {
         $controller = new \App\Controllers\AutoriApiController();
@@ -2084,11 +2089,15 @@ return function (App $app): void {
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
     // API Editori (server-side DataTables)
+    // Admin-only: this feed runs SELECT e.* and exposes publisher PII
+    // (telefono, email, referente_*, codice_fiscale). Guard it like its
+    // sibling /api/editori/bulk-* and merge routes so anonymous visitors
+    // can't exfiltrate contact data (CWE-862).
     $app->get('/api/editori', function ($request, $response) use ($app) {
         $controller = new \App\Controllers\EditoriApiController();
         $db = $app->getContainer()->get('db');
         return $controller->list($request, $response, $db);
-    });
+    })->add(new AdminAuthMiddleware());
 
     // API Editori - Bulk Delete
     $app->post('/api/editori/bulk-delete', function ($request, $response) use ($app) {

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2698,10 +2698,29 @@ return function (App $app): void {
             ];
         }
 
+        // Anti-DNS-rebinding: the DNS check above and curl's own resolution are
+        // two separate lookups — pin curl to the exact IPs already validated as
+        // public so it can't be steered to an internal address on the second
+        // lookup (same fix as /api/plugins/proxy-image; a whitelisted host that
+        // is compromised could otherwise resolve internally). Entries in $ips /
+        // $aaaaRecords already passed the NO_PRIV_RANGE|NO_RES_RANGE filter.
+        // Scheme is guaranteed 'https' here (enforced with a 403 above).
+        $coverPort = isset($parts['port']) ? (int) $parts['port'] : 443;
+        $coverIps = $ips;
+        foreach ($aaaaRecords as $record) {
+            if (!empty($record['ipv6'])) {
+                $coverIps[] = $record['ipv6'];
+            }
+        }
+        if ($coverIps === []) {
+            return $response->withStatus(403);
+        }
+
         $ch = curl_init($url);
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_RESOLVE => [$host . ':' . $coverPort . ':' . implode(',', $coverIps)],
             CURLOPT_TIMEOUT => 10,
             CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_SSL_VERIFYPEER => true,

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2809,12 +2809,35 @@ return function (App $app): void {
             }
         }
 
+        // Security scan F5 (CWE-918): the DNS check above (gethostbynamel /
+        // dns_get_record) and curl's own resolution are two SEPARATE lookups —
+        // a rebinding attacker can answer "public IP" to the first and
+        // "127.0.0.1" to curl's, so validating the hostname is not enough. Pin
+        // curl to the exact IPs we just validated as public via CURLOPT_RESOLVE
+        // so it never re-resolves. All entries in $ips / $aaaaRecords already
+        // passed the NO_PRIV_RANGE|NO_RES_RANGE filter above.
+        $port = isset($parts['port']) ? (int) $parts['port'] : 443;
+        $validatedIps = $ips;
+        foreach ($aaaaRecords as $record) {
+            if (!empty($record['ipv6'])) {
+                $validatedIps[] = $record['ipv6'];
+            }
+        }
+        if ($validatedIps === []) {
+            return $response->withStatus(403);
+        }
+        $resolveEntry = $host . ':' . $port . ':' . implode(',', $validatedIps);
+
         // Fetch image with secure settings
         $ch = curl_init($url);
         curl_setopt_array($ch, [
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_FOLLOWLOCATION => true,
-            CURLOPT_MAXREDIRS => 3,
+            // F5: never follow redirects — a 3xx to an internal host would be
+            // fetched by curl BEFORE any post-hoc URL re-validation could run,
+            // and the response body would already have been read. Reject 3xx.
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_RESOLVE => [$resolveEntry],
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTPS,
             CURLOPT_TIMEOUT => 10,
             CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_SSL_VERIFYPEER => true,
@@ -2827,59 +2850,12 @@ return function (App $app): void {
 
         $img = curl_exec($ch);
         $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $finalUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
         curl_close($ch);
 
+        // A 3xx means the origin tried to redirect us (potentially to an
+        // internal target); with FOLLOWLOCATION off we simply refuse it.
         if ($img === false || $httpCode !== 200) {
             return $response->withStatus(404);
-        }
-
-        // Re-validate final URL after redirects to prevent SSRF via redirect
-        if ($finalUrl && $finalUrl !== $url) {
-            $finalParts = parse_url($finalUrl);
-            if (!$finalParts || !isset($finalParts['scheme'], $finalParts['host'])) {
-                return $response->withStatus(403);
-            }
-
-            // Ensure redirect stayed on HTTPS
-            if (strtolower($finalParts['scheme']) !== 'https') {
-                return $response->withStatus(403);
-            }
-
-            $finalHost = strtolower($finalParts['host']);
-
-            // Check if redirect went to private network
-            if (in_array($finalHost, $blockedHosts, true)) {
-                return $response->withStatus(403);
-            }
-
-            foreach ($privatePatterns as $pattern) {
-                if (preg_match($pattern, $finalHost)) {
-                    return $response->withStatus(403);
-                }
-            }
-
-            // DNS resolution check for redirect target
-            $finalIps = @gethostbynamel($finalHost) ?: [];
-            $finalAAAA = @dns_get_record($finalHost, DNS_AAAA) ?: [];
-
-            if (!$finalIps && !$finalAAAA) {
-                return $response->withStatus(403);
-            }
-
-            // Validate redirect target resolves to public IPs only
-            foreach ($finalIps as $ip) {
-                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
-                    return $response->withStatus(403);
-                }
-            }
-
-            foreach ($finalAAAA as $record) {
-                $ipv6 = $record['ipv6'] ?? null;
-                if ($ipv6 && filter_var($ipv6, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
-                    return $response->withStatus(403);
-                }
-            }
         }
 
         // Validate it's actually an image

--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -185,7 +185,7 @@ class HtmlHelper
      *
      * @return bool True when REMOTE_ADDR is in the trusted-proxy list
      */
-    private static function isRemoteAddrTrustedProxy(): bool
+    public static function isRemoteAddrTrustedProxy(): bool
     {
         $trustedRaw = $_ENV['TRUSTED_PROXIES'] ?? getenv('TRUSTED_PROXIES');
         $trustedEnv = is_string($trustedRaw) ? $trustedRaw : '';

--- a/app/Support/RememberMeService.php
+++ b/app/Support/RememberMeService.php
@@ -435,6 +435,14 @@ class RememberMeService
      */
     private function getClientIP(): ?string
     {
+        // Security scan F6 (CWE-807): this IP is written to the security audit
+        // log and the session-management UI. Only trust client-supplied
+        // forwarding headers when the direct peer is a configured trusted proxy;
+        // otherwise a client can forge the audit IP by setting X-Forwarded-For.
+        if (!HtmlHelper::isRemoteAddrTrustedProxy()) {
+            return $_SERVER['REMOTE_ADDR'] ?? null;
+        }
+
         // Check various headers that might contain the real IP (behind proxy/load balancer)
         $headers = [
             'HTTP_X_FORWARDED_FOR',

--- a/app/Views/cms/edit-home.php
+++ b/app/Views/cms/edit-home.php
@@ -730,22 +730,27 @@ document.addEventListener('DOMContentLoaded', function() {
             const fileInput = document.getElementById('hero-background-input');
             const dataTransfer = new DataTransfer();
 
-            // Create a File object from Uppy file data
-            fetch(file.data instanceof File ? URL.createObjectURL(file.data) : file.preview)
-                .then(res => res.blob())
-                .then(blob => {
-                    const newFile = new File([blob], file.name, { type: file.type });
-                    dataTransfer.items.add(newFile);
-                    fileInput.files = dataTransfer.files;
-                })
-                .catch(err => {
-                    console.error('Error converting file:', err);
-                    // Fallback: if file.data is already a File object
-                    if (file.data instanceof File) {
-                        dataTransfer.items.add(file.data);
+            // Uppy already hands us a File in file.data — use it directly.
+            // The previous code did fetch(URL.createObjectURL(file.data)),
+            // which a strict `connect-src` CSP blocks (blob: is not always
+            // allowed), so the hero image never reached the form (issue #292).
+            // Only fall back to fetching a preview URL when file.data is not
+            // itself a File (mirrors the logo uploader in settings/index.php).
+            if (file.data instanceof File) {
+                dataTransfer.items.add(file.data);
+                fileInput.files = dataTransfer.files;
+            } else if (file.preview) {
+                fetch(file.preview)
+                    .then(res => res.blob())
+                    .then(blob => {
+                        const newFile = new File([blob], file.name, { type: file.type });
+                        dataTransfer.items.add(newFile);
                         fileInput.files = dataTransfer.files;
-                    }
-                });
+                    })
+                    .catch(err => {
+                        console.error('Error converting file:', err);
+                    });
+            }
         });
 
         // Handle file removed

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1486,13 +1486,16 @@ $additional_css = "
         margin-right: auto;
     }
 
-    /* Responsive related-books grid: one row of as many cards as fit the
-       viewport (≈6 desktop, 4 laptop, 3 tablet, 2 phone), overflow hidden — so
-       the COUNT shown adapts to screen size instead of being a fixed 3.
-       grid-auto-rows:0 + overflow:hidden collapse every row after the first. */
+    /* Responsive related-books grid: one visible row, capped at 4 cards on
+       wide/high-res screens and degrading to 3/2/1 as the viewport narrows —
+       each column is at least a quarter of the row (minus the 3 inter-column
+       gaps) OR 200px, whichever is larger, so auto-fill can never pack more
+       than 4 columns even on a high-resolution laptop. grid-auto-rows:0 +
+       overflow:hidden collapse every row after the first, so extra related
+       books beyond the first 4 stay clipped rather than wrapping. */
     .related-books-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(max(200px, calc((100% - 3 * 1.5rem) / 4)), 1fr));
         /* row-gap:0 so the zero-height clipped rows don't add trailing
            whitespace below the single visible row (F002). Horizontal spacing
            between cards in the visible row is preserved via column-gap. */
@@ -1750,6 +1753,12 @@ ob_start();
                     <h1 class="fw-bold mb-3" id="book-title" style="font-size: clamp(1.5rem, 3.5vw, 2.25rem);">
                         <?= htmlspecialchars(html_entity_decode($book['titolo'] ?? '', ENT_QUOTES, 'UTF-8')) ?>
                     </h1>
+
+                    <?php if (!empty($book['sottotitolo'])): ?>
+                    <p class="book-subtitle-hero mb-3" id="book-subtitle" style="font-size: clamp(1.05rem, 2vw, 1.35rem); color: var(--text-muted, #6b7280); font-weight: 500; line-height: 1.4;">
+                        <?= htmlspecialchars(html_entity_decode($book['sottotitolo'], ENT_QUOTES, 'UTF-8')) ?>
+                    </p>
+                    <?php endif; ?>
 
                     <div class="authors-list" id="book-authors-list">
                         <?php foreach($authors as $author): ?>

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -3,6 +3,10 @@ use App\Support\ConfigStore;
 
 // Variables passed from controller
 $libro = $libro ?? [];
+// Security: borrower PII (loan history, active-loan/per-copy borrower) is gated
+// on this flag. Default to false so a code path that includes this view without
+// setting it can never leak PII to a non-admin/staff viewer (finding F2).
+$isAdminOrStaff = $isAdminOrStaff ?? false;
 $isCatalogueMode = ConfigStore::isCatalogueMode();
 // i18n-2 (refactor): centralised label map; see App\Support\SeriesLabels.
 $seriesTypeLabels = \App\Support\SeriesLabels::types();
@@ -280,6 +284,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
           </h3>
         </div>
         <div class="card-body space-y-3 text-sm text-gray-700">
+          <?php if ($isAdminOrStaff): ?>
           <div class="flex items-center justify-between">
             <span class="font-medium"><?= __("Utente") ?></span>
             <span class="text-right">
@@ -287,6 +292,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
               <span class="text-xs text-gray-500"><?php echo App\Support\HtmlHelper::e($activeLoan['utente_email'] ?? ''); ?></span>
             </span>
           </div>
+          <?php endif; ?>
           <div class="flex items-center justify-between">
             <span class="font-medium"><?= __("Dal") ?></span>
             <span><?php echo App\Support\HtmlHelper::e(format_date($activeLoan['data_prestito'] ?? '', false, '/')); ?></span>
@@ -1019,7 +1025,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                   <?php endif; ?>
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap text-sm">
-                  <?php if (!empty($copia['utente_nome'])): ?>
+                  <?php if ($isAdminOrStaff && !empty($copia['utente_nome'])): ?>
                     <div class="text-gray-900">
                       <?php echo App\Support\HtmlHelper::e($copia['utente_nome'] . ' ' . $copia['utente_cognome']); ?>
                     </div>
@@ -1183,7 +1189,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
   </div>
   <?php endif; ?>
 
-  <?php if (!empty($loanHistory) && count($loanHistory) > 0 && !$isCatalogueMode): ?>
+  <?php if ($isAdminOrStaff && !empty($loanHistory) && count($loanHistory) > 0 && !$isCatalogueMode): ?>
   <div class="mt-6">
     <div class="card">
       <div class="card-header">
@@ -1782,11 +1788,13 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
           <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
           <input type="hidden" name="redirect_to" value="<?php echo htmlspecialchars($bookPath ?? url('/admin/books/' . (int)($libro['id'] ?? 0)), ENT_QUOTES, 'UTF-8'); ?>">
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm text-gray-700">
+            <?php if ($isAdminOrStaff): ?>
             <div>
               <div class="text-xs text-gray-500 uppercase"><?= __("Utente") ?></div>
               <div class="font-medium"><?php echo App\Support\HtmlHelper::e($activeLoan['utente_nome'] ?? __('Sconosciuto')); ?></div>
               <div class="text-xs text-gray-500"><?php echo App\Support\HtmlHelper::e($activeLoan['utente_email'] ?? ''); ?></div>
             </div>
+            <?php endif; ?>
             <div>
               <div class="text-xs text-gray-500 uppercase"><?= __("Prestito") ?></div>
               <div class="font-medium"><?= __("Dal") ?> <?php echo App\Support\HtmlHelper::e(format_date($activeLoan['data_prestito'] ?? '', false, '/')); ?></div>

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -680,6 +680,9 @@ use App\Support\HtmlHelper;
     }
     $apiEnabled = ($advancedSettings['api_enabled'] ?? '0') === '1';
     $apiEndpoint = \App\Controllers\SeoController::resolveBaseUrl() . '/api/public/books/search';
+    // Security scan F11 (CWE-522): only real admins may see the API key VALUES.
+    // 'staff' can reach this page but must never receive the secrets in the HTML.
+    $isAdmin = $isAdmin ?? (($_SESSION['user']['tipo_utente'] ?? '') === 'admin');
   ?>
 
   <div class="bg-white border border-gray-200 rounded-2xl overflow-hidden mt-6 max-sm:!bg-transparent max-sm:!rounded-none max-sm:!shadow-none max-sm:!border-0">
@@ -720,6 +723,7 @@ use App\Support\HtmlHelper;
       </form>
 
       <!-- <?= __("API Keys") ?> Management -->
+      <?php if (!empty($isAdmin)): ?>
       <div class="space-y-4">
         <div class="flex items-center justify-between">
           <h4 class="text-base font-semibold text-gray-900 flex items-center gap-2">
@@ -809,6 +813,12 @@ use App\Support\HtmlHelper;
           </div>
         <?php endif; ?>
       </div>
+      <?php else: ?>
+      <div class="p-4 bg-gray-50 rounded-xl border border-gray-200 text-sm text-gray-600 flex items-center gap-2">
+        <i class="fas fa-lock text-gray-400"></i>
+        <?= __("Solo gli amministratori possono visualizzare e gestire le API key.") ?>
+      </div>
+      <?php endif; ?>
 
       <!-- API Documentation -->
       <details class="border border-gray-200 rounded-xl overflow-hidden">
@@ -838,8 +848,8 @@ use App\Support\HtmlHelper;
                 <pre class="mt-2 bg-gray-900 text-green-400 p-2 rounded overflow-x-auto"><code>X-API-Key: your-api-key-here</code></pre>
               </div>
               <div class="bg-gray-50 rounded-lg p-3 border border-gray-200">
-                <strong class="text-gray-900"><?= __("Query parameter:") ?></strong>
-                <pre class="mt-2 bg-gray-900 text-green-400 p-2 rounded overflow-x-auto"><code>?api_key=your-api-key-here</code></pre>
+                <strong class="text-gray-900"><?= __("Authorization header:") ?></strong>
+                <pre class="mt-2 bg-gray-900 text-green-400 p-2 rounded overflow-x-auto"><code>Authorization: Bearer your-api-key-here</code></pre>
               </div>
             </div>
           </div>

--- a/app/Views/settings/contacts-tab.php
+++ b/app/Views/settings/contacts-tab.php
@@ -144,7 +144,7 @@ use App\Support\HtmlHelper;
           <input type="password" autocomplete="off"
                  id="recaptcha_secret_key"
                  name="recaptcha_secret_key"
-                 value="<?php echo HtmlHelper::e($recaptchaSecret); ?>"
+                 value="<?php echo htmlspecialchars((string) $recaptchaSecret, ENT_QUOTES, 'UTF-8'); ?>"
                  class="mt-1 block w-full rounded-xl border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-3 px-4 font-mono" />
           <?php else: ?>
           <input type="password" autocomplete="off" disabled

--- a/app/Views/settings/contacts-tab.php
+++ b/app/Views/settings/contacts-tab.php
@@ -132,11 +132,27 @@ use App\Support\HtmlHelper;
 
         <div>
           <label for="recaptcha_secret_key" class="block text-sm font-medium text-gray-700"><?= __("Secret Key") ?></label>
+          <?php
+            // Security scan F11 (CWE-522): the reCAPTCHA secret must never reach
+            // 'staff'. Only admins get the real value in an editable field; for
+            // everyone else the field is masked AND disabled (disabled inputs are
+            // not submitted), so the value neither leaks nor gets wiped on save.
+            $isAdmin = $isAdmin ?? (($_SESSION['user']['tipo_utente'] ?? '') === 'admin');
+            $recaptchaSecret = (string) ($contactSettings['recaptcha_secret_key'] ?? '');
+          ?>
+          <?php if (!empty($isAdmin)): ?>
           <input type="password" autocomplete="off"
                  id="recaptcha_secret_key"
                  name="recaptcha_secret_key"
-                 value="<?php echo HtmlHelper::e($contactSettings['recaptcha_secret_key'] ?? ''); ?>"
+                 value="<?php echo HtmlHelper::e($recaptchaSecret); ?>"
                  class="mt-1 block w-full rounded-xl border-gray-300 focus:border-gray-500 focus:ring-gray-500 text-sm py-3 px-4 font-mono" />
+          <?php else: ?>
+          <input type="password" autocomplete="off" disabled
+                 id="recaptcha_secret_key"
+                 value="<?php echo $recaptchaSecret !== '' ? '••••••••••••' : ''; ?>"
+                 placeholder="<?= htmlspecialchars(__('Solo gli amministratori possono modificare questa chiave.'), ENT_QUOTES, 'UTF-8') ?>"
+                 class="mt-1 block w-full rounded-xl border-gray-300 bg-gray-100 text-gray-400 text-sm py-3 px-4 font-mono cursor-not-allowed" />
+          <?php endif; ?>
         </div>
 
         <p class="text-xs text-gray-500">

--- a/docs/api.MD
+++ b/docs/api.MD
@@ -45,7 +45,7 @@ Pinakes exposes **two distinct API surfaces** with different authentication mode
 | Surface | Routes | Auth |
 |---------|--------|------|
 | **Internal / admin API** | `/api/libri`, `/api/prestiti`, `/api/utenti`, `/api/autori`, `/api/editori`, `/api/generi/*`, `/api/dewey/*`, `/api/search/*`, `/api/collane/*`, `/api/collocazione/*`, `/api/books/{id}/availability*`, ... | **Session-based** (browser cookies + role middleware). Used by the admin UI / DataTables. |
-| **Public API** | `/api/public/*` | **API key** via `ApiKeyMiddleware`. Requires `api.enabled = '1'` in settings and a valid key in the `X-API-Key` header or `api_key` query parameter. |
+| **Public API** | `/api/public/*` | **API key** via `ApiKeyMiddleware`. Requires `api.enabled = '1'` in settings and a valid key in the `X-API-Key` (or `Authorization: Bearer`) header. |
 
 The internal endpoints below are **not** intended for third-party integration — they are session-gated through `AuthMiddleware`/`AdminAuthMiddleware` and return HTML-laced DataTables payloads. For programmatic third-party access use the **Public API** described below.
 
@@ -101,9 +101,13 @@ session-based admin endpoints.
 
 ### Passing the key
 
-Provide the key in **either**:
-- HTTP header (preferred): `X-API-Key: <key>`
-- Query parameter: `?api_key=<key>`
+Provide the key in an HTTP header (either form):
+- `X-API-Key: <key>`
+- `Authorization: Bearer <key>`
+
+The key is **never** accepted as a `?api_key=` query parameter: query strings
+are written to web-server access logs, so a key passed that way leaks to anyone
+with log access. Header-only avoids that exposure.
 
 Each authenticated request updates the key's `last_used` timestamp
 (non-blocking; failures are logged, not fatal).

--- a/installer/classes/Validator.php
+++ b/installer/classes/Validator.php
@@ -116,7 +116,15 @@ class Validator {
             return true;
 
         } catch (PDOException $e) {
-            $this->errors['connection'] = __("Connessione al database fallita") . ": " . $e->getMessage();
+            // Security scan F4 (CWE-918): the raw PDO error is an error-based
+            // oracle. On the unauthenticated /installer test-connection path it
+            // lets a caller tell "connection refused" from "MySQL handshake"
+            // from "timeout" for any attacker-chosen host:port/socket, turning
+            // the installer into an internal port scanner. Keep the detail in
+            // the server log for legitimate install debugging, but return only a
+            // generic, non-oracle message to the client.
+            error_log('[Installer] DB connection test failed: ' . $e->getMessage());
+            $this->errors['connection'] = __("Connessione al database fallita. Verifica host, porta, nome utente e password.");
             return false;
         }
     }

--- a/installer/database/migrations/migrate_0.7.41.sql
+++ b/installer/database/migrations/migrate_0.7.41.sql
@@ -10,14 +10,14 @@
 -- refreshes the metadata / re-activates the language.
 --
 -- total_keys/translated_keys mirror the shipped locale/da_DK.json key count
--- (6607 keys, exact parity with locale/it_IT.json).
+-- (6611 keys after v0.7.42 added 4 UI strings, exact parity with locale/it_IT.json).
 --
 -- See CLAUDE.md "Migration file version MUST be ≤ release version": this file
 -- runs only once version.json reaches 0.7.41 (updater compares
 -- migrationVersion <= toVersion).
 
 INSERT INTO `languages` (`code`, `name`, `native_name`, `flag_emoji`, `is_default`, `is_active`, `translation_file`, `total_keys`, `translated_keys`, `completion_percentage`, `created_at`, `updated_at`)
-VALUES ('da_DK', 'Danish', 'Dansk', '🇩🇰', 0, 1, 'locale/da_DK.json', 6607, 6607, 100.00, NOW(), NOW())
+VALUES ('da_DK', 'Danish', 'Dansk', '🇩🇰', 0, 1, 'locale/da_DK.json', 6611, 6611, 100.00, NOW(), NOW())
 ON DUPLICATE KEY UPDATE
     is_active = 1,
     name = VALUES(name),

--- a/installer/database/migrations/migrate_0.7.42.sql
+++ b/installer/database/migrations/migrate_0.7.42.sql
@@ -1,0 +1,20 @@
+-- Migration 0.7.42
+--
+-- v0.7.42 added 4 UI strings for the security hardening in this release
+-- (settings admin-only API-key notices, the "Authorization header:" label, and
+-- the "Percorso file non valido" language-upload error). The da_DK catalogue was
+-- brought to full parity with it_IT, so its shipped key count grew 6607 -> 6611.
+--
+-- Fresh installs and upgrades from <0.7.41 get 6611 straight from
+-- migrate_0.7.41.sql (updated in lockstep with the locale file). This migration
+-- only fixes installs that already applied migrate_0.7.41 at the old count of
+-- 6607 — it bumps them to 6611 so the language-management UI reports the correct
+-- completion. Idempotent: it never lowers a count and skips rows already at 6611.
+
+UPDATE `languages`
+SET `total_keys` = 6611,
+    `translated_keys` = 6611,
+    `completion_percentage` = 100.00,
+    `updated_at` = NOW()
+WHERE `code` = 'da_DK'
+  AND `total_keys` < 6611;

--- a/installer/steps/step6.php
+++ b/installer/steps/step6.php
@@ -33,6 +33,34 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $installer->loadEnvConfig();
             $pdo = $installer->getDatabaseConnection();
 
+            // Security scan F2 (CWE-312): encrypt the SMTP password at rest with
+            // the SAME AES-256-GCM scheme the running app uses
+            // (App\Support\SettingsEncryption), so a DB-only read (dump, backup,
+            // SQLi elsewhere) cannot recover the plaintext credential. The
+            // installer has no composer autoloader, so the scheme is inlined
+            // here; SettingsEncryption::decrypt() reads it back transparently
+            // (prefix "ENC:", key = sha256(PLUGIN_ENCRYPTION_KEY, raw), payload =
+            // iv[12] | tag[16] | ciphertext). If no key is available we ABORT
+            // rather than silently persist the password in cleartext.
+            $smtpPasswordStored = $smtpPassword;
+            if ($smtpPassword !== '') {
+                $encKeyRaw = $_ENV['PLUGIN_ENCRYPTION_KEY'] ?? getenv('PLUGIN_ENCRYPTION_KEY') ?: '';
+                if ($encKeyRaw === '' || $encKeyRaw === false) {
+                    $encKeyRaw = $_ENV['APP_KEY'] ?? getenv('APP_KEY') ?: '';
+                }
+                if ($encKeyRaw === '' || $encKeyRaw === false) {
+                    throw new Exception(__("Chiave di cifratura non disponibile: impossibile salvare la password SMTP in modo sicuro."));
+                }
+                $encKey = hash('sha256', (string)$encKeyRaw, true);
+                $iv = random_bytes(12);
+                $tag = '';
+                $cipher = openssl_encrypt($smtpPassword, 'aes-256-gcm', $encKey, OPENSSL_RAW_DATA, $iv, $tag);
+                if ($cipher === false) {
+                    throw new Exception(__("Cifratura della password SMTP fallita."));
+                }
+                $smtpPasswordStored = 'ENC:' . base64_encode($iv . $tag . $cipher);
+            }
+
             // CRITICAL FIX: Save email settings directly to database
             // During installation, ConfigStore doesn't work because config/settings.php doesn't exist yet
             // We save directly to the settings table using PDO
@@ -45,7 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 ['email', 'smtp_host', $smtpHost],
                 ['email', 'smtp_port', (string)$smtpPort],
                 ['email', 'smtp_username', $smtpUsername],
-                ['email', 'smtp_password', $smtpPassword],
+                ['email', 'smtp_password', $smtpPasswordStored],
                 ['email', 'smtp_security', $smtpEncryption],
             ];
 

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6605,5 +6605,9 @@
   "Estensione non riuscita, riprova.": "Forlængelsen mislykkedes. Prøv igen.",
   "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.": "Forlængelsen blev annulleret: Mindst ét lån ville være i konflikt med et andet lån eller en reservation.",
   "Estendi": "Forlæng",
-  "Lingue non disponibili.": "Sprog er ikke tilgængelige."
+  "Lingue non disponibili.": "Sprog er ikke tilgængelige.",
+  "Authorization header:": "Authorization-header:",
+  "Percorso file non valido": "Ugyldig filsti",
+  "Solo gli amministratori possono modificare questa chiave.": "Kun administratorer kan redigere denne nøgle.",
+  "Solo gli amministratori possono visualizzare e gestire le API key.": "Kun administratorer kan se og administrere API-nøgler."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6605,5 +6605,9 @@
   "Estensione non riuscita, riprova.": "Verlängerung fehlgeschlagen, bitte erneut versuchen.",
   "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.": "Verlängerung abgebrochen: Mindestens eine Ausleihe würde mit einer anderen Ausleihe oder Reservierung in Konflikt geraten.",
   "Estendi": "Verlängern",
-  "Lingue non disponibili.": "Sprachen sind nicht verfügbar."
+  "Lingue non disponibili.": "Sprachen sind nicht verfügbar.",
+  "Authorization header:": "Authorization-Header:",
+  "Percorso file non valido": "Ungültiger Dateipfad",
+  "Solo gli amministratori possono modificare questa chiave.": "Nur Administratoren können diesen Schlüssel bearbeiten.",
+  "Solo gli amministratori possono visualizzare e gestire le API key.": "Nur Administratoren können API-Schlüssel anzeigen und verwalten."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6605,5 +6605,9 @@
   "Estensione non riuscita, riprova.": "Extension failed, please try again.",
   "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.": "Extension cancelled: at least one loan would conflict with another loan or reservation.",
   "Estendi": "Extend",
-  "Lingue non disponibili.": "Languages are unavailable."
+  "Lingue non disponibili.": "Languages are unavailable.",
+  "Authorization header:": "Authorization header:",
+  "Percorso file non valido": "Invalid file path",
+  "Solo gli amministratori possono modificare questa chiave.": "Only administrators can edit this key.",
+  "Solo gli amministratori possono visualizzare e gestire le API key.": "Only administrators can view and manage API keys."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6605,5 +6605,9 @@
   "Estensione non riuscita, riprova.": "La prolongation a échoué, veuillez réessayer.",
   "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.": "Prolongation annulée : au moins un prêt entrerait en conflit avec un autre prêt ou une réservation.",
   "Estendi": "Prolonger",
-  "Lingue non disponibili.": "Les langues ne sont pas disponibles."
+  "Lingue non disponibili.": "Les langues ne sont pas disponibles.",
+  "Authorization header:": "En-tête Authorization :",
+  "Percorso file non valido": "Chemin de fichier invalide",
+  "Solo gli amministratori possono modificare questa chiave.": "Seuls les administrateurs peuvent modifier cette clé.",
+  "Solo gli amministratori possono visualizzare e gestire le API key.": "Seuls les administrateurs peuvent voir et gérer les clés API."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6605,5 +6605,9 @@
   "Estensione non riuscita, riprova.": "Estensione non riuscita, riprova.",
   "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.": "Estensione annullata: almeno un prestito entrerebbe in conflitto con un altro prestito o una prenotazione.",
   "Estendi": "Estendi",
-  "Lingue non disponibili.": "Lingue non disponibili."
+  "Lingue non disponibili.": "Lingue non disponibili.",
+  "Authorization header:": "Authorization header:",
+  "Percorso file non valido": "Percorso file non valido",
+  "Solo gli amministratori possono modificare questa chiave.": "Solo gli amministratori possono modificare questa chiave.",
+  "Solo gli amministratori possono visualizzare e gestire le API key.": "Solo gli amministratori possono visualizzare e gestire le API key."
 }

--- a/tests/extra-features.spec.js
+++ b/tests/extra-features.spec.js
@@ -223,6 +223,12 @@ test.describe.serial('User Profile & Dashboard', () => {
     const newPhone = `333${Date.now().toString().slice(-7)}`;
     await page.fill('#telefono', newPhone);
 
+    // #255 makes address required-by-config on some installs; fill it (guarded
+    // on the field's presence) so the profile form actually submits and the
+    // phone persists regardless of the install's required-field config.
+    const addrField = page.locator('#indirizzo, input[name="indirizzo"], textarea[name="indirizzo"]').first();
+    if (await addrField.count()) { await addrField.fill('Via Profilo 1'); }
+
     // Submit profile update form
     const form = page.locator('form[action*="aggiorna"], form[action*="update"]').first();
     await form.locator('button[type="submit"]').click();
@@ -343,6 +349,11 @@ test.describe.serial('Admin User Management', () => {
     await page.fill('input[name="cognome"]', `NewUser${RUN_ID}`);
     await page.fill('input[name="email"]', newEmail);
     await page.fill('input[name="telefono"]', '3339999999');
+
+    // #255 makes address required-by-config on some installs; fill it (guarded)
+    // so the create form submits instead of 302-redirecting back to /create.
+    const addr9 = page.locator('input[name="indirizzo"], textarea[name="indirizzo"]').first();
+    if (await addr9.count()) { await addr9.fill('Via Admin 1'); }
 
     // Select user type
     const tipoSelect = page.locator('select[name="tipo_utente"]');

--- a/tests/migration-0.7.42.unit.php
+++ b/tests/migration-0.7.42.unit.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural test for migrate_0.7.42.sql — bumps the da_DK translation key
+ * count from the pre-0.7.42 value (6607) to the current shipped count after
+ * v0.7.42 added 4 UI strings, for installs that already applied migrate_0.7.41
+ * at the old count.
+ *
+ * Runs the REAL migration file against a sandbox `languages` table (project
+ * pattern: same SQL, only the table name rewritten) and asserts:
+ *   - a da_DK row still at the old count is bumped to the current file count,
+ *   - completion stays 100.00,
+ *   - other locales are untouched,
+ *   - a second run is a no-op (idempotent — guarded by total_keys < 6611),
+ *   - a row ALREADY at the current count is not lowered/rewritten.
+ *
+ * Run:  php tests/migration-0.7.42.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) {
+        $pass++;
+        echo "  OK  {$label}\n";
+    } else {
+        $fail++;
+        echo "  FAIL {$label}\n";
+    }
+};
+
+echo "A. Real migration against a sandbox languages table\n";
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+try {
+    $socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', (int) ($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — the migration section is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$SB = 'zz_mig_languages_0742';
+$migration = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.42.sql');
+$sandbox = static fn (string $sql): string => str_replace('`languages`', "`{$SB}`", $sql);
+
+$runMigration = static function () use ($db, $migration, $sandbox): void {
+    foreach (array_filter(array_map('trim', preg_split('/;\s*\n/', $sandbox(preg_replace('/^--.*$/m', '', $migration) ?? $migration)))) as $statement) {
+        if ($statement !== '') {
+            $db->query($statement);
+        }
+    }
+};
+
+$cleanup = static function () use ($db, $SB): void {
+    $db->query("DROP TABLE IF EXISTS {$SB}");
+};
+
+// The count the migration targets — read from the shipped locale file so the
+// test tracks the real key count rather than a stale literal.
+$expectedKeys = count(json_decode((string) file_get_contents($root . '/locale/da_DK.json'), true, 512, JSON_THROW_ON_ERROR));
+
+try {
+    $cleanup();
+
+    $db->query("CREATE TABLE {$SB} (
+        id int NOT NULL AUTO_INCREMENT,
+        code varchar(10) NOT NULL,
+        name varchar(100) NOT NULL,
+        native_name varchar(100) NOT NULL,
+        flag_emoji varchar(10) DEFAULT NULL,
+        is_default tinyint(1) DEFAULT 0,
+        is_active tinyint(1) DEFAULT 1,
+        translation_file varchar(255) DEFAULT NULL,
+        total_keys int DEFAULT 0,
+        translated_keys int DEFAULT 0,
+        completion_percentage decimal(5,2) DEFAULT 0.00,
+        created_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        UNIQUE KEY unique_code (code)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    // Post-0.7.41 install state: da_DK present at the OLD count of 6607.
+    $db->query("INSERT INTO {$SB} (code, name, native_name, is_default, is_active, translation_file, total_keys, translated_keys, completion_percentage) VALUES
+        ('it_IT','Italian','Italiano',1,1,'locale/it_IT.json',6611,6611,100.00),
+        ('da_DK','Danish','Dansk',0,1,'locale/da_DK.json',6607,6607,100.00)");
+
+    $runMigration();
+
+    $row = $db->query("SELECT total_keys, translated_keys, completion_percentage FROM {$SB} WHERE code='da_DK'")->fetch_assoc();
+    $check($row !== null && (int) $row['total_keys'] === $expectedKeys, "da_DK total_keys bumped to {$expectedKeys}");
+    $check($row !== null && (int) $row['translated_keys'] === $expectedKeys, "da_DK translated_keys bumped to {$expectedKeys}");
+    $check($row !== null && (float) $row['completion_percentage'] === 100.00, 'completion_percentage stays 100.00');
+
+    $it = (int) $db->query("SELECT total_keys FROM {$SB} WHERE code='it_IT'")->fetch_row()[0];
+    $check($it === 6611, 'other locales untouched (it_IT unchanged)');
+
+    // Idempotency: a second run is a no-op (guarded by total_keys < 6611).
+    $db->query("UPDATE {$SB} SET updated_at='2000-01-01 00:00:00' WHERE code='da_DK'");
+    $runMigration();
+    $stamp = $db->query("SELECT updated_at FROM {$SB} WHERE code='da_DK'")->fetch_row()[0];
+    $check($stamp === '2000-01-01 00:00:00', 'second run is a no-op (row already at target not rewritten)');
+
+    $cleanup();
+} catch (\Throwable $e) {
+    $fail++;
+    echo "  FAIL exception: {$e->getMessage()}\n";
+    $cleanup();
+}
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/security-scan-findings.unit.php
+++ b/tests/security-scan-findings.unit.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression guards for the 2026-07-25 security scan findings.
+ *
+ *   F1 (CWE-807) — RateLimitMiddleware must NOT trust client forwarding headers
+ *                  unless REMOTE_ADDR is a configured trusted proxy, otherwise a
+ *                  rotating X-Forwarded-For mints unlimited rate-limit buckets.
+ *   F6 (CWE-807) — same rule for RememberMeService audit IP.
+ *   F3 (CWE-862) — private mode must NOT allow-list /feed.xml, /sitemap, /llms.txt
+ *                  (they leak catalog content to unauthenticated visitors).
+ *   F2 (CWE-312) — the installer's inline SMTP-password encryption must round-trip
+ *                  through the app's SettingsEncryption::decrypt().
+ *
+ * Run: php tests/security-scan-findings.unit.php   (exit 0 iff all pass)
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Middleware\RateLimitMiddleware;
+use App\Middleware\PrivateModeMiddleware;
+use App\Support\RememberMeService;
+use App\Support\SettingsEncryption;
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $cond, string $label) use (&$passed, &$failed): void {
+    if ($cond) { $passed++; echo "  OK  {$label}\n"; return; }
+    $failed++; echo "  FAIL {$label}\n";
+};
+
+$invoke = static function (object $obj, string $method, ...$args) {
+    $r = new ReflectionMethod($obj, $method);
+    $r->setAccessible(true);
+    return $r->invoke($obj, ...$args);
+};
+
+// Clean proxy env for the default (Apache-direct) posture.
+putenv('TRUSTED_PROXIES');
+unset($_ENV['TRUSTED_PROXIES']);
+
+echo "F1 — RateLimitMiddleware trusted-proxy gate\n";
+// In production Slim populates getServerParams() from $_SERVER, so the PSR-7
+// REMOTE_ADDR and $_SERVER['REMOTE_ADDR'] (which HtmlHelper's trusted-proxy
+// check reads) are the same value — mirror that here.
+$_SERVER['REMOTE_ADDR'] = '203.0.113.9';
+$factory = new \Slim\Psr7\Factory\ServerRequestFactory();
+$req = $factory->createServerRequest('POST', '/accedi', ['REMOTE_ADDR' => '203.0.113.9'])
+    ->withHeader('X-Forwarded-For', '8.8.8.8');
+$mw = new RateLimitMiddleware(15, 300, 'login');
+
+$check($invoke($mw, 'getClientIP', $req) === '203.0.113.9',
+    'no trusted proxy: spoofed X-Forwarded-For is ignored, keys on REMOTE_ADDR');
+
+putenv('TRUSTED_PROXIES=203.0.113.9');
+$_ENV['TRUSTED_PROXIES'] = '203.0.113.9';
+$check($invoke($mw, 'getClientIP', $req) === '8.8.8.8',
+    'peer is a trusted proxy: forwarded header is honored');
+putenv('TRUSTED_PROXIES');
+unset($_ENV['TRUSTED_PROXIES']);
+
+echo "F6 — RememberMeService audit IP trusted-proxy gate\n";
+// getClientIP() reads $_SERVER; construct without touching the DB via reflection.
+$ref = new ReflectionClass(RememberMeService::class);
+$svc = $ref->newInstanceWithoutConstructor();
+$_SERVER['REMOTE_ADDR'] = '203.0.113.50';
+$_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.4.4';
+$check($invoke($svc, 'getClientIP') === '203.0.113.50',
+    'no trusted proxy: forged X-Forwarded-For not written to audit IP');
+putenv('TRUSTED_PROXIES=203.0.113.50');
+$_ENV['TRUSTED_PROXIES'] = '203.0.113.50';
+$check($invoke($svc, 'getClientIP') === '8.8.4.4',
+    'peer is a trusted proxy: forwarded audit IP honored');
+putenv('TRUSTED_PROXIES');
+unset($_ENV['TRUSTED_PROXIES'], $_SERVER['HTTP_X_FORWARDED_FOR']);
+
+echo "F3 — private mode does not allow-list content endpoints\n";
+$pm = new PrivateModeMiddleware();
+foreach (['/feed.xml' => false, '/sitemap.xml' => false, '/sitemap' => false, '/llms.txt' => false,
+          '/assets/app.css' => true, '/favicon.ico' => true, '/robots.txt' => true] as $path => $expected) {
+    $check($invoke($pm, 'isAllowed', $path) === $expected,
+        "isAllowed('{$path}') === " . ($expected ? 'true' : 'false'));
+}
+
+echo "F2 — installer inline cipher round-trips through the app decrypt\n";
+putenv('PLUGIN_ENCRYPTION_KEY=regression-key-xyz');
+$_ENV['PLUGIN_ENCRYPTION_KEY'] = 'regression-key-xyz';
+SettingsEncryption::resetKeyCache();
+$plain = 'p@ss"w0rd,\'; DROP';
+// Mirror step6.php exactly.
+$encKey = hash('sha256', 'regression-key-xyz', true);
+$iv = random_bytes(12);
+$tag = '';
+$cipher = openssl_encrypt($plain, 'aes-256-gcm', $encKey, OPENSSL_RAW_DATA, $iv, $tag);
+$stored = 'ENC:' . base64_encode($iv . $tag . $cipher);
+$check(str_starts_with($stored, 'ENC:') && SettingsEncryption::decrypt($stored) === $plain,
+    'installer-encrypted SMTP password decrypts to the original plaintext');
+SettingsEncryption::resetKeyCache();
+putenv('PLUGIN_ENCRYPTION_KEY');
+unset($_ENV['PLUGIN_ENCRYPTION_KEY']);
+
+echo "\nPassed: {$passed}   Failed: {$failed}\n";
+exit($failed > 0 ? 1 : 0);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "name": "Pinakes",
-    "version": "0.7.41",
+    "version": "0.7.42",
     "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Summary

Release-prep branch for **v0.7.42** — a security-hardening + bug-fix release. It closes a set of access-control, SSRF, open-redirect and data-exposure issues found in a full security audit of `app/`, `public/` and `installer/`, and fixes three OPAC/CMS regressions reported by users.

## Security (audit findings)

**High**
- **Access control on internal APIs** — `GET /api/editori` and `GET /api/libri` were reachable without a session and returned every column, exposing publisher PII (email, phone, tax code, referent contacts) and internal book fields (price, private notes, inventory numbers). Now behind the admin-session middleware, matching how the API docs already describe them.
- **Borrower privacy** — a non-admin patron could open `/admin/books/{id}` and read every borrower's name, email and loan history. Borrower identity is now gated to admin/staff only.
- **Update privilege boundary** — a `staff` user could upload+install an update package or trigger a full update over the app files (a route to code execution). Those actions (and `saveToken`) now require an explicit `admin` re-check.

**Medium/Low** — public search API no longer leaks borrower name/email; admin routes re-validate role+status against the DB each request (immediate demotion/suspension); settings no longer expose API keys / reCAPTCHA secret to staff; API keys accepted only via header, never `?api_key=`; open redirect after login and on the language switch (`/\` backslash bypass) fixed in all sanitizers; path-traversal on language-file upload; SSRF in the image proxy (redirect + DNS-rebinding) and the installer DB test; plaintext SMTP password in the installer; CSV/formula injection in two exports; reset-link Host-header poisoning; login timing side channel; rate-limit bypass via forged forwarding headers.

Two independent Opus reviewers audited the fixes; the one real regression they found (a staff save wiping the admin reCAPTCHA secret) and two minor residuals are fixed in the final commit.

## Bug fixes
- **Book subtitle now shows on the public book page** (#293).
- **Hero background upload works under a strict `connect-src` CSP** (#292) — no longer fetches a `blob:` URL.
- **Related-books count** caps at 4 on high-resolution screens and adapts down to 3/2/1.

## Database
- `migrate_0.7.42.sql` — bumps the `da_DK` translation key count (6607 → 6611) for installs already on 0.7.41 (idempotent). New behavioural migration test.

## Testing
- PHPStan level 5 clean; full unit battery green (incl. new `migration-0.7.42` and `security-scan-findings` tests); `code-quality` 15/15. The related-books and subtitle fixes were verified in a real browser at 5 viewport widths. Full E2E suite + reinstall regression to run before release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Rafforzati i controlli di accesso per API, pagine amministrative e operazioni di aggiornamento.
  * Limitata la visualizzazione dei dati personali dei prestatori a amministratori e staff.
  * Le API accettano le chiavi solo tramite header.
  * Aggiunta protezione avanzata per password SMTP e link di reimpostazione.

* **Correzioni**
  * Migliorata la sicurezza contro redirect indesiderati, SSRF, traversal e spoofing degli indirizzi IP.
  * Corretta la visualizzazione dei sottotitoli dei libri e della griglia dei libri correlati.
  * Migliorato l’upload dell’immagine Hero con policy CSP restrittive.

* **Documentazione**
  * Aggiornate le note di rilascio e la documentazione API per la versione 0.7.42.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->