### PR TITLE
fix(opac): stop injecting <br> between HTML paragraphs in descriptions (#313)

### DIFF
--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -81,6 +81,35 @@ class HtmlHelper
     }
 
     /**
+     * Render a rich-text field that may be EITHER editor HTML OR legacy plain
+     * text with newlines (imported records).
+     *
+     * Plain text gets nl2br so its line breaks survive. Content that is already
+     * block-structured HTML is left as-is: the editor (TinyMCE) separates its
+     * <p> paragraphs with a literal "\n", and running nl2br over that injects a
+     * stray <br> between every block, double-spacing the output (issue #313).
+     * The result is always sanitized.
+     *
+     * @param string|null $value Raw stored value
+     * @return string Sanitized HTML ready to echo
+     */
+    public static function richText(?string $value): string
+    {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        // If the value already carries block/line HTML, its line breaks are
+        // markup — nl2br would turn the newlines *between* blocks into <br>.
+        $hasBlockHtml = preg_match(
+            '/<(?:p|br|div|ul|ol|li|h[1-6]|blockquote|pre|table|hr)\b/i',
+            $value
+        ) === 1;
+
+        return self::sanitizeHtml($hasBlockHtml ? $value : nl2br($value, false));
+    }
+
+    /**
      * Return a public absolute HTTP(S) URL, or an empty string when unsafe.
      *
      * This is intentionally stricter than FILTER_VALIDATE_URL alone: values

--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -81,19 +81,20 @@ class HtmlHelper
     }
 
     /**
-     * Render a rich-text field that may be EITHER editor HTML OR legacy plain
-     * text with newlines (imported records).
+     * Render `libri.descrizione`, which may be either editor HTML or legacy
+     * plain text with newlines (imported records).
      *
      * Plain text gets nl2br so its line breaks survive. Content that is already
      * block-structured HTML is left as-is: the editor (TinyMCE) separates its
      * <p> paragraphs with a literal "\n", and running nl2br over that injects a
      * stray <br> between every block, double-spacing the output (issue #313).
-     * The result is always sanitized.
+     * The result is always sanitized. This intentionally remains specific to
+     * the book-description field addressed by issue #313.
      *
      * @param string|null $value Raw stored value
      * @return string Sanitized HTML ready to echo
      */
-    public static function richText(?string $value): string
+    public static function bookDescription(?string $value): string
     {
         if ($value === null || $value === '') {
             return '';

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -2026,7 +2026,7 @@ ob_start();
                                         : \App\Support\MediaLabels::formatTracklist($musicDescription) ?>
                                 </div>
                             <?php else: ?>
-                                <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($book['descrizione']) ?></div>
+                                <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::bookDescription($book['descrizione']) ?></div>
                             <?php endif; ?>
                         <?php else: ?>
                             <p class="text-gray-500"><?= __("Nessuna descrizione disponibile per questo libro.") ?></p>
@@ -2263,7 +2263,7 @@ ob_start();
                                     <?php elseif (in_array($fieldName, ['value'])): ?>
                                         € <?= number_format((float)$field['value'], 2) ?>
                                     <?php elseif (in_array($fieldName, ['review', 'comment'])): ?>
-                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($field['value']) ?></div>
+                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) ?></div>
                                     <?php else: ?>
                                         <?= htmlspecialchars($field['value'], ENT_QUOTES, 'UTF-8') ?>
                                     <?php endif; ?>
@@ -2297,7 +2297,7 @@ ob_start();
                                     <?php elseif (in_array($fieldName, ['value'])): ?>
                                         € <?= number_format((float)$field['value'], 2) ?>
                                     <?php elseif (in_array($fieldName, ['review', 'comment'])): ?>
-                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($field['value']) ?></div>
+                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) ?></div>
                                     <?php else: ?>
                                         <?= htmlspecialchars($field['value'], ENT_QUOTES, 'UTF-8') ?>
                                     <?php endif; ?>

--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -2026,7 +2026,7 @@ ob_start();
                                         : \App\Support\MediaLabels::formatTracklist($musicDescription) ?>
                                 </div>
                             <?php else: ?>
-                                <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::sanitizeHtml(nl2br($book['descrizione'], false)) ?></div>
+                                <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($book['descrizione']) ?></div>
                             <?php endif; ?>
                         <?php else: ?>
                             <p class="text-gray-500"><?= __("Nessuna descrizione disponibile per questo libro.") ?></p>
@@ -2263,7 +2263,7 @@ ob_start();
                                     <?php elseif (in_array($fieldName, ['value'])): ?>
                                         € <?= number_format((float)$field['value'], 2) ?>
                                     <?php elseif (in_array($fieldName, ['review', 'comment'])): ?>
-                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) ?></div>
+                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($field['value']) ?></div>
                                     <?php else: ?>
                                         <?= htmlspecialchars($field['value'], ENT_QUOTES, 'UTF-8') ?>
                                     <?php endif; ?>
@@ -2297,7 +2297,7 @@ ob_start();
                                     <?php elseif (in_array($fieldName, ['value'])): ?>
                                         € <?= number_format((float)$field['value'], 2) ?>
                                     <?php elseif (in_array($fieldName, ['review', 'comment'])): ?>
-                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) ?></div>
+                                        <div class="prose prose-sm max-w-none"><?= \App\Support\HtmlHelper::richText($field['value']) ?></div>
                                     <?php else: ?>
                                         <?= htmlspecialchars($field['value'], ENT_QUOTES, 'UTF-8') ?>
                                     <?php endif; ?>

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -718,7 +718,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
               ?>
               <?= \App\Support\MediaLabels::formatTracklist($descText) ?>
             <?php else: ?>
-              <?php echo App\Support\HtmlHelper::sanitizeHtml(nl2br($libro['descrizione'], false)); ?>
+              <?php echo App\Support\HtmlHelper::richText($libro['descrizione']); ?>
             <?php endif; ?>
           </div>
         </div>
@@ -805,7 +805,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                       echo ' <span class="text-gray-600">(' . $rating . '/5)</span>';
                   } elseif ($fieldName === 'review' || $fieldName === 'comment') {
                       // Multi-line text
-                      echo '<div class="prose prose-sm max-w-none">' . App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) . '</div>';
+                      echo '<div class="prose prose-sm max-w-none">' . App\Support\HtmlHelper::richText($field['value']) . '</div>';
                   } elseif (in_array($fieldName, ['entry_date', 'date_started', 'date_read', 'lending_start', 'lending_end'])) {
                       // Date formatting
                       echo App\Support\HtmlHelper::e(format_date($field['value'], false, '/'));

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -718,7 +718,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
               ?>
               <?= \App\Support\MediaLabels::formatTracklist($descText) ?>
             <?php else: ?>
-              <?php echo App\Support\HtmlHelper::richText($libro['descrizione']); ?>
+              <?php echo App\Support\HtmlHelper::bookDescription($libro['descrizione']); ?>
             <?php endif; ?>
           </div>
         </div>
@@ -805,7 +805,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                       echo ' <span class="text-gray-600">(' . $rating . '/5)</span>';
                   } elseif ($fieldName === 'review' || $fieldName === 'comment') {
                       // Multi-line text
-                      echo '<div class="prose prose-sm max-w-none">' . App\Support\HtmlHelper::richText($field['value']) . '</div>';
+                      echo '<div class="prose prose-sm max-w-none">' . App\Support\HtmlHelper::sanitizeHtml(nl2br($field['value'], false)) . '</div>';
                   } elseif (in_array($fieldName, ['entry_date', 'date_started', 'date_read', 'lending_start', 'lending_end'])) {
                       // Date formatting
                       echo App\Support\HtmlHelper::e(format_date($field['value'], false, '/'));

--- a/tests/bookdescription-render-313.unit.php
+++ b/tests/bookdescription-render-313.unit.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Reusable guards for the issue #313 fix (OPAC description double-spacing).
+ * Complements richtext-nl2br-313.unit.php with edge cases and a render-site
+ * source guard so the description field can't silently regress to raw nl2br().
+ *
+ * Run:  php tests/bookdescription-render-313.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\HtmlHelper;
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+// 1. Windows CRLF plain text keeps one <br> per line break (not two).
+$crlf = "Prima riga\r\nSeconda riga";
+$out = HtmlHelper::bookDescription($crlf);
+$check(substr_count($out, '<br') === 1, "01 CRLF plain text yields exactly one <br> per newline");
+
+// 2. HTML with attributes on the block tag is still detected as HTML (no <br>).
+$attr = "<p class=\"lead\">Uno.</p>\n<p>Due.</p>";
+$out = HtmlHelper::bookDescription($attr);
+$check(!str_contains($out, '<br'), "02 block tag with attributes is treated as HTML (no injected <br>)");
+
+// 3. A leading plain sentence before a block still counts as HTML overall
+//    (has a block marker), so its internal newline is not turned into <br>.
+$mixed = "Intro\n<p>Blocco.</p>";
+$out = HtmlHelper::bookDescription($mixed);
+$check(!str_contains($out, '<br'), "03 value containing any block marker suppresses nl2br");
+
+// 4. Render source guard: the OPAC book detail renders the description through
+//    the helper, never raw nl2br() — the exact regression #313 fixed.
+$bookDetail = (string) file_get_contents($root . '/app/Views/frontend/book-detail.php');
+$check(
+    str_contains($bookDetail, 'HtmlHelper::bookDescription($book[\'descrizione\'])')
+        && !preg_match('/nl2br\(\s*\$book\[\'descrizione\'\]/', $bookDetail),
+    "04 book-detail renders \$book['descrizione'] via bookDescription(), not raw nl2br()"
+);
+
+// 5. Same guard for the admin book sheet.
+$scheda = (string) file_get_contents($root . '/app/Views/libri/scheda_libro.php');
+$check(
+    str_contains($scheda, 'HtmlHelper::bookDescription($libro[\'descrizione\'])')
+        && !preg_match('/nl2br\(\s*\$libro\[\'descrizione\'\]/', $scheda),
+    "05 admin scheda renders \$libro['descrizione'] via bookDescription(), not raw nl2br()"
+);
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/richtext-nl2br-313.unit.php
+++ b/tests/richtext-nl2br-313.unit.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression test for issue #313 — the OPAC injected <br> between the <p>
+ * paragraphs of a book description.
+ *
+ * Root cause: the book description (and custom rich-text fields) were rendered
+ * with sanitizeHtml(nl2br($value, false)). Editor HTML separates its <p> blocks
+ * with a literal "\n", so nl2br turned every inter-block newline into a stray
+ * <br>, double-spacing the output. HtmlHelper::richText() applies nl2br only to
+ * plain-text values and leaves block HTML untouched.
+ *
+ * Run:  php tests/richtext-nl2br-313.unit.php   (exit 0 iff all pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\HtmlHelper;
+
+$pass = 0;
+$fail = 0;
+$check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
+    if ($ok) { $pass++; echo "  OK  {$label}\n"; }
+    else     { $fail++; echo "  FAIL {$label}\n"; }
+};
+
+// ── 1. The bug: editor HTML must NOT gain <br> between paragraphs ────────────
+$html = "<p>Para uno.</p>\n<p>Para due.</p>\n<p>Para tre.</p>";
+$out = HtmlHelper::richText($html);
+$check(!str_contains($out, '<br'), "01 HTML paragraphs render without an injected <br> (issue #313)");
+$check(substr_count($out, '<p>') === 3, "02 all three paragraphs are preserved");
+
+// ── 2. Plain text still gets its line breaks ────────────────────────────────
+$plain = "Prima riga\nSeconda riga\nTerza riga";
+$out = HtmlHelper::richText($plain);
+$check(substr_count($out, '<br') === 2, "03 plain text keeps its newlines as <br>");
+
+// A single-block value that only uses <br> is already HTML → left as-is (no
+// doubling): the two <br> stay two, they are not turned into four.
+$brHtml = "Riga uno<br>Riga due";
+$out = HtmlHelper::richText($brHtml);
+$check(substr_count($out, '<br') === 1, "04 a <br>-only value is treated as HTML, not re-broken");
+
+// Other block markers are detected too (div / ul / heading).
+foreach (['<div>x</div>', '<ul><li>x</li></ul>', '<h2>x</h2>'] as $i => $block) {
+    $withNl = $block . "\ntail";
+    $out = HtmlHelper::richText($withNl);
+    // The trailing "\ntail" newline must not become a <br> when the value is HTML.
+    $check(!str_contains($out, '<br'), sprintf("0%d block HTML (%s) suppresses nl2br", 5 + $i, strtok($block, '>') . '>'));
+}
+
+// ── 3. Sanitisation is still applied ────────────────────────────────────────
+$out = HtmlHelper::richText('<p>ok</p><script>alert(1)</script>');
+$check(!str_contains($out, '<script'), "08 script tags are still stripped (sanitised)");
+
+$out = HtmlHelper::richText("plain <script>alert(1)</script> text");
+$check(!str_contains($out, '<script'), "09 script in plain-text path is stripped too");
+
+// ── 4. Empty / null ─────────────────────────────────────────────────────────
+$check(HtmlHelper::richText(null) === '', "10 null => empty string");
+$check(HtmlHelper::richText('') === '', "11 empty => empty string");
+
+// ── 5. Cyrillic content (the reporter's data) survives ──────────────────────
+$cyr = "<p>Америка&hellip;</p>\n<p>Однако&hellip;</p>";
+$out = HtmlHelper::richText($cyr);
+$check(str_contains($out, 'Америка') && !str_contains($out, '<br'), "12 Cyrillic paragraphs render clean (reporter's case)");
+
+echo "\n{$pass} PASS, {$fail} FAIL\n";
+exit($fail === 0 ? 0 : 1);

--- a/tests/richtext-nl2br-313.unit.php
+++ b/tests/richtext-nl2br-313.unit.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
  * Regression test for issue #313 — the OPAC injected <br> between the <p>
  * paragraphs of a book description.
  *
- * Root cause: the book description (and custom rich-text fields) were rendered
- * with sanitizeHtml(nl2br($value, false)). Editor HTML separates its <p> blocks
+ * Root cause: the book description was rendered with
+ * sanitizeHtml(nl2br($value, false)). Editor HTML separates its <p> blocks
  * with a literal "\n", so nl2br turned every inter-block newline into a stray
- * <br>, double-spacing the output. HtmlHelper::richText() applies nl2br only to
- * plain-text values and leaves block HTML untouched.
+ * <br>, double-spacing the output. HtmlHelper::bookDescription() applies nl2br
+ * only to plain-text values and leaves block HTML untouched. The helper is
+ * intentionally specific to `libri.descrizione`; other fields are outside #313.
  *
  * Run:  php tests/richtext-nl2br-313.unit.php   (exit 0 iff all pass)
  */
@@ -28,43 +29,43 @@ $check = static function (bool $ok, string $label) use (&$pass, &$fail): void {
 
 // ── 1. The bug: editor HTML must NOT gain <br> between paragraphs ────────────
 $html = "<p>Para uno.</p>\n<p>Para due.</p>\n<p>Para tre.</p>";
-$out = HtmlHelper::richText($html);
+$out = HtmlHelper::bookDescription($html);
 $check(!str_contains($out, '<br'), "01 HTML paragraphs render without an injected <br> (issue #313)");
 $check(substr_count($out, '<p>') === 3, "02 all three paragraphs are preserved");
 
 // ── 2. Plain text still gets its line breaks ────────────────────────────────
 $plain = "Prima riga\nSeconda riga\nTerza riga";
-$out = HtmlHelper::richText($plain);
+$out = HtmlHelper::bookDescription($plain);
 $check(substr_count($out, '<br') === 2, "03 plain text keeps its newlines as <br>");
 
 // A single-block value that only uses <br> is already HTML → left as-is (no
 // doubling): the two <br> stay two, they are not turned into four.
 $brHtml = "Riga uno<br>Riga due";
-$out = HtmlHelper::richText($brHtml);
+$out = HtmlHelper::bookDescription($brHtml);
 $check(substr_count($out, '<br') === 1, "04 a <br>-only value is treated as HTML, not re-broken");
 
 // Other block markers are detected too (div / ul / heading).
 foreach (['<div>x</div>', '<ul><li>x</li></ul>', '<h2>x</h2>'] as $i => $block) {
     $withNl = $block . "\ntail";
-    $out = HtmlHelper::richText($withNl);
+    $out = HtmlHelper::bookDescription($withNl);
     // The trailing "\ntail" newline must not become a <br> when the value is HTML.
     $check(!str_contains($out, '<br'), sprintf("0%d block HTML (%s) suppresses nl2br", 5 + $i, strtok($block, '>') . '>'));
 }
 
 // ── 3. Sanitisation is still applied ────────────────────────────────────────
-$out = HtmlHelper::richText('<p>ok</p><script>alert(1)</script>');
+$out = HtmlHelper::bookDescription('<p>ok</p><script>alert(1)</script>');
 $check(!str_contains($out, '<script'), "08 script tags are still stripped (sanitised)");
 
-$out = HtmlHelper::richText("plain <script>alert(1)</script> text");
+$out = HtmlHelper::bookDescription("plain <script>alert(1)</script> text");
 $check(!str_contains($out, '<script'), "09 script in plain-text path is stripped too");
 
 // ── 4. Empty / null ─────────────────────────────────────────────────────────
-$check(HtmlHelper::richText(null) === '', "10 null => empty string");
-$check(HtmlHelper::richText('') === '', "11 empty => empty string");
+$check(HtmlHelper::bookDescription(null) === '', "10 null => empty string");
+$check(HtmlHelper::bookDescription('') === '', "11 empty => empty string");
 
 // ── 5. Cyrillic content (the reporter's data) survives ──────────────────────
 $cyr = "<p>Америка&hellip;</p>\n<p>Однако&hellip;</p>";
-$out = HtmlHelper::richText($cyr);
+$out = HtmlHelper::bookDescription($cyr);
 $check(str_contains($out, 'Америка') && !str_contains($out, '<br'), "12 Cyrillic paragraphs render clean (reporter's case)");
 
 echo "\n{$pass} PASS, {$fail} FAIL\n";


### PR DESCRIPTION
Fixes #313.

## The bug

On the OPAC, a book description whose source is clean `<p>…</p>` paragraphs rendered with visible extra spacing — a stray `<br>` between every paragraph.

## Cause

The book description was rendered with `sanitizeHtml(nl2br($value, false))`. TinyMCE separates its `<p>` blocks with a literal `\n`, so `nl2br` turned every inter-block newline into a `<br>`:

```
<p>Para uno.</p><br>
<p>Para due.</p><br>
<p>Para tre.</p>
```

`nl2br` is only right for the *other* kind of description — legacy plain text imported with bare newlines.

## Fix

`HtmlHelper::bookDescription()` applies `nl2br` **only** when the value is plain text (no block/line HTML) and leaves already-structured HTML untouched, then sanitises. Plain-text descriptions keep their line breaks; editor HTML renders as authored. Both book-description call sites (the OPAC `book-detail` and the admin `scheda`) use it. Custom fields are intentionally unchanged, and no database migration rewrites stored content.

## Test

`tests/richtext-nl2br-313.unit.php` (12 checks): HTML paragraphs render without an injected `<br>`, plain text keeps its breaks, block markers (`br`/`div`/`ul`/heading) suppress `nl2br`, sanitisation still strips scripts, and the reporter's Cyrillic data renders clean. PHPStan level 5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * Le descrizioni dei libri ora gestiscono correttamente testo semplice, HTML strutturato, paragrafi e interruzioni di riga.
  * I contenuti vengono sanitizzati per una visualizzazione più sicura.
  * Gestiti anche valori vuoti o mancanti e contenuti in caratteri cirillici.

* **Test**
  * Aggiunti controlli automatici per formattazione, sanitizzazione e visualizzazione delle descrizioni nelle diverse viste.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->