### PR TITLE
Remove min-height from book title style

### DIFF
--- a/app/Views/frontend/catalog-grid.php
+++ b/app/Views/frontend/catalog-grid.php
@@ -275,7 +275,6 @@ $getBookStatusBadge = static function ($book) {
     
     .book-title {
         font-size: 1rem;
-        min-height: 2.4em;
     }
 }
 


### PR DESCRIPTION
Before 
<img width="884" height="946" alt="Screenshot 2026-07-27 184920" src="https://github.com/user-attachments/assets/8bfb7255-9940-40ef-a75f-4d1035b1576f" />

After
<img width="915" height="722" alt="image" src="https://github.com/user-attachments/assets/3d01234a-f5d6-41ae-87a7-48bce5c98196" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la visualizzazione delle card dei libri su dispositivi mobili, mantenendo un’altezza minima coerente per i titoli anche su schermi più piccoli.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->