### PR TITLE
Fix loan auto-approval and soft-delete catalog counts

### DIFF
--- a/app/Controllers/AutoriApiController.php
+++ b/app/Controllers/AutoriApiController.php
@@ -172,7 +172,10 @@ class AutoriApiController
         $selectNaz = $colNaz !== null ? "a.`$colNaz` AS nazionalita" : "'' AS nazionalita";
         $sql_prepared = "SELECT a.id, a.nome, a.pseudonimo, a.data_nascita, a.data_morte, a.biografia, a.sito_web,
                        $selectNaz,
-                       (SELECT COUNT(*) FROM libri_autori la WHERE la.autore_id = a.id) AS libri_count
+                       (SELECT COUNT(*)
+                          FROM libri_autori la
+                          JOIN libri l ON l.id = la.libro_id AND l.deleted_at IS NULL
+                         WHERE la.autore_id = a.id) AS libri_count
                 FROM autori a $where_prepared ORDER BY $orderColumn $orderDir LIMIT ?, ?";
 
         $stmt = $db->prepare($sql_prepared);
@@ -377,7 +380,10 @@ class AutoriApiController
 
         $sql = "SELECT a.id, a.nome, a.pseudonimo, a.data_nascita, a.data_morte, a.sito_web,
                        $selectNaz,
-                       (SELECT COUNT(*) FROM libri_autori la WHERE la.autore_id = a.id) AS libri_count
+                       (SELECT COUNT(*)
+                          FROM libri_autori la
+                          JOIN libri l ON l.id = la.libro_id AND l.deleted_at IS NULL
+                         WHERE la.autore_id = a.id) AS libri_count
                 FROM autori a
                 WHERE a.id IN ($placeholders)
                 ORDER BY a.nome ASC";

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -1054,7 +1054,8 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
                    LEFT JOIN generi gfp ON gf.parent_id = gfp.id
                    LEFT JOIN generi gfpp ON gfp.parent_id = gfpp.id
                    LEFT JOIN generi sg ON l.sottogenere_id = sg.id
-                   WHERE (
+                   WHERE l.deleted_at IS NULL
+                   AND (
                        l.genere_id = g.id
                        OR l.sottogenere_id = g.id
                        OR l.genere_id IN (SELECT id FROM generi WHERE parent_id = g.id)

--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -526,10 +526,13 @@ class LoanApprovalController
 
             $db->commit();
 
-            // Send appropriate notification to user
+            // Send appropriate notification to user. Issue #301 explicitly keeps
+            // the approval email in the auto-approval flow; manual immediate
+            // approvals retain the more specific pickup-ready notification.
             try {
                 $notificationService = new \App\Support\NotificationService($db);
-                if ($isFutureLoan) {
+                $automaticApproval = (bool) $request->getAttribute('automatic_loan_approval', false);
+                if ($isFutureLoan || $automaticApproval) {
                     // Future loan: send general approval notification
                     $notificationService->sendLoanApprovedNotification($loanId);
                 } else {

--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -1278,7 +1278,7 @@ class SettingsController
     }
 
     /**
-     * @return array{loan_duration_days: int, pickup_expiry_days: int, max_renewals: int, max_active_loans_per_user: int, max_loan_duration_days: int}
+     * @return array{loan_duration_days: int, pickup_expiry_days: int, max_renewals: int, max_active_loans_per_user: int, max_loan_duration_days: int, auto_approve_requests: bool}
      */
     private function resolveLoansSettings(SettingsRepository $repository): array
     {
@@ -1288,6 +1288,7 @@ class SettingsController
             'max_renewals'             => (int) ($repository->get('loans', 'max_renewals', '3') ?? 3),
             'max_active_loans_per_user' => (int) ($repository->get('loans', 'max_active_loans_per_user', '0') ?? 0),
             'max_loan_duration_days'   => (int) ($repository->get('loans', 'max_loan_duration_days', '90') ?? 90),
+            'auto_approve_requests'    => $repository->autoApproveLoanRequests(),
         ];
     }
 
@@ -1311,12 +1312,16 @@ class SettingsController
         $maxRenewals      = min(100,  max(0, (int) ($data['max_renewals'] ?? 3)));                // 0 … 100
         $maxActiveLoans   = min(1000, max(0, (int) ($data['max_active_loans_per_user'] ?? 0)));   // 0 (unlimited) … 1000
         $maxLoanDuration  = min(3650, max(1, (int) ($data['max_loan_duration_days'] ?? 90)));     // 1 day … 10 years (reservation-window cap enforced by ReservationsController)
+        $autoApprove      = isset($data['auto_approve_requests'])
+            && is_scalar($data['auto_approve_requests'])
+            && (string) $data['auto_approve_requests'] === '1';
 
         $repository->set('loans', 'loan_duration_days', (string) $loanDurationDays);
         $repository->set('loans', 'pickup_expiry_days', (string) $pickupExpiryDays);
         $repository->set('loans', 'max_renewals', (string) $maxRenewals);
         $repository->set('loans', 'max_active_loans_per_user', (string) $maxActiveLoans);
         $repository->set('loans', 'max_loan_duration_days', (string) $maxLoanDuration);
+        $repository->set('loans', 'auto_approve_requests', $autoApprove ? '1' : '0');
 
         $_SESSION['success_message'] = __('Impostazioni prestiti aggiornate correttamente.');
         return $response->withHeader('Location', url('/admin/settings?tab=loans'))->withStatus(302);

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -9,6 +9,7 @@ use App\Support\SecureLogger;
 use App\Controllers\ReservationManager;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Psr7\Response as SlimResponse;
 
 class UserActionsController
 {
@@ -585,7 +586,9 @@ class UserActionsController
                 }
             }
 
-            // Insert as 'pendente' - requires admin approval
+            // Always create the canonical pending request first. When automatic
+            // approval is enabled, the same race-safe approval controller used by
+            // admins promotes it immediately after request creation.
             $stmt = $db->prepare("INSERT INTO prestiti (libro_id, utente_id, data_prestito, data_scadenza, stato, attivo) VALUES (?, ?, ?, ?, 'pendente', 0)");
             $stmt->bind_param('iiss', $libroId, $utenteId, $data_prestito, $data_scadenza);
 
@@ -599,6 +602,11 @@ class UserActionsController
             $stmt->close();
             $db->commit();
 
+            // Promote immediately before performing slower email I/O, minimizing
+            // the post-commit window in which another request could claim the
+            // same copy. The canonical approval path re-checks every constraint.
+            $autoApproved = $this->autoApproveLoanRequest($request, $db, $newLoanId);
+
             // Notify admins about new loan request (outside transaction)
             try {
                 $notificationService = new \App\Support\NotificationService($db);
@@ -607,7 +615,11 @@ class UserActionsController
                 SecureLogger::warning(__('Notifica richiesta prestito fallita'), ['error' => $e->getMessage()]);
             }
 
-            return $this->back($response, ['loan_request_success' => 1]);
+            return $this->back($response, [
+                'loan_request_success' => 1,
+                'loan_id' => $newLoanId,
+                'auto_approved' => $autoApproved ? 1 : 0,
+            ]);
 
         } catch (\Throwable $e) {
             $db->rollback();
@@ -761,6 +773,46 @@ class UserActionsController
 
         $sep = (str_contains($referer, '?') ? '&' : '?');
         return $response->withHeader('Location', $referer . $sep . $qs)->withStatus(302);
+    }
+
+    /**
+     * Promote a newly-created request through the canonical approval pipeline.
+     * A failure deliberately leaves the request pending, so an administrator can
+     * still process it instead of losing an otherwise valid request.
+     */
+    private function autoApproveLoanRequest(Request $request, mysqli $db, int $loanId): bool
+    {
+        $settings = new \App\Models\SettingsRepository($db);
+        if (!$settings->autoApproveLoanRequests()) {
+            return false;
+        }
+
+        try {
+            $approvalRequest = $request
+                ->withParsedBody(['loan_id' => $loanId])
+                ->withAttribute('automatic_loan_approval', true);
+            $result = (new LoanApprovalController())->approveLoan(
+                $approvalRequest,
+                new SlimResponse(),
+                $db
+            );
+
+            if ($result->getStatusCode() >= 200 && $result->getStatusCode() < 300) {
+                return true;
+            }
+
+            SecureLogger::warning('Automatic loan approval left request pending', [
+                'loan_id' => $loanId,
+                'status' => $result->getStatusCode(),
+            ]);
+        } catch (\Throwable $e) {
+            SecureLogger::warning('Automatic loan approval failed; request left pending', [
+                'loan_id' => $loanId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return false;
     }
 
     /**

--- a/app/Models/SettingsRepository.php
+++ b/app/Models/SettingsRepository.php
@@ -83,6 +83,16 @@ class SettingsRepository
     }
 
     /**
+     * Whether user loan requests should skip the manual approval queue.
+     * Kept here so the web flow and the Mobile API share the same default and
+     * interpretation of the persisted setting.
+     */
+    public function autoApproveLoanRequests(): bool
+    {
+        return ($this->get('loans', 'auto_approve_requests', '0') ?? '0') === '1';
+    }
+
+    /**
      * @return array<string,string>
      */
     public function getCategory(string $category): array

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1857,7 +1857,9 @@ ob_start();
                 <div id="book-alerts">
                     <?php if (!empty($_GET['loan_request_success'])): ?>
                         <div class="alert alert-success alert-dismissible fade show" role="alert">
-                            <i class="fas fa-check-circle me-2"></i><?= __("Prestito richiesto con successo.") ?>
+                            <i class="fas fa-check-circle me-2"></i><?= !empty($_GET['auto_approved'])
+                              ? __("Prestito approvato. Il libro è in attesa di ritiro.")
+                              : __("Prestito richiesto con successo.") ?>
                             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="<?= __('Chiudi') ?>"></button>
                         </div>
                     <?php elseif (!empty($_GET['loan_error'])): ?>

--- a/app/Views/settings/loans-tab.php
+++ b/app/Views/settings/loans-tab.php
@@ -7,6 +7,45 @@
   <form action="<?= htmlspecialchars(url('/admin/settings/loans'), ENT_QUOTES, 'UTF-8') ?>" method="post" class="space-y-6">
     <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
 
+    <!-- Automatic approval -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div class="space-y-4">
+        <h2 class="text-xl font-semibold text-gray-900 flex items-center gap-2">
+          <i class="fas fa-check-double text-gray-500"></i>
+          <?= __("Approvazione automatica") ?>
+        </h2>
+        <p class="text-sm text-gray-600"><?= __("Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.") ?></p>
+        <div class="bg-gray-50 border border-gray-200 rounded-xl p-4">
+          <div class="flex items-start gap-2">
+            <i class="fas fa-info-circle text-gray-600 mt-0.5"></i>
+            <div class="text-xs text-gray-700">
+              <?= __("Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.") ?>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="bg-white border border-gray-200 rounded-2xl p-5 space-y-4 max-sm:!bg-transparent max-sm:!border-0 max-sm:!rounded-none max-sm:!shadow-none max-sm:!p-0">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <span id="auto_approve_requests_label" class="text-sm font-semibold text-gray-900"><?= __("Auto-approva le richieste") ?></span>
+            <p id="auto_approve_requests_desc" class="text-xs text-gray-600 mt-1"><?= __("Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.") ?></p>
+          </div>
+          <label class="relative inline-flex items-center cursor-pointer shrink-0">
+            <input type="checkbox"
+                   id="auto_approve_requests"
+                   name="auto_approve_requests"
+                   value="1"
+                   aria-labelledby="auto_approve_requests_label"
+                   aria-describedby="auto_approve_requests_desc"
+                   <?php echo !empty($loansSettings['auto_approve_requests']) ? 'checked' : ''; ?>
+                   class="toggle-checkbox sr-only">
+            <div class="toggle-bg w-11 h-6 bg-gray-200 rounded-full transition-colors"></div>
+            <div class="toggle-dot absolute top-[2px] left-[2px] bg-white border border-gray-300 rounded-full h-5 w-5 transition-transform"></div>
+          </label>
+        </div>
+      </div>
+    </div>
+
     <!-- Loan duration -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div class="space-y-4">

--- a/installer/database/data_da_DK.sql
+++ b/installer/database/data_da_DK.sql
@@ -31,6 +31,10 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('loans', 'max_loan_duration_days', '90', 'Maksimal lånevarighed, der kan anmodes om, i dage')
 ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('loans', 'auto_approve_requests', '0', 'Godkend låneanmodninger automatisk')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
+
 INSERT INTO `generi` VALUES (1,'Prosa',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
 INSERT INTO `generi` VALUES (2,'Poesi',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
 INSERT INTO `generi` VALUES (3,'Teater',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);

--- a/installer/database/data_de_DE.sql
+++ b/installer/database/data_de_DE.sql
@@ -214,6 +214,10 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('loans', 'max_loan_duration_days', '90', 'Maximal anforderbare Ausleihdauer in Tagen')
 ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('loans', 'auto_approve_requests', '0', 'Ausleihanfragen automatisch genehmigen')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
+
 -- ============================================================================
 -- System Settings - Complete default configuration
 -- These replace the old storage/settings.json file

--- a/installer/database/data_en_US.sql
+++ b/installer/database/data_en_US.sql
@@ -214,6 +214,10 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('loans', 'max_loan_duration_days', '90', 'Maximum requestable loan duration in days')
 ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('loans', 'auto_approve_requests', '0', 'Automatically approve loan requests')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
+
 -- ============================================================================
 -- System Settings - Complete default configuration
 -- These replace the old storage/settings.json file

--- a/installer/database/data_fr_FR.sql
+++ b/installer/database/data_fr_FR.sql
@@ -214,6 +214,10 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('loans', 'max_loan_duration_days', '90', 'Durée maximale demandable pour un emprunt en jours')
 ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('loans', 'auto_approve_requests', '0', 'Approuver automatiquement les demandes de prêt')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
+
 -- ============================================================================
 -- System Settings - Complete default configuration
 -- These replace the old storage/settings.json file

--- a/installer/database/data_it_IT.sql
+++ b/installer/database/data_it_IT.sql
@@ -31,6 +31,10 @@ INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `desc
 ('loans', 'max_loan_duration_days', '90', 'Durata massima richiedibile per un prestito in giorni')
 ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
 
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`) VALUES
+('loans', 'auto_approve_requests', '0', 'Approva automaticamente le richieste di prestito')
+ON DUPLICATE KEY UPDATE description = VALUES(description), updated_at = NOW();
+
 INSERT INTO `generi` VALUES (1,'Prosa',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
 INSERT INTO `generi` VALUES (2,'Poesia',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);
 INSERT INTO `generi` VALUES (3,'Teatro',NULL,'2025-10-20 16:20:00','2025-10-20 16:20:00',NULL);

--- a/installer/database/migrations/migrate_0.7.46.sql
+++ b/installer/database/migrations/migrate_0.7.46.sql
@@ -1,0 +1,7 @@
+-- Migration 0.7.46
+-- Issue #301: optional automatic approval of immediate loan requests.
+-- Safe and idempotent: existing administrators keep the manual workflow.
+
+INSERT INTO `system_settings` (`category`, `setting_key`, `setting_value`, `description`)
+VALUES ('loans', 'auto_approve_requests', '0', 'Approva automaticamente le richieste di prestito')
+ON DUPLICATE KEY UPDATE `setting_value` = `setting_value`;

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6652,5 +6652,11 @@
   "Titolo della recensione": "Anmeldelsens titel",
   "Email dell'utente": "Brugerens e-mail",
   "Nome completo dell'utente": "Brugerens fulde navn",
-  "Link alla lista dei desideri": "Link til ønskelisten"
+  "Link alla lista dei desideri": "Link til ønskelisten",
+  "Approvazione automatica": "Automatisk godkendelse",
+  "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.": "Godkend låneanmodninger automatisk, og flyt dem direkte til afventer afhentning.",
+  "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.": "E-mails om den nye anmodning til administratorer og om godkendelsen til låneren sendes fortsat.",
+  "Auto-approva le richieste": "Godkend anmodninger automatisk",
+  "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.": "Spring manuel godkendelse over for nye lån, som brugerne anmoder om.",
+  "Prestito approvato. Il libro è in attesa di ritiro.": "Lånet er godkendt. Bogen afventer afhentning."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6652,5 +6652,11 @@
   "Titolo della recensione": "Titel der Rezension",
   "Email dell'utente": "E-Mail des Benutzers",
   "Nome completo dell'utente": "Vollständiger Name des Benutzers",
-  "Link alla lista dei desideri": "Link zur Wunschliste"
+  "Link alla lista dei desideri": "Link zur Wunschliste",
+  "Approvazione automatica": "Automatische Genehmigung",
+  "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.": "Genehmigt Ausleihanfragen automatisch und setzt sie direkt auf Abholung ausstehend.",
+  "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.": "Die E-Mails zur neuen Anfrage an die Verwaltung und zur Genehmigung an die ausleihende Person werden weiterhin versendet.",
+  "Auto-approva le richieste": "Anfragen automatisch genehmigen",
+  "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.": "Überspringt die manuelle Genehmigung neuer Ausleihanfragen.",
+  "Prestito approvato. Il libro è in attesa di ritiro.": "Ausleihe genehmigt. Das Buch wartet auf Abholung."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6652,5 +6652,11 @@
   "Titolo della recensione": "Review title",
   "Email dell'utente": "User's email",
   "Nome completo dell'utente": "User's full name",
-  "Link alla lista dei desideri": "Link to the wishlist"
+  "Link alla lista dei desideri": "Link to the wishlist",
+  "Approvazione automatica": "Automatic approval",
+  "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.": "Automatically approve loan requests and move them directly to awaiting pickup.",
+  "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.": "The new request email to administrators and the approval email to the patron will still be sent.",
+  "Auto-approva le richieste": "Auto-approve requests",
+  "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.": "Skip manual approval for new loans requested by patrons.",
+  "Prestito approvato. Il libro è in attesa di ritiro.": "Loan approved. The book is awaiting pickup."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6652,5 +6652,11 @@
   "Titolo della recensione": "Titre de l'avis",
   "Email dell'utente": "E-mail de l'utilisateur",
   "Nome completo dell'utente": "Nom complet de l'utilisateur",
-  "Link alla lista dei desideri": "Lien vers la liste de souhaits"
+  "Link alla lista dei desideri": "Lien vers la liste de souhaits",
+  "Approvazione automatica": "Approbation automatique",
+  "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.": "Approuve automatiquement les demandes de prêt et les place directement en attente de retrait.",
+  "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.": "Les e-mails de nouvelle demande aux administrateurs et d'approbation à l'usager continueront d'être envoyés.",
+  "Auto-approva le richieste": "Approuver automatiquement",
+  "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.": "Désactive l'approbation manuelle des nouveaux prêts demandés par les usagers.",
+  "Prestito approvato. Il libro è in attesa di ritiro.": "Prêt approuvé. Le livre est en attente de retrait."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6652,5 +6652,11 @@
   "Titolo della recensione": "Titolo della recensione",
   "Email dell'utente": "Email dell'utente",
   "Nome completo dell'utente": "Nome completo dell'utente",
-  "Link alla lista dei desideri": "Link alla lista dei desideri"
+  "Link alla lista dei desideri": "Link alla lista dei desideri",
+  "Approvazione automatica": "Approvazione automatica",
+  "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.": "Approva automaticamente le richieste di prestito e passa subito allo stato in attesa di ritiro.",
+  "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.": "Le email per la nuova richiesta agli amministratori e per l'approvazione all'utente continueranno a essere inviate.",
+  "Auto-approva le richieste": "Auto-approva le richieste",
+  "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.": "Disattiva la fase di approvazione manuale per i nuovi prestiti richiesti dagli utenti.",
+  "Prestito approvato. Il libro è in attesa di ritiro.": "Prestito approvato. Il libro è in attesa di ritiro."
 }

--- a/storage/plugins/mobile-api/src/Controllers/ActionsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ActionsController.php
@@ -177,7 +177,8 @@ final class ActionsController
      * rules. The body is `{ book_id, desired_date? }`.
      *
      *   - With NO desired_date AND a copy currently loanable → immediate loan
-     *     request (UserActionsController::loan), pending admin approval.
+     *     request (UserActionsController::loan), either pending admin approval
+     *     or immediately ready for pickup when auto-approval is enabled.
      *   - Otherwise (a future desired_date, or no copy free now) → reservation in
      *     the queue (UserActionsController::reserve).
      *
@@ -231,10 +232,19 @@ final class ActionsController
                 $outcome   = $this->redirectOutcome($result);
 
                 if (isset($outcome['loan_request_success'])) {
+                    $autoApproved = ($outcome['auto_approved'] ?? '0') === '1';
                     return ResponseEnvelope::success(
                         $response,
-                        ['type' => 'loan', 'book_id' => $bookId],
-                        ['message' => __('Richiesta di prestito inviata. In attesa di approvazione.')],
+                        [
+                            'type' => 'loan',
+                            'book_id' => $bookId,
+                            'loan_id' => isset($outcome['loan_id']) ? (int) $outcome['loan_id'] : null,
+                            'auto_approved' => $autoApproved,
+                            'status' => $autoApproved ? 'da_ritirare' : 'pendente',
+                        ],
+                        ['message' => $autoApproved
+                            ? __('Prestito approvato. Il libro è in attesa di ritiro.')
+                            : __('Richiesta di prestito inviata. In attesa di approvazione.')],
                         201
                     );
                 }

--- a/storage/plugins/mobile-api/src/Controllers/HealthController.php
+++ b/storage/plugins/mobile-api/src/Controllers/HealthController.php
@@ -69,6 +69,7 @@ final class HealthController
             // hides loans, reservations and wishlist everywhere. The app must do
             // the same, so we gate those feature flags off and expose the mode.
             $catalogueMode = (bool) ConfigStore::isCatalogueMode();
+            $loanApprovalRequired = !(new \App\Models\SettingsRepository($this->db))->autoApproveLoanRequests();
 
             $data = [
                 'name'                 => $name,
@@ -88,6 +89,7 @@ final class HealthController
                     'reviews'       => !$catalogueMode,
                 ],
                 'catalogue_mode'       => $catalogueMode,
+                'loan_approval_required' => $loanApprovalRequired,
                 'app_access_enabled'   => $appAccessEnabled,
                 'registration_enabled' => $registrationEnabled,
                 // Lightweight registration summary (a convenience mirror). The

--- a/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
+++ b/storage/plugins/mobile-api/src/Controllers/OpenApiController.php
@@ -622,7 +622,7 @@ final class OpenApiController
                 'post' => [
                     'tags'        => ['loans'],
                     'summary'     => 'Request a reservation / loan',
-                    'description' => 'Honors existing overlap, availability, and max-active-loans rules (same as the web form). Returns error codes for overlap, unavailable, or queue position.',
+                    'description' => 'Honors existing overlap, availability, max-active-loans, and automatic-approval settings (same as the web form). For immediate loans, data.auto_approved and data.status tell the client whether the request is pending or ready for pickup.',
                     'operationId' => 'postReservation',
                     'security'    => [['bearerAuth' => []]],
                     'requestBody' => [
@@ -630,7 +630,22 @@ final class OpenApiController
                         'content'  => ['application/json' => ['schema' => ['$ref' => '#/components/schemas/ReservationRequest']]],
                     ],
                     'responses' => [
-                        '201' => ['description' => 'Reservation created.', 'content' => $json],
+                        '201' => [
+                            'description' => 'Reservation or loan request created.',
+                            'content' => ['application/json' => ['schema' => [
+                                'allOf' => [['$ref' => '#/components/schemas/Envelope']],
+                                'properties' => ['data' => [
+                                    'type' => 'object',
+                                    'properties' => [
+                                        'type' => ['type' => 'string', 'enum' => ['loan', 'reservation']],
+                                        'book_id' => ['type' => 'integer'],
+                                        'loan_id' => ['type' => 'integer', 'nullable' => true],
+                                        'auto_approved' => ['type' => 'boolean', 'nullable' => true],
+                                        'status' => ['type' => 'string', 'nullable' => true, 'enum' => ['pendente', 'da_ritirare']],
+                                    ],
+                                ]],
+                            ]]],
+                        ],
                         '400' => ['$ref' => '#/components/responses/UnprocessableEntity'],
                         '401' => ['$ref' => '#/components/responses/Unauthorized'],
                         '409' => ['description' => 'Overlap or book unavailable.', 'content' => $json],
@@ -1485,6 +1500,10 @@ final class OpenApiController
                 'catalogue_mode'       => [
                     'type'        => 'boolean',
                     'description' => 'True when the instance is in catalogue-only mode (loans, reservations and wishlist disabled).',
+                ],
+                'loan_approval_required' => [
+                    'type' => 'boolean',
+                    'description' => 'False when immediate loan requests are automatically approved and move directly to da_ritirare.',
                 ],
                 'app_access_enabled'   => ['type' => 'boolean'],
                 'registration_enabled' => ['type' => 'boolean'],

--- a/tests/issues-301-306.unit.php
+++ b/tests/issues-301-306.unit.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+/** Regression guards for GitHub issues #301 and #306. */
+$root = dirname(__DIR__);
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    echo ($condition ? '[PASS] ' : '[FAIL] ') . $label . PHP_EOL;
+    $condition ? $passed++ : $failed++;
+};
+
+$authors = (string) file_get_contents($root . '/app/Controllers/AutoriApiController.php');
+$frontend = (string) file_get_contents($root . '/app/Controllers/FrontendController.php');
+$publishers = (string) file_get_contents($root . '/app/Controllers/EditoriApiController.php');
+$settingsRepo = (string) file_get_contents($root . '/app/Models/SettingsRepository.php');
+$settingsController = (string) file_get_contents($root . '/app/Controllers/SettingsController.php');
+$settingsView = (string) file_get_contents($root . '/app/Views/settings/loans-tab.php');
+$actions = (string) file_get_contents($root . '/app/Controllers/UserActionsController.php');
+$approval = (string) file_get_contents($root . '/app/Controllers/LoanApprovalController.php');
+$mobileActions = (string) file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/ActionsController.php');
+$mobileHealth = (string) file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/HealthController.php');
+$mobileDocs = (string) file_get_contents($root . '/storage/plugins/mobile-api/src/Controllers/OpenApiController.php');
+$migration = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.46.sql');
+
+$check(
+    substr_count($authors, 'JOIN libri l ON l.id = la.libro_id AND l.deleted_at IS NULL') === 2,
+    'author list and bulk export count only non-deleted books'
+);
+$check(
+    str_contains($frontend, 'SELECT COUNT(DISTINCT l.id)')
+        && str_contains($frontend, 'WHERE l.deleted_at IS NULL')
+        && str_contains($frontend, 'OR l.sottogenere_id = g.id'),
+    'genre facet count excludes soft-deleted books'
+);
+$check(
+    substr_count($publishers, 'AND l.deleted_at IS NULL') >= 3,
+    'publisher list/filter/export counts exclude soft-deleted books'
+);
+
+$check(str_contains($settingsRepo, 'function autoApproveLoanRequests()'), 'loan setting has a shared typed accessor');
+$check(
+    str_contains($settingsController, "set('loans', 'auto_approve_requests'")
+        && str_contains($settingsView, 'name="auto_approve_requests"')
+        && str_contains($settingsView, 'class="toggle-checkbox sr-only"'),
+    'loan settings persist an accessible toggle using the existing switch component'
+);
+$check(
+    strpos($actions, 'autoApproveLoanRequest($request, $db, $newLoanId)') < strpos($actions, 'notifyLoanRequest($newLoanId)'),
+    'automatic approval runs before slow email I/O while preserving the administrator notification'
+);
+$check(
+    str_contains($approval, "getAttribute('automatic_loan_approval'")
+        && str_contains($approval, 'sendLoanApprovedNotification($loanId)'),
+    'automatic approval sends the patron approval email'
+);
+$check(
+    str_contains($mobileActions, "'auto_approved' => \$autoApproved")
+        && str_contains($mobileActions, "'status' => \$autoApproved ? 'da_ritirare' : 'pendente'")
+        && str_contains($mobileHealth, "'loan_approval_required' => \$loanApprovalRequired")
+        && str_contains($mobileDocs, 'data.auto_approved'),
+    'Mobile API advertises the setting and returns the actual request outcome'
+);
+$check(
+    str_contains($migration, "'auto_approve_requests', '0'")
+        && str_contains($migration, 'ON DUPLICATE KEY UPDATE `setting_value` = `setting_value`'),
+    'upgrade migration is idempotent and preserves manual approval by default'
+);
+
+foreach (['it_IT', 'en_US', 'fr_FR', 'de_DE', 'da_DK'] as $locale) {
+    $catalog = json_decode((string) file_get_contents($root . "/locale/{$locale}.json"), true, 512, JSON_THROW_ON_ERROR);
+    $check(isset($catalog['Approvazione automatica']), "{$locale} includes auto-approval translations");
+}
+
+echo PHP_EOL . "Passed: {$passed}   Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);

--- a/tests/loan-auto-approval-301.unit.php
+++ b/tests/loan-auto-approval-301.unit.php
@@ -1,0 +1,222 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural database contract for #301 — automatic approval of immediate loan
+ * requests. Exercises the REAL SettingsRepository accessor and the REAL
+ * UserActionsController::autoApproveLoanRequest() (which delegates to the
+ * canonical LoanApprovalController::approveLoan pipeline) against seeded
+ * libri/copie/utenti/prestiti rows, and asserts the observable state
+ * transitions rather than string-matching the source.
+ *
+ * Run: php tests/loan-auto-approval-301.unit.php
+ */
+
+use App\Controllers\UserActionsController;
+use App\Models\CopyRepository;
+use App\Models\SettingsRepository;
+use App\Support\DateHelper;
+use Slim\Psr7\Factory\ServerRequestFactory;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — mandatory for this test: {$e->getMessage()}\n");
+    exit(1);
+}
+
+// Keep email out of the way — approveLoan sends the patron notification; the
+// 'mail' driver never blocks, but we also don't want a stray SMTP config to hang.
+$db->query("UPDATE system_settings SET setting_value='mail' WHERE category='email' AND setting_key IN ('driver_mode','type')");
+
+$run = substr(hash('sha256', uniqid((string) getmypid(), true)), 0, 10);
+$titlePrefix = 'ZZAUTO301_' . $run;
+$emailDomain = '@auto301.test.local';
+
+// Preserve the global auto-approve setting so the run doesn't leave it toggled.
+$origAuto = null;
+if ($r = $db->query("SELECT setting_value FROM system_settings WHERE category='loans' AND setting_key='auto_approve_requests'")) {
+    if ($row = $r->fetch_assoc()) {
+        $origAuto = $row['setting_value'];
+    }
+}
+
+$cleanup = static function () use ($db, $titlePrefix, $emailDomain, $origAuto): void {
+    $titleLike = $titlePrefix . '%';
+    $emailLike = '%' . $emailDomain;
+    foreach ([
+        'DELETE p FROM prestiti p JOIN libri l ON l.id = p.libro_id WHERE l.titolo LIKE ?',
+        'DELETE r FROM prenotazioni r JOIN libri l ON l.id = r.libro_id WHERE l.titolo LIKE ?',
+        'DELETE c FROM copie c JOIN libri l ON l.id = c.libro_id WHERE l.titolo LIKE ?',
+        'DELETE FROM libri WHERE titolo LIKE ?',
+    ] as $sql) {
+        $stmt = $db->prepare($sql);
+        $stmt->bind_param('s', $titleLike);
+        $stmt->execute();
+        $stmt->close();
+    }
+    $stmt = $db->prepare('DELETE FROM utenti WHERE email LIKE ?');
+    $stmt->bind_param('s', $emailLike);
+    $stmt->execute();
+    $stmt->close();
+    // Restore the auto-approve setting to its pre-test value (or remove it).
+    if ($origAuto === null) {
+        $db->query("DELETE FROM system_settings WHERE category='loans' AND setting_key='auto_approve_requests'");
+    } else {
+        $stmt = $db->prepare("INSERT INTO system_settings (category, setting_key, setting_value) VALUES ('loans','auto_approve_requests',?) ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)");
+        $stmt->bind_param('s', $origAuto);
+        $stmt->execute();
+        $stmt->close();
+    }
+};
+
+$cleanup();
+set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
+    try { $cleanup(); } catch (Throwable) {}
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    $db->close();
+    exit(1);
+});
+
+$pass = 0;
+$check = static function (bool $ok, string $label) use (&$pass): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $pass++;
+    echo "  OK  {$label}\n";
+};
+
+// ── Fixture helpers ─────────────────────────────────────────────────────────
+$bookSeq = 0;
+$makeBook = static function (int $copies) use ($db, $titlePrefix, $run, &$bookSeq): int {
+    $bookSeq++;
+    $title = $titlePrefix . '_' . $bookSeq;
+    $stmt = $db->prepare("INSERT INTO libri (titolo, stato, copie_totali, copie_disponibili) VALUES (?, 'disponibile', ?, ?)");
+    $stmt->bind_param('sii', $title, $copies, $copies);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+    $copyRepo = new CopyRepository($db);
+    for ($i = 1; $i <= $copies; $i++) {
+        $copyRepo->create($bookId, 'ZZA301-' . $run . '-' . $bookSeq . '-' . $i, 'disponibile');
+    }
+    return $bookId;
+};
+
+$userSeq = 0;
+$makeUser = static function () use ($db, $run, $emailDomain, &$userSeq): int {
+    $userSeq++;
+    $card = 'ZZA301' . strtoupper($run) . $userSeq;
+    $email = $run . '-' . $userSeq . $emailDomain;
+    $password = password_hash('test', PASSWORD_BCRYPT);
+    $stmt = $db->prepare("INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente) VALUES (?, 'Auto', 'Test', ?, ?, 'standard')");
+    $stmt->bind_param('sss', $card, $email, $password);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    return $id;
+};
+
+$today = DateHelper::today();
+$due = (new DateTimeImmutable($today))->modify('+14 days')->format('Y-m-d');
+
+// A fresh pending request: attivo=0, stato='pendente', no copy assigned yet,
+// data_prestito = today so approval yields the immediate 'da_ritirare' state.
+$makePendingLoan = static function (int $bookId, int $userId, ?string $state = 'pendente') use ($db, $today, $due): int {
+    $attivo = $state === 'pendente' ? 0 : 1;
+    $stmt = $db->prepare("INSERT INTO prestiti (libro_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo) VALUES (?, ?, ?, ?, ?, 'diretto', ?)");
+    $stmt->bind_param('iisssi', $bookId, $userId, $today, $due, $state, $attivo);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    return $id;
+};
+
+$setAuto = static function (?string $value) use ($db): void {
+    if ($value === null) {
+        $db->query("DELETE FROM system_settings WHERE category='loans' AND setting_key='auto_approve_requests'");
+        return;
+    }
+    (new SettingsRepository($db))->set('loans', 'auto_approve_requests', $value);
+};
+
+$accessor = static fn (): bool => (new SettingsRepository($db))->autoApproveLoanRequests();
+
+// autoApproveLoanRequest() is private — invoke the real method by reflection so
+// the test drives the exact code path the loan() request handler triggers.
+$controller = new UserActionsController();
+$autoMethod = new ReflectionMethod($controller, 'autoApproveLoanRequest');
+$autoMethod->setAccessible(true);
+$autoApprove = static function (int $loanId) use ($controller, $autoMethod, $db): bool {
+    $request = (new ServerRequestFactory())->createServerRequest('POST', '/prestito');
+    return (bool) $autoMethod->invoke($controller, $request, $db, $loanId);
+};
+
+$loanField = static function (int $loanId, string $col) use ($db) {
+    $stmt = $db->prepare("SELECT {$col} AS v FROM prestiti WHERE id = ?");
+    $stmt->bind_param('i', $loanId);
+    $stmt->execute();
+    $v = $stmt->get_result()->fetch_assoc()['v'] ?? null;
+    $stmt->close();
+    return $v;
+};
+
+// ── A. Setting accessor: the default must be safe for existing installs ──────
+echo "A. SettingsRepository::autoApproveLoanRequests() accessor\n";
+$setAuto(null);
+$check($accessor() === false, '01 absent setting → off (existing installs keep the manual queue)');
+$setAuto('0');
+$check($accessor() === false, "02 setting '0' → off");
+$setAuto('1');
+$check($accessor() === true, "03 setting '1' → on");
+$setAuto('yes');
+$check($accessor() === false, "04 any non-'1' value → off (strict opt-in)");
+
+// ── B. Auto-approval behaviour through the canonical pipeline ────────────────
+echo "B. autoApproveLoanRequest() behaviour\n";
+
+// 05 — OFF: the request must remain in the manual pendente queue.
+$setAuto('0');
+$loanOff = $makePendingLoan($makeBook(1), $makeUser());
+$check($autoApprove($loanOff) === false, '05 setting off → returns false');
+$check($loanField($loanOff, 'stato') === 'pendente', '05b setting off → loan stays pendente (manual workflow preserved)');
+
+// 06-08 — ON with an available copy: promoted to da_ritirare via the real pipeline.
+$setAuto('1');
+$loanOn = $makePendingLoan($makeBook(1), $makeUser());
+$check($autoApprove($loanOn) === true, '06 setting on + available copy → returns true');
+$check($loanField($loanOn, 'stato') === 'da_ritirare', "07 auto-approved loan → stato 'da_ritirare' (waiting for pickup)");
+$check($loanField($loanOn, 'pickup_deadline') !== null, '08 auto-approved immediate loan → pickup_deadline is set');
+
+// 09 — reuses the pipeline: a copy is locked/assigned and the loan is activated.
+$check((int) $loanField($loanOn, 'attivo') === 1 && $loanField($loanOn, 'copia_id') !== null,
+    '09 auto-approval assigns a physical copy and activates the loan (canonical pipeline)');
+
+// 10 — ON but no available copy: must not force-approve; request stays pending.
+$setAuto('1');
+$loanNoCopy = $makePendingLoan($makeBook(0), $makeUser());
+$check($autoApprove($loanNoCopy) === false, '10 setting on + no available copy → returns false (graceful)');
+$check($loanField($loanNoCopy, 'stato') === 'pendente', '10b no-copy request is left pending, never wrongly auto-approved');
+
+$cleanup();
+$db->close();
+echo "\n{$pass} checks passed\n";
+exit(0);

--- a/tests/migration-0.7.46.unit.php
+++ b/tests/migration-0.7.46.unit.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural test for migrate_0.7.46.sql (issue #301 — optional automatic
+ * approval of immediate loan requests).
+ *
+ * Runs the REAL migration file against a sandbox `system_settings` table
+ * (project pattern: same SQL, only the table name rewritten) and asserts:
+ *   - the loans/auto_approve_requests setting is created with the safe default '0'
+ *     (existing installs keep the manual approval queue);
+ *   - a second run is idempotent AND does not clobber an administrator's choice —
+ *     ON DUPLICATE KEY UPDATE keeps the stored value, so a '1' the admin set is
+ *     preserved rather than reset to '0';
+ *   - no duplicate row is created (UNIQUE(category, setting_key)).
+ *
+ * Run:  php tests/migration-0.7.46.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) {
+        $pass++;
+        echo "  OK  {$label}\n";
+    } else {
+        $fail++;
+        echo "  FAIL {$label}\n";
+    }
+};
+
+echo "A. Real migration against a sandbox system_settings table\n";
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', (int) ($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    // A migration test that silently skips its DB section is a false green in CI.
+    fwrite(STDERR, "FAIL: database unreachable — the migration section is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$SB = 'zz_mig_settings_0746';
+$migration = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.46.sql');
+// Retarget the REAL migration at a sandbox table so the test never touches the
+// live system_settings.
+$sandbox = static fn (string $sql): string => str_replace('`system_settings`', "`{$SB}`", $sql);
+
+$runMigration = static function () use ($db, $migration, $sandbox): void {
+    // array_filter drops the empty tail after the final ';', so every remaining
+    // statement is non-empty.
+    foreach (array_filter(array_map('trim', preg_split('/;\s*\n/', $sandbox(preg_replace('/^--.*$/m', '', $migration) ?? $migration)))) as $statement) {
+        $db->query($statement);
+    }
+};
+
+$readSetting = static function () use ($db, $SB): ?string {
+    $row = $db->query("SELECT setting_value FROM {$SB} WHERE category='loans' AND setting_key='auto_approve_requests'")->fetch_assoc();
+    return $row === null ? null : (string) $row['setting_value'];
+};
+
+$cleanup = static function () use ($db, $SB): void {
+    $db->query("DROP TABLE IF EXISTS {$SB}");
+};
+
+try {
+    $cleanup();
+
+    $db->query("CREATE TABLE {$SB} (
+        id int NOT NULL AUTO_INCREMENT,
+        category varchar(50) NOT NULL,
+        setting_key varchar(100) NOT NULL,
+        setting_value text,
+        description text,
+        created_at timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        UNIQUE KEY unique_setting (category, setting_key)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    // Pre-migration: setting absent.
+    $check($readSetting() === null, 'auto_approve_requests absent before migration');
+
+    $runMigration();
+
+    // Fresh install / upgrade: the setting is created with the safe default '0'.
+    $check($readSetting() === '0', "migration creates loans/auto_approve_requests = '0' (manual approval stays the default)");
+    $count = (int) $db->query("SELECT COUNT(*) FROM {$SB} WHERE category='loans' AND setting_key='auto_approve_requests'")->fetch_row()[0];
+    $check($count === 1, 'exactly one settings row created');
+
+    // An administrator turns auto-approval ON.
+    $db->query("UPDATE {$SB} SET setting_value='1' WHERE category='loans' AND setting_key='auto_approve_requests'");
+
+    // Re-running the migration must NOT reset that choice (ON DUPLICATE KEY UPDATE
+    // keeps the stored value) and must not duplicate the row.
+    $runMigration();
+    $check($readSetting() === '1', "second run preserves the admin's '1' (does not reset to '0')");
+    $count = (int) $db->query("SELECT COUNT(*) FROM {$SB} WHERE category='loans' AND setting_key='auto_approve_requests'")->fetch_row()[0];
+    $check($count === 1, 'second run does not duplicate the row (idempotent upsert)');
+
+    $cleanup();
+} catch (\Throwable $e) {
+    $fail++;
+    echo "  FAIL exception: {$e->getMessage()}\n";
+    $cleanup();
+}
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
     "name": "Pinakes",
-    "version": "0.7.45",
+    "version": "0.7.46",
     "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Summary

This pull request resolves the loan auto-approval request and the stale author book counts reported in #301 and #306.

Loan requests previously always entered the manual `pendente` queue. Libraries that do not need a separate availability review therefore had to approve every request before it could move to pickup. A new setting in **Settings → Loans** now lets administrators automatically promote immediate requests to `da_ritirare`. The implementation reuses the canonical approval pipeline, including eligibility, capacity, copy locking, availability recalculation, and pickup deadlines. Administrator request notifications and the patron approval email remain enabled.

The Mobile API exposes `loan_approval_required` through discovery and returns the resulting `loan_id`, `auto_approved` flag, and status when creating an immediate loan. Its OpenAPI contract documents the new fields.

Author list counts were derived directly from `libri_autori`, so associations belonging to soft-deleted books were still included even though author detail pages correctly hid those books. Both the list and bulk export now join `libri` and require `deleted_at IS NULL`. The same audit confirmed publisher counts were already correct and found one equivalent inconsistency in genre facet counts, which is fixed here as well.

The setting defaults to disabled for backward compatibility. Fresh-install seed data, an idempotent 0.7.46 migration, and all bundled translations are included.

## Validation

- PHPStan on all changed PHP controllers and repositories: no errors
- PHP syntax checks: passed
- Issue-specific regression suite: 14 checks passed
- Language derived-stat and export-completeness suites: passed
- Swagger static contract test: passed
- Composer validation: passed
- `git diff --check`: passed

Closes #301
Closes #306
