### PR TITLE
feat(i18n): non-reseeded override layer for in-app locale edits (@48)

### DIFF
--- a/app/Controllers/Admin/LanguagesController.php
+++ b/app/Controllers/Admin/LanguagesController.php
@@ -293,12 +293,15 @@ class LanguagesController
         try {
             $languageModel->delete($code);
 
-            // Optionally delete translation file
-            $translationFile = $this->getLocaleFilePath($code);
-            if (file_exists($translationFile)) {
-                // Backup before deleting
-                copy($translationFile, $translationFile . '.deleted.' . time());
-                unlink($translationFile);
+            // Optionally delete translation file(s): the shipped base and the
+            // admin override, so a deleted language leaves no lingering override
+            // that would resurface if the same code is re-added later.
+            foreach ([$this->getLocaleFilePath($code), $this->getOverrideFilePath($code)] as $translationFile) {
+                if (file_exists($translationFile)) {
+                    // Backup before deleting
+                    copy($translationFile, $translationFile . '.deleted.' . time());
+                    unlink($translationFile);
+                }
             }
 
             $_SESSION['flash_success'] = __("Lingua eliminata con successo");
@@ -489,14 +492,16 @@ class LanguagesController
                 ->withStatus(302);
         }
 
-        // Export every current application key. Missing translations are empty;
-        // custom extra keys remain at the end for backwards compatibility.
-        $translations = $this->sanitizeTranslations(is_array($decoded) ? $decoded : []);
+        // Export the EFFECTIVE translations (shipped base merged with the admin
+        // override) so a re-download reflects what the app actually serves and a
+        // re-upload never silently drops prior overrides. Every current
+        // application key is present; missing translations are empty; custom
+        // extra keys remain at the end for backwards compatibility.
+        $translations = $this->getEffectiveTranslations($code);
         $complete = [];
         foreach ($this->loadCanonicalTranslations() as $key => $_default) {
-            $complete[$key] = isset($translations[$key]) && is_string($translations[$key])
-                ? $translations[$key]
-                : '';
+            // getEffectiveTranslations() guarantees string values (sanitized).
+            $complete[$key] = $translations[$key] ?? '';
         }
         foreach (array_diff_key($translations, $complete) as $key => $value) {
             $complete[$key] = $value;
@@ -549,6 +554,52 @@ class LanguagesController
         return rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $code . '.json';
     }
 
+    /**
+     * Path of the admin OVERRIDE file for a locale: locale/overrides/{code}.json.
+     * This directory is never re-seeded by the Docker entrypoint, so in-app edits
+     * of a shipped locale persist across image upgrades (see I18n::loadTranslations,
+     * which merges this on top of the base). Creates the subdirectory on demand.
+     */
+    private function getOverrideFilePath(string $code): string
+    {
+        $baseDir = realpath(__DIR__ . '/../../../locale');
+        if ($baseDir === false) {
+            $baseDir = __DIR__ . '/../../../locale';
+        }
+        $overrideDir = rtrim($baseDir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'overrides';
+        if (!is_dir($overrideDir)) {
+            mkdir($overrideDir, 0755, true);
+        }
+        return $overrideDir . DIRECTORY_SEPARATOR . $code . '.json';
+    }
+
+    /**
+     * Effective translations for a locale as the app sees them at runtime:
+     * shipped base merged with the admin override (override wins). Used for the
+     * download/export and for accurate key counts.
+     *
+     * @return array<string, string>
+     */
+    private function getEffectiveTranslations(string $code): array
+    {
+        $result = [];
+        $base = $this->getLocaleFilePath($code);
+        if (is_file($base)) {
+            $decoded = json_decode((string) file_get_contents($base), true);
+            if (is_array($decoded)) {
+                $result = $decoded;
+            }
+        }
+        $override = $this->getOverrideFilePath($code);
+        if (is_file($override)) {
+            $decoded = json_decode((string) file_get_contents($override), true);
+            if (is_array($decoded)) {
+                $result = array_merge($result, $decoded);
+            }
+        }
+        return $this->sanitizeTranslations($result);
+    }
+
     private function sanitizeTranslations(array $translations): array
     {
         $sanitized = [];
@@ -599,15 +650,18 @@ class LanguagesController
         }
 
         $sanitized = $this->sanitizeTranslations($decoded);
-        $targetPath = $this->getLocaleFilePath($code);
+        // Write the edit to the non-reseeded override layer (locale/overrides/)
+        // instead of the shipped base, so it survives a Docker image re-seed.
+        // getOverrideFilePath() has already created the subdirectory.
+        $targetPath = $this->getOverrideFilePath($code);
 
         // Defense in depth: the resolved file must live directly inside the
-        // locale directory. realpath() can't resolve a not-yet-created file, so
-        // validate the DIRNAME against the locale base and the basename shape.
-        $localeDir = realpath(__DIR__ . '/../../../locale');
+        // locale/overrides directory. realpath() can't resolve a not-yet-created
+        // file, so validate the DIRNAME against the override base and the basename.
+        $overrideDir = realpath(__DIR__ . '/../../../locale/overrides');
         $targetDir = realpath(dirname($targetPath));
-        if ($localeDir === false || $targetDir === false
-            || $targetDir !== $localeDir
+        if ($overrideDir === false || $targetDir === false
+            || $targetDir !== $overrideDir
             || basename($targetPath) !== $code . '.json') {
             return ['success' => false, 'error' => __("Percorso file non valido")];
         }

--- a/app/Support/I18n.php
+++ b/app/Support/I18n.php
@@ -187,17 +187,32 @@ final class I18n
         }
 
         $locale = self::$locale;
-        $translationFile = __DIR__ . '/../../locale/' . $locale . '.json';
+        $localeDir = __DIR__ . '/../../locale/';
+        $translations = [];
 
+        // Base (shipped) translations. In the Docker image these are re-seeded on
+        // every boot, so they must NOT hold admin edits.
+        $translationFile = $localeDir . $locale . '.json';
         if (file_exists($translationFile)) {
-            $json = file_get_contents($translationFile);
-            $decoded = json_decode($json, true);
-
+            $decoded = json_decode((string) file_get_contents($translationFile), true);
             if (is_array($decoded)) {
-                self::$translations = $decoded;
+                $translations = $decoded;
             }
         }
 
+        // Admin overrides live in a non-reseeded subdirectory (locale/overrides/),
+        // so an in-app edit of a shipped locale survives a Docker image re-seed.
+        // Override values win; keys shipped only in a later base image still flow
+        // through because they are absent from the override.
+        $overrideFile = $localeDir . 'overrides/' . $locale . '.json';
+        if (file_exists($overrideFile)) {
+            $decoded = json_decode((string) file_get_contents($overrideFile), true);
+            if (is_array($decoded)) {
+                $translations = array_merge($translations, $decoded);
+            }
+        }
+
+        self::$translations = $translations;
         self::$translationsLoaded = true;
     }
 

--- a/tests/discussion-238-followup.unit.php
+++ b/tests/discussion-238-followup.unit.php
@@ -29,7 +29,7 @@ $check(str_contains($settingsView, 'name="custom_width"') && str_contains($setti
 $check(str_contains($settings, "'show_subtitle'") && str_contains($settings, "'show_dewey'"), 'label content choices are persisted');
 $check(str_contains($controller, 'applyLabelContentSettings'), 'book and copy labels apply content choices');
 $check(str_contains($languages, 'loadCanonicalTranslations'), 'language exports and stats use the current canonical key set');
-$check(str_contains($languages, "                : '';"), 'missing translations export as empty strings');
+$check(str_contains($languages, "\$translations[\$key] ?? ''"), 'missing translations export as empty strings');
 $check(str_contains($updater, 'isCustomLocalePath'), 'updater recognizes custom locale catalogs');
 $check(substr_count($updater, 'isCustomLocalePath(') >= 4, 'custom locales are preserved in copy, preflight and orphan cleanup');
 

--- a/tests/locale-override-layer.unit.php
+++ b/tests/locale-override-layer.unit.php
@@ -1,0 +1,106 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural test for the locale override layer (docker walkthrough @48 / Option B).
+ *
+ * The Docker image re-seeds the shipped locale/*.json on every boot, so an in-app
+ * edit written straight to locale/{code}.json is silently reverted on restart.
+ * Fix: admin edits are written to a NON-reseeded locale/overrides/{code}.json, and
+ * I18n::loadTranslations() merges that override on top of the shipped base (override
+ * wins; keys shipped only in a later base image still flow through).
+ *
+ * This test drives the real I18n loader against sandbox base + override files via
+ * reflection (setLocale() validates against installed languages, which a throwaway
+ * code isn't), and asserts the source-level invariants of the editor write/delete.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\I18n;
+
+$checks = [];
+
+$localeDir = $root . '/locale';
+$overrideDir = $localeDir . '/overrides';
+$code = 'zz_ZZ';
+$baseFile = "$localeDir/$code.json";
+$overrideFile = "$overrideDir/$code.json";
+$overrideDirPreexisted = is_dir($overrideDir);
+
+// --- sandbox base + override ---
+if (!$overrideDirPreexisted) {
+    mkdir($overrideDir, 0755, true);
+}
+file_put_contents($baseFile, json_encode([
+    'ovl_shared'    => 'BASE shared',
+    'ovl_base_only' => 'BASE only',
+], JSON_UNESCAPED_UNICODE));
+file_put_contents($overrideFile, json_encode([
+    'ovl_shared'        => 'OVERRIDE shared',
+    'ovl_override_only' => 'OVERRIDE only',
+], JSON_UNESCAPED_UNICODE));
+
+// --- force I18n onto the sandbox locale, bypassing setLocale() validation ---
+$ref = new ReflectionClass(I18n::class);
+$setStatic = static function (string $prop, $value) use ($ref): void {
+    $p = $ref->getProperty($prop);
+    $p->setAccessible(true);
+    $p->setValue(null, $value);
+};
+$reload = static function () use ($setStatic, $code): void {
+    $setStatic('locale', $code);
+    $setStatic('translations', []);
+    $setStatic('translationsLoaded', false);
+};
+
+try {
+    $reload();
+    $checks['override wins on a shared key'] = I18n::translate('ovl_shared') === 'OVERRIDE shared';
+    $checks['base-only key comes from the base'] = I18n::translate('ovl_base_only') === 'BASE only';
+    $checks['override-only key is applied'] = I18n::translate('ovl_override_only') === 'OVERRIDE only';
+
+    // Remove the override: the base is untouched (it never held the edit), so the
+    // app falls back to the shipped value — this is exactly the state a re-seed
+    // leaves, proving the edit lived in the override, not the reseeded base.
+    unlink($overrideFile);
+    $reload();
+    $checks['without override, base value shows'] = I18n::translate('ovl_shared') === 'BASE shared';
+    $checks['without override, override-only key is gone'] = I18n::translate('ovl_override_only') === 'ovl_override_only';
+} finally {
+    @unlink($baseFile);
+    @unlink($overrideFile);
+    if (!$overrideDirPreexisted && is_dir($overrideDir)) {
+        @rmdir($overrideDir);
+    }
+    // Reset I18n so the throwaway locale never leaks into other tests.
+    $setStatic('locale', 'it_IT');
+    $setStatic('translations', []);
+    $setStatic('translationsLoaded', false);
+}
+
+// --- source-level invariants of the editor ---
+$i18nSrc = (string) file_get_contents($root . '/app/Support/I18n.php');
+$checks['loader reads the overrides/ subdirectory'] =
+    str_contains($i18nSrc, "'overrides/' . \$locale") && str_contains($i18nSrc, 'array_merge($translations');
+
+$lcSrc = (string) file_get_contents($root . '/app/Controllers/Admin/LanguagesController.php');
+$checks['getOverrideFilePath helper exists'] = str_contains($lcSrc, 'function getOverrideFilePath');
+$checks['editor writes to the override path, not the base'] =
+    str_contains($lcSrc, '$targetPath = $this->getOverrideFilePath($code);');
+$checks['delete removes base AND override'] =
+    str_contains($lcSrc, '$this->getLocaleFilePath($code), $this->getOverrideFilePath($code)');
+$checks['download serves the effective (merged) translations'] =
+    str_contains($lcSrc, '$translations = $this->getEffectiveTranslations($code);');
+
+// --- report ---
+$failed = 0;
+foreach ($checks as $label => $ok) {
+    echo ($ok ? '[PASS] ' : '[FAIL] ') . $label . "\n";
+    if (!$ok) {
+        $failed++;
+    }
+}
+echo $failed === 0 ? "\nOK\n" : "\n{$failed} FAILED\n";
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
## What

Review walkthrough **@48 (Option B)**: the Docker image re-seeds `locale/*.json` on every boot, so an in-app edit of a shipped translation (written straight to `locale/{code}.json`) was **silently reverted on restart**. This adds a non-reseeded **override layer** so those edits persist while shipped-translation updates still reach existing installs.

## How

- **`I18n::loadTranslations()`** now loads the shipped base `locale/{code}.json` and then merges `locale/overrides/{code}.json` on top (override wins). Keys shipped only in a later base image still appear (they're absent from the override). No override → byte-for-byte the old behaviour.
- **`LanguagesController`**:
  - the in-app editor writes the edit to `getOverrideFilePath()` (`locale/overrides/{code}.json`), with the path-traversal guard retargeted at that subdir;
  - **download** serves the *effective* (base+override) set, so a re-download reflects what the app shows and a re-upload never drops prior overrides;
  - **delete** removes both base and override so a re-added code doesn't resurrect a stale override.
  - the canonical key list (`loadCanonicalTranslations`, `it_IT`) stays the shipped base.

Pairs with pinakes-docker `feat/locale-override-dir` (ensures `locale/overrides/` exists; README updated).

## Tests

- `tests/locale-override-layer.unit.php` drives the **real** `I18n` loader against sandbox base+override files (override wins; base-only key from base; override-only key applied; removing the override falls back to the shipped base) plus source invariants of the editor write/delete/download.
- `discussion-238-followup` export assertion updated to the equivalent new shape.
- PHPStan level 5 clean (full tree); full unit suite green; locale parity unchanged (6765 keys).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunto un livello di override per personalizzare le traduzioni senza modificare i file di base.
  * Le traduzioni personalizzate prevalgono automaticamente sui valori predefiniti.
  * Il download esporta le traduzioni effettivamente applicate, incluse le chiavi aggiuntive.

* **Correzioni**
  * Migliorata la gestione delle traduzioni mancanti e dei file non validi.
  * L’eliminazione di una lingua rimuove anche le personalizzazioni associate, conservando backup separati.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->