### PR TITLE
fix(books): make the book-editor availability field read-only (#351)

### DIFF
--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -1003,7 +1003,7 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
       \App\Support\Hooks::do('book.form.fields', [$bookData, $bookId]);
       ?>
 
-      <div class="flex flex-col sm:flex-row gap-4 justify-end">
+      <div id="bookFormActions" class="flex flex-col sm:flex-row gap-4 justify-end">
         <button type="button" id="btnCancel" class="btn-secondary order-2 sm:order-1">
           <i class="fas fa-times mr-2"></i>
           <?= __("Annulla") ?>
@@ -1016,6 +1016,34 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
     </form>
   </div>
 </div>
+<!--
+  The global "scroll to top" button is position:fixed in the bottom-right
+  corner; the form's Save/Cancel row is right-aligned at the end of the page.
+  Scrolled all the way down to save, the floating button lands on top of the
+  Save button. While the action row is in view (i.e. you're already at the
+  bottom), hide the floating button. The rule is !important so it overrides the
+  inline opacity the scroll-to-top partial sets on scroll; scoped to this page
+  via the body class, so no other page is affected. Degrades to the old
+  behaviour where IntersectionObserver is unavailable.
+-->
+<style>
+  body.book-actions-visible #scroll-to-top {
+    opacity: 0 !important;
+    pointer-events: none !important;
+  }
+</style>
+<script>
+(function() {
+  var actions = document.getElementById('bookFormActions');
+  if (!actions || typeof IntersectionObserver === 'undefined') {
+    return;
+  }
+  var observer = new IntersectionObserver(function(entries) {
+    document.body.classList.toggle('book-actions-visible', entries[0].isIntersecting);
+  }, { rootMargin: '0px 0px -8px 0px' });
+  observer.observe(actions);
+})();
+</script>
 <!-- CSS and JavaScript Libraries - partial-specific assets only (vendor.css/vendor.bundle.js loaded by layout) -->
 <link rel="stylesheet" href="<?= htmlspecialchars(assetUrl('star-rating/dist/star-rating.min.css'), ENT_QUOTES, 'UTF-8') ?>">
 <script src="<?= htmlspecialchars(assetUrl('star-rating/dist/star-rating.min.js'), ENT_QUOTES, 'UTF-8') ?>"></script>

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -314,7 +314,7 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
           <div>
             <label for="stato" class="form-label"><?= __("Disponibilità") ?></label>
             <?php $statoCorrente = strtolower((string) ($book['stato'] ?? '')); ?>
-            <select id="stato" name="stato" class="form-input">
+            <select id="stato" name="stato" class="form-input" disabled aria-readonly="true">
               <option value="disponibile" <?php echo $statoCorrente === 'disponibile' ? 'selected' : ''; ?>><?= __("Disponibile") ?></option>
               <option value="non_disponibile" <?php echo $statoCorrente === 'non_disponibile' ? 'selected' : ''; ?>><?= __("Non Disponibile") ?></option>
               <option value="prestato" <?php echo $statoCorrente === 'prestato' ? 'selected' : ''; ?>><?= __("Prestato") ?></option>

--- a/tests/book-create-edit-351.spec.js
+++ b/tests/book-create-edit-351.spec.js
@@ -1,0 +1,171 @@
+// Behavioral E2E: create a book, edit it, and verify the fix for issue #351
+// (the "Availability" / #stato select in the book editor is read-only because
+// availability is derived from physical copies, not user input).
+//
+// Form under test: app/Views/libri/partials/book_form.php
+//   - create: GET /admin/books/create → POST (LibriController::store)
+//   - edit:   GET /admin/books/edit/<id> → POST (LibriController::update)
+//   - #stato is rendered with `disabled aria-readonly="true"` and update()
+//     unsets $fields['stato'] server-side.
+//
+// Requires an installed Pinakes instance and admin login. Skips when env is
+// incomplete to avoid silent failures.
+
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8082';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS  = process.env.E2E_ADMIN_PASS  || '';
+const DB_HOST = process.env.E2E_DB_HOST   || 'localhost';
+const DB_USER = process.env.E2E_DB_USER   || '';
+const DB_PASS = process.env.E2E_DB_PASS   || '';
+const DB_NAME = process.env.E2E_DB_NAME   || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const CREATE_BOOK_URL = `${BASE}/admin/books/create`;
+
+const TAG = Date.now();
+const CREATE_TITLE = `E2E CreateEdit351 ${TAG}`;
+const EDITED_SUBTITLE = `E2E Edited Subtitle 351 ${TAG}`;
+
+test.skip(
+  !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME,
+  'book-create-edit-351 requires E2E_ADMIN_EMAIL/PASS + DB_USER/NAME',
+);
+
+function dbQuery(sql) {
+  const args = ['-N', '-B', '-e', sql];
+  if (DB_HOST) args.push('-h', DB_HOST);
+  if (DB_SOCKET) args.push('-S', DB_SOCKET);
+  args.push('-u', DB_USER);
+  if (DB_PASS !== '') args.push(`-p${DB_PASS}`);
+  args.push(DB_NAME);
+  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 }).trim();
+}
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/admin`);
+  if (page.url().includes('admin') && !page.url().match(/login|accedi|anmelden/)) return;
+  for (const slug of ['accedi', 'login', 'anmelden']) {
+    const resp = await page.goto(`${BASE}/${slug}`).catch(() => null);
+    if (resp && resp.status() === 200 && (await page.locator('input[name="email"]').count()) > 0) break;
+  }
+  await page.fill('input[name="email"]', ADMIN_EMAIL);
+  await page.fill('input[name="password"]', ADMIN_PASS);
+  await Promise.all([
+    page.waitForURL(/admin/, { timeout: 15000 }),
+    page.locator('button[type="submit"]').click(),
+  ]);
+}
+
+// Submits #bookForm and clicks through the SweetAlert confirm if one appears
+// (duplicate-check / info dialogs use SweetAlert2, not native dialogs).
+async function submitBookForm(page) {
+  await page.locator('#bookForm button[type="submit"]').click();
+  const swalConfirm = page.locator('.swal2-confirm');
+  if (await swalConfirm.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await swalConfirm.click();
+  }
+}
+
+test.describe.serial('book create + edit — #351 read-only availability', () => {
+  let context;
+  let page;
+  let bookId = 0;
+  let statoBeforeEdit = '';
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext();
+    page = await context.newPage();
+    await loginAsAdmin(page);
+  });
+
+  test.afterAll(async () => {
+    if (bookId > 0) {
+      // FK-safe order: copies first, then the book. Hard delete — this is
+      // isolated test data tagged with a timestamp.
+      try { dbQuery(`DELETE FROM copie WHERE libro_id = ${bookId}`); } catch (_) { /* test cleanup */ }
+      try { dbQuery(`DELETE FROM libri WHERE id = ${bookId}`); } catch (_) { /* test cleanup */ }
+    }
+    await context?.close();
+  });
+
+  test('1. Create a book with minimal required fields and verify it in the DB', async () => {
+    test.setTimeout(60000);
+    await page.goto(CREATE_BOOK_URL);
+    await expect(page.locator('#bookForm')).toBeVisible({ timeout: 10000 });
+
+    // titolo is the only field store() enforces; anno/lingua keep the record realistic.
+    await page.fill('#titolo', CREATE_TITLE);
+    await page.fill('#anno_pubblicazione', '2024');
+    await page.fill('#lingua', 'Italiano');
+
+    await submitBookForm(page);
+
+    await expect.poll(
+      () => dbQuery(`SELECT COUNT(*) FROM libri WHERE titolo = '${CREATE_TITLE}' AND deleted_at IS NULL`),
+      { timeout: 30000 },
+    ).toBe('1');
+    await page.waitForURL(/\/admin\/books(?:\/\d+)?(?:\?.*)?$/, { timeout: 30000 });
+
+    const row = dbQuery(`SELECT id, titolo FROM libri WHERE titolo = '${CREATE_TITLE}' AND deleted_at IS NULL`);
+    expect(row, 'created book must exist exactly once in DB').toContain(CREATE_TITLE);
+    bookId = parseInt(row.split('\t')[0], 10);
+    expect(bookId).toBeGreaterThan(0);
+
+    // Baseline for test 5: the availability value the disabled field must not alter.
+    statoBeforeEdit = dbQuery(`SELECT stato FROM libri WHERE id = ${bookId}`);
+    expect(statoBeforeEdit.length).toBeGreaterThan(0);
+  });
+
+  test('2. Editor loads the created book with its fields populated', async () => {
+    test.skip(bookId === 0, 'requires test 1 to have created a book');
+    await page.goto(`${BASE}/admin/books/edit/${bookId}`);
+    await expect(page.locator('#bookForm')).toBeVisible({ timeout: 10000 });
+
+    const dataMode = await page.locator('#bookForm').getAttribute('data-mode');
+    expect(['edit', 'modifica']).toContain(String(dataMode || '').toLowerCase());
+    await expect(page.locator('#titolo')).toHaveValue(CREATE_TITLE);
+    await expect(page.locator('#anno_pubblicazione')).toHaveValue('2024');
+  });
+
+  test('3. #351 — Availability (#stato) select is disabled (read-only)', async () => {
+    test.skip(bookId === 0, 'requires test 1 to have created a book');
+    await page.goto(`${BASE}/admin/books/edit/${bookId}`);
+    await expect(page.locator('#bookForm')).toBeVisible({ timeout: 10000 });
+
+    const stato = page.locator('#stato');
+    await expect(stato).toHaveCount(1);
+    await expect(stato).toBeDisabled();
+    await expect(stato).toHaveAttribute('aria-readonly', 'true');
+
+    // It must also be disabled on the create form — availability is derived
+    // from copies in both modes.
+    await page.goto(CREATE_BOOK_URL);
+    await expect(page.locator('#bookForm')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('#stato')).toBeDisabled();
+  });
+
+  test('4. Editing the subtitle persists to the DB', async () => {
+    test.skip(bookId === 0, 'requires test 1 to have created a book');
+    test.setTimeout(60000);
+    await page.goto(`${BASE}/admin/books/edit/${bookId}`);
+    await expect(page.locator('#bookForm')).toBeVisible({ timeout: 10000 });
+
+    await page.fill('#sottotitolo', EDITED_SUBTITLE);
+    await submitBookForm(page);
+
+    await expect.poll(
+      () => dbQuery(`SELECT sottotitolo FROM libri WHERE id = ${bookId}`),
+      { timeout: 30000 },
+    ).toBe(EDITED_SUBTITLE);
+    // Title untouched by the edit.
+    expect(dbQuery(`SELECT titolo FROM libri WHERE id = ${bookId}`)).toBe(CREATE_TITLE);
+  });
+
+  test('5. #351 — the disabled availability field did not alter libri.stato', async () => {
+    test.skip(bookId === 0 || statoBeforeEdit === '', 'requires tests 1 and 4');
+    const statoAfterEdit = dbQuery(`SELECT stato FROM libri WHERE id = ${bookId}`);
+    expect(statoAfterEdit, 'stato must be unchanged after an edit-save with the disabled select').toBe(statoBeforeEdit);
+  });
+});

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -2842,7 +2842,12 @@ test.describe.serial('Phase 18: Issue Regressions', () => {
     await page.waitForLoadState('domcontentloaded');
 
     const statoField = page.locator('#stato, select[name="stato"]');
-    if (await statoField.isVisible({ timeout: 2000 }).catch(() => false)) {
+    // #stato (availability) is a derived value and read-only by design (#351):
+    // the <select> is disabled. Only edit it when it is actually editable —
+    // selectOption()/fill() on a disabled control waits for actionability until
+    // the test times out (which closes the page and cascades in this serial file).
+    if (await statoField.isVisible({ timeout: 2000 }).catch(() => false)
+        && await statoField.isEditable().catch(() => false)) {
       // Select a value
       if (await statoField.evaluate(el => el.tagName === 'SELECT')) {
         const options = await statoField.locator('option').count();

--- a/tests/ncip-server.spec.js
+++ b/tests/ncip-server.spec.js
@@ -247,17 +247,41 @@ test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (20 tests)', () => {
     let testUserId = 0;
     /** @type {number} */
     let createdLoanId = 0;
+    /** Dedicated book created in beforeAll (0 if we fell back to a shared book) */
+    let dedicatedBookId = 0;
     /** Track specific prestiti IDs created during these tests for targeted cleanup */
     let createdPrestitiIds = /** @type {number[]} */ ([]);
 
     test.beforeAll(async ({ browser }) => {
         await ensureNcipPlugin(browser);
 
-        // Find a book with available copies.
-        const bookRow = dbQuery(
-            "SELECT id FROM libri WHERE deleted_at IS NULL AND copie_disponibili > 0 ORDER BY id LIMIT 1"
-        );
-        testBookId = parseInt(bookRow) || 0;
+        // Create a DEDICATED book with a real available copy row. A book with
+        // copie_disponibili > 0 at the aggregate level may have no individual
+        // `copie` row, and NCIP CheckOut needs a real available copy — otherwise
+        // it returns "No copies available" and test 9 fails nondeterministically
+        // depending on which shared book happens to sort first.
+        const runId = `${Date.now().toString(36)}${Math.floor(process.hrtime()[1] % 1e6)}`;
+        try {
+            dbQuery(
+                "INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) " +
+                `VALUES ('NCIP Test Book ${runId}', 1, 1, NOW(), NOW())`
+            );
+            testBookId = parseInt(dbQuery(
+                `SELECT id FROM libri WHERE titolo = 'NCIP Test Book ${runId}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`
+            )) || 0;
+            if (testBookId > 0) {
+                dedicatedBookId = testBookId;
+                dbQuery(
+                    "INSERT INTO copie (libro_id, numero_inventario, stato, created_at) " +
+                    `VALUES (${testBookId}, 'NCIP-${runId}', 'disponibile', NOW())`
+                );
+            }
+        } catch {
+            // Fall back to any book with aggregate availability (older behaviour).
+            testBookId = parseInt(dbQuery(
+                "SELECT id FROM libri WHERE deleted_at IS NULL AND copie_disponibili > 0 ORDER BY id LIMIT 1"
+            )) || 0;
+        }
 
         // Find any non-admin user; fall back to any user if none found.
         const userRow = dbQuery(
@@ -504,6 +528,19 @@ test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (20 tests)', () => {
                 // FK-safe: child table first (ncip_transactions → prestiti), then parent
                 dbQuery(`DELETE FROM ncip_transactions WHERE prestito_id IN (${idList})`);
                 dbQuery(`DELETE FROM prestiti WHERE id IN (${idList})`);
+            } catch { /* best-effort */ }
+        }
+        // Remove the dedicated book + its copy. Delete EVERY prestito on its
+        // copies first (not only the tracked ids — RequestItem/CheckOut may
+        // leave an untracked loan), FK-safe: ncip_transactions → prestiti →
+        // copie → libri.
+        if (dedicatedBookId > 0) {
+            try {
+                const copiaSub = `SELECT id FROM copie WHERE libro_id = ${dedicatedBookId}`;
+                dbQuery(`DELETE FROM ncip_transactions WHERE prestito_id IN (SELECT id FROM prestiti WHERE copia_id IN (${copiaSub}))`);
+                dbQuery(`DELETE FROM prestiti WHERE copia_id IN (${copiaSub})`);
+                dbQuery(`DELETE FROM copie WHERE libro_id = ${dedicatedBookId}`);
+                dbQuery(`DELETE FROM libri WHERE id = ${dedicatedBookId}`);
             } catch { /* best-effort */ }
         }
     });


### PR DESCRIPTION
Two small fixes to the book editor.

## 1. Availability field is read-only (closes #351)

The "Disponibilità" (Availability) select was editable but had no effect: `LibriController::update()` already discards the `stato` field on save, because a book's availability is a **derived summary** recomputed from the physical copies (`DataIntegrity::recalculateBookAvailability()`). Editing it did nothing — the value reverted on the next recalculation.

`#stato` is now `disabled aria-readonly="true"`, matching the already-disabled genre selects in the same form. To make a copy unavailable (damaged, lost, in maintenance), edit that copy's status under `/admin/books/<id>` — the correct per-copy granularity.

## 2. Scroll-to-top button no longer covers Save

The global scroll-to-top button is fixed in the bottom-right corner; the Save/Cancel row is right-aligned at the end of the page, so scrolling down to save put the floating button on top of Save. The action row now carries an id observed by an `IntersectionObserver`; while it is in view, a body class hides the floating button via a scoped `!important` rule (overriding the inline opacity the scroll-to-top partial sets on scroll). No other page is affected; degrades gracefully without `IntersectionObserver`.

## Tests

`tests/book-create-edit-351.spec.js` (E2E, 5 checks, green locally): create a book (DB-verified), the editor loads it, `#stato` is `disabled`, an edited subtitle persists, and the disabled availability field cannot alter `libri.stato`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * Il campo “Stato” nei moduli di creazione e modifica dei libri è ora disabilitato e in sola lettura.
  * Il pulsante globale “Torna su” viene nascosto e disabilitato quando sono visibili le azioni del modulo.
  * Il comportamento precedente viene mantenuto nei browser che non supportano questa funzionalità.

* **Test**
  * Aggiunti controlli automatici per verificare il campo “Stato” e la persistenza dei dati durante la creazione e modifica dei libri.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->