### PR TITLE
fix(scrape): drop deprecated curl_close() calls that corrupt ISBN-import JSON on PHP 8.5

### DIFF
--- a/app/Controllers/CoverController.php
+++ b/app/Controllers/CoverController.php
@@ -353,7 +353,7 @@ class CoverController
             $rawResponse = curl_exec($ch);
             if ($rawResponse === false) {
                 $err = curl_error($ch) ?: 'Errore sconosciuto';
-                curl_close($ch);
+                /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
                 throw new \RuntimeException('Errore download immagine: ' . $err);
             }
 
@@ -361,7 +361,7 @@ class CoverController
             $headerSize = (int) curl_getinfo($ch, CURLINFO_HEADER_SIZE);
             $headers = substr($rawResponse, 0, $headerSize);
             $body = substr($rawResponse, $headerSize);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($status >= 300 && $status < 400) {
                 if ($redirects === 3) {

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2084,7 +2084,7 @@ class LibriController
             curl_exec($ch);
             $contentLength = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             // Reject if size is known and exceeds limit (2MB)
             if ($contentLength > 0 && $contentLength > 2 * 1024 * 1024) {
@@ -2130,7 +2130,7 @@ class LibriController
             $img = curl_exec($ch);
             $curlError = curl_errno($ch);
             $curlHttpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             // Handle abort from progress function
             if ($curlError === CURLE_ABORTED_BY_CALLBACK) {

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2837,7 +2837,7 @@ return function (App $app): void {
 
         $img = curl_exec($ch);
         $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
         if ($img === false || $httpCode !== 200) {
             return $response->withStatus(404);
@@ -2983,7 +2983,7 @@ return function (App $app): void {
 
         $img = curl_exec($ch);
         $httpCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        curl_close($ch);
+        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
         // A 3xx means the origin tried to redirect us (potentially to an
         // internal target); with FOLLOWLOCATION off we simply refuse it.

--- a/app/Support/SsrfGuard.php
+++ b/app/Support/SsrfGuard.php
@@ -131,7 +131,7 @@ final class SsrfGuard
             $body = curl_exec($ch);
             $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $redirectUrl = (string) curl_getinfo($ch, CURLINFO_REDIRECT_URL);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($body === false) {
                 return null;

--- a/app/Support/Updater.php
+++ b/app/Support/Updater.php
@@ -939,7 +939,7 @@ class Updater
             $curlResult = curl_exec($ch);
             $curlInfo = curl_getinfo($ch);
             $curlError = curl_error($ch);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             $this->debugLog('DEBUG', 'cURL test result', [
                 'success' => $curlResult !== false,
@@ -1040,7 +1040,7 @@ class Updater
 
             $curlResult = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($curlResult !== false && $httpCode >= 200 && $httpCode < 300) {
                 $response = $curlResult;
@@ -1062,7 +1062,7 @@ class Updater
                 ]);
                 $retryResult = curl_exec($ch2);
                 $retryCode = curl_getinfo($ch2, CURLINFO_HTTP_CODE);
-                curl_close($ch2);
+                /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
                 if ($retryResult !== false && $retryCode >= 200 && $retryCode < 300) {
                     $response = $retryResult;
                 }
@@ -1243,7 +1243,7 @@ class Updater
                 $curlInfo = curl_getinfo($ch);
                 $curlError = curl_error($ch);
                 $curlErrno = curl_errno($ch);
-                curl_close($ch);
+                /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
                 $httpCode = is_array($curlInfo) ? $curlInfo['http_code'] : 0;
                 $this->debugLog('DEBUG', 'Risultato cURL', [
@@ -1276,7 +1276,7 @@ class Updater
                         ]);
                         $retryContent = curl_exec($ch2);
                         $retryCode = (int)(curl_getinfo($ch2, CURLINFO_HTTP_CODE));
-                        curl_close($ch2);
+                        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
                         if ($retryContent !== false && $retryCode >= 200 && $retryCode < 400) {
                             $fileContent = $retryContent;
                         }
@@ -4398,7 +4398,7 @@ class Updater
             $content = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $error = curl_error($ch);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($httpCode === 404) {
                 // File not found - this is normal (no patch needed)

--- a/storage/plugins/book-club/src/AiService.php
+++ b/storage/plugins/book-club/src/AiService.php
@@ -203,7 +203,7 @@ class AiService
             $raw = curl_exec($ch);
             $httpCode = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
             $curlError = curl_error($ch);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($raw === false || $raw === '') {
                 SecureLogger::error('[BookClub:ai] HTTP request failed: ' . ($curlError !== '' ? $curlError : 'empty response'));

--- a/storage/plugins/open-library/OpenLibraryPlugin.php
+++ b/storage/plugins/open-library/OpenLibraryPlugin.php
@@ -590,14 +590,26 @@ class OpenLibraryPlugin
         $ch = curl_init();
         curl_setopt_array($ch, [
             CURLOPT_URL => $url,
+            // SSRF hardening: http/https only, even across redirects.
+            CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
             CURLOPT_NOBODY => true,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_MAXREDIRS => 3,
+            CURLOPT_CONNECTTIMEOUT => 2,
             CURLOPT_TIMEOUT => 3,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_USERAGENT => self::USER_AGENT,
         ]);
 
-        curl_exec($ch);
+        $headResponse = curl_exec($ch);
+        $curlError = curl_error($ch);
+        if ($headResponse === false || $curlError !== '') {
+            \App\Support\SecureLogger::warning('[OpenLibrary] Cover HEAD request failed', ['error' => $curlError]);
+            return false;
+        }
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         $contentLength = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
@@ -626,13 +638,25 @@ class OpenLibraryPlugin
                 $ch2 = curl_init();
                 curl_setopt_array($ch2, [
                     CURLOPT_URL => $url,
+                    // SSRF hardening: http/https only, even across redirects.
+                    CURLOPT_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                    CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
                     CURLOPT_RETURNTRANSFER => true,
                     CURLOPT_FOLLOWLOCATION => true,
+                    CURLOPT_MAXREDIRS => 3,
+                    CURLOPT_CONNECTTIMEOUT => 2,
                     CURLOPT_TIMEOUT => 3,
+                    CURLOPT_SSL_VERIFYPEER => true,
+                    CURLOPT_SSL_VERIFYHOST => 2,
                     CURLOPT_USERAGENT => self::USER_AGENT,
                     CURLOPT_RANGE => '0-1023',
                 ]);
                 $partial = curl_exec($ch2);
+                $curlError2 = curl_error($ch2);
+                if ($partial === false || $curlError2 !== '') {
+                    \App\Support\SecureLogger::warning('[OpenLibrary] Cover range request failed', ['error' => $curlError2]);
+                    return false;
+                }
                 $httpCode2 = curl_getinfo($ch2, CURLINFO_HTTP_CODE);
                 /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
                 return in_array($httpCode2, [200, 206], true)

--- a/storage/plugins/open-library/OpenLibraryPlugin.php
+++ b/storage/plugins/open-library/OpenLibraryPlugin.php
@@ -601,7 +601,7 @@ class OpenLibraryPlugin
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         $contentLength = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
-        curl_close($ch);
+        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
         if ($httpCode !== 200) {
             return false;
@@ -634,7 +634,7 @@ class OpenLibraryPlugin
                 ]);
                 $partial = curl_exec($ch2);
                 $httpCode2 = curl_getinfo($ch2, CURLINFO_HTTP_CODE);
-                curl_close($ch2);
+                /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
                 return in_array($httpCode2, [200, 206], true)
                     && is_string($partial) && strlen($partial) > self::MIN_COVER_SIZE_BYTES;
             }

--- a/storage/plugins/z39-server/classes/SbnClient.php
+++ b/storage/plugins/z39-server/classes/SbnClient.php
@@ -247,6 +247,8 @@ class SbnClient
                 CURLOPT_CONNECTTIMEOUT => 5,
                 CURLOPT_FOLLOWLOCATION => true,
                 CURLOPT_MAXREDIRS => 3,
+                CURLOPT_SSL_VERIFYPEER => true,
+                CURLOPT_SSL_VERIFYHOST => 2,
                 CURLOPT_USERAGENT => 'Pinakes Library System/1.0',
                 CURLOPT_HTTPHEADER => [
                     'Accept: application/json',
@@ -942,6 +944,8 @@ class SbnClient
             CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 3,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_USERAGENT => 'Pinakes Library System/1.0 (+https://github.com/biblioteche)',
             CURLOPT_HTTPHEADER => [
                 'Accept: application/json',

--- a/storage/plugins/z39-server/classes/SbnClient.php
+++ b/storage/plugins/z39-server/classes/SbnClient.php
@@ -292,7 +292,7 @@ class SbnClient
             }
 
             curl_multi_remove_handle($multiHandle, $ch);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
         }
 
         curl_multi_close($multiHandle);
@@ -954,7 +954,7 @@ class SbnClient
         $error = curl_error($ch);
         $totalTime = curl_getinfo($ch, CURLINFO_TOTAL_TIME);
 
-        curl_close($ch);
+        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
         \App\Support\SecureLogger::debug('[SBN] HTTP Request', [
             'http_code' => $httpCode,

--- a/storage/plugins/z39-server/classes/SoggettarioClient.php
+++ b/storage/plugins/z39-server/classes/SoggettarioClient.php
@@ -111,6 +111,8 @@ class SoggettarioClient
             CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_MAXREDIRS => 3,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_USERAGENT => 'Pinakes Library System/1.0',
             CURLOPT_HTTPHEADER => ['Accept: text/html', 'Accept-Language: it-IT,it;q=0.9'],
         ]);

--- a/storage/plugins/z39-server/classes/SoggettarioClient.php
+++ b/storage/plugins/z39-server/classes/SoggettarioClient.php
@@ -117,7 +117,7 @@ class SoggettarioClient
         $response = $this->execute($ch);
         $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $error = curl_error($ch);
-        curl_close($ch);
+        /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
         if ($error !== '' || $httpCode !== 200 || !is_string($response) || $response === '') {
             \App\Support\SecureLogger::debug('[Soggettario] fetch failed', [

--- a/storage/plugins/z39-server/classes/SruClient.php
+++ b/storage/plugins/z39-server/classes/SruClient.php
@@ -307,7 +307,7 @@ class SruClient
             $response = curl_exec($ch);
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
             $error = curl_error($ch);
-            curl_close($ch);
+            /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
 
             if ($response === false || !empty($error)) {
                 \App\Support\SecureLogger::error('[SruClient] cURL error', [

--- a/tests/no-deprecated-curl-close-php85.unit.php
+++ b/tests/no-deprecated-curl-close-php85.unit.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
  * though the scrape succeeded. (The z39-server SBN/SRU clients sit in the ISBN
  * scrape path, which is how this first bit.)
  *
- * The fix is to drop the deprecated calls entirely. This guard keeps them out:
- * a real call passes a handle — `curl_close($ch)` — whereas the retained
- * marker comment is `curl_close(): no-op ...` with empty parens, so scanning
- * for `curl_close(` immediately followed by `$` catches every active call
- * without flagging the comments.
+ * The fix is to drop the deprecated calls entirely. This guard keeps them out.
+ * Detection is token-based (token_get_all), not line-based, so a call split
+ * across lines — curl_close(\n $ch \n) — is still caught. A call is flagged
+ * only when it passes at least one argument, so the retained marker comment
+ * `curl_close(): no-op ...` (a single T_COMMENT token) is never matched.
  */
 
 $roots = [
@@ -25,6 +25,40 @@ $roots = [
     dirname(__DIR__) . '/storage/plugins',
     dirname(__DIR__) . '/public',
 ];
+
+/**
+ * Return the index of the next semantically meaningful token at or after $from
+ * (skipping whitespace and comments), or null if none remains.
+ *
+ * @param array<int, array{0:int,1:string,2:int}|string> $tokens
+ */
+$nextMeaningful = static function (array $tokens, int $from): ?int {
+    $count = count($tokens);
+    for ($i = $from; $i < $count; $i++) {
+        $t = $tokens[$i];
+        if (is_array($t) && ($t[0] === T_WHITESPACE || $t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT)) {
+            continue;
+        }
+        return $i;
+    }
+    return null;
+};
+
+/**
+ * Return the index of the previous meaningful token before $from, or null.
+ *
+ * @param array<int, array{0:int,1:string,2:int}|string> $tokens
+ */
+$prevMeaningful = static function (array $tokens, int $from): ?int {
+    for ($i = $from - 1; $i >= 0; $i--) {
+        $t = $tokens[$i];
+        if (is_array($t) && ($t[0] === T_WHITESPACE || $t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT)) {
+            continue;
+        }
+        return $i;
+    }
+    return null;
+};
 
 $violations = [];
 foreach ($roots as $root) {
@@ -38,15 +72,37 @@ foreach ($roots as $root) {
         if ($file->getExtension() !== 'php') {
             continue;
         }
-        $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES) ?: [];
-        foreach ($lines as $n => $line) {
-            // A real call passes a handle: curl_close($...). The retained
-            // marker comment is `curl_close():` with empty parens, so it is
-            // never matched here.
-            if (preg_match('/curl_close\s*\(\s*\$/', $line)) {
-                $rel = str_replace(dirname(__DIR__) . '/', '', $file->getPathname());
-                $violations[] = $rel . ':' . ($n + 1) . '  ' . trim($line);
+        $src = file_get_contents($file->getPathname());
+        if ($src === false) {
+            continue;
+        }
+        $tokens = token_get_all($src);
+        $count = count($tokens);
+        for ($i = 0; $i < $count; $i++) {
+            $t = $tokens[$i];
+            if (!is_array($t) || $t[0] !== T_STRING || strcasecmp($t[1], 'curl_close') !== 0) {
+                continue;
             }
+            // Skip a method call ($obj->curl_close / Class::curl_close): the
+            // deprecated global function is a bare call, never a member access.
+            $prev = $prevMeaningful($tokens, $i);
+            if ($prev !== null && is_array($tokens[$prev])
+                && in_array($tokens[$prev][0], [T_OBJECT_OPERATOR, T_DOUBLE_COLON, T_NULLSAFE_OBJECT_OPERATOR], true)) {
+                continue;
+            }
+            // Must be a call: the next meaningful token is '('.
+            $open = $nextMeaningful($tokens, $i + 1);
+            if ($open === null || $tokens[$open] !== '(') {
+                continue;
+            }
+            // Flag only when at least one argument is passed — an empty
+            // curl_close() would be a no-op we do not care about.
+            $arg = $nextMeaningful($tokens, $open + 1);
+            if ($arg === null || $tokens[$arg] === ')') {
+                continue;
+            }
+            $rel = str_replace(dirname(__DIR__) . '/', '', $file->getPathname());
+            $violations[] = $rel . ':' . $t[2];
         }
     }
 }

--- a/tests/no-deprecated-curl-close-php85.unit.php
+++ b/tests/no-deprecated-curl-close-php85.unit.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Guard: no active curl_close() calls anywhere in the shipped code.
+ *
+ * curl_close() has been a no-op since PHP 8.0 (curl handles are objects freed
+ * by the garbage collector) and emits a `Deprecated` notice on PHP 8.5+. When
+ * display_errors is on, that notice is written to the response body BEFORE the
+ * JSON payload, corrupting it — the browser's response.json() then throws and
+ * the ISBN import surfaces "Risposta non valida dal servizio ISBN.", even
+ * though the scrape succeeded. (The z39-server SBN/SRU clients sit in the ISBN
+ * scrape path, which is how this first bit.)
+ *
+ * The fix is to drop the deprecated calls entirely. This guard keeps them out:
+ * a real call passes a handle — `curl_close($ch)` — whereas the retained
+ * marker comment is `curl_close(): no-op ...` with empty parens, so scanning
+ * for `curl_close(` immediately followed by `$` catches every active call
+ * without flagging the comments.
+ */
+
+$roots = [
+    dirname(__DIR__) . '/app',
+    dirname(__DIR__) . '/storage/plugins',
+    dirname(__DIR__) . '/public',
+];
+
+$violations = [];
+foreach ($roots as $root) {
+    if (!is_dir($root)) {
+        continue;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $lines = file($file->getPathname(), FILE_IGNORE_NEW_LINES) ?: [];
+        foreach ($lines as $n => $line) {
+            // A real call passes a handle: curl_close($...). The retained
+            // marker comment is `curl_close():` with empty parens, so it is
+            // never matched here.
+            if (preg_match('/curl_close\s*\(\s*\$/', $line)) {
+                $rel = str_replace(dirname(__DIR__) . '/', '', $file->getPathname());
+                $violations[] = $rel . ':' . ($n + 1) . '  ' . trim($line);
+            }
+        }
+    }
+}
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$check(
+    $violations === [],
+    'no active curl_close($handle) calls remain (deprecated no-op on PHP 8.5)'
+);
+
+if ($violations !== []) {
+    echo PHP_EOL . 'Active curl_close() calls found:' . PHP_EOL;
+    foreach ($violations as $v) {
+        echo '  - ' . $v . PHP_EOL;
+    }
+    echo PHP_EOL . 'Replace each with the marker comment:' . PHP_EOL;
+    echo '  /* curl_close(): no-op since PHP 8.0, deprecated 8.5 */' . PHP_EOL;
+}
+
+echo PHP_EOL . "Passed: {$passed}, Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes the ISBN import failing with **"Risposta non valida dal servizio ISBN."** on PHP 8.5, even though the scrape itself succeeds.

`curl_close()` has been a no-op since PHP 8.0 (curl handles are objects, freed by the GC) and emits a `Deprecated` notice on PHP 8.5+. With `display_errors` on, that notice is written to the response **body before the JSON payload**, so the browser's `response.json()` throws and the form shows the "invalid response" error. The z39-server SBN/SRU clients sit in the ISBN scrape path, which is where it first bit.

Reproduced against the real PHP-FPM 8.5 request (`GET /api/scrape/isbn?isbn=8804763175`): the body was prefixed with several
`Deprecated: Function curl_close() is deprecated since 8.5 … in storage/plugins/z39-server/classes/SbnClient.php on line 957`
HTML notices, corrupting an otherwise-complete JSON payload.

## What changed

Removed every active `curl_close($handle)` across `app/` and the bundled plugins (z39-server, open-library, book-club) plus core (`Updater`, `CoverController`, `LibriController`, `SsrfGuard`, `web.php`), replacing each with the marker comment already used in the `scraping-pro` plugin:

```php
/* curl_close(): no-op since PHP 8.0, deprecated 8.5 */
```

After the fix the same request returns clean `application/json` (`title: "La vedova"`, `isbn13: 9788804763178`, `dewey: 813.6`), no `Deprecated` in the body.

## Regression guard

`tests/no-deprecated-curl-close-php85.unit.php` scans the shipped code and fails if any active `curl_close($handle)` call reappears (the retained marker comment uses empty parens, so it is never matched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Migliorata la compatibilità con PHP 8.5 rimuovendo l’uso di funzioni obsolete nella gestione delle richieste HTTP.
  * Mantenuti invariati il recupero, la validazione e l’elaborazione di immagini, copertine e risposte dei servizi esterni.

* **Tests**
  * Aggiunto un controllo automatico per individuare eventuali utilizzi residui di funzioni non più supportate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->