### PR TITLE
Change 'Curator' to 'Editor' in en_US translation

### DIFF
--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -1028,7 +1028,7 @@
   "Cronologia Aggiornamenti": "Update History",
   "Cronologia Import": "Import History",
   "Cronologia degli aggiornamenti eseguiti": "History of executed updates",
-  "Curatore": "Curator",
+  "Curatore": "Editor",
   "DVD": "DVD",
   "Da": "From",
   "Da %s (%s)": "From %s (%s)",


### PR DESCRIPTION
We were confused by what does "Curator" mean for so long, and now I finally figured out that's an Editor!

Yes, it's called Editor in English: http://id.loc.gov/vocabulary/relators/edt

Please, make other necessary changes if that's required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Aggiornata la traduzione inglese di “Curatore”, ora visualizzata come “Editor”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->