### PR TITLE
fix(#299): stop TinyMCE double-prefixing URLs in email templates (and every editor)

### DIFF
--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -26,6 +26,10 @@ class SettingsController
         // l'invio li risolve per (name, locale_installazione), quindi seminare
         // sempre it_IT li renderebbe invisibili su installazioni non italiane.
         $repository->ensureEmailTemplates($this->templateDefaults(), \App\Support\I18n::getInstallationLocale());
+        // #299: repair any stored template whose links were double-prefixed with
+        // the admin base by the old WYSIWYG behaviour. Idempotent, cheap (LIKE
+        // filter), runs before the templates are read for display below.
+        $repository->healCorruptedTemplateUrls();
 
         $appSettings = $this->resolveAppSettings($repository);
         $emailSettings = $this->resolveEmailSettings($repository);

--- a/app/Models/SettingsRepository.php
+++ b/app/Models/SettingsRepository.php
@@ -163,6 +163,44 @@ class SettingsRepository
         }
     }
 
+    /**
+     * #299: repair email templates already stored with links double-prefixed by
+     * the admin base — the WYSIWYG editor used to resolve placeholder URLs (e.g.
+     * href="{{login_url}}") against the admin page, saving
+     * href="https://host/admin/{{login_url}}". The editor no longer does this
+     * (convert_urls:false), and EmailService heals at render time, but the stored
+     * value stays wrong until repaired. Runs on every install (all locales).
+     *
+     * Portable across MySQL 5.7+/MariaDB (no REGEXP_REPLACE): the LIKE narrows to
+     * the few possibly-affected rows, the fix is done in PHP. Idempotent.
+     *
+     * @return int number of template rows actually repaired
+     */
+    public function healCorruptedTemplateUrls(): int
+    {
+        $stmt = $this->prepare("SELECT name, locale, body FROM email_templates WHERE body LIKE '%/admin/{{%'");
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $rows = [];
+        while ($row = $result->fetch_assoc()) {
+            $rows[] = $row;
+        }
+        $stmt->close();
+
+        $healed = 0;
+        foreach ($rows as $row) {
+            $fixed = \App\Support\EmailService::healPlaceholderUrls((string) $row['body']);
+            if ($fixed !== (string) $row['body']) {
+                $update = $this->prepare('UPDATE email_templates SET body = ? WHERE name = ? AND locale = ?');
+                $update->bind_param('sss', $fixed, $row['name'], $row['locale']);
+                $update->execute();
+                $update->close();
+                $healed++;
+            }
+        }
+        return $healed;
+    }
+
     public function getEmailTemplate(string $name, ?string $locale = null): ?array
     {
         $locale = $this->resolveTemplateLocale($locale);

--- a/app/Support/EmailService.php
+++ b/app/Support/EmailService.php
@@ -315,6 +315,20 @@ class EmailService {
             $italianToEnglish = array_flip(self::PLACEHOLDER_ALIASES);
         }
 
+        // #299: heal templates corrupted by a WYSIWYG editor that resolved a
+        // placeholder URL against the admin page — e.g. href="{{login_url}}"
+        // was saved as href="https://host/admin/{{login_url}}", so substituting
+        // the (already absolute) URL produced a double-prefixed link. Strip an
+        // absolute "…/admin/" prefix sitting directly in front of a
+        // {{placeholder}} BEFORE substitution. The editor no longer does this
+        // (convert_urls:false), but templates already saved need repairing.
+        // A legitimate template never puts a host+/admin/ in front of a token.
+        $content = preg_replace(
+            '#https?://[^"\'\s<>]*?/admin/(\{\{[a-zA-Z0-9_]+\}\})#',
+            '$1',
+            $content
+        ) ?? $content;
+
         foreach ($normalizedVariables as $key => $value) {
             if ($escapeHtml) {
                 $replacement = in_array($key, self::RAW_HTML_VARIABLES, true)

--- a/app/Support/EmailService.php
+++ b/app/Support/EmailService.php
@@ -300,6 +300,26 @@ class EmailService {
      * non HTML) i valori non vengono HTML-escaped ma vengono ripuliti da
      * CR/LF per impedire header injection.
      */
+    /**
+     * #299: repair a template corrupted by a WYSIWYG editor that resolved a
+     * placeholder URL against the admin page — e.g. `href="{{login_url}}"` was
+     * saved as `href="https://host/admin/{{login_url}}"`, so substituting the
+     * (already absolute) URL produced a double-prefixed link. Strip an absolute
+     * `…/admin/` prefix sitting directly in front of a `{{placeholder}}`. The
+     * editor no longer does this (convert_urls:false); this heals values already
+     * saved, both at render time and when repairing stored templates in the DB.
+     * A legitimate template never puts a host+`/admin/` in front of a token, so
+     * this is safe. Returns the input unchanged when nothing matches.
+     */
+    public static function healPlaceholderUrls(string $content): string
+    {
+        return preg_replace(
+            '#https?://[^"\'\s<>]*?/admin/(\{\{[a-zA-Z0-9_]+\}\})#',
+            '$1',
+            $content
+        ) ?? $content;
+    }
+
     public function replaceVariables(string $content, array $variables, bool $escapeHtml = true): string {
         // Normalize English variable keys to Italian names for consistent processing
         // This ensures RAW_HTML_VARIABLES check works regardless of input key language
@@ -316,18 +336,8 @@ class EmailService {
         }
 
         // #299: heal templates corrupted by a WYSIWYG editor that resolved a
-        // placeholder URL against the admin page — e.g. href="{{login_url}}"
-        // was saved as href="https://host/admin/{{login_url}}", so substituting
-        // the (already absolute) URL produced a double-prefixed link. Strip an
-        // absolute "…/admin/" prefix sitting directly in front of a
-        // {{placeholder}} BEFORE substitution. The editor no longer does this
-        // (convert_urls:false), but templates already saved need repairing.
-        // A legitimate template never puts a host+/admin/ in front of a token.
-        $content = preg_replace(
-            '#https?://[^"\'\s<>]*?/admin/(\{\{[a-zA-Z0-9_]+\}\})#',
-            '$1',
-            $content
-        ) ?? $content;
+        // placeholder URL against the admin page (see healPlaceholderUrls).
+        $content = self::healPlaceholderUrls($content);
 
         foreach ($normalizedVariables as $key => $value) {
             if ($escapeHtml) {

--- a/app/Views/admin/cms-edit.php
+++ b/app/Views/admin/cms-edit.php
@@ -177,6 +177,9 @@ document.addEventListener('DOMContentLoaded', function() {
   if (window.tinymce) {
    tinymce.init({
      selector: '#tinymce-editor',
+     // #299: never rewrite URLs against the admin page's base_url — it
+     // prefixes links/placeholders with /admin and double-prefixes on re-edit.
+     convert_urls: false,
      base_url: <?= json_encode(assetUrl('tinymce'), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
      suffix: '.min',
      model: 'dom',

--- a/app/Views/admin/settings.php
+++ b/app/Views/admin/settings.php
@@ -401,6 +401,9 @@ function initTinyMCE() {
 // TinyMCE Configuration
 tinymce.init({
   selector: '#template-body',
+  // #299: never rewrite URLs against the admin page's base_url — it prefixed
+  // email links/placeholders with /admin and double-prefixed on re-edit.
+  convert_urls: false,
   base_url: <?= json_encode(assetUrl("tinymce"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
   suffix: '.min',
   model: 'dom',

--- a/app/Views/cms/edit-home.php
+++ b/app/Views/cms/edit-home.php
@@ -988,6 +988,9 @@ document.addEventListener('DOMContentLoaded', function() {
   if (window.tinymce) {
    tinymce.init({
      selector: '#text_content_body',
+     // #299: never rewrite URLs against the admin page's base_url — it
+     // prefixes links/placeholders with /admin and double-prefixes on re-edit.
+     convert_urls: false,
      base_url: <?= json_encode(assetUrl('tinymce'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>,
      suffix: '.min',
      model: 'dom',

--- a/app/Views/events/form.php
+++ b/app/Views/events/form.php
@@ -397,6 +397,9 @@ document.addEventListener('DOMContentLoaded', function() {
   if (window.tinymce) {
     tinymce.init({
       selector: '#event_content',
+      // #299: never rewrite URLs against the admin page's base_url — it
+      // prefixes links/placeholders with /admin and double-prefixes on re-edit.
+      convert_urls: false,
       base_url: <?= json_encode(assetUrl("tinymce"), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
       suffix: '.min',
       model: 'dom',

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -4884,6 +4884,9 @@ function initBookTinyMCE() {
 
     tinymce.init({
         selector: '#descrizione',
+        // #299: never rewrite URLs against the admin page's base_url — it
+        // prefixes links/placeholders with /admin and double-prefixes on re-edit.
+        convert_urls: false,
         base_url: TINYMCE_BASE,
         suffix: '.min',
         model: 'dom',

--- a/app/Views/settings/index.php
+++ b/app/Views/settings/index.php
@@ -993,6 +993,9 @@ $activeTab = $activeTab ?? 'general';
     if (window.tinymce) {
       tinymce.init({
         selector: 'textarea.tinymce-editor',
+        // #299: never rewrite URLs against the admin page's base_url — it
+        // prefixes links/placeholders with /admin and double-prefixes on re-edit.
+        convert_urls: false,
         base_url: <?= json_encode(assetUrl('tinymce'), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
         suffix: '.min',
         model: 'dom',

--- a/tests/email-template-url-prefix-299.unit.php
+++ b/tests/email-template-url-prefix-299.unit.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Issue #299 — email templates double-prefixed after a first WYSIWYG edit.
+ *
+ * The TinyMCE editor (convert_urls default on) resolved placeholder URLs
+ * against the admin page, so `href="{{login_url}}"` was saved as
+ * `href="https://host/admin/{{login_url}}"`. Substituting the (already
+ * absolute) URL then produced `https://host/admin/https://host/accedi`.
+ *
+ * The editors now set convert_urls:false so this never happens again, but
+ * templates ALREADY saved on existing installs are still corrupt. EmailService
+ * heals them at render time by stripping an absolute `…/admin/` prefix sitting
+ * directly in front of a {{placeholder}} before substitution. This pins that.
+ *
+ * Run: php tests/email-template-url-prefix-299.unit.php   (exit 0 iff all pass)
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use App\Support\EmailService;
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $cond, string $label) use (&$passed, &$failed): void {
+    if ($cond) { $passed++; echo "  OK  {$label}\n"; return; }
+    $failed++; echo "  FAIL {$label}\n";
+};
+
+// replaceVariables() uses only static constants (no $this->db / mailer), so we
+// can exercise it without touching the DB or PHPMailer.
+$svc = (new ReflectionClass(EmailService::class))->newInstanceWithoutConstructor();
+$render = static fn(string $body, array $vars): string => $svc->replaceVariables($body, $vars);
+
+// 1) The bug: a corrupted href must render as the plain absolute URL, once.
+$out = $render('<a href="https://lib.example.org/admin/{{login_url}}">Log in</a>',
+    ['login_url' => 'https://lib.example.org/accedi']);
+$check(strpos($out, 'https://lib.example.org/accedi') !== false, 'corrupted href resolves to the real URL');
+$check(strpos($out, '/admin/https://') === false, 'no double /admin/ + absolute-URL prefix remains');
+$check($out === '<a href="https://lib.example.org/accedi">Log in</a>', 'exact healed output');
+
+// 2) A clean template is unchanged by the healing + substitution.
+$out = $render('<a href="{{login_url}}">Log in</a>', ['login_url' => 'https://lib.example.org/accedi']);
+$check($out === '<a href="https://lib.example.org/accedi">Log in</a>', 'clean placeholder still substitutes correctly');
+
+// 3) http (not https) prefixes are healed too.
+$out = $render('<a href="http://x.test/admin/{{reset_url}}">Reset</a>', ['reset_url' => 'http://x.test/reset?t=abc']);
+$check($out === '<a href="http://x.test/reset?t=abc">Reset</a>', 'http:// prefix healed');
+
+// 4) A deeper base path (subdir install) is healed.
+$out = $render('<a href="https://x.test/lib/admin/{{book_url}}">Book</a>', ['book_url' => 'https://x.test/lib/libro/5']);
+$check($out === '<a href="https://x.test/lib/libro/5">Book</a>', 'subdir base + /admin/ prefix healed');
+
+// 5) A legitimate URL that merely CONTAINS /admin/ but is NOT followed by a
+//    placeholder must be left untouched.
+$out = $render('<a href="https://x.test/admin/users">Users</a>', []);
+$check($out === '<a href="https://x.test/admin/users">Users</a>', 'real /admin/ URL without a token is untouched');
+
+// 6) A non-URL placeholder is never affected by the healing.
+$out = $render('Ciao {{nome}}', ['nome' => 'Mario']);
+$check($out === 'Ciao Mario', 'non-URL placeholder substitutes normally');
+
+// 7) Two corrupted links in one body both heal.
+$out = $render(
+    '<a href="https://x.test/admin/{{book_url}}">B</a> <a href="https://x.test/admin/{{wishlist_url}}">W</a>',
+    ['book_url' => 'https://x.test/libro/1', 'wishlist_url' => 'https://x.test/wishlist']);
+$check(strpos($out, '/admin/https://') === false && strpos($out, 'https://x.test/libro/1') !== false
+    && strpos($out, 'https://x.test/wishlist') !== false, 'multiple corrupted links all heal');
+
+echo "\n{$passed} passed, {$failed} failed\n";
+exit($failed === 0 ? 0 : 1);

--- a/tests/tinymce-url-prefix-299.spec.js
+++ b/tests/tinymce-url-prefix-299.spec.js
@@ -1,0 +1,91 @@
+// @ts-check
+// Issue #299 — the WYSIWYG editors double-prefixed URLs. TinyMCE's convert_urls
+// (on by default) resolved a placeholder href like {{login_url}} against the
+// admin page's base, so it was saved as https://host/admin/{{login_url}} and
+// the rendered email link came out double-prefixed. The fix sets
+// convert_urls:false on EVERY TinyMCE instance so the editor never rewrites URLs.
+//
+// This drives a real browser: for each editor, it feeds an href with a
+// placeholder through TinyMCE and asserts the round-tripped content keeps the
+// placeholder verbatim with NO /admin/ prefix — the behaviour that was broken.
+//
+// Run: /tmp/run-e2e.sh tests/tinymce-url-prefix-299.spec.js --config=tests/playwright.config.js --workers=1
+const { test, expect } = require('@playwright/test');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E credentials not configured');
+
+async function login(page) {
+  await page.goto(`${BASE}/accedi`);
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await page.locator('button[type="submit"]').click();
+  await page.waitForFunction(
+    () => !location.pathname.includes('accedi') && !location.pathname.includes('login'),
+    { timeout: 15000 },
+  );
+}
+
+// Each editor: the page URL and how to grab its TinyMCE instance. The email
+// editor uses a class (multiple instances); the rest use a stable id. Selection
+// is a plain if/else inside the page callback — no eval, no new Function.
+const CASES = [
+  { name: 'email template (settings/index)', url: '/admin/settings?tab=templates', kind: 'class', sel: 'tinymce-editor' },
+  { name: 'book description (book_form)',     url: '/admin/books/create',           kind: 'id',    sel: 'descrizione' },
+  { name: 'event content (events/form)',      url: '/admin/cms/events/create',      kind: 'id',    sel: 'event_content' },
+  { name: 'home text (cms/edit-home)',        url: '/admin/cms/home',               kind: 'id',    sel: 'text_content_body' },
+];
+
+test.describe.serial('#299 TinyMCE does not prefix URLs (convert_urls:false)', () => {
+  for (const c of CASES) {
+    test(c.name, async ({ page }) => {
+      await login(page);
+      await page.goto(`${BASE}${c.url}`);
+      await page.waitForLoadState('networkidle');
+
+      // Wait until the target editor exists and is initialised. For the
+      // class-based email editor, resolve the textarea in the DOM and look the
+      // editor up by the id TinyMCE assigns it (avoids relying on tm.editors).
+      await page.waitForFunction(
+        ({ kind, sel }) => {
+          const tm = window.tinymce;
+          if (!tm) return false;
+          let ed = null;
+          if (kind === 'class') {
+            const ta = document.querySelector('textarea.' + sel);
+            ed = ta && ta.id ? tm.get(ta.id) : null;
+          } else {
+            ed = tm.get(sel);
+          }
+          return !!ed && ed.initialized === true;
+        },
+        { kind: c.kind, sel: c.sel },
+        { timeout: 20000 },
+      );
+
+      const result = await page.evaluate(({ kind, sel }) => {
+        const tm = window.tinymce;
+        let ed = null;
+        if (kind === 'class') {
+          const ta = document.querySelector('textarea.' + sel);
+          ed = ta && ta.id ? tm.get(ta.id) : null;
+        } else {
+          ed = tm.get(sel);
+        }
+        ed.setContent('<p><a href="{{login_url}}">x</a></p>');
+        return { convertUrls: ed.options.get('convert_urls'), content: ed.getContent() };
+      }, { kind: c.kind, sel: c.sel });
+
+      // The knob is off…
+      expect(result.convertUrls, `${c.name}: convert_urls must be false`).toBe(false);
+      // …and behaviourally: the placeholder survives untouched, no /admin/ prefix,
+      // no URL-encoded braces (%7B%7B) — both symptoms of a rewrite.
+      expect(result.content, `${c.name}: placeholder kept verbatim`).toContain('{{login_url}}');
+      expect(result.content, `${c.name}: no /admin/ prefix injected`).not.toMatch(/\/admin\/\{\{|\/admin\/%7B/);
+      expect(result.content, `${c.name}: braces not URL-encoded`).not.toContain('%7B%7B');
+    });
+  }
+});

--- a/tests/tinymce-url-prefix-299.spec.js
+++ b/tests/tinymce-url-prefix-299.spec.js
@@ -11,12 +11,25 @@
 //
 // Run: /tmp/run-e2e.sh tests/tinymce-url-prefix-299.spec.js --config=tests/playwright.config.js --workers=1
 const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
 const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_USER = process.env.E2E_DB_USER || '';
+const DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const DB_NAME = process.env.E2E_DB_NAME || '';
 
 test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'E2E credentials not configured');
+
+function db(sql) {
+  const args = [];
+  if (DB_SOCKET) args.push('-S', DB_SOCKET);
+  args.push('-u', DB_USER, DB_NAME, '-N', '-B', '-e', sql);
+  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000, env: { ...process.env, MYSQL_PWD: DB_PASS } }).trim();
+}
+function sqlq(s) { return "'" + String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'") + "'"; }
 
 async function login(page) {
   await page.goto(`${BASE}/accedi`);
@@ -44,9 +57,10 @@ test.describe.serial('#299 TinyMCE does not prefix URLs (convert_urls:false)', (
     test(c.name, async ({ page }) => {
       await login(page);
       await page.goto(`${BASE}${c.url}`);
-      await page.waitForLoadState('networkidle');
 
-      // Wait until the target editor exists and is initialised. For the
+      // Wait until the target editor exists and is initialised (this is the
+      // real readiness signal — no networkidle, which is flaky on pages that
+      // poll or hold connections open). For the
       // class-based email editor, resolve the textarea in the DOM and look the
       // editor up by the id TinyMCE assigns it (avoids relying on tm.editors).
       await page.waitForFunction(
@@ -88,4 +102,35 @@ test.describe.serial('#299 TinyMCE does not prefix URLs (convert_urls:false)', (
       expect(result.content, `${c.name}: braces not URL-encoded`).not.toContain('%7B%7B');
     });
   }
+});
+
+// The DB-repair half of the fix: an install whose template was ALREADY saved
+// corrupted must be healed. SettingsController runs healCorruptedTemplateUrls()
+// when the settings page is rendered, so opening it repairs the stored value.
+test.describe('#299 stored templates are healed on settings open', () => {
+  test('a template corrupted with an /admin/ prefix is repaired in the DB', async ({ page }) => {
+    test.skip(!DB_USER || !DB_NAME, 'DB not configured');
+    const NAME = '__heal299_test__';
+    const LOCALE = 'it_IT';
+    const corrupted = '<p><a href="http://localhost:8081/admin/{{login_url}}">Accedi</a></p>';
+    db(`INSERT INTO email_templates (name, locale, subject, body, active)
+        VALUES (${sqlq(NAME)}, ${sqlq(LOCALE)}, 'Heal test', ${sqlq(corrupted)}, 1)
+        ON DUPLICATE KEY UPDATE body=VALUES(body), active=1`);
+    try {
+      // Sanity: the corrupt prefix is really in the DB before we open settings.
+      expect(db(`SELECT body FROM email_templates WHERE name=${sqlq(NAME)} AND locale=${sqlq(LOCALE)}`))
+        .toContain('/admin/{{login_url}}');
+
+      await login(page);
+      // Rendering the settings page runs the server-side heal.
+      await page.goto(`${BASE}/admin/settings?tab=templates`);
+      await page.waitForLoadState('domcontentloaded');
+
+      const body = db(`SELECT body FROM email_templates WHERE name=${sqlq(NAME)} AND locale=${sqlq(LOCALE)}`);
+      expect(body, 'placeholder is preserved').toContain('{{login_url}}');
+      expect(body, 'admin prefix stripped from the stored value').not.toContain('/admin/{{login_url}}');
+    } finally {
+      db(`DELETE FROM email_templates WHERE name=${sqlq(NAME)} AND locale=${sqlq(LOCALE)}`);
+    }
+  });
 });


### PR DESCRIPTION
## Problem

[#299](https://github.com/fabiodalez-dev/Pinakes/issues/299): email templates come out with links double-prefixed by the admin base after the template is edited once in the WYSIWYG editor. An href of `{{login_url}}` is saved as `https://host/admin/{{login_url}}`, so the sent email link becomes `https://host/admin/https://host/accedi`.

## Root cause

TinyMCE's `convert_urls` (**on by default**) resolves every href against the editing page's base URL — which is the admin page — so it prefixes links, and even placeholder tokens like `{{login_url}}`, with `/admin`. On re-edit it compounds.

`relative_urls: false` alone does **not** prevent this: it only chooses absolute vs relative output for a conversion that still happens. The correct switch is **`convert_urls: false`**, which tells TinyMCE to leave URLs exactly as written.

## Fix

- **`convert_urls: false` on all six TinyMCE inits**: `settings/index` (email templates — the reported case), `book_form` (`#descrizione`), `events/form` (`#event_content`), `cms/edit-home` (`#text_content_body`), `admin/cms-edit` (`#tinymce-editor`), and the legacy `admin/settings` view (dead code — not routed — fixed for consistency).
- **Heal already-corrupted templates.** `EmailService::replaceVariables` now strips an absolute `…/admin/` prefix sitting directly in front of a `{{placeholder}}` before substitution, so existing installs (like the reporter's) don't need every template re-saved after updating. A legitimate template never puts a host+`/admin/` in front of a token, so this is safe.

## Tests

| Test | Covers |
|------|--------|
| `tests/email-template-url-prefix-299.unit.php` (9) | The healing: corrupted href → correct single URL; http/https; subdir base; multiple links; no-ops for real `/admin/` URLs and non-URL placeholders. |
| `tests/tinymce-url-prefix-299.spec.js` (4) | Real browser feeds an href with a placeholder through each editor and asserts `convert_urls` is false AND the placeholder round-trips verbatim — no `/admin/` prefix, no `%7B%7B` encoding. |

All green. Full-tree PHPStan level 5 clean.

Closes #299.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Risolto il problema dei doppi prefissi `/admin/` nei link con segnaposto dei template email.
  * Gli URL nei contenuti modificati con l’editor vengono ora preservati senza riscritture o prefissi indesiderati.
  * I template già interessati dal problema vengono automaticamente riparati durante la sostituzione dei segnaposto.

* **Test**
  * Aggiunti controlli automatici per verificare la corretta gestione degli URL nei template email e negli editor amministrativi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->