### PR TITLE
Remove dormant fetch(blob:) fallback in 3 Uppy uploaders (follow-up to #292)

### DIFF
--- a/app/Views/cms/edit-home.php
+++ b/app/Views/cms/edit-home.php
@@ -739,17 +739,15 @@ document.addEventListener('DOMContentLoaded', function() {
             if (file.data instanceof File) {
                 dataTransfer.items.add(file.data);
                 fileInput.files = dataTransfer.files;
-            } else if (file.preview) {
-                fetch(file.preview)
-                    .then(res => res.blob())
-                    .then(blob => {
-                        const newFile = new File([blob], file.name, { type: file.type });
-                        dataTransfer.items.add(newFile);
-                        fileInput.files = dataTransfer.files;
-                    })
-                    .catch(err => {
-                        console.error('Error converting file:', err);
-                    });
+            } else if (file.data instanceof Blob) {
+                // file.data is a Blob but not a File — wrap it directly. No
+                // fetch(file.preview): file.preview can be a blob: URL, and
+                // fetching it violates a strict connect-src CSP (the #292 bug
+                // class). With only UppyDragDrop in use, file.data is always a
+                // File/Blob; a non-Blob file.data (only from a remote-source
+                // Uppy plugin, none used here) fails closed instead.
+                dataTransfer.items.add(new File([file.data], file.name, { type: file.type }));
+                fileInput.files = dataTransfer.files;
             }
         });
 

--- a/app/Views/events/form.php
+++ b/app/Views/events/form.php
@@ -480,18 +480,12 @@ document.addEventListener('DOMContentLoaded', function() {
           normalizedFile = file.data;
         } else if (file.data instanceof Blob) {
           normalizedFile = new File([file.data], file.name, { type: file.type });
-        } else if (file.preview) {
-          fetch(file.preview)
-            .then(res => res.blob())
-            .then(blob => {
-              const fetchedFile = new File([blob], file.name, { type: file.type });
-              dataTransfer.items.add(fetchedFile);
-              fileInput.files = dataTransfer.files;
-              updatePreview(fetchedFile);
-            })
-            .catch(err => console.error('Error loading preview blob:', err));
-          return;
         }
+        // No fetch(file.preview) fallback: file.preview can be a blob: URL,
+        // and fetching it violates a strict connect-src CSP (the #292 bug
+        // class). The File/Blob branches above cover every case UppyDragDrop
+        // produces; a non-Blob file.data (only from a remote-source Uppy
+        // plugin, none used here) leaves normalizedFile null and fails closed.
 
         if (normalizedFile) {
           dataTransfer.items.add(normalizedFile);

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -1170,22 +1170,12 @@ $activeTab = $activeTab ?? 'general';
             if (logoFileInput) {
               logoFileInput.files = dataTransfer.files;
             }
-          } else if (file.preview) {
-            fetch(file.preview)
-              .then(res => res.blob())
-              .then(blob => {
-                const newFile = new File([blob], file.name, { type: file.type });
-                dataTransfer.items.add(newFile);
-                if (logoFileInput) {
-                  logoFileInput.files = dataTransfer.files;
-                }
-              })
-              .catch(() => {
-                if (logoFileInput) {
-                  logoFileInput.value = '';
-                }
-              });
           }
+          // No fetch(file.preview) fallback: file.preview can be a blob: URL,
+          // and fetching it violates a strict connect-src CSP (the #292 bug
+          // class). The File/Blob branches above cover every case UppyDragDrop
+          // produces; a non-Blob file.data (only from a remote-source Uppy
+          // plugin, none used here) fails closed rather than doing a blob: fetch.
 
           if (previewSrc) {
             currentLogoPreviewSrc = previewSrc;


### PR DESCRIPTION
## Summary

Follow-up to #292 (hero upload under a strict CSP). A CSP compatibility audit of the frontend found that the exact `fetch(blob:)` class the #292 fix addressed still lives as a **fallback branch** in three Uppy uploaders:

- `app/Views/cms/edit-home.php` — hero background (the file #292 touched: the fix reordered the branches but left the fallback)
- `app/Views/settings/index.php` — logo
- `app/Views/events/form.php` — event image

`file.preview` can be a `blob:` URL Uppy generates for image thumbnails, so `fetch(file.preview)` violates a strict `connect-src 'self'` policy (no `blob:`) — the same bug as #292.

## Why it's low-risk / not exploitable today

Every uploader in the app uses only `UppyDragDrop` — no remote-source plugin (Url/Webcam/GoogleDrive/…) is `.use()`d anywhere. With local drag-drop/file-input, `file.data` is always a real `File`/`Blob`, so the `instanceof File` / `instanceof Blob` branches always win and the `fetch(file.preview)` fallback is **dead code**. It would arm the moment a remote-source plugin is added — hence closing the latent bug class rather than just the reachable instance.

## Change

Removed the `fetch(file.preview)` fallback in all three uploaders. The File/Blob branches cover every case `UppyDragDrop` produces; anything else fails closed instead of doing a `blob:` fetch. `edit-home` also gains the `instanceof Blob` branch the other two already had, for symmetry. This matches the fetch-free pattern already used by `autori/crea_autore.php` and `libri/partials/book_form.php` (`new File([file.data])` + `FileReader`).

## Testing

- `php -l` clean on all three views.
- The #292 E2E (`tests/hero-upload-292.spec.js`) still passes: hero upload works and fetches no `blob:` URL.
- The rest of the frontend was audited and confirmed CSP-compatible: 137 `fetch()` calls all same-origin (`'self'`), no external-origin fetch/XHR/WebSocket, and the remaining `createObjectURL` uses are `img.src` previews or file-download clicks (governed by `img-src`/navigation, not `connect-src`).
