### PR TITLE
fix(book): align the info-card header with the meta rows on mobile

### DIFF
--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1126,11 +1126,14 @@ $additional_css = "
         /* Explicit `none` (not just omitted) so it beats the global .card-header
            border in main.css. The header is just a small section label above the
            meta rows, not a boxed card head, so the hairline read as clutter.
-           Balanced vertical padding; margin keeps the label inset in line with
-           the .card-body content (1.5rem). */
+           Inset the label with PADDING (not margin) so it always lines up with
+           the .card-body content (1.5rem): main.css forces
+           `.card-header { margin: 0 !important }`, so a margin-based inset only
+           held while the inline styles happened to win the cascade. Padding is
+           not overridden, so the label stays aligned regardless of load order. */
         border-bottom: none;
-        margin: 0 1.5rem;
-        padding: 0.5rem 0;
+        margin: 0;
+        padding: 0.5rem 1.5rem;
     }
 
     .card-header h6 {
@@ -1474,12 +1477,12 @@ $additional_css = "
         }
 
         /* Match the header inset to the reduced .card-body padding (1rem) so the
-           section label lines up with the meta rows below it on mobile. Needs
-           !important to beat main.css .card-header { margin:0 !important } which
-           otherwise leaves the label flush-left of the inset meta rows. */
+           section label lines up with the meta rows below it on mobile. Padding
+           (not margin) keeps it aligned regardless of cascade order — see the
+           base .card-header rule. */
         .card-header {
-            margin-left: 1rem !important;
-            margin-right: 1rem !important;
+            padding-left: 1rem;
+            padding-right: 1rem;
         }
     }
 


### PR DESCRIPTION
## Problem

On the single-book page (mobile), the **Informazioni Libro** card's header label didn't line up with the meta rows below it.

## Cause

The header was inset with a horizontal **margin** while the card body inset its content with **padding**. `main.css` forces `.card-header { margin: 0 !important }`, so the inline margin only held while the page's inline styles won the cascade. Whenever `main.css` won (a different bundle / load order), the header margin collapsed to `0` and the label sat flush-left of the indented meta rows — the reported misalignment. The old code even used `!important` and a comment acknowledging the fight.

## Fix

Inset the header with **padding** instead of margin, at both breakpoints (1.5rem desktop, 1rem mobile — matching the body). `main.css` does not override the header's padding, so the label stays aligned with the meta rows regardless of stylesheet order, without an `!important` war.

## Verification

On a 390px viewport the header label, meta labels and meta values all sit at the same **48px** inset. Forcing `.card-header { margin: 0 !important }` (the scenario that used to break it) no longer moves the header — it stays at 48px because the inset is now padding-based.

`php -l` clean; PHPStan level 5 clean.