### PR TITLE
Group authoring fields together

### DIFF
--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -258,6 +258,17 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
               <p class="text-xs text-gray-500 mt-1"><?= __("Lingua originale del libro") ?></p>
             </div>
           </div>
+
+          <!-- Authors with Choices.js -->
+          <div>
+            <label for="autori_select" class="form-label"><?= __("Autori") ?></label>
+            <select id="autori_select" name="autori_select[]" multiple placeholder="<?= __('Cerca autori esistenti o aggiungine di nuovi...') ?>" data-initial-authors="<?php echo $initialAuthorsJson; ?>">
+              <!-- Options will be populated dynamically -->
+            </select>
+            <div id="autori_hidden"></div>
+            <p class="text-xs text-gray-500 mt-1"><?= __("Puoi selezionare più autori o aggiungerne di nuovi digitando il nome") ?></p>
+          </div>
+
           <?php
           // Contributor roles as entity pickers (issue #237). Same Choices.js +
           // /api/search/autori autocomplete as authors, so an illustrator/
@@ -298,16 +309,6 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
             </select>
             <div id="editori_hidden"></div>
             <p class="text-xs text-gray-500 mt-1"><?= __("Puoi selezionare più editori o aggiungerne di nuovi digitando il nome") ?></p>
-          </div>
-
-          <!-- Authors with Choices.js -->
-          <div>
-            <label for="autori_select" class="form-label"><?= __("Autori") ?></label>
-            <select id="autori_select" name="autori_select[]" multiple placeholder="<?= __('Cerca autori esistenti o aggiungine di nuovi...') ?>" data-initial-authors="<?php echo $initialAuthorsJson; ?>">
-              <!-- Options will be populated dynamically -->
-            </select>
-            <div id="autori_hidden"></div>
-            <p class="text-xs text-gray-500 mt-1"><?= __("Puoi selezionare più autori o aggiungerne di nuovi digitando il nome") ?></p>
           </div>
 
           <!-- Book Status -->


### PR DESCRIPTION
Request from our librarians:

<img width="2158" height="1598" alt="image" src="https://github.com/user-attachments/assets/a8afe9d7-69bc-4e74-8bc5-6857300bf25b" />

Seems reasonable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti dell’interfaccia**
  * Spostato il campo per la selezione degli autori subito dopo il campo “Lingua”.
  * La funzionalità e il comportamento del campo rimangono invariati.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->