### PR TITLE
fix(ci): correct changelog-extraction awk regex in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
           # shellcheck disable=SC2153
           version=${RELEASE_TAG#v}
           section=$(awk -v version="$version" \
-            '$0 ~ "^## \\[" version "\\]" {flag=1; next} /^## \\[/ {flag=0} flag' \
+            '$0 ~ "^## \\[" version "\\]" {flag=1; next} /^## \[/ {flag=0} flag' \
             CHANGELOG.md)
           if [ -z "$(printf '%s' "$section" | tr -d '[:space:]')" ]; then
             section="See CHANGELOG.md for details."


### PR DESCRIPTION
The release workflow's "Extract version changelog" step used a literal regex with a double backslash before the bracket, which gawk rejects as an unterminated regexp. Prerelease tags never reached this step (they stop at the source-policy gate), so the stable v0.7.59 tag was the first to hit it — the release built, verified and attested but then failed to publish. The single-backslash form parses on both gawk and BSD awk and correctly bounds the changelog section (verified locally: 30 lines extracted for 0.7.59).

Needed to unblock the stable 0.7.59 release, which will be re-tagged once this lands on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Manutenzione**
  * Aggiornato il processo di rilascio automatico per mantenere invariata l’estrazione delle informazioni di versione dal changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->