### PR TITLE
fix(ui): vertically center chip/button contents across the backend (#316)

### DIFF
--- a/app/Views/admin/imports_history.php
+++ b/app/Views/admin/imports_history.php
@@ -194,7 +194,7 @@ $title = __("Storico Import");
                     </div>
                   </td>
                   <td class="px-6 py-4 whitespace-nowrap">
-                    <span class="px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?= $status['bg'] ?> <?= $status['text'] ?>">
+                    <span class="items-center px-2 py-1 inline-flex text-xs leading-5 font-semibold rounded-full <?= $status['bg'] ?> <?= $status['text'] ?>">
                       <i class="fas <?= $status['icon'] ?> mr-1"></i>
                       <?= __(ucfirst($import['status'])) ?>
                     </span>

--- a/app/Views/admin/integrity_report.php
+++ b/app/Views/admin/integrity_report.php
@@ -17,10 +17,10 @@
                     </div>
                 </div>
                 <div class="flex space-x-3">
-                    <button onclick="performMaintenance()" class="bg-gray-800 hover:bg-gray-900 text-white font-medium py-2 px-4 rounded-lg transition-colors">
+                    <button onclick="performMaintenance()" class="inline-flex items-center bg-gray-800 hover:bg-gray-900 text-white font-medium py-2 px-4 rounded-lg transition-colors">
                         <i class="fas fa-tools mr-2"></i><?= __("Esegui Manutenzione") ?>
                     </button>
-                    <button onclick="location.reload()" class="bg-gray-100 hover:bg-gray-200 text-gray-900 border border-gray-300 font-medium py-2 px-4 rounded-lg transition-colors">
+                    <button onclick="location.reload()" class="inline-flex items-center bg-gray-100 hover:bg-gray-200 text-gray-900 border border-gray-300 font-medium py-2 px-4 rounded-lg transition-colors">
                         <i class="fas fa-sync-alt mr-2"></i><?= __("Aggiorna") ?>
                     </button>
                 </div>

--- a/app/Views/admin/pending_loans.php
+++ b/app/Views/admin/pending_loans.php
@@ -102,10 +102,10 @@
                                 </div>
                             </div>
                             <div class="mt-3 flex gap-2">
-                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
+                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
                                     <i class="fas fa-edit mr-1"></i><?= __("Gestisci") ?>
                                 </a>
-                                <button type="button" class="flex-1 bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors return-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center flex-1 bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors return-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-undo mr-1"></i><?= __("Restituisci") ?>
                                 </button>
                             </div>
@@ -176,11 +176,11 @@
                             </div>
                             <div class="mt-3">
                                 <?php if ($isExpired): ?>
-                                <button type="button" class="w-full bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors shadow-sm cancel-pickup-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center w-full bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors shadow-sm cancel-pickup-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-times mr-1"></i><?= __("Annulla Prestito Scaduto") ?>
                                 </button>
                                 <?php else: ?>
-                                <button type="button" class="w-full bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors confirm-pickup-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center w-full bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors confirm-pickup-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-check-circle mr-1"></i><?= __("Conferma Ritiro") ?>
                                 </button>
                                 <?php endif; ?>
@@ -244,10 +244,10 @@
                                 </div>
                             </div>
                             <div class="mt-3 flex gap-2">
-                                <button type="button" class="flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-3 rounded-lg transition-colors approve-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-3 rounded-lg transition-colors approve-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-check mr-1"></i><?= __("Approva") ?>
                                 </button>
-                                <button type="button" class="flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors reject-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors reject-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-times mr-1"></i><?= __("Rifiuta") ?>
                                 </button>
                             </div>
@@ -305,7 +305,7 @@
                                 </div>
                             </div>
                             <div class="mt-3">
-                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="block w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
+                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center block w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
                                     <i class="fas fa-edit mr-1"></i><?= __("Gestisci") ?>
                                 </a>
                             </div>
@@ -368,10 +368,10 @@
                                 </div>
                             </div>
                             <div class="mt-3 flex gap-2">
-                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
+                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
                                     <i class="fas fa-edit mr-1"></i><?= __("Gestisci") ?>
                                 </a>
-                                <button type="button" class="flex-1 bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors return-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center flex-1 bg-green-600 hover:bg-green-500 text-white font-medium py-2 px-3 rounded-lg transition-colors return-btn text-sm" data-loan-id="<?= $loan['id'] ?>">
                                     <i class="fas fa-undo mr-1"></i><?= __("Restituisci") ?>
                                 </button>
                             </div>
@@ -438,10 +438,10 @@
                                 </div>
                             </div>
                             <div class="mt-3 flex gap-2">
-                                <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
+                                <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center flex-1 bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
                                     <i class="fas fa-eye mr-1"></i><?= __("Dettagli") ?>
                                 </a>
-                                <button type="button" class="flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors cancel-reservation-btn text-sm" data-reservation-id="<?= $reservation['id'] ?>">
+                                <button type="button" class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors cancel-reservation-btn text-sm" data-reservation-id="<?= $reservation['id'] ?>">
                                     <i class="fas fa-times mr-1"></i><?= __("Annulla") ?>
                                 </button>
                             </div>

--- a/app/Views/admin/pending_loans.php
+++ b/app/Views/admin/pending_loans.php
@@ -305,7 +305,7 @@
                                 </div>
                             </div>
                             <div class="mt-3">
-                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center block w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
+                                <a href="<?= htmlspecialchars(url('/admin/loans/edit/' . $loan['id']), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center justify-center w-full bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-medium py-2 px-3 rounded-lg transition-colors text-center text-sm">
                                     <i class="fas fa-edit mr-1"></i><?= __("Gestisci") ?>
                                 </a>
                             </div>

--- a/app/Views/admin/plugins.php
+++ b/app/Views/admin/plugins.php
@@ -119,11 +119,11 @@ $pluginHasSettings = $pluginHasSettings ?? [];
                                                 v<?= HtmlHelper::e($plugin['version']) ?>
                                             </span>
                                             <?php if ($plugin['is_active']): ?>
-                                                <span class="px-2 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
+                                                <span class="inline-flex items-center px-2 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
                                                     <i class="fas fa-check-circle mr-1"></i><?= __("Attivo") ?>
                                                 </span>
                                             <?php else: ?>
-                                                <span class="px-2 py-1 text-xs font-medium bg-gray-100 text-gray-500 rounded-lg">
+                                                <span class="inline-flex items-center px-2 py-1 text-xs font-medium bg-gray-100 text-gray-500 rounded-lg">
                                                     <i class="fas fa-pause-circle mr-1"></i><?= __("Inattivo") ?>
                                                 </span>
                                             <?php endif; ?>
@@ -315,13 +315,13 @@ $pluginHasSettings = $pluginHasSettings ?? [];
                                 <?php endif; ?>
                                 <?php if ($plugin['is_active']): ?>
                                     <button onclick="deactivatePlugin(<?= (int)$plugin['id'] ?>)"
-                                        class="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-all duration-200 text-sm font-medium">
+                                        class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-all duration-200 text-sm font-medium">
                                         <i class="fas fa-pause mr-1"></i>
                                         <?= __("Disattiva") ?>
                                     </button>
                                 <?php else: ?>
                                     <button onclick="activatePlugin(<?= (int)$plugin['id'] ?>)"
-                                        class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-all duration-200 text-sm font-medium">
+                                        class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-all duration-200 text-sm font-medium">
                                         <i class="fas fa-check mr-1"></i>
                                         <?= __("Attiva plugin") ?>
                                     </button>
@@ -389,7 +389,7 @@ $pluginHasSettings = $pluginHasSettings ?? [];
                         <?= __("Annulla") ?>
                     </button>
                     <button type="button" id="uploadButton"
-                        class="px-6 py-3 bg-black text-white rounded-xl hover:bg-gray-800 transition-all duration-200 font-medium disabled:opacity-50 disabled:cursor-not-allowed">
+                        class="inline-flex items-center px-6 py-3 bg-black text-white rounded-xl hover:bg-gray-800 transition-all duration-200 font-medium disabled:opacity-50 disabled:cursor-not-allowed">
                         <i class="fas fa-upload mr-2"></i>
                         <?= __("Installa Plugin") ?>
                     </button>
@@ -684,7 +684,7 @@ $pluginHasSettings = $pluginHasSettings ?? [];
                             </optgroup>
                         </select>
                         <button type="button" onclick="addZ39ServerRow()"
-                            class="px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm font-medium transition-colors whitespace-nowrap w-full sm:w-auto">
+                            class="inline-flex items-center justify-center px-3 py-1.5 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg text-sm font-medium transition-colors whitespace-nowrap w-full sm:w-auto">
                             <i class="fas fa-plus mr-1"></i> <?= __("Personalizzato") ?>
                         </button>
                     </div>
@@ -858,7 +858,7 @@ $pluginHasSettings = $pluginHasSettings ?? [];
             <button onclick="closeGoodLibModal()" class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
                 <?= __("Annulla") ?>
             </button>
-            <button onclick="saveGoodLibSettings()" id="goodlibSaveBtn" class="px-4 py-2 text-sm font-medium text-white bg-purple-600 rounded-lg hover:bg-purple-700 transition-colors">
+            <button onclick="saveGoodLibSettings()" id="goodlibSaveBtn" class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-purple-600 rounded-lg hover:bg-purple-700 transition-colors">
                 <i class="fas fa-save mr-1"></i><?= __("Salva") ?>
             </button>
         </div>

--- a/app/Views/admin/reviews/index.php
+++ b/app/Views/admin/reviews/index.php
@@ -88,12 +88,12 @@ use App\Support\HtmlHelper;
 
                         <div class="mt-4 flex gap-3">
                             <button type="button"
-                                    class="flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg transition-colors approve-btn shadow-sm"
+                                    class="inline-flex items-center justify-center flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg transition-colors approve-btn shadow-sm"
                                     data-review-id="<?php echo (int)$review['id']; ?>">
                                 <i class="fas fa-check mr-2"></i><?= __("Approva") ?>
                             </button>
                             <button type="button"
-                                    class="flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-4 rounded-lg transition-colors reject-btn shadow-sm"
+                                    class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-4 rounded-lg transition-colors reject-btn shadow-sm"
                                     data-review-id="<?php echo (int)$review['id']; ?>">
                                 <i class="fas fa-times mr-2"></i><?= __("Rifiuta") ?>
                             </button>

--- a/app/Views/admin/themes.php
+++ b/app/Views/admin/themes.php
@@ -47,7 +47,7 @@ $pageTitle = __('Gestione Temi');
                        class="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50">
                         <?= __('Personalizza') ?>
                     </a>
-                    <button type="submit" class="rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800">
+                    <button type="submit" class="inline-flex items-center rounded-lg bg-gray-900 px-5 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800">
                         <i class="fas fa-save mr-1" aria-hidden="true"></i><?= __('Salva') ?>
                     </button>
                 </div>
@@ -137,7 +137,7 @@ $pageTitle = __('Gestione Temi');
                                 </p>
                             </div>
                             <?php if ($isActive): ?>
-                                <span class="shrink-0 ml-2 px-2 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-md">
+                                <span class="inline-flex items-center shrink-0 ml-2 px-2 py-1 bg-green-100 text-green-700 text-xs font-medium rounded-md">
                                     <i class="fas fa-check-circle mr-1"></i><?= __("Attivo") ?>
                                 </span>
                             <?php endif; ?>
@@ -171,14 +171,14 @@ $pageTitle = __('Gestione Temi');
                         <div class="flex gap-2">
                             <?php if (!$isActive): ?>
                                 <button onclick="activateTheme(<?= (int)$theme['id'] ?>)"
-                                        class="flex-1 px-3 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors text-sm font-medium">
+                                        class="inline-flex items-center justify-center flex-1 px-3 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors text-sm font-medium">
                                     <i class="fas fa-check mr-1"></i>
                                     <?= __("Attiva tema") ?>
                                 </button>
                             <?php endif; ?>
 
                             <a href="<?= htmlspecialchars(url('/admin/themes/' . (int)$theme['id'] . '/customize'), ENT_QUOTES, 'UTF-8') ?>"
-                               class="<?= $isActive ? 'flex-1' : '' ?> px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium text-center">
+                               class="inline-flex items-center justify-center <?= $isActive ? 'flex-1' : '' ?> px-3 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors text-sm font-medium text-center">
                                 <i class="fas fa-sliders-h mr-1"></i>
                                 <?= __("Personalizza") ?>
                             </a>

--- a/app/Views/admin/updates.php
+++ b/app/Views/admin/updates.php
@@ -125,11 +125,11 @@ $hasGithubToken ??= false;
                     <p class="text-sm text-gray-500 mt-1"><?= __("Configura un token per evitare i limiti di rate della GitHub API (60 req/ora → 5000 req/ora)") ?></p>
                 </div>
                 <?php if ($hasGithubToken): ?>
-                <span class="px-3 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
+                <span class="inline-flex items-center px-3 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
                     <i class="fas fa-check-circle mr-1"></i><?= __("Configurato") ?>
                 </span>
                 <?php else: ?>
-                <span class="px-3 py-1 text-xs font-medium bg-yellow-100 text-yellow-700 rounded-lg">
+                <span class="inline-flex items-center px-3 py-1 text-xs font-medium bg-yellow-100 text-yellow-700 rounded-lg">
                     <i class="fas fa-exclamation-circle mr-1"></i><?= __("Non configurato") ?>
                 </span>
                 <?php endif; ?>
@@ -148,7 +148,7 @@ $hasGithubToken ??= false;
                             class="flex-1 rounded-lg border-gray-300 shadow-sm focus:border-green-500 focus:ring-green-500 text-sm font-mono"
                             autocomplete="new-password"
                             <?= $hasGithubToken ? 'readonly onfocus="this.removeAttribute(\'readonly\');this.type=\'password\';this.value=\'\';this.placeholder=\'ghp_xxxxxxxxxxxxxxxxxxxx\';"' : '' ?>>
-                        <button type="submit" class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm">
+                        <button type="submit" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors text-sm">
                             <i class="fas fa-save mr-1"></i><?= __("Salva") ?>
                         </button>
                         <?php if ($hasGithubToken): ?>
@@ -179,11 +179,11 @@ $hasGithubToken ??= false;
                 <div class="flex items-center justify-between">
                     <h2 class="text-lg font-semibold text-gray-900"><?= __("Requisiti di Sistema") ?></h2>
                     <?php if ($requirements['met']): ?>
-                    <span class="px-3 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
+                    <span class="inline-flex items-center px-3 py-1 text-xs font-medium bg-green-100 text-green-700 rounded-lg">
                         <i class="fas fa-check-circle mr-1"></i><?= __("Tutti soddisfatti") ?>
                     </span>
                     <?php else: ?>
-                    <span class="px-3 py-1 text-xs font-medium bg-red-100 text-red-700 rounded-lg">
+                    <span class="inline-flex items-center px-3 py-1 text-xs font-medium bg-red-100 text-red-700 rounded-lg">
                         <i class="fas fa-times-circle mr-1"></i><?= __("Alcuni mancanti") ?>
                     </span>
                     <?php endif; ?>
@@ -296,7 +296,7 @@ $hasGithubToken ??= false;
                     <div id="uppy-manual-update" class="border-2 border-dashed border-gray-300 rounded-xl p-8 text-center hover:border-gray-400 transition-colors bg-gray-50"></div>
                     <div class="mt-4">
                         <button id="manual-update-submit-btn" onclick="submitManualUpdate()" disabled
-                            class="w-full px-6 py-3 bg-green-600 text-white rounded-xl hover:bg-green-700 transition-all duration-200 shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-green-600">
+                            class="inline-flex items-center justify-center w-full px-6 py-3 bg-green-600 text-white rounded-xl hover:bg-green-700 transition-all duration-200 shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-green-600">
                             <i class="fas fa-upload mr-2"></i>
                             <span id="manual-update-btn-text"><?= __("Avvia Aggiornamento") ?></span>
                         </button>
@@ -489,7 +489,7 @@ $hasGithubToken ??= false;
                                 default => $log['status']
                             };
                             ?>
-                            <span class="px-2 py-1 text-xs font-medium <?= $statusClass ?> rounded-lg">
+                            <span class="inline-flex items-center px-2 py-1 text-xs font-medium <?= $statusClass ?> rounded-lg">
                                 <i class="fas <?= $statusIcon ?> mr-1"></i>
                                 <?= HtmlHelper::e($statusText) ?>
                             </span>

--- a/app/Views/autori/index.php
+++ b/app/Views/autori/index.php
@@ -70,7 +70,7 @@ $autori = $data['autori'];
           </div>
 
           <!-- Toggle Advanced Filters -->
-          <button id="toggle-advanced" class="px-3 py-2 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-200">
+          <button id="toggle-advanced" class="inline-flex items-center px-3 py-2 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-200">
             <i class="fas fa-sliders-h mr-1"></i>
             <span class="hidden sm:inline"><?= __("Altri filtri") ?></span>
             <i id="toggle-advanced-icon" class="fas fa-chevron-down text-xs ml-1 transition-transform"></i>
@@ -165,13 +165,13 @@ $autori = $data['autori'];
           </button>
         </div>
         <div class="flex items-center gap-2">
-          <button id="bulk-merge" class="px-4 py-2 bg-blue-500 text-white hover:bg-blue-600 rounded-lg transition-colors text-sm">
+          <button id="bulk-merge" class="inline-flex items-center px-4 py-2 bg-blue-500 text-white hover:bg-blue-600 rounded-lg transition-colors text-sm">
             <i class="fas fa-compress-arrows-alt mr-2"></i><?= __("Unisci") ?>
           </button>
-          <button id="bulk-export" class="px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
+          <button id="bulk-export" class="inline-flex items-center px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
             <i class="fas fa-download mr-2"></i><?= __("Esporta") ?>
           </button>
-          <button id="bulk-delete" class="px-4 py-2 bg-red-500 text-white hover:bg-red-600 rounded-lg transition-colors text-sm">
+          <button id="bulk-delete" class="inline-flex items-center px-4 py-2 bg-red-500 text-white hover:bg-red-600 rounded-lg transition-colors text-sm">
             <i class="fas fa-trash mr-2"></i><?= __("Elimina") ?>
           </button>
         </div>

--- a/app/Views/collane/dettaglio.php
+++ b/app/Views/collane/dettaglio.php
@@ -90,7 +90,7 @@ if ($seriesType === '') { $seriesType = 'serie'; }
       <?php endif; ?>
       <label for="descrizione" class="form-label"><?= __("Descrizione") ?></label>
       <textarea name="descrizione" rows="3" class="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 mb-3" placeholder="<?= HtmlHelper::e(__('Descrizione della collana...')) ?>"><?= HtmlHelper::e($collanaDesc ?? '') ?></textarea>
-      <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
+      <button type="submit" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
         <i class="fas fa-save mr-2"></i><?= __("Salva descrizione") ?>
       </button>
     </form>
@@ -218,7 +218,7 @@ if ($seriesType === '') { $seriesType = 'serie'; }
         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
         <input type="hidden" name="old_name" value="<?= HtmlHelper::e($collana) ?>">
         <input type="text" name="new_name" value="<?= HtmlHelper::e($collana) ?>" class="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 mb-3" required>
-        <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
+        <button type="submit" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
           <i class="fas fa-save mr-2"></i><?= __("Rinomina") ?>
         </button>
       </form>
@@ -234,7 +234,7 @@ if ($seriesType === '') { $seriesType = 'serie'; }
           <input type="text" name="target" id="merge-target" placeholder="<?= HtmlHelper::e(__('Nome collana di destinazione')) ?>" class="mt-1 block w-full rounded-lg border border-gray-300 px-4 py-2 mb-3" required autocomplete="off">
           <div id="merge-suggestions" class="absolute z-10 w-full bg-white border border-gray-200 rounded-lg shadow-lg hidden max-h-48 overflow-y-auto"></div>
         </div>
-        <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
+        <button type="submit" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm">
           <i class="fas fa-compress-arrows-alt mr-2"></i><?= __("Unisci") ?>
         </button>
       </form>
@@ -250,7 +250,7 @@ if ($seriesType === '') { $seriesType = 'serie'; }
         <input type="hidden" name="collana" value="<?= HtmlHelper::e($collana) ?>">
         <div class="flex gap-2">
           <input type="text" name="parent_title" value="<?= HtmlHelper::e($collana) ?>" class="flex-1 rounded-lg border border-gray-300 px-4 py-2" placeholder="<?= HtmlHelper::e(__('Titolo dell\'opera completa')) ?>" required>
-          <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm whitespace-nowrap">
+          <button type="submit" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium text-sm whitespace-nowrap">
             <i class="fas fa-plus mr-2"></i><?= __("Crea opera") ?>
           </button>
         </div>
@@ -265,7 +265,7 @@ if ($seriesType === '') { $seriesType = 'serie'; }
       <form method="post" action="<?= htmlspecialchars(url('/admin/series/delete'), ENT_QUOTES, 'UTF-8') ?>" data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro? La collana verrà rimossa da tutti i libri.'), ENT_QUOTES, 'UTF-8') ?>">
         <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
         <input type="hidden" name="nome" value="<?= HtmlHelper::e($collana) ?>">
-        <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium text-sm">
+        <button type="submit" class="inline-flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium text-sm">
           <i class="fas fa-trash mr-2"></i><?= __("Elimina collana") ?>
         </button>
       </form>

--- a/app/Views/collane/index.php
+++ b/app/Views/collane/index.php
@@ -26,7 +26,7 @@ $seriesTypeLabels = SeriesLabels::types();
       </h1>
       <p class="text-sm text-gray-600 mt-1"><?= __("Gestisci collane, spin-off e cicli di serie") ?></p>
     </div>
-    <button type="button" onclick="createCollana()" class="px-4 py-2 bg-gray-800 text-white hover:bg-gray-900 rounded-lg transition-colors text-sm font-medium">
+    <button type="button" onclick="createCollana()" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white hover:bg-gray-900 rounded-lg transition-colors text-sm font-medium">
       <i class="fas fa-plus mr-2"></i><?= __("Nuova Collana") ?>
     </button>
   </div>

--- a/app/Views/collocazione/index.php
+++ b/app/Views/collocazione/index.php
@@ -192,7 +192,7 @@
                   <input name="nome" class="px-4 py-2 bg-white border border-gray-300 rounded-lg text-gray-900 w-full focus:outline-none focus:ring-2 focus:ring-gray-400" placeholder="<?= __('Scaffale Narrativa') ?>">
                 </div>
                 <div class="flex items-end">
-                  <button type="submit" class="px-6 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors w-full">
+                  <button type="submit" class="inline-flex items-center justify-center px-6 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors w-full">
                     <i class="fas fa-plus mr-2"></i>
                     <?= __("Aggiungi") ?>
                   </button>
@@ -274,7 +274,7 @@
                   <input name="numero_livello" type="number" class="px-4 py-2 bg-white border border-gray-300 rounded-lg text-gray-900 w-full focus:outline-none focus:ring-2 focus:ring-gray-400" value="1" min="1">
                 </div>
                 <div class="flex items-end">
-                  <button type="submit" class="px-6 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors w-full">
+                  <button type="submit" class="inline-flex items-center justify-center px-6 py-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors w-full">
                     <i class="fas fa-plus mr-2"></i>
                     <?= __("Aggiungi") ?>
                   </button>

--- a/app/Views/dashboard/index.php
+++ b/app/Views/dashboard/index.php
@@ -143,11 +143,11 @@ $applicationToday = \App\Support\DateHelper::today();
           <?= __("Calendario Prestiti e Prenotazioni") ?>
         </h2>
         <div class="flex items-center gap-3">
-          <a href="<?= htmlspecialchars($icsUrl ?? url('/calendar/events.ics'), ENT_QUOTES, 'UTF-8') ?>" class="px-3 py-1.5 text-sm bg-purple-600 text-white hover:bg-purple-500 rounded-lg transition-colors duration-200 whitespace-nowrap">
+          <a href="<?= htmlspecialchars($icsUrl ?? url('/calendar/events.ics'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-3 py-1.5 text-sm bg-purple-600 text-white hover:bg-purple-500 rounded-lg transition-colors duration-200 whitespace-nowrap">
             <i class="fas fa-calendar-plus mr-1"></i>
             <?= __("Sincronizza (ICS)") ?>
           </a>
-          <button type="button" id="copy-ics-url" class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200 whitespace-nowrap">
+          <button type="button" id="copy-ics-url" class="inline-flex items-center px-3 py-1.5 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200 whitespace-nowrap">
             <i class="fas fa-copy mr-1"></i>
             <?= __("Copia Link") ?>
           </button>
@@ -203,7 +203,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-orange-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($pickupLoans) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-orange-600 text-white hover:bg-orange-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-orange-600 text-white hover:bg-orange-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-external-link-alt mr-1"></i>
             <?= __("Gestisci tutti") ?>
           </a>
@@ -261,15 +261,15 @@ $applicationToday = \App\Support\DateHelper::today();
               </div>
               <div class="px-5 pb-5">
                 <?php if ($isExpired): ?>
-                  <button type="button" class="w-full bg-red-600 hover:bg-red-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors cancel-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
+                  <button type="button" class="inline-flex items-center justify-center w-full bg-red-600 hover:bg-red-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors cancel-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
                     <i class="fas fa-times mr-2"></i><?= __("Annulla Prestito Scaduto") ?>
                   </button>
                 <?php else: ?>
                   <div class="flex gap-3">
-                    <button type="button" class="flex-1 bg-green-600 hover:bg-green-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors confirm-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
+                    <button type="button" class="inline-flex items-center justify-center flex-1 bg-green-600 hover:bg-green-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors confirm-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
                       <i class="fas fa-check mr-2"></i><?= __("Conferma Ritiro") ?>
                     </button>
-                    <button type="button" class="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-2.5 px-4 rounded-lg transition-colors cancel-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
+                    <button type="button" class="inline-flex items-center justify-center flex-1 bg-gray-200 hover:bg-gray-300 text-gray-700 font-medium py-2.5 px-4 rounded-lg transition-colors cancel-pickup-btn" data-loan-id="<?= (int)$loan['id']; ?>">
                       <i class="fas fa-times mr-2"></i><?= __("Annulla") ?>
                     </button>
                   </div>
@@ -299,7 +299,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-blue-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($pending) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-blue-600 text-white hover:bg-blue-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-external-link-alt mr-1"></i>
             <?= __("Gestisci tutte") ?>
           </a>
@@ -361,10 +361,10 @@ $applicationToday = \App\Support\DateHelper::today();
               </div>
               <div class="px-5 pb-5 mt-auto">
                 <div class="flex gap-3">
-                  <button type="button" class="flex-1 bg-gray-900 hover:bg-gray-800 text-white font-medium py-2.5 px-4 rounded-lg transition-colors approve-btn" data-loan-id="<?= (int)$loan['id']; ?>">
+                  <button type="button" class="inline-flex items-center justify-center flex-1 bg-gray-900 hover:bg-gray-800 text-white font-medium py-2.5 px-4 rounded-lg transition-colors approve-btn" data-loan-id="<?= (int)$loan['id']; ?>">
                     <i class="fas fa-check mr-2"></i><?= __("Approva") ?>
                   </button>
-                  <button type="button" class="flex-1 bg-red-600 hover:bg-red-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors reject-btn" data-loan-id="<?= (int)$loan['id']; ?>">
+                  <button type="button" class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-700 text-white font-medium py-2.5 px-4 rounded-lg transition-colors reject-btn" data-loan-id="<?= (int)$loan['id']; ?>">
                     <i class="fas fa-times mr-2"></i><?= __("Rifiuta") ?>
                   </button>
                 </div>
@@ -397,7 +397,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-cyan-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($scheduledLoans) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-cyan-600 text-white hover:bg-cyan-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/loans/pending'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-cyan-600 text-white hover:bg-cyan-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-external-link-alt mr-1"></i>
             <?= __("Gestisci tutti") ?>
           </a>
@@ -477,7 +477,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-red-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($overdue) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-red-600 text-white hover:bg-red-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-red-600 text-white hover:bg-red-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-external-link-alt mr-1"></i>
             <?= __("Gestisci") ?>
           </a>
@@ -535,7 +535,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-purple-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($reservations) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-purple-600 text-white hover:bg-purple-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-purple-600 text-white hover:bg-purple-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-external-link-alt mr-1"></i>
             <?= __("Gestisci tutte") ?>
           </a>
@@ -619,7 +619,7 @@ $applicationToday = \App\Support\DateHelper::today();
         </div>
         <div class="flex items-center gap-3">
           <span class="bg-green-500 text-white text-sm font-bold px-3 py-1 rounded-full"><?= count($active) ?></span>
-          <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
+          <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-green-600 text-white hover:bg-green-700 rounded-lg transition-colors duration-200 whitespace-nowrap font-medium">
             <i class="fas fa-eye mr-1"></i>
             <?= __("Vedi tutti") ?>
           </a>
@@ -716,7 +716,7 @@ $applicationToday = \App\Support\DateHelper::today();
             <p class="text-sm text-gray-500"><?= __("Aggiunti di recente al catalogo") ?></p>
           </div>
         </div>
-        <a href="<?= htmlspecialchars(url('/admin/books'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200 font-medium">
+        <a href="<?= htmlspecialchars(url('/admin/books'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200 font-medium">
           <i class="fas fa-eye mr-1"></i>
           <?= __("Vedi tutti") ?>
         </a>

--- a/app/Views/editori/index.php
+++ b/app/Views/editori/index.php
@@ -61,7 +61,7 @@ $editori = $data['editori'];
           </div>
 
           <!-- Toggle Advanced Filters -->
-          <button id="toggle-advanced" class="px-3 py-2 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-200">
+          <button id="toggle-advanced" class="inline-flex items-center px-3 py-2 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-200">
             <i class="fas fa-sliders-h mr-1"></i>
             <span class="hidden sm:inline"><?= __("Altri filtri") ?></span>
             <i id="toggle-advanced-icon" class="fas fa-chevron-down text-xs ml-1 transition-transform"></i>
@@ -147,13 +147,13 @@ $editori = $data['editori'];
           </button>
         </div>
         <div class="flex items-center gap-2">
-          <button id="bulk-merge" class="px-4 py-2 bg-blue-500 text-white hover:bg-blue-600 rounded-lg transition-colors text-sm">
+          <button id="bulk-merge" class="inline-flex items-center px-4 py-2 bg-blue-500 text-white hover:bg-blue-600 rounded-lg transition-colors text-sm">
             <i class="fas fa-compress-arrows-alt mr-2"></i><?= __("Unisci") ?>
           </button>
-          <button id="bulk-export" class="px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
+          <button id="bulk-export" class="inline-flex items-center px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
             <i class="fas fa-download mr-2"></i><?= __("Esporta") ?>
           </button>
-          <button id="bulk-delete" class="px-4 py-2 bg-red-500 text-white hover:bg-red-600 rounded-lg transition-colors text-sm">
+          <button id="bulk-delete" class="inline-flex items-center px-4 py-2 bg-red-500 text-white hover:bg-red-600 rounded-lg transition-colors text-sm">
             <i class="fas fa-trash mr-2"></i><?= __("Elimina") ?>
           </button>
         </div>

--- a/app/Views/generi/dettaglio_genere.php
+++ b/app/Views/generi/dettaglio_genere.php
@@ -212,7 +212,7 @@ $genereName = $genere['nome'] ?? 'Genere';
                   ?>
                 </select>
               </div>
-              <button type="submit" class="px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors text-sm whitespace-nowrap">
+              <button type="submit" class="inline-flex items-center px-4 py-2 bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors text-sm whitespace-nowrap">
                 <i class="fas fa-compress-arrows-alt mr-1"></i><?= __("Unisci") ?>
               </button>
             </div>
@@ -234,7 +234,7 @@ $genereName = $genere['nome'] ?? 'Genere';
                 data-swal-confirm-button="<?= htmlspecialchars(__('Elimina tutto'), ENT_QUOTES, 'UTF-8') ?>">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') ?>">
             <input type="hidden" name="cascade_delete" value="1">
-            <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm">
+            <button type="submit" class="inline-flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm">
               <i class="fas fa-trash-alt mr-1"></i><?= __("Elimina genere e sottogeneri") ?>
             </button>
           </form>
@@ -244,7 +244,7 @@ $genereName = $genere['nome'] ?? 'Genere';
                 data-swal-confirm="<?= htmlspecialchars(__('Sei sicuro di voler eliminare questo genere?'), ENT_QUOTES, 'UTF-8') ?>"
                 data-swal-confirm-button="<?= htmlspecialchars(__('Elimina'), ENT_QUOTES, 'UTF-8') ?>">
             <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8') ?>">
-            <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm">
+            <button type="submit" class="inline-flex items-center px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors text-sm">
               <i class="fas fa-trash-alt mr-1"></i><?= __("Elimina") ?>
             </button>
           </form>

--- a/app/Views/libri/index.php
+++ b/app/Views/libri/index.php
@@ -347,16 +347,16 @@ $libri = $data['libri'];
           </button>
         </div>
         <div class="flex items-center gap-2">
-          <button id="bulk-export" class="px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
+          <button id="bulk-export" class="inline-flex items-center px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
             <i class="fas fa-download mr-2"></i><?= __("Esporta selezionati") ?>
           </button>
-          <button id="bulk-assign-collana" class="px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
+          <button id="bulk-assign-collana" class="inline-flex items-center px-4 py-2 bg-white text-gray-700 hover:bg-gray-50 rounded-lg transition-colors text-sm border border-gray-300">
             <i class="fas fa-layer-group mr-2"></i><?= __("Assegna collana") ?>
           </button>
-          <button id="bulk-fetch-covers" class="px-4 py-2 bg-gray-800 text-white hover:bg-black rounded-lg transition-colors text-sm">
+          <button id="bulk-fetch-covers" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white hover:bg-black rounded-lg transition-colors text-sm">
             <i class="fas fa-image mr-2"></i><?= __("Scarica copertine") ?>
           </button>
-          <button id="bulk-delete" class="px-4 py-2 bg-red-600 text-white hover:bg-red-700 rounded-lg transition-colors text-sm">
+          <button id="bulk-delete" class="inline-flex items-center px-4 py-2 bg-red-600 text-white hover:bg-red-700 rounded-lg transition-colors text-sm">
             <i class="fas fa-trash mr-2"></i><?= __("Elimina") ?>
           </button>
         </div>

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -608,7 +608,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg border-2 border-red-300
                     if (empty($keyword)) continue;
                 ?>
                   <a href="<?= htmlspecialchars(url('/admin/books?keywords=' . urlencode($keyword)), ENT_QUOTES, 'UTF-8') ?>"
-                     class="inline-block px-2 py-1 mr-2 mb-2 text-xs bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-full transition-colors">
+                     class="inline-flex items-center px-2 py-1 mr-2 mb-2 text-xs bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-full transition-colors">
                     <i class="fas fa-tag mr-1"></i><?php echo App\Support\HtmlHelper::e($keyword); ?>
                   </a>
                 <?php endforeach; ?>

--- a/app/Views/prenotazioni/crea_prenotazione.php
+++ b/app/Views/prenotazioni/crea_prenotazione.php
@@ -24,7 +24,7 @@
                         </div><?= __("Crea Nuova Prenotazione") ?></h1>
                     <p class="text-lg text-gray-600 ml-22"><?= __("Registra una prenotazione per permettere ad un utente di riservare un libro specifico") ?></p>
                 </div>
-                <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="px-6 py-3 bg-white border border-gray-300 text-gray-700 rounded-xl hover:bg-gray-50 transition-colors shadow-sm">
+                <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-6 py-3 bg-white border border-gray-300 text-gray-700 rounded-xl hover:bg-gray-50 transition-colors shadow-sm">
                     <i class="fas fa-arrow-left mr-2"></i><?= __("Torna alle Prenotazioni") ?></a>
             </div>
         </div>
@@ -221,11 +221,11 @@
                     <!-- Buttons -->
                     <div class="flex items-center justify-between pt-12 border-t-2 border-gray-200">
                         <a href="<?= htmlspecialchars(url('/admin/reservations'), ENT_QUOTES, 'UTF-8') ?>"
-                           class="px-8 py-4 text-lg border-2 border-gray-300 text-gray-700 rounded-2xl hover:bg-gray-50 transition-colors font-semibold shadow-md">
+                           class="inline-flex items-center px-8 py-4 text-lg border-2 border-gray-300 text-gray-700 rounded-2xl hover:bg-gray-50 transition-colors font-semibold shadow-md">
                             <i class="fas fa-times mr-3"></i>Annulla
                         </a>
                         <button type="submit"
-                                class="px-12 py-4 text-lg bg-gray-900 text-white rounded-2xl hover:bg-gray-800 transition-colors font-semibold shadow-xl">
+                                class="inline-flex items-center px-12 py-4 text-lg bg-gray-900 text-white rounded-2xl hover:bg-gray-800 transition-colors font-semibold shadow-xl">
                             <i class="fas fa-save mr-3"></i><?= __("Crea Prenotazione") ?></button>
                     </div>
 

--- a/app/Views/prestiti/crea_prestito.php
+++ b/app/Views/prestiti/crea_prestito.php
@@ -200,9 +200,9 @@ $isItalian = str_starts_with($currentLocale, 'it');
 
     <!-- Pulsanti -->
     <div class="flex items-center gap-4">
-      <button type="submit" class="px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium">
+      <button type="submit" class="inline-flex items-center px-4 py-2 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium">
         <i class="fas fa-save mr-2"></i><?= __("Crea Prestito") ?></button>
-      <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="px-4 py-2 bg-gray-100 text-gray-900 border border-gray-300 rounded-lg hover:bg-gray-200 transition-colors font-medium">
+      <a href="<?= htmlspecialchars(url('/admin/loans'), ENT_QUOTES, 'UTF-8') ?>" class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-900 border border-gray-300 rounded-lg hover:bg-gray-200 transition-colors font-medium">
         <i class="fas fa-times mr-2"></i><?= __("Annulla") ?>
       </a>
     </div>

--- a/app/Views/prestiti/index.php
+++ b/app/Views/prestiti/index.php
@@ -240,10 +240,10 @@ $applicationToday = \App\Support\DateHelper::today();
               </div>
             </div>
             <div class="mt-4 flex gap-3">
-              <button type="button" class="flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg transition-colors approve-btn shadow-sm" data-loan-id="<?= (int)$loan['id'] ?>">
+              <button type="button" class="inline-flex items-center justify-center flex-1 bg-gray-900 hover:bg-gray-700 text-white font-medium py-2 px-4 rounded-lg transition-colors approve-btn shadow-sm" data-loan-id="<?= (int)$loan['id'] ?>">
                 <i class="fas fa-check mr-2"></i><?= __("Approva") ?>
               </button>
-              <button type="button" class="flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-4 rounded-lg transition-colors reject-btn shadow-sm" data-loan-id="<?= (int)$loan['id'] ?>">
+              <button type="button" class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-4 rounded-lg transition-colors reject-btn shadow-sm" data-loan-id="<?= (int)$loan['id'] ?>">
                 <i class="fas fa-times mr-2"></i><?= __("Rifiuta") ?>
               </button>
             </div>
@@ -413,7 +413,7 @@ $applicationToday = \App\Support\DateHelper::today();
              class="w-20 px-2 py-1.5 border border-gray-300 rounded-lg text-sm text-center">
       <span class="text-sm text-gray-600"><?= __('giorni') ?></span>
       <button id="loans-bulk-extend" type="button"
-              class="px-4 py-2 bg-gray-800 text-white hover:bg-black rounded-lg transition-colors text-sm">
+              class="inline-flex items-center px-4 py-2 bg-gray-800 text-white hover:bg-black rounded-lg transition-colors text-sm">
         <i class="fas fa-calendar-plus mr-1"></i><?= __('Estendi prestiti selezionati') ?>
       </button>
       <button id="loans-bulk-clear" type="button"

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -589,7 +589,7 @@ use App\Support\HtmlHelper;
               <?php endif; ?>
             <?php elseif ($sitemapExists && $sitemapFileModified): ?>
               <span class="text-gray-900 ml-2"><?php echo format_date(date('Y-m-d H:i:s', $sitemapFileModified), true, '/'); ?></span>
-              <span class="ml-2 text-xs bg-yellow-100 px-2 py-1 rounded-full text-yellow-800">
+              <span class="inline-flex items-center ml-2 text-xs bg-yellow-100 px-2 py-1 rounded-full text-yellow-800">
                 <i class="fas fa-info-circle"></i> File esistente (data modifica)
               </span>
             <?php else: ?>

--- a/app/Views/utenti/index.php
+++ b/app/Views/utenti/index.php
@@ -153,7 +153,7 @@
           <?= __("Filtri di Ricerca") ?>
         </h2>
         <div class="flex items-center gap-2">
-          <button id="btn-pending-approvals" class="px-3 py-1.5 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200">
+          <button id="btn-pending-approvals" class="inline-flex items-center px-3 py-1.5 text-sm bg-gray-100 text-gray-700 hover:bg-gray-200 rounded-lg transition-colors duration-200">
             <i class="fas fa-user-clock mr-2"></i> <?= __("Solo sospesi") ?>
           </button>
           <button id="toggle-filters" class="text-sm text-gray-600 hover:text-gray-800">


### PR DESCRIPTION
Fixes #316.

## Problem

Pill/chip buttons that hold a Font Awesome icon next to a text label laid the icon and text out inline, so they aligned to the text baseline and left asymmetric vertical space — more below than above. The content looked not vertically centered.

## Fix

Add `inline-flex items-center` (plus `justify-center` on full-width / `flex-1` buttons) to every such control, so flexbox centers the icon and label within the button height.

## Scope — found with a workflow

Audited the backend view controls that combine rounded pill/button classes with icons, including both exact locations shown in #316. **82 occurrences across 21 files** matched the pattern (icon + text label without vertical centering); 5 text-only false positives were excluded. The change is limited to display/alignment classes — no markup, colors, sizing, spacing, or logic changes.

Files touched: dashboard, admin (plugins, pending_loans, updates, themes, reviews, integrity_report, imports_history), book detail, prestiti, prenotazioni, editori, autori, libri, generi, collane, collocazione, utenti, settings.

## Verification

`php -l` clean on all 21 files; PHPStan level 5 clean; no conflicting display classes. Verified against both #316 screenshots: the dashboard calendar buttons and the book keyword chip now use flex alignment, with icon and text vertically centered via `align-items: center`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Stile**
  * Uniformato il layout di pulsanti, collegamenti, badge e indicatori nelle principali pagine dell’applicazione.
  * Migliorati allineamento, centratura, spaziatura e dimensionamento degli elementi interattivi.
  * Mantenuti invariati contenuti, destinazioni e comportamenti delle funzionalità esistenti.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
