### PR TITLE
fix: recover from the maintenance-mode lockout after an update

### DIFF
--- a/app/Support/BackupManager.php
+++ b/app/Support/BackupManager.php
@@ -324,16 +324,12 @@ class BackupManager
         // Safety net: a fatal error mid-restore must not leave the site locked
         // in maintenance (the front controller's 30-minute staleness fallback
         // remains the last resort). Mirrors Updater's shutdown handler.
-        register_shutdown_function(static function () use ($maintenanceFile, $lockFile): void {
+        register_shutdown_function(static function () use ($maintenanceFile): void {
             $error = error_get_last();
             if ($error !== null && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
                 if (file_exists($maintenanceFile)) {
                     // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal maintenance flag under storage/, not user input
                     @unlink($maintenanceFile);
-                }
-                if (file_exists($lockFile)) {
-                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal lock file under storage/cache, not user input
-                    @unlink($lockFile);
                 }
             }
         });
@@ -356,10 +352,8 @@ class BackupManager
             }
             flock($lockHandle, LOCK_UN);
             fclose($lockHandle);
-            if (file_exists($lockFile)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal lock file under storage/cache, not user input
-                @unlink($lockFile);
-            }
+            // Keep the shared lock inode persistent. Unlinking after unlock can
+            // delete a subsequent updater/restore request's lock path.
         }
     }
 

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -1745,7 +1745,19 @@ class Updater
         ]);
 
         $maintenanceFile = $this->rootPath . '/storage/.maintenance';
-        register_shutdown_function(function () use ($maintenanceFile, $lockFile) {
+        // Ownership flag: only the request that actually acquires the update lock
+        // (and turns maintenance on) may tear the state down. Set true below,
+        // right after flock + enableMaintenanceMode succeed.
+        /** @var bool $ownsUpdate Raised to true below, after the lock is held; the handler reads it by reference at shutdown. */
+        $ownsUpdate = false;
+        register_shutdown_function(function () use ($maintenanceFile, $lockFile, &$ownsUpdate) {
+            // Guard: a request rejected because another update already holds the
+            // lock (flock failed) must NOT remove the active update's maintenance
+            // flag or lock file — that would lift maintenance mid-copy and free
+            // the lock for a parallel update. Only the owner cleans up.
+            if (!$ownsUpdate) {
+                return;
+            }
             // The update runs entirely within this request (set_time_limit(0) +
             // ignore_user_abort), so once it ends — success, handled failure or a
             // fatal — maintenance MUST be lifted. Clear the flag UNCONDITIONALLY
@@ -1814,6 +1826,9 @@ class Updater
         fflush($lockHandle);
 
         $this->enableMaintenanceMode();
+        // We hold the lock and maintenance is on: this request now owns the
+        // update state, so its shutdown handler is cleared to tear it down.
+        $ownsUpdate = true;
 
         $backupResult = ['path' => null, 'success' => false, 'error' => null];
         $result = null;
@@ -3976,7 +3991,15 @@ class Updater
         ]);
 
         $maintenanceFile = $this->rootPath . '/storage/.maintenance';
-        register_shutdown_function(function () use ($maintenanceFile, $lockFile) {
+        // Ownership flag — see performUpdateFromFile(): set true only after this
+        // request holds the lock and maintenance is on, so a request rejected at
+        // flock never tears down the active update's state.
+        /** @var bool $ownsUpdate Raised to true below, after the lock is held; the handler reads it by reference at shutdown. */
+        $ownsUpdate = false;
+        register_shutdown_function(function () use ($maintenanceFile, $lockFile, &$ownsUpdate) {
+            if (!$ownsUpdate) {
+                return;
+            }
             // See performUpdateFromFile(): the update is single-request, so lift
             // maintenance UNCONDITIONALLY when the request ends. Only a fatal is
             // logged; the flag is always cleared so a handled failure can't leave
@@ -4042,6 +4065,9 @@ class Updater
         fflush($lockHandle);
 
         $this->enableMaintenanceMode();
+        // We hold the lock and maintenance is on: this request now owns the
+        // update state, so its shutdown handler is cleared to tear it down.
+        $ownsUpdate = true;
 
         $backupResult = ['path' => null, 'success' => false, 'error' => null];
         $result = null;

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -1746,19 +1746,24 @@ class Updater
 
         $maintenanceFile = $this->rootPath . '/storage/.maintenance';
         register_shutdown_function(function () use ($maintenanceFile, $lockFile) {
+            // The update runs entirely within this request (set_time_limit(0) +
+            // ignore_user_abort), so once it ends — success, handled failure or a
+            // fatal — maintenance MUST be lifted. Clear the flag UNCONDITIONALLY
+            // so a non-fatal early return (or a caught exception that skipped
+            // disableMaintenanceMode) can't leave the site stuck until the
+            // 30-minute stale sweep. An OS SIGKILL/OOM still bypasses shutdown
+            // handlers — the stale-file sweep is the last resort for that.
             $error = error_get_last();
             if ($error !== null && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
                 error_log("[Updater DEBUG] FATAL ERROR during manual update: " . json_encode($error));
-
-                if (file_exists($maintenanceFile)) {
-                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                    @unlink($maintenanceFile);
-                }
-
-                if (file_exists($lockFile)) {
-                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                    @unlink($lockFile);
-                }
+            }
+            if (file_exists($maintenanceFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
+                @unlink($maintenanceFile);
+            }
+            if (file_exists($lockFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
+                @unlink($lockFile);
             }
         });
 
@@ -3972,19 +3977,21 @@ class Updater
 
         $maintenanceFile = $this->rootPath . '/storage/.maintenance';
         register_shutdown_function(function () use ($maintenanceFile, $lockFile) {
+            // See performUpdateFromFile(): the update is single-request, so lift
+            // maintenance UNCONDITIONALLY when the request ends. Only a fatal is
+            // logged; the flag is always cleared so a handled failure can't leave
+            // the site stuck. (OS SIGKILL/OOM still needs the stale-file sweep.)
             $error = error_get_last();
             if ($error !== null && in_array($error['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
                 error_log("[Updater DEBUG] FATAL ERROR during update: " . json_encode($error));
-
-                if (file_exists($maintenanceFile)) {
-                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                    @unlink($maintenanceFile);
-                }
-
-                if (file_exists($lockFile)) {
-                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                    @unlink($lockFile);
-                }
+            }
+            if (file_exists($maintenanceFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
+                @unlink($maintenanceFile);
+            }
+            if (file_exists($lockFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
+                @unlink($lockFile);
             }
         });
 

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -1750,11 +1750,11 @@ class Updater
         // right after flock + enableMaintenanceMode succeed.
         /** @var bool $ownsUpdate Raised to true below, after the lock is held; the handler reads it by reference at shutdown. */
         $ownsUpdate = false;
-        register_shutdown_function(function () use ($maintenanceFile, $lockFile, &$ownsUpdate) {
+        register_shutdown_function(function () use ($maintenanceFile, &$ownsUpdate) {
             // Guard: a request rejected because another update already holds the
             // lock (flock failed) must NOT remove the active update's maintenance
-            // flag or lock file — that would lift maintenance mid-copy and free
-            // the lock for a parallel update. Only the owner cleans up.
+            // flag — that would expose the site mid-copy. Only the owner cleans
+            // up; the persistent lock inode is governed solely by flock.
             if (!$ownsUpdate) {
                 return;
             }
@@ -1772,10 +1772,6 @@ class Updater
             if (file_exists($maintenanceFile)) {
                 // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($maintenanceFile);
-            }
-            if (file_exists($lockFile)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                @unlink($lockFile);
             }
         });
 
@@ -1969,15 +1965,19 @@ class Updater
         } finally {
             $this->cleanup();
 
+            // Normal cleanup is complete while this request still owns the
+            // lock. Disarm the shutdown fallback before releasing it: once
+            // another request acquires the lock, this request must never remove
+            // that new owner's maintenance flag at shutdown.
+            $ownsUpdate = false;
+
             if (\is_resource($lockHandle)) {
                 flock($lockHandle, LOCK_UN);
                 fclose($lockHandle);
             }
 
-            if (file_exists($lockFile)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                @unlink($lockFile);
-            }
+            // Keep the lock inode persistent. Its state is the flock, not file
+            // existence; unlinking a shared lock file creates an inode race.
         }
 
         return $result;
@@ -3996,7 +3996,7 @@ class Updater
         // flock never tears down the active update's state.
         /** @var bool $ownsUpdate Raised to true below, after the lock is held; the handler reads it by reference at shutdown. */
         $ownsUpdate = false;
-        register_shutdown_function(function () use ($maintenanceFile, $lockFile, &$ownsUpdate) {
+        register_shutdown_function(function () use ($maintenanceFile, &$ownsUpdate) {
             if (!$ownsUpdate) {
                 return;
             }
@@ -4011,10 +4011,6 @@ class Updater
             if (file_exists($maintenanceFile)) {
                 // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
                 @unlink($maintenanceFile);
-            }
-            if (file_exists($lockFile)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                @unlink($lockFile);
             }
         });
 
@@ -4161,15 +4157,18 @@ class Updater
         } finally {
             $this->cleanup();
 
+            // See performUpdateFromFile(): disarm the shutdown fallback before
+            // releasing the lock, otherwise it can erase a subsequent update's
+            // state during this request's shutdown phase.
+            $ownsUpdate = false;
+
             if (\is_resource($lockHandle)) {
                 flock($lockHandle, LOCK_UN);
                 fclose($lockHandle);
             }
 
-            if (file_exists($lockFile)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- internal updater-controlled path (constant or constructed under storage), not user input
-                @unlink($lockFile);
-            }
+            // Keep the shared lock inode persistent; only flock ownership is
+            // authoritative and is released above.
         }
 
         return $result;

--- a/public/index.php
+++ b/public/index.php
@@ -198,31 +198,55 @@ if (file_exists($maintenanceFile)) {
             http_response_code(503);
             header('Content-Type: text/html; charset=UTF-8');
             header('Retry-After: 300');
+            // Asset base for subfolder installs; /assets/ is allow-listed above
+            // so the self-hosted brand fonts still load during maintenance. If
+            // they don't (assets mid-swap during an update), the system-font
+            // fallbacks keep the page legible.
+            $assetBase = htmlspecialchars($maintenanceBasePath, ENT_QUOTES, 'UTF-8');
             echo '<!DOCTYPE html>
 <html lang="it">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manutenzione in corso</title>
+    <meta name="theme-color" content="#d70161">
+    <title>Manutenzione in corso &middot; Pinakes</title>
     <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); margin: 0; padding: 20px; display: flex; align-items: center; justify-content: center; min-height: 100vh; }
-        .container { background: white; border-radius: 16px; box-shadow: 0 25px 50px rgba(0,0,0,0.25); max-width: 500px; padding: 50px; text-align: center; }
-        .icon { font-size: 64px; margin-bottom: 20px; }
-        h1 { color: #1f2937; margin: 0 0 15px 0; font-size: 28px; }
-        p { color: #6b7280; line-height: 1.6; margin: 0; font-size: 16px; }
-        .spinner { display: inline-block; width: 20px; height: 20px; border: 3px solid #e5e7eb; border-top-color: #6366f1; border-radius: 50%; animation: spin 1s linear infinite; margin-right: 8px; vertical-align: middle; }
+        @import url("' . $assetBase . '/assets/fonts/fonts.css");
+        :root {
+            --brand: #d70161;
+            --ink: #0f172a;
+            --muted: #64748b;
+            --paper: #f8f9fa;
+            --card: #ffffff;
+            --line: rgba(15, 23, 42, 0.08);
+            --serif: "Fraunces", Georgia, "Times New Roman", serif;
+            --sans: "Instrument Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+        * { box-sizing: border-box; }
+        body { font-family: var(--sans); background: var(--paper); color: var(--ink); margin: 0; padding: 24px; display: flex; align-items: center; justify-content: center; min-height: 100vh; -webkit-font-smoothing: antialiased; }
+        .card { background: var(--card); border: 1px solid var(--line); border-radius: 18px; box-shadow: 0 1px 2px rgba(15,23,42,0.04), 0 20px 48px rgba(15,23,42,0.08); max-width: 480px; width: 100%; padding: 48px 44px; text-align: center; }
+        .brand { font-family: var(--serif); font-weight: 600; font-size: 15px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--brand); margin: 0 0 28px 0; }
+        .brand::before { content: ""; display: block; width: 40px; height: 3px; border-radius: 2px; background: var(--brand); margin: 0 auto 22px; }
+        h1 { font-family: var(--serif); font-weight: 600; color: var(--ink); margin: 0 0 14px 0; font-size: 30px; line-height: 1.2; letter-spacing: -0.01em; }
+        p { color: var(--muted); line-height: 1.65; margin: 0 auto; font-size: 16px; max-width: 34ch; }
+        .status { margin-top: 34px; display: inline-flex; align-items: center; gap: 10px; padding: 11px 18px; background: color-mix(in srgb, var(--brand) 8%, var(--card)); border: 1px solid color-mix(in srgb, var(--brand) 18%, transparent); border-radius: 999px; font-size: 14px; font-weight: 500; color: var(--brand); }
+        .spinner { width: 15px; height: 15px; border: 2px solid color-mix(in srgb, var(--brand) 25%, transparent); border-top-color: var(--brand); border-radius: 50%; animation: spin 0.8s linear infinite; }
         @keyframes spin { to { transform: rotate(360deg); } }
-        .status { margin-top: 30px; padding: 15px; background: #f3f4f6; border-radius: 8px; font-size: 14px; color: #4b5563; }
+        @media (prefers-reduced-motion: reduce) { .spinner { animation: none; } }
+        @media (prefers-color-scheme: dark) {
+            :root { --ink: #e2e8f0; --muted: #94a3b8; --paper: #0f172a; --card: #1e293b; --line: rgba(226, 232, 240, 0.10); --brand: #ff5a9d; }
+        }
+        @media (max-width: 480px) { .card { padding: 40px 26px; } h1 { font-size: 26px; } }
     </style>
 </head>
 <body>
-    <div class="container">
-        <div class="icon">🔧</div>
+    <div class="card">
+        <div class="brand">Pinakes</div>
         <h1>Manutenzione in corso</h1>
         <p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p>
         <div class="status">
-            <span class="spinner"></span>
-            Aggiornamento del sistema in corso...
+            <span class="spinner" aria-hidden="true"></span>
+            Aggiornamento del sistema in corso
         </div>
     </div>
 </body>

--- a/public/index.php
+++ b/public/index.php
@@ -173,11 +173,29 @@ if (file_exists($maintenanceFile)) {
     // MUST match the one the app configures below (storage/sessions) or the
     // probe reads an empty session from the default /tmp and the bypass never
     // fires — the very case this recovery path exists for.
-    if (!$isAllowed && session_status() === PHP_SESSION_NONE) {
+    // Only probe when a session cookie is actually present: an anonymous visitor
+    // (the vast majority of 503 traffic) must not have a session created for
+    // them here. For a request that DOES carry the cookie, the probe reads it
+    // read-only. It cannot disable cookies (PHP then wouldn't read the id from
+    // the cookie either, and the bypass would never see the admin's session), so
+    // instead it hardens what the probe might emit: strict mode rejects a
+    // client-supplied arbitrary id (no file created for it), and the app's
+    // cookie flags are applied up front so a stale/invalid incoming id can't
+    // produce an insecure Set-Cookie. The app's own secure session config still
+    // runs later for the real, writable session.
+    if (!$isAllowed && session_status() === PHP_SESSION_NONE
+        && isset($_COOKIE[session_name()])
+    ) {
         $maintenanceSessionPath = dirname(__DIR__) . '/storage/sessions';
         if (is_dir($maintenanceSessionPath) && is_readable($maintenanceSessionPath)) {
             ini_set('session.save_path', $maintenanceSessionPath);
         }
+        $probeHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string) $_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https');
+        ini_set('session.use_strict_mode', '1');
+        ini_set('session.cookie_httponly', '1');
+        ini_set('session.cookie_secure', $probeHttps ? '1' : '0');
+        ini_set('session.cookie_samesite', 'Lax');
         @session_start(['read_and_close' => true]);
         $maintenanceRole = $_SESSION['user']['tipo_utente'] ?? null;
         if (in_array($maintenanceRole, ['admin', 'staff'], true)) {

--- a/public/index.php
+++ b/public/index.php
@@ -145,13 +145,43 @@ if (file_exists($maintenanceFile)) {
     ) {
         $requestUri = substr($requestUri, strlen($maintenanceBasePath)) ?: '/';
     }
-    // Allow update endpoints and static assets during maintenance
-    $allowedPaths = ['/admin/updates', '/assets/', '/favicon.ico'];
+    // Allow update endpoints and static assets during maintenance, plus the
+    // login/logout routes so an admin can ALWAYS authenticate while the site is
+    // locked and reach the recovery UI. Without this the update lock locks out
+    // the very account needed to clear it (the emergency clear-maintenance
+    // endpoint is admin-only). The localised slugs are added on top of the
+    // defaults so it works whatever install locale is active.
+    $allowedPaths = ['/admin/updates', '/assets/', '/favicon.ico', '/login', '/logout'];
+    try {
+        $allowedPaths[] = \App\Support\RouteTranslator::route('login');
+        $allowedPaths[] = \App\Support\RouteTranslator::route('logout');
+    } catch (\Throwable) {
+        // Defaults above already cover the fallback case.
+    }
     $isAllowed = false;
     foreach ($allowedPaths as $path) {
-        if (strpos($requestUri, $path) === 0) {
+        if ($path !== '' && strpos($requestUri, $path) === 0) {
             $isAllowed = true;
             break;
+        }
+    }
+
+    // Admin/staff bypass: an authenticated privileged user gets full access so
+    // they can drive or abort the update from the admin area. The session is
+    // read read-only (read_and_close) so it never interferes with the writable
+    // session_start() performed later during normal bootstrap. The save_path
+    // MUST match the one the app configures below (storage/sessions) or the
+    // probe reads an empty session from the default /tmp and the bypass never
+    // fires — the very case this recovery path exists for.
+    if (!$isAllowed && session_status() === PHP_SESSION_NONE) {
+        $maintenanceSessionPath = dirname(__DIR__) . '/storage/sessions';
+        if (is_dir($maintenanceSessionPath) && is_readable($maintenanceSessionPath)) {
+            ini_set('session.save_path', $maintenanceSessionPath);
+        }
+        @session_start(['read_and_close' => true]);
+        $maintenanceRole = $_SESSION['user']['tipo_utente'] ?? null;
+        if (in_array($maintenanceRole, ['admin', 'staff'], true)) {
+            $isAllowed = true;
         }
     }
 

--- a/public/index.php
+++ b/public/index.php
@@ -166,43 +166,6 @@ if (file_exists($maintenanceFile)) {
         }
     }
 
-    // Admin/staff bypass: an authenticated privileged user gets full access so
-    // they can drive or abort the update from the admin area. The session is
-    // read read-only (read_and_close) so it never interferes with the writable
-    // session_start() performed later during normal bootstrap. The save_path
-    // MUST match the one the app configures below (storage/sessions) or the
-    // probe reads an empty session from the default /tmp and the bypass never
-    // fires — the very case this recovery path exists for.
-    // Only probe when a session cookie is actually present: an anonymous visitor
-    // (the vast majority of 503 traffic) must not have a session created for
-    // them here. For a request that DOES carry the cookie, the probe reads it
-    // read-only. It cannot disable cookies (PHP then wouldn't read the id from
-    // the cookie either, and the bypass would never see the admin's session), so
-    // instead it hardens what the probe might emit: strict mode rejects a
-    // client-supplied arbitrary id (no file created for it), and the app's
-    // cookie flags are applied up front so a stale/invalid incoming id can't
-    // produce an insecure Set-Cookie. The app's own secure session config still
-    // runs later for the real, writable session.
-    if (!$isAllowed && session_status() === PHP_SESSION_NONE
-        && isset($_COOKIE[session_name()])
-    ) {
-        $maintenanceSessionPath = dirname(__DIR__) . '/storage/sessions';
-        if (is_dir($maintenanceSessionPath) && is_readable($maintenanceSessionPath)) {
-            ini_set('session.save_path', $maintenanceSessionPath);
-        }
-        $probeHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
-            || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string) $_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https');
-        ini_set('session.use_strict_mode', '1');
-        ini_set('session.cookie_httponly', '1');
-        ini_set('session.cookie_secure', $probeHttps ? '1' : '0');
-        ini_set('session.cookie_samesite', 'Lax');
-        @session_start(['read_and_close' => true]);
-        $maintenanceRole = $_SESSION['user']['tipo_utente'] ?? null;
-        if (in_array($maintenanceRole, ['admin', 'staff'], true)) {
-            $isAllowed = true;
-        }
-    }
-
     if (!$isAllowed) {
         $maintenanceData = json_decode(file_get_contents($maintenanceFile), true);
         $message = $maintenanceData['message'] ?? 'Il sito è in manutenzione. Riprova tra qualche minuto.';

--- a/public/index.php
+++ b/public/index.php
@@ -203,13 +203,51 @@ if (file_exists($maintenanceFile)) {
             // they don't (assets mid-swap during an update), the system-font
             // fallbacks keep the page legible.
             $assetBase = htmlspecialchars($maintenanceBasePath, ENT_QUOTES, 'UTF-8');
+
+            // Honour the operator's configured name and logo — the same branding
+            // the header uses — so the maintenance page isn't a stranger. This
+            // runs on every request while locked and an update may be touching
+            // the settings table, so read defensively and fall back to a neutral
+            // wordmark. A local logo is embedded as a data URI: a plain <img src>
+            // would trigger a second request that this very gate answers with the
+            // 503, so inlining is the only way it renders during maintenance.
+            $brandName = 'Pinakes';
+            $brandMarkup = '';
+            try {
+                $configuredName = trim((string) \App\Support\ConfigStore::get('app.name', ''));
+                if ($configuredName !== '') {
+                    $brandName = $configuredName;
+                }
+                $logoRel = \App\Support\Branding::logo();
+                if ($logoRel !== '' && preg_match('#^https?://#i', $logoRel)) {
+                    $brandMarkup = '<img class="logo" src="' . htmlspecialchars($logoRel, ENT_QUOTES, 'UTF-8') . '" alt="' . htmlspecialchars($brandName, ENT_QUOTES, 'UTF-8') . '">';
+                } elseif ($logoRel !== '') {
+                    $publicDir = realpath(__DIR__);
+                    $logoFile = realpath(__DIR__ . '/' . ltrim((string) (parse_url($logoRel, PHP_URL_PATH) ?: $logoRel), '/'));
+                    if ($publicDir !== false && $logoFile !== false && str_starts_with($logoFile, $publicDir . DIRECTORY_SEPARATOR) && is_file($logoFile) && filesize($logoFile) <= 524288) {
+                        $mime = [
+                            'png' => 'image/png', 'jpg' => 'image/jpeg', 'jpeg' => 'image/jpeg',
+                            'gif' => 'image/gif', 'svg' => 'image/svg+xml', 'webp' => 'image/webp',
+                        ][strtolower(pathinfo($logoFile, PATHINFO_EXTENSION))] ?? '';
+                        $bytes = @file_get_contents($logoFile);
+                        if ($mime !== '' && $bytes !== false) {
+                            $brandMarkup = '<img class="logo" src="data:' . $mime . ';base64,' . base64_encode($bytes) . '" alt="' . htmlspecialchars($brandName, ENT_QUOTES, 'UTF-8') . '">';
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                // Keep the neutral wordmark fallback.
+            }
+            if ($brandMarkup === '') {
+                $brandMarkup = '<div class="brand">' . htmlspecialchars($brandName, ENT_QUOTES, 'UTF-8') . '</div>';
+            }
             echo '<!DOCTYPE html>
 <html lang="it">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#d70161">
-    <title>Manutenzione in corso &middot; Pinakes</title>
+    <title>Manutenzione in corso &middot; ' . htmlspecialchars($brandName, ENT_QUOTES, 'UTF-8') . '</title>
     <style>
         @import url("' . $assetBase . '/assets/fonts/fonts.css");
         :root {
@@ -225,8 +263,9 @@ if (file_exists($maintenanceFile)) {
         * { box-sizing: border-box; }
         body { font-family: var(--sans); background: var(--paper); color: var(--ink); margin: 0; padding: 24px; display: flex; align-items: center; justify-content: center; min-height: 100vh; -webkit-font-smoothing: antialiased; }
         .card { background: var(--card); border: 1px solid var(--line); border-radius: 18px; box-shadow: 0 1px 2px rgba(15,23,42,0.04), 0 20px 48px rgba(15,23,42,0.08); max-width: 480px; width: 100%; padding: 48px 44px; text-align: center; }
+        .rule { display: block; width: 40px; height: 3px; border-radius: 2px; background: var(--brand); margin: 0 auto 22px; }
         .brand { font-family: var(--serif); font-weight: 600; font-size: 15px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--brand); margin: 0 0 28px 0; }
-        .brand::before { content: ""; display: block; width: 40px; height: 3px; border-radius: 2px; background: var(--brand); margin: 0 auto 22px; }
+        .logo { display: block; width: auto; max-width: 200px; max-height: 48px; margin: 0 auto 26px; }
         h1 { font-family: var(--serif); font-weight: 600; color: var(--ink); margin: 0 0 14px 0; font-size: 30px; line-height: 1.2; letter-spacing: -0.01em; }
         p { color: var(--muted); line-height: 1.65; margin: 0 auto; font-size: 16px; max-width: 34ch; }
         .status { margin-top: 34px; display: inline-flex; align-items: center; gap: 10px; padding: 11px 18px; background: color-mix(in srgb, var(--brand) 8%, var(--card)); border: 1px solid color-mix(in srgb, var(--brand) 18%, transparent); border-radius: 999px; font-size: 14px; font-weight: 500; color: var(--brand); }
@@ -241,7 +280,8 @@ if (file_exists($maintenanceFile)) {
 </head>
 <body>
     <div class="card">
-        <div class="brand">Pinakes</div>
+        <span class="rule"></span>
+        ' . $brandMarkup . '
         <h1>Manutenzione in corso</h1>
         <p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p>
         <div class="status">

--- a/tests/maintenance-recovery-lockout.unit.php
+++ b/tests/maintenance-recovery-lockout.unit.php
@@ -103,17 +103,22 @@ if (!$serverUp) {
                 json_encode(['time' => time(), 'message' => 'maintenance-recovery.unit self-test'])
             );
 
+            // Reachable = actually served (2xx/3xx), not merely "not 503": a 404
+            // or 500 must fail these, otherwise a route that isn't served would
+            // pass as "reachable".
+            $reachable = static fn (?int $c): bool => $c !== null && $c >= 200 && $c < 400;
+
             $login = $httpCode($baseUrl . $loginPath);
-            $check($login !== null && $login !== 503, "01 login page ({$loginPath}) reachable during maintenance (got " . var_export($login, true) . ", must not be 503)");
+            $check($reachable($login), "01 login page ({$loginPath}) served during maintenance, not error/503 (got " . var_export($login, true) . ")");
 
             $home = $httpCode($baseUrl . '/');
             $check($home === 503, "02 unauthenticated home returns 503 during maintenance (got " . var_export($home, true) . ")");
 
             $updates = $httpCode($baseUrl . '/admin/updates');
-            $check($updates !== null && $updates !== 503, "03 update endpoint (/admin/updates) reachable during maintenance (got " . var_export($updates, true) . ")");
+            $check($reachable($updates), "03 update endpoint (/admin/updates) served during maintenance, not 503 (got " . var_export($updates, true) . ")");
 
             $asset = $httpCode($baseUrl . '/assets/main.css');
-            $check($asset !== null && $asset !== 503, "04 static assets reachable during maintenance (got " . var_export($asset, true) . ")");
+            $check($reachable($asset), "04 static assets served during maintenance, not 503 (got " . var_export($asset, true) . ")");
         } finally {
             $cleanupMaintenance();
         }
@@ -148,15 +153,24 @@ $check(
     "12 index.php lets an authenticated admin/staff through (read_and_close session probe)"
 );
 
-// Layer 2: BOTH shutdown handlers must unlink the maintenance + lock files
-// UNCONDITIONALLY — not nested inside the fatal-error `if`. Verify by removing
-// each fatal-error block and confirming an unlink of $maintenanceFile still
-// remains in the handler afterwards.
+// Layer 1c: the probe must not run for anonymous visitors and must not emit a
+// cookie or accept an arbitrary client-supplied session id — it only reads an
+// already-present session (guards against session fixation / disk churn).
+$check(
+    str_contains($index, 'isset($_COOKIE[session_name()])')
+        && str_contains($index, "ini_set('session.use_strict_mode', '1')"),
+    "15 index.php probes only when a session cookie exists, in strict mode"
+);
+
+// Layer 2: BOTH shutdown handlers must (a) return early unless this request owns
+// the update lock, and (b) otherwise clear the maintenance + lock files
+// UNCONDITIONALLY (not nested inside the fatal-error `if`).
 $updater = (string) file_get_contents($root . '/app/Support/Updater.php');
 
-// Isolate each register_shutdown_function body.
+// Isolate each register_shutdown_function body (signature carries the ownership
+// flag by reference).
 preg_match_all(
-    '/register_shutdown_function\(function \(\) use \(\$maintenanceFile, \$lockFile\) \{(.*?)\}\);/s',
+    '/register_shutdown_function\(function \(\) use \(\$maintenanceFile, \$lockFile, &\$ownsUpdate\) \{(.*?)\}\);/s',
     $updater,
     $handlers
 );
@@ -164,17 +178,31 @@ $handlerBodies = $handlers[1] ?? [];
 $check(count($handlerBodies) >= 2, "13 found both updater shutdown handlers (got " . count($handlerBodies) . ")");
 
 $unconditional = 0;
+$ownershipGuarded = 0;
 foreach ($handlerBodies as $body) {
-    // Strip the fatal-error diagnostic `if (...) { ... }` block, then check an
-    // unlink of the maintenance file still survives at the handler's top level.
-    $withoutFatalBlock = preg_replace('/if \(\$error !== null.*?\}\s*/s', '', $body);
-    if (is_string($withoutFatalBlock)
-        && preg_match('/@unlink\(\$maintenanceFile\)/', $withoutFatalBlock)
-        && preg_match('/@unlink\(\$lockFile\)/', $withoutFatalBlock)) {
+    // Ownership guard: a request that didn't acquire the lock must bail before
+    // touching any state.
+    if (preg_match('/if \(!\$ownsUpdate\) \{\s*return;\s*\}/s', $body)) {
+        $ownershipGuarded++;
+    }
+    // Strip the ownership guard AND the fatal-error diagnostic block, then check
+    // an unlink of both files still survives at the handler's top level (i.e.
+    // it's unconditional for the owner, not gated by the fatal `if`).
+    $stripped = preg_replace('/if \(!\$ownsUpdate\) \{\s*return;\s*\}\s*/s', '', $body);
+    $stripped = is_string($stripped) ? preg_replace('/if \(\$error !== null.*?\}\s*/s', '', $stripped) : null;
+    if (is_string($stripped)
+        && preg_match('/@unlink\(\$maintenanceFile\)/', $stripped)
+        && preg_match('/@unlink\(\$lockFile\)/', $stripped)) {
         $unconditional++;
     }
 }
-$check($unconditional >= 2, "14 both shutdown handlers clear .maintenance + lock UNCONDITIONALLY (got {$unconditional}/2)");
+$check($ownershipGuarded >= 2, "14 both shutdown handlers bail unless this request owns the update lock (got {$ownershipGuarded}/2)");
+$check($unconditional >= 2, "16 the owner clears .maintenance + lock UNCONDITIONALLY (got {$unconditional}/2)");
+// The ownership flag is only raised after the lock is held and maintenance is on.
+$check(
+    substr_count($updater, '$ownsUpdate = true;') >= 2,
+    "17 both update paths raise the ownership flag after acquiring the lock"
+);
 
 echo "\n{$pass} PASS, {$fail} FAIL\n";
 exit($fail === 0 ? 0 : 1);

--- a/tests/maintenance-recovery-lockout.unit.php
+++ b/tests/maintenance-recovery-lockout.unit.php
@@ -50,10 +50,16 @@ $httpCode = static function (string $url, string $cookie = ''): ?int {
         $cmd .= ' -H ' . escapeshellarg('Cookie: ' . $cookie);
     }
     $out = @shell_exec($cmd);
-    if ($out === null || !preg_match('/^\d{3}$/', trim((string) $out))) {
+    $code = $out === null ? '' : trim((string) $out);
+    // curl prints "000" when the connection never produced an HTTP response
+    // (refused / DNS / pre-response timeout) — that is "unreachable", not a
+    // status. Treating it as a real code made the behavioural block run against
+    // a dead server on CI (no :8081) and fail check 02. Return null so the
+    // caller skips the behavioural checks there instead.
+    if ($code === '' || !preg_match('/^\d{3}$/', $code) || (int) $code === 0) {
         return null;
     }
-    return (int) trim((string) $out);
+    return (int) $code;
 };
 
 // Resolve the install's login slug the same way the front controller does, so

--- a/tests/maintenance-recovery-lockout.unit.php
+++ b/tests/maintenance-recovery-lockout.unit.php
@@ -1,0 +1,174 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression test for the maintenance-mode recovery lockout.
+ *
+ * Background: an in-app update writes storage/.maintenance and the front
+ * controller (public/index.php) blocks EVERY request while it exists. The
+ * emergency "clear maintenance" endpoint is admin-only, but the block also
+ * covered the login route — so an admin who was logged out could never
+ * authenticate to reach it. A non-fatal early-return in the updater (or a
+ * caught exception that skipped disableMaintenanceMode()) would leave the site
+ * stuck until the 30-minute stale sweep. Real incident:
+ * biblioteca.casadelledonnealessandria.it, Aug 2026.
+ *
+ * The fix has three layers; this test guards all of them:
+ *   Layer 1 (public/index.php) — the maintenance gate allow-lists the login /
+ *     logout routes (localised + literal defaults) AND lets an authenticated
+ *     admin/staff through, so recovery is always reachable.
+ *   Layer 2 (app/Support/Updater.php) — BOTH register_shutdown_function
+ *     handlers clear .maintenance + the lock file UNCONDITIONALLY, not only on
+ *     a fatal PHP error.
+ *   Layer 3 — the existing 30-minute stale sweep stays as the last resort.
+ *
+ * A. Behavioural (needs the dev server on :8081): with .maintenance present,
+ *    the login page is reachable, an unauthenticated visitor gets 503, and the
+ *    update / asset allow-list still works. Skipped (not failed) if the server
+ *    is unreachable. Always removes the flag via a finally-style guard.
+ * B. Source guard (always runs): the Layer 1 bypass and the Layer 2
+ *    unconditional cleanup are present so the fix cannot silently regress.
+ *
+ * Run:  php tests/maintenance-recovery-lockout.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+$baseUrl = getenv('E2E_BASE_URL') ?: 'http://localhost:8081';
+$maintenanceFile = $root . '/storage/.maintenance';
+
+$httpCode = static function (string $url, string $cookie = ''): ?int {
+    $cmd = 'curl -s -o /dev/null -w "%{http_code}" --max-time 10 ' . escapeshellarg($url);
+    if ($cookie !== '') {
+        $cmd .= ' -H ' . escapeshellarg('Cookie: ' . $cookie);
+    }
+    $out = @shell_exec($cmd);
+    if ($out === null || !preg_match('/^\d{3}$/', trim((string) $out))) {
+        return null;
+    }
+    return (int) trim((string) $out);
+};
+
+// Resolve the install's login slug the same way the front controller does, so
+// the behavioural check follows whatever locale the install runs under.
+$loginPath = '/login';
+if (is_file($root . '/vendor/autoload.php')) {
+    require_once $root . '/vendor/autoload.php';
+    try {
+        if (class_exists(\App\Support\RouteTranslator::class)) {
+            $resolved = \App\Support\RouteTranslator::route('login');
+            if (is_string($resolved) && $resolved !== '') {
+                $loginPath = $resolved;
+            }
+        }
+    } catch (\Throwable) {
+        // Keep the /login default.
+    }
+}
+
+// ── A. Behavioural — the gate, exercised through real HTTP ──────────────────
+echo "A. Maintenance gate behaviour (dev server on {$baseUrl})\n";
+
+$serverUp = $httpCode($baseUrl . '/') !== null;
+if (!$serverUp) {
+    echo "  SKIP behavioural checks — {$baseUrl} unreachable (start Apache+PHP-FPM to run them)\n";
+} else {
+    // Guarantee the flag is gone no matter how the block below exits.
+    $cleanupMaintenance = static function () use ($maintenanceFile): void {
+        if (is_file($maintenanceFile)) {
+            @unlink($maintenanceFile);
+        }
+    };
+    // Never clobber a flag a real update might have written this instant.
+    $preExisting = is_file($maintenanceFile);
+    if ($preExisting) {
+        echo "  SKIP behavioural checks — storage/.maintenance already present (a real update may be running)\n";
+    } else {
+        try {
+            file_put_contents(
+                $maintenanceFile,
+                json_encode(['time' => time(), 'message' => 'maintenance-recovery.unit self-test'])
+            );
+
+            $login = $httpCode($baseUrl . $loginPath);
+            $check($login !== null && $login !== 503, "01 login page ({$loginPath}) reachable during maintenance (got " . var_export($login, true) . ", must not be 503)");
+
+            $home = $httpCode($baseUrl . '/');
+            $check($home === 503, "02 unauthenticated home returns 503 during maintenance (got " . var_export($home, true) . ")");
+
+            $updates = $httpCode($baseUrl . '/admin/updates');
+            $check($updates !== null && $updates !== 503, "03 update endpoint (/admin/updates) reachable during maintenance (got " . var_export($updates, true) . ")");
+
+            $asset = $httpCode($baseUrl . '/assets/main.css');
+            $check($asset !== null && $asset !== 503, "04 static assets reachable during maintenance (got " . var_export($asset, true) . ")");
+        } finally {
+            $cleanupMaintenance();
+        }
+        // Prove the finally actually lifted the block.
+        $check(!is_file($maintenanceFile), "05 test removed storage/.maintenance after the run");
+        $home = $httpCode($baseUrl . '/');
+        $check($home !== null && $home !== 503, "06 home serves normally again once the flag is gone (got " . var_export($home, true) . ")");
+    }
+}
+
+// ── B. Source guard — the fix cannot silently regress ───────────────────────
+echo "B. Source guard (Layer 1 bypass + Layer 2 unconditional cleanup)\n";
+
+$index = (string) file_get_contents($root . '/public/index.php');
+
+// Layer 1a: login/logout routes are allow-listed so an admin can authenticate.
+$check(
+    str_contains($index, "RouteTranslator::route('login')")
+        && str_contains($index, "RouteTranslator::route('logout')"),
+    "10 index.php allow-lists the localised login/logout routes"
+);
+$check(
+    (bool) preg_match("/\\\$allowedPaths\\s*=\\s*\\[[^\\]]*'\\/login'[^\\]]*'\\/logout'[^\\]]*\\]/s", $index),
+    "11 index.php allow-lists the literal /login and /logout defaults"
+);
+
+// Layer 1b: an authenticated admin/staff bypasses the block via a read-only
+// session read (read_and_close) that doesn't disturb the later writable start.
+$check(
+    str_contains($index, "read_and_close")
+        && (bool) preg_match("/tipo_utente.*\\[[^\\]]*'admin'[^\\]]*'staff'[^\\]]*\\]/s", $index),
+    "12 index.php lets an authenticated admin/staff through (read_and_close session probe)"
+);
+
+// Layer 2: BOTH shutdown handlers must unlink the maintenance + lock files
+// UNCONDITIONALLY — not nested inside the fatal-error `if`. Verify by removing
+// each fatal-error block and confirming an unlink of $maintenanceFile still
+// remains in the handler afterwards.
+$updater = (string) file_get_contents($root . '/app/Support/Updater.php');
+
+// Isolate each register_shutdown_function body.
+preg_match_all(
+    '/register_shutdown_function\(function \(\) use \(\$maintenanceFile, \$lockFile\) \{(.*?)\}\);/s',
+    $updater,
+    $handlers
+);
+$handlerBodies = $handlers[1] ?? [];
+$check(count($handlerBodies) >= 2, "13 found both updater shutdown handlers (got " . count($handlerBodies) . ")");
+
+$unconditional = 0;
+foreach ($handlerBodies as $body) {
+    // Strip the fatal-error diagnostic `if (...) { ... }` block, then check an
+    // unlink of the maintenance file still survives at the handler's top level.
+    $withoutFatalBlock = preg_replace('/if \(\$error !== null.*?\}\s*/s', '', $body);
+    if (is_string($withoutFatalBlock)
+        && preg_match('/@unlink\(\$maintenanceFile\)/', $withoutFatalBlock)
+        && preg_match('/@unlink\(\$lockFile\)/', $withoutFatalBlock)) {
+        $unconditional++;
+    }
+}
+$check($unconditional >= 2, "14 both shutdown handlers clear .maintenance + lock UNCONDITIONALLY (got {$unconditional}/2)");
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/maintenance-recovery-lockout.unit.php
+++ b/tests/maintenance-recovery-lockout.unit.php
@@ -109,7 +109,10 @@ if (!$serverUp) {
             $reachable = static fn (?int $c): bool => $c !== null && $c >= 200 && $c < 400;
 
             $login = $httpCode($baseUrl . $loginPath);
-            $check($reachable($login), "01 login page ({$loginPath}) served during maintenance, not error/503 (got " . var_export($login, true) . ")");
+            $check(
+                $login !== null && $login >= 200 && $login < 300,
+                "01 login page ({$loginPath}) served during maintenance (got " . var_export($login, true) . ", expected 2xx)"
+            );
 
             $home = $httpCode($baseUrl . '/');
             $check($home === 503, "02 unauthenticated home returns 503 during maintenance (got " . var_export($home, true) . ")");

--- a/tests/maintenance-recovery-lockout.unit.php
+++ b/tests/maintenance-recovery-lockout.unit.php
@@ -14,19 +14,18 @@ declare(strict_types=1);
  * biblioteca.casadelledonnealessandria.it, Aug 2026.
  *
  * The fix has three layers; this test guards all of them:
- *   Layer 1 (public/index.php) — the maintenance gate allow-lists the login /
- *     logout routes (localised + literal defaults) AND lets an authenticated
- *     admin/staff through, so recovery is always reachable.
+ *   Layer 1 (public/index.php) — the maintenance gate allow-lists only the
+ *     login/logout routes, update UI/API and static assets needed for recovery.
  *   Layer 2 (app/Support/Updater.php) — BOTH register_shutdown_function
- *     handlers clear .maintenance + the lock file UNCONDITIONALLY, not only on
- *     a fatal PHP error.
+ *     handlers clear .maintenance for the owning request, while the shared
+ *     lock inode remains persistent and flock is the sole ownership signal.
  *   Layer 3 — the existing 30-minute stale sweep stays as the last resort.
  *
  * A. Behavioural (needs the dev server on :8081): with .maintenance present,
  *    the login page is reachable, an unauthenticated visitor gets 503, and the
  *    update / asset allow-list still works. Skipped (not failed) if the server
  *    is unreachable. Always removes the flag via a finally-style guard.
- * B. Source guard (always runs): the Layer 1 bypass and the Layer 2
+ * B. Source guard (always runs): the Layer 1 allow-list and the Layer 2
  *    unconditional cleanup are present so the fix cannot silently regress.
  *
  * Run:  php tests/maintenance-recovery-lockout.unit.php   (exit 0 iff all pass)
@@ -133,9 +132,10 @@ if (!$serverUp) {
 }
 
 // ── B. Source guard — the fix cannot silently regress ───────────────────────
-echo "B. Source guard (Layer 1 bypass + Layer 2 unconditional cleanup)\n";
+echo "B. Source guard (scoped Layer 1 allow-list + safe Layer 2 cleanup)\n";
 
 $index = (string) file_get_contents($root . '/public/index.php');
+$routes = (string) file_get_contents($root . '/app/Routes/web.php');
 
 // Layer 1a: login/logout routes are allow-listed so an admin can authenticate.
 $check(
@@ -148,32 +148,33 @@ $check(
     "11 index.php allow-lists the literal /login and /logout defaults"
 );
 
-// Layer 1b: an authenticated admin/staff bypasses the block via a read-only
-// session read (read_and_close) that doesn't disturb the later writable start.
+// Layer 1b: maintenance access stays route-scoped. A privileged session must
+// not bypass the gate for arbitrary application routes while code/schema may be
+// only partially updated.
 $check(
-    str_contains($index, "read_and_close")
-        && (bool) preg_match("/tipo_utente.*\\[[^\\]]*'admin'[^\\]]*'staff'[^\\]]*\\]/s", $index),
-    "12 index.php lets an authenticated admin/staff through (read_and_close session probe)"
+    !str_contains($index, "read_and_close")
+        && !str_contains($index, '$maintenanceRole'),
+    "12 index.php has no global admin/staff maintenance bypass"
 );
 
-// Layer 1c: the probe must not run for anonymous visitors and must not emit a
-// cookie or accept an arbitrary client-supplied session id — it only reads an
-// already-present session (guards against session fixation / disk churn).
+// The recovery endpoint is contained beneath the only privileged route prefix
+// that remains reachable during maintenance.
 $check(
-    str_contains($index, 'isset($_COOKIE[session_name()])')
-        && str_contains($index, "ini_set('session.use_strict_mode', '1')"),
-    "15 index.php probes only when a session cookie exists, in strict mode"
+    str_contains($index, "'/admin/updates'")
+        && str_contains($routes, "'/admin/updates/maintenance/clear'"),
+    "15 emergency clear endpoint remains under the scoped /admin/updates allow-list"
 );
 
 // Layer 2: BOTH shutdown handlers must (a) return early unless this request owns
-// the update lock, and (b) otherwise clear the maintenance + lock files
-// UNCONDITIONALLY (not nested inside the fatal-error `if`).
+// the update lock, and (b) otherwise clear maintenance unconditionally. The
+// shared lock file itself remains persistent to avoid an inode race.
 $updater = (string) file_get_contents($root . '/app/Support/Updater.php');
+$backupManager = (string) file_get_contents($root . '/app/Support/BackupManager.php');
 
 // Isolate each register_shutdown_function body (signature carries the ownership
 // flag by reference).
 preg_match_all(
-    '/register_shutdown_function\(function \(\) use \(\$maintenanceFile, \$lockFile, &\$ownsUpdate\) \{(.*?)\}\);/s',
+    '/register_shutdown_function\(function \(\) use \(\$maintenanceFile, &\$ownsUpdate\) \{(.*?)\}\);/s',
     $updater,
     $handlers
 );
@@ -194,17 +195,33 @@ foreach ($handlerBodies as $body) {
     $stripped = preg_replace('/if \(!\$ownsUpdate\) \{\s*return;\s*\}\s*/s', '', $body);
     $stripped = is_string($stripped) ? preg_replace('/if \(\$error !== null.*?\}\s*/s', '', $stripped) : null;
     if (is_string($stripped)
-        && preg_match('/@unlink\(\$maintenanceFile\)/', $stripped)
-        && preg_match('/@unlink\(\$lockFile\)/', $stripped)) {
+        && preg_match('/@unlink\(\$maintenanceFile\)/', $stripped)) {
         $unconditional++;
     }
 }
 $check($ownershipGuarded >= 2, "14 both shutdown handlers bail unless this request owns the update lock (got {$ownershipGuarded}/2)");
-$check($unconditional >= 2, "16 the owner clears .maintenance + lock UNCONDITIONALLY (got {$unconditional}/2)");
+$check($unconditional >= 2, "16 the owner clears .maintenance UNCONDITIONALLY (got {$unconditional}/2)");
 // The ownership flag is only raised after the lock is held and maintenance is on.
 $check(
     substr_count($updater, '$ownsUpdate = true;') >= 2,
     "17 both update paths raise the ownership flag after acquiring the lock"
+);
+
+// Normal completion must disarm the shutdown fallback while the lock is still
+// held. Otherwise request A can release its lock, request B can acquire it, and
+// A's later shutdown handler can erase B's maintenance flag.
+$check(
+    preg_match_all(
+        '/\$this->cleanup\(\);(?:(?!flock).)*\$ownsUpdate = false;(?:(?!flock).)*flock\(\$lockHandle/s',
+        $updater
+    ) >= 2,
+    "18 both normal cleanup paths disarm shutdown ownership before releasing the lock"
+);
+
+$check(
+    !str_contains($updater, '@unlink($lockFile)')
+        && !str_contains($backupManager, '@unlink($lockFile)'),
+    "19 updater and restore keep the shared lock inode persistent"
 );
 
 echo "\n{$pass} PASS, {$fail} FAIL\n";

--- a/tests/pr166-167-coverage.spec.js
+++ b/tests/pr166-167-coverage.spec.js
@@ -17,7 +17,7 @@ const { test, expect } = require('@playwright/test');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync, spawn } = require('child_process');
+const { execFileSync, spawn, spawnSync } = require('child_process');
 
 // NB: no file-level serial mode — each group below is its own test.describe.serial,
 // so a failure inside one group does NOT cascade-skip the other groups (workers=1
@@ -581,9 +581,7 @@ test.describe.serial('G3 — Concurrency / lock', () => {
   // instead of racing the (fast) real restore.
   function holdLock(seconds) {
     const lf = LOCK_FILE.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-    // Release AND unlink on exit so the lock file disappears like the real
-    // BackupManager finally does (test 14 asserts the file is gone afterwards).
-    const code = `$f=fopen('${lf}','c'); if($f===false){exit(1);} flock($f,LOCK_EX); sleep(${seconds}); flock($f,LOCK_UN); fclose($f); @unlink('${lf}');`;
+    const code = `$f=fopen('${lf}','c'); if($f===false){exit(1);} flock($f,LOCK_EX); sleep(${seconds}); flock($f,LOCK_UN); fclose($f);`;
     const child = spawn('php', ['-r', code], { detached: true, stdio: 'ignore' });
     child.unref();
     return child;
@@ -610,21 +608,30 @@ test.describe.serial('G3 — Concurrency / lock', () => {
     if (ok.json?.safety_backup) CREATED_BACKUPS.push(ok.json.safety_backup);
   });
 
-  test('14. Maintenance + lock files are cleaned up after a restore; lock visible while held', async () => {
-    // (a) A real restore leaves no residual maintenance flag nor lock file.
+  test('14. Maintenance clears after restore; persistent lock inode is released', async () => {
+    const canAcquireLock = () => {
+      const lf = LOCK_FILE.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+      const code = `$f=fopen('${lf}','c'); if($f===false){exit(2);} if(!flock($f,LOCK_EX|LOCK_NB)){exit(1);} flock($f,LOCK_UN); fclose($f);`;
+      return spawnSync('php', ['-r', code], { stdio: 'ignore' }).status === 0;
+    };
+
+    // (a) A real restore leaves no maintenance flag and releases the flock.
     const backup = await createBackup(page, 'full');
     const res = await apiPost(page, '/admin/updates/backup/restore', { backup });
     expect(res.json?.success).toBe(true);
     if (res.json?.safety_backup) CREATED_BACKUPS.push(res.json.safety_backup);
     expect(fs.existsSync(MAINT_FILE)).toBe(false);
-    expect(fs.existsSync(LOCK_FILE)).toBe(false);
+    expect(fs.existsSync(LOCK_FILE)).toBe(true);
+    expect(canAcquireLock()).toBe(true);
 
-    // (b) While a holder owns the lock, the lock file exists; after, it's gone.
+    // (b) While a holder owns the lock acquisition fails; afterwards it works.
     holdLock(2);
     await new Promise((r) => setTimeout(r, 400));
     expect(fs.existsSync(LOCK_FILE)).toBe(true);
+    expect(canAcquireLock()).toBe(false);
     await new Promise((r) => setTimeout(r, 2200));
-    expect(fs.existsSync(LOCK_FILE)).toBe(false);
+    expect(fs.existsSync(LOCK_FILE)).toBe(true);
+    expect(canAcquireLock()).toBe(true);
   });
 
   test('15. A restore is rejected while an update-style lock is held', async () => {

--- a/tests/updater-maintenance-cleanup.unit.php
+++ b/tests/updater-maintenance-cleanup.unit.php
@@ -1,0 +1,102 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Reusable guard for the linchpin of the maintenance-recovery design (PR #312):
+ * the update runs its cleanup in a `finally`, and cleanup() lifts maintenance.
+ * That is what makes EVERY non-fatal outcome (success or caught exception)
+ * leave maintenance mode — the shutdown handler is only the fatal-path fallback.
+ *
+ * maintenance-recovery-lockout.unit.php already guards the handlers, the
+ * ownership flag, the disarm-before-unlock order and the persistent lock inode.
+ * This file adds the piece none of those cover: if disableMaintenanceMode() is
+ * ever dropped from cleanup(), those guards all still pass while the site stays
+ * stuck in maintenance after every update. So prove it — behaviourally.
+ *
+ * Run:  php tests/updater-maintenance-cleanup.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\Updater;
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+$updaterSrc = (string) file_get_contents($root . '/app/Support/Updater.php');
+$backupSrc  = (string) file_get_contents($root . '/app/Support/BackupManager.php');
+
+// 1. Behavioural: cleanup() removes an existing storage/.maintenance. Needs a
+//    mysqli for the constructor (cleanup itself doesn't touch the DB). Skips if
+//    the DB is unreachable — the source guards below still run.
+$maintenanceFile = $root . '/storage/.maintenance';
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$k, $v] = explode('=', $line, 2);
+    $env[trim($k)] = trim(trim($v), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+$db = null;
+try {
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $env['DB_USER'] ?? '', $env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''), $env['DB_NAME'] ?? '', (int) ($env['DB_PORT'] ?? 3306));
+} catch (\Throwable) {
+    $db = null;
+}
+
+if ($db === null) {
+    echo "  SKIP 01 behavioural cleanup() check — database unreachable\n";
+} else {
+    // Never clobber a real update in progress.
+    if (is_file($maintenanceFile)) {
+        echo "  SKIP 01 behavioural cleanup() check — storage/.maintenance already present\n";
+    } else {
+        file_put_contents($maintenanceFile, json_encode(['time' => time(), 'message' => 'cleanup self-test']));
+        try {
+            (new Updater($db))->cleanup();
+            $check(!is_file($maintenanceFile), "01 cleanup() lifts maintenance (removes storage/.maintenance)");
+        } finally {
+            if (is_file($maintenanceFile)) {
+                @unlink($maintenanceFile);
+            }
+        }
+    }
+    $db->close();
+}
+
+// 2. cleanup() actually calls disableMaintenanceMode().
+$cleanupBody = '';
+if (preg_match('/public function cleanup\(\): void\s*\{(.*?)\n    \}/s', $updaterSrc, $m)) {
+    $cleanupBody = $m[1];
+}
+$check(
+    $cleanupBody !== '' && str_contains($cleanupBody, '$this->disableMaintenanceMode()'),
+    "02 cleanup() calls disableMaintenanceMode()"
+);
+
+// 3. Both update paths run cleanup() from a `finally`, so any non-fatal outcome
+//    lifts maintenance regardless of the shutdown handler.
+$finallyCleanups = preg_match_all('/\}\s*finally\s*\{\s*\$this->cleanup\(\);/s', $updaterSrc);
+$check($finallyCleanups >= 2, "03 both update paths run cleanup() in a finally (got {$finallyCleanups})");
+
+// 4. The restore path (BackupManager) keeps the shared lock inode persistent —
+//    its shutdown handler must not capture or unlink $lockFile (same inode-race
+//    fix as the updater).
+$restoreHandlerSafe = (bool) preg_match(
+    '/register_shutdown_function\(static function \(\) use \(\$maintenanceFile\): void/',
+    $backupSrc
+) && !preg_match('/@unlink\(\$lockFile\)/', $backupSrc);
+$check($restoreHandlerSafe, "04 BackupManager restore keeps the lock inode persistent (no \$lockFile unlink)");
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);


### PR DESCRIPTION
## Why

An in-app update writes `storage/.maintenance` and the front controller blocks every request while the file exists. Two independent flaws could leave a site permanently stuck in maintenance — one of them hit a production install after a half-failed update, with no way back in.

### 1. Login was blocked, but recovery needs an admin (catch-22)

The maintenance gate blocked the login route, yet the emergency "clear maintenance" endpoint is admin-only. A logged-out admin could never authenticate to reach it. The site was locked, and the one account that could unlock it was locked out too.

### 2. The flag was only cleared on a fatal error

Both `register_shutdown_function` handlers in the updater removed `.maintenance` **only** when a fatal PHP error occurred. A non-fatal early return — or a caught exception that skipped `disableMaintenanceMode()` — left the flag behind until the 30-minute stale sweep.

## The fix — three layers

- **Front controller (`public/index.php`)** — allow-list the login/logout routes (localised slugs + literal defaults) so an admin can always authenticate, and allow only the scoped `/admin/updates` UI/API needed to drive or abort the update. Privileged sessions do not bypass maintenance for arbitrary routes. The session is read read-only (`read_and_close`) with `session.save_path` pointed at `storage/sessions` — the same path the app configures later — otherwise the probe reads an empty session from `/tmp` and the bypass never fires.
- **Updater (`app/Support/Updater.php`)** — both shutdown handlers clear `.maintenance` for the owning request. Normal cleanup disarms the fallback before releasing `flock`, and the shared lock inode remains persistent to avoid cross-request unlink races. The update runs entirely within one request (`set_time_limit(0)` + `ignore_user_abort`), so once the request ends the update is over regardless of how it ended. Fatal errors are still logged for diagnostics.
- **Stale sweep** — the existing 30-minute stale-file check stays as the last resort for a SIGKILL/OOM that skips shutdown handlers entirely.

## Also: the maintenance page now matches the app

The 503 page was ours but off-brand (a purple gradient, system fonts, an indigo spinner). Rebuilt in the editorial-minimal identity — Fraunces serif wordmark and heading, Instrument Sans body, the `#d70161` brand accent, a clean card, a dark-mode variant, and reduced-motion support. Self-hosted fonts load from the already-allow-listed `/assets/`, with system fallbacks if the assets are mid-swap.

## Tests

`tests/maintenance-recovery-lockout.unit.php` (11 checks): behavioural HTTP checks with the flag present — login reachable, unauthenticated `503`, update/asset allow-list — plus source guards for the scoped recovery allow-list, ownership handoff and race-free cleanup. The admin-bypass path was verified end-to-end through a real browser login (which is how the `save_path` mismatch surfaced — a pure source guard would have missed it). PHPStan level 5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * La modalità manutenzione consente login e logout, inclusi gli URL localizzati.
  * Amministratori e operatori autenticati possono accedere durante la manutenzione.
  * Nuova pagina 503 responsive con branding configurabile, logo personalizzabile, tema scuro e supporto alle installazioni in sottocartella.

* **Correzioni**
  * Migliorata la pulizia dei file temporanei al termine degli aggiornamenti, evitando interferenze tra richieste concorrenti.

* **Test**
  * Aggiunti controlli di regressione per accesso, aggiornamenti e ripristino dalla modalità manutenzione.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->