### PR TITLE
fix(book): make the info/share cards flush with the sheet on mobile

### DIFF
--- a/app/Views/frontend/book-detail.php
+++ b/app/Views/frontend/book-detail.php
@@ -1472,17 +1472,19 @@ $additional_css = "
             padding: 0.3rem 0.7rem;
         }
 
+        /* On phones the card sits in a full-width column whose content edge is
+           already the page gutter, so any horizontal padding here pushes the
+           card's rows further in than the title, the description and every other
+           block on the page. Drop the horizontal padding (keep the vertical
+           rhythm) so the header label, meta rows and social buttons line up flush
+           with the rest of the sheet. */
         .card-body {
-            padding: 1rem;
+            padding: 1rem 0;
         }
 
-        /* Match the header inset to the reduced .card-body padding (1rem) so the
-           section label lines up with the meta rows below it on mobile. Padding
-           (not margin) keeps it aligned regardless of cascade order — see the
-           base .card-header rule. */
         .card-header {
-            padding-left: 1rem;
-            padding-right: 1rem;
+            padding-left: 0;
+            padding-right: 0;
         }
     }
 

--- a/public/assets/frontend-layouts.css
+++ b/public/assets/frontend-layouts.css
@@ -2130,12 +2130,12 @@ body.layout-soft :is(.bc-btn, .archive-page .ui-button, .archive-body .ui-button
   }
 
   body[class*="layout-"] #book-share-card .card-header {
-    margin-inline: 1rem;
+    margin-inline: 0;
     padding-block: 1rem;
   }
 
   body[class*="layout-"] #book-share-card .card-body.px-3 {
-    padding: 1rem !important;
+    padding: 1rem 0 !important;
   }
 
   body[class*="layout-"] .book-meta-empty {


### PR DESCRIPTION
On phones the book-detail cards sat in a full-width column whose content edge is already the page gutter, but the cards' own horizontal padding pushed their rows ~16px further right than the title, description and every other block — so the info card and share buttons looked misaligned with the rest of the sheet.

Drop the horizontal padding on mobile (keep the vertical rhythm) so the header label, meta rows and social buttons line up flush at the same 32px edge as the description. `book-detail.php` handles `#book-info-card`; the share card is fixed in `frontend-layouts.css` where the higher-specificity layout rules govern it (an inline override could never win that cascade). Desktop insets are unchanged — the edits live only in the mobile media queries.

Verified at 390px: info-card header, meta labels/values, share header, social buttons and the description all sit at 32px.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Stile**
  * Migliorata la visualizzazione delle schede nella versione mobile.
  * Allineati bordi, intestazioni, righe e pulsanti social al contenitore dello schermo.
  * Ottimizzato il layout della scheda di condivisione del libro, mantenendo il corretto spazio verticale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->