### PR TITLE
feat(copies): manage physical copies (add + set status) from the book summary

### DIFF
--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -9,7 +9,6 @@ use App\Controllers\ReservationManager;
 use App\Models\CopyRepository;
 use App\Services\ReservationReassignmentService;
 use App\Support\DataIntegrity;
-use App\Support\RouteTranslator;
 use App\Support\SecureLogger;
 use mysqli;
 
@@ -25,13 +24,16 @@ class CopyController
         // than the previous same-host comparison and port-agnostic.
         return \App\Support\RefererGuard::localPath(
             (string) ($_SERVER['HTTP_REFERER'] ?? ''),
-            $default ?? RouteTranslator::route('admin_books')
+            // Admin routes are fixed English literals — never routed through the
+            // i18n system (CLAUDE.md rule #4 / decision #145).
+            $default ?? '/admin/books'
         );
     }
 
     private function adminBookPath(int $bookId): string
     {
-        return str_replace('{id}', (string) $bookId, RouteTranslator::route('admin_book'));
+        // Fixed admin literal, not an i18n route (CLAUDE.md rule #4).
+        return '/admin/books/' . $bookId;
     }
 
     /**

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -297,10 +297,12 @@ class CopyController
     /**
      * Crea una nuova copia fisica per un libro, direttamente dalla scheda.
      *
-     * Loan states ('prestato'/'prenotato') are never created here — those belong
-     * to the Prestiti system. A lost/damaged/maintenance copy is allowed: the
-     * availability recalculation then excludes it from copie_totali, so marking a
-     * copy lost reduces the book's total on its own.
+     * A copy is never *created* in a loan state here — 'prestato'/'prenotato'
+     * belong to the Prestiti system — but creating an available copy may promote a
+     * waiting reservation, which sets that new copy to 'prenotato' before commit.
+     * A copy created out of circulation ('perso'/'danneggiato'/'manutenzione'/
+     * 'in_restauro'/'in_trasferimento') is excluded from copie_totali by the
+     * availability recalculation, so marking a copy lost reduces the book's total.
      */
     public function createCopy(Request $request, Response $response, mysqli $db, int $bookId): Response
     {
@@ -316,6 +318,15 @@ class CopyController
             return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
         }
         $note = trim((string) ($data['note'] ?? ''));
+        if ($note !== '') {
+            // Consistency with numero_inventario below: drop control characters
+            // (keeping tab/newline for multi-line notes) and cap the length
+            // defensively before persisting.
+            $note = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $note);
+            if (mb_strlen($note) > 500) {
+                $note = mb_substr($note, 0, 500);
+            }
+        }
 
         // Inventory code: honour an explicit value (must be unique), otherwise
         // auto-allocate the next collision-free "{base}-C{N}" like book creation.
@@ -445,9 +456,11 @@ class CopyController
             return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
         }
 
-        // Permetti eliminazione solo per copie perse, danneggiate o in manutenzione
-        if (!in_array($stato, ['perso', 'danneggiato', 'manutenzione'])) {
-            $_SESSION['error_message'] = __('Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.');
+        // Permetti eliminazione solo per copie fuori circolazione (perse, danneggiate,
+        // in manutenzione, in restauro o in trasferimento). Una copia disponibile o
+        // impegnata non si elimina: prima se ne cambia lo stato.
+        if (!in_array($stato, ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
+            $_SESSION['error_message'] = __('Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.');
             return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
         }
 

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -128,7 +128,7 @@ class CopyController
             return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
         }
         $stato = $statoInput;
-        $note = $noteInput;
+        $note = $this->sanitizeNote($noteInput);
 
         // Validazione stato (deve corrispondere all'enum in copie.stato)
         $statiValidi = ['disponibile', 'prestato', 'prenotato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
@@ -340,16 +340,7 @@ class CopyController
             $_SESSION['error_message'] = __('Stato non valido.');
             return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
         }
-        $note = trim($noteInput);
-        if ($note !== '') {
-            // Consistency with numero_inventario below: drop control characters
-            // (keeping tab/newline for multi-line notes) and cap the length
-            // defensively before persisting.
-            $note = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $note);
-            if (mb_strlen($note) > 500) {
-                $note = mb_substr($note, 0, 500);
-            }
-        }
+        $note = $this->sanitizeNote($noteInput);
 
         // Inventory code: honour an explicit value (must be unique), otherwise
         // auto-allocate the next collision-free "{base}-C{N}" like book creation.
@@ -426,7 +417,9 @@ class CopyController
                 throw new \RuntimeException('Unable to recalculate book availability.');
             }
 
-            $db->commit();
+            if (!$db->commit()) {
+                throw new \RuntimeException('Unable to commit physical-copy creation.');
+            }
             $transactionStarted = false;
         } catch (\Throwable $e) {
             if ($transactionStarted) {
@@ -450,6 +443,21 @@ class CopyController
 
         $_SESSION['success_message'] = __('Copia aggiunta con successo.');
         return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
+    }
+
+    /**
+     * Normalize an administrator-entered copy note consistently in create/edit.
+     */
+    private function sanitizeNote(string $note): string
+    {
+        $note = trim($note);
+        if ($note === '') {
+            return '';
+        }
+
+        // Keep tab/newline for multi-line notes, drop other control characters.
+        $note = (string) preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $note);
+        return mb_strlen($note) > 500 ? mb_substr($note, 0, 500) : $note;
     }
 
     /**

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -133,11 +133,11 @@ class CopyController
         $note = $this->sanitizeNote($noteInput);
 
         // Validazione stato (deve corrispondere all'enum in copie.stato)
-        // 'prestato'/'prenotato' are owned by the loan/reservation system and must
-        // never be set directly here. 'prestato' is still listed so the explicit
-        // guard below can emit its dedicated message; 'prenotato' is not settable
-        // at all and is rejected as an invalid state.
-        $statiValidi = ['disponibile', 'prestato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
+        // 'prestato'/'prenotato' are owned by the loan/reservation system. They
+        // remain valid only so an existing loan-owned state can be preserved
+        // while staff update the copy note; transitions into them are rejected
+        // explicitly after loading the current row.
+        $statiValidi = ['disponibile', 'prestato', 'prenotato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
         if (!in_array($stato, $statiValidi, true)) {
             $_SESSION['error_message'] = __('Stato non valido.');
             return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
@@ -158,6 +158,15 @@ class CopyController
 
         $libroId = (int) $copy['libro_id'];
         $statoCorrente = $copy['stato'];
+
+        if ($stato === 'prenotato' && $statoCorrente !== 'prenotato') {
+            $_SESSION['error_message'] = __('Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato "Prenotato".');
+            return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
+        }
+        if ($statoCorrente === 'prenotato' && $stato === 'disponibile') {
+            $_SESSION['error_message'] = __('Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.');
+            return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
+        }
 
         // Prestito "in carico" su questa copia (in_corso/in_ritardo): usato per la
         // chiusura automatica quando la copia torna 'disponibile'.

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -366,16 +366,21 @@ class CopyController
             // control characters must fall back to automatic allocation.
             if ($numero === '') {
                 $base = !empty($book['numero_inventario']) ? (string) $book['numero_inventario'] : "LIB-{$bookId}";
-                $codes = $repo->allocateInventoryCodes($base, 1);
-                $numero = $codes[0] ?? ($base . '-C1');
+                $newCopyId = $repo->createWithAllocatedInventoryCode(
+                    $bookId,
+                    $base,
+                    $stato,
+                    $note !== '' ? $note : null
+                );
             } elseif ($repo->inventoryCodeExists($numero)) {
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Esiste già una copia con questo numero di inventario.');
                 return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+            } else {
+                $newCopyId = $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
             }
 
-            $newCopyId = $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
             if ($newCopyId <= 0) {
                 throw new \RuntimeException('Unable to create the physical copy.');
             }
@@ -431,74 +436,109 @@ class CopyController
     {
         // CSRF validated by CsrfMiddleware
 
-        // Recupera la copia per ottenere il libro_id e verificare lo stato
-        $stmt = $db->prepare("SELECT libro_id, stato FROM copie WHERE id = ?");
+        // Resolve the parent first; the transaction below then follows the
+        // canonical circulation lock order (book -> copy -> loans).
+        $stmt = $db->prepare('SELECT libro_id FROM copie WHERE id = ?');
         $stmt->bind_param('i', $copyId);
         $stmt->execute();
-        $result = $stmt->get_result();
-        $copy = $result->fetch_assoc();
+        $copy = $stmt->get_result()->fetch_assoc();
         $stmt->close();
-
         if (!$copy) {
             $_SESSION['error_message'] = __('Copia non trovata.');
             return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
         }
 
         $libroId = (int) $copy['libro_id'];
-        $stato = $copy['stato'];
-
-        // Verifica se la copia è trattenuta da QUALSIASI impegno HOLDING (prestito
-        // attivo o pendente-con-copia, incluse prenotazioni future e ritiri in attesa).
-        $hasPrestito = $this->isCopyHeld($db, $copyId);
-
-        if ($hasPrestito) {
-            $_SESSION['error_message'] = __('Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.');
-            return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
-        }
-
-        // Permetti eliminazione solo per copie fuori circolazione (perse, danneggiate,
-        // in manutenzione, in restauro o in trasferimento). Una copia disponibile o
-        // impegnata non si elimina: prima se ne cambia lo stato.
-        if (!in_array($stato, ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
-            $_SESSION['error_message'] = __('Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.');
-            return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
-        }
-
-        // Anche i prestiti CHIUSI referenziano copia_id e il FK fk_prestiti_copia
-        // è ON DELETE RESTRICT: senza questo check la DELETE esplode con
-        // mysqli_sql_exception (500). Una copia con storico non si elimina, si
-        // mette fuori circolazione cambiandone lo stato.
-        $stmt = $db->prepare("SELECT 1 FROM prestiti WHERE copia_id = ? LIMIT 1");
-        $stmt->bind_param('i', $copyId);
-        $stmt->execute();
-        $hasHistory = (bool) $stmt->get_result()->fetch_row();
-        $stmt->close();
-
-        if ($hasHistory) {
-            $_SESSION['error_message'] = __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.');
-            return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
-        }
-
-        // Elimina la copia. Difesa in profondità: un prestito creato tra il check
-        // e la DELETE fa comunque scattare il FK — intercetta e degrada a errore
-        // gestito invece di propagare un 500.
+        $transactionStarted = false;
         try {
-            $stmt = $db->prepare("DELETE FROM copie WHERE id = ?");
+            if (!$db->begin_transaction()) {
+                throw new \RuntimeException('Unable to begin copy-delete transaction.');
+            }
+            $transactionStarted = true;
+
+            $lockBook = $db->prepare('SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE');
+            $lockBook->bind_param('i', $libroId);
+            $lockBook->execute();
+            $bookExists = (bool) $lockBook->get_result()->fetch_row();
+            $lockBook->close();
+            if (!$bookExists) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Libro non trovato o non più disponibile.');
+                return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+            }
+
+            // Re-read under lock: state and commitments may have changed since
+            // the initial parent lookup.
+            $stmt = $db->prepare('SELECT stato FROM copie WHERE id = ? AND libro_id = ? FOR UPDATE');
+            $stmt->bind_param('ii', $copyId, $libroId);
+            $stmt->execute();
+            $lockedCopy = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$lockedCopy) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Copia non trovata.');
+                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+            }
+
+            // A copy with any current/future commitment or historical loan is
+            // retained permanently; operators can only move it out of circulation.
+            if ($this->isCopyHeld($db, $copyId)) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.');
+                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+            }
+            if (!in_array($lockedCopy['stato'], ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.');
+                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+            }
+
+            $stmt = $db->prepare('SELECT 1 FROM prestiti WHERE copia_id = ? LIMIT 1 FOR UPDATE');
             $stmt->bind_param('i', $copyId);
             $stmt->execute();
+            $hasHistory = (bool) $stmt->get_result()->fetch_row();
             $stmt->close();
-        } catch (\mysqli_sql_exception $e) {
-            // 1451 = Cannot delete or update a parent row (vincolo FK)
-            if ((int) $e->getCode() !== 1451) {
-                throw $e;
+            if ($hasHistory) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.');
+                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
             }
-            $_SESSION['error_message'] = __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.');
+
+            $stmt = $db->prepare('DELETE FROM copie WHERE id = ?');
+            $stmt->bind_param('i', $copyId);
+            $stmt->execute();
+            $deleted = $stmt->affected_rows;
+            $stmt->close();
+            if ($deleted !== 1) {
+                throw new \RuntimeException('Physical copy delete did not affect exactly one row.');
+            }
+
+            if (!(new DataIntegrity($db))->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                throw new \RuntimeException('Unable to recalculate availability after copy delete.');
+            }
+            if (!$db->commit()) {
+                throw new \RuntimeException('Unable to commit copy-delete transaction.');
+            }
+            $transactionStarted = false;
+        } catch (\Throwable $e) {
+            if ($transactionStarted) {
+                try {
+                    $db->rollback();
+                } catch (\Throwable $rollbackError) {
+                    // best-effort
+                }
+            }
+            SecureLogger::error('[CopyController] deleteCopy failed', ['copy' => $copyId, 'error' => $e->getMessage()]);
+            $_SESSION['error_message'] = (int) $e->getCode() === 1451
+                ? __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.')
+                : __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
             return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
         }
-
-        // Ricalcola disponibilità del libro
-        $integrity = new \App\Support\DataIntegrity($db);
-        $integrity->recalculateBookAvailability($libroId);
 
         $_SESSION['success_message'] = __('Copia eliminata con successo.');
         return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -5,6 +5,10 @@ namespace App\Controllers;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
+use App\Controllers\ReservationManager;
+use App\Models\CopyRepository;
+use App\Services\ReservationReassignmentService;
+use App\Support\DataIntegrity;
 use App\Support\SecureLogger;
 use mysqli;
 
@@ -303,16 +307,6 @@ class CopyController
         $data = (array) $request->getParsedBody();
         // CSRF validated by CsrfMiddleware
 
-        $stmt = $db->prepare("SELECT id, numero_inventario FROM libri WHERE id = ? AND deleted_at IS NULL");
-        $stmt->bind_param('i', $bookId);
-        $stmt->execute();
-        $book = $stmt->get_result()->fetch_assoc();
-        $stmt->close();
-        if (!$book) {
-            $_SESSION['error_message'] = __('Libro non trovato.');
-            return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
-        }
-
         // Only physical statuses a copy can be created in — loan states are
         // managed by the Prestiti system, never set here.
         $stato = (string) ($data['stato'] ?? 'disponibile');
@@ -323,35 +317,97 @@ class CopyController
         }
         $note = trim((string) ($data['note'] ?? ''));
 
-        $repo = new \App\Models\CopyRepository($db);
-
         // Inventory code: honour an explicit value (must be unique), otherwise
         // auto-allocate the next collision-free "{base}-C{N}" like book creation.
         $numero = trim((string) ($data['numero_inventario'] ?? ''));
         if ($numero !== '') {
-            $numero = preg_replace('/[\x00-\x1F]/', '', $numero);
+            $numero = trim((string) preg_replace('/[\x00-\x1F]/', '', $numero));
             if (mb_strlen($numero) > 100) {
                 $numero = mb_substr($numero, 0, 100);
             }
-            if ($repo->inventoryCodeExists($numero)) {
+        }
+
+        $repo = new CopyRepository($db);
+        $reassignmentService = null;
+        $reservationManager = null;
+        $transactionStarted = false;
+
+        try {
+            // Keep the same canonical lock order used by circulation writes:
+            // book first, then copies/loans. Copy creation, queue processing and
+            // derived counters must become visible as one atomic change.
+            $db->begin_transaction();
+            $transactionStarted = true;
+
+            $stmt = $db->prepare("SELECT id, numero_inventario FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE");
+            $stmt->bind_param('i', $bookId);
+            $stmt->execute();
+            $book = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if (!$book) {
+                $db->rollback();
+                $transactionStarted = false;
+                $_SESSION['error_message'] = __('Libro non trovato.');
+                return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+            }
+
+            // Re-evaluate after sanitisation: an explicit value made only of
+            // control characters must fall back to automatic allocation.
+            if ($numero === '') {
+                $base = !empty($book['numero_inventario']) ? (string) $book['numero_inventario'] : "LIB-{$bookId}";
+                $codes = $repo->allocateInventoryCodes($base, 1);
+                $numero = $codes[0] ?? ($base . '-C1');
+            } elseif ($repo->inventoryCodeExists($numero)) {
+                $db->rollback();
+                $transactionStarted = false;
                 $_SESSION['error_message'] = __('Esiste già una copia con questo numero di inventario.');
                 return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
             }
-        } else {
-            $base = !empty($book['numero_inventario']) ? (string) $book['numero_inventario'] : "LIB-{$bookId}";
-            $codes = $repo->allocateInventoryCodes($base, 1);
-            $numero = $codes[0] ?? ($base . '-C1');
-        }
 
-        try {
-            $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
+            $newCopyId = $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
+            if ($newCopyId <= 0) {
+                throw new \RuntimeException('Unable to create the physical copy.');
+            }
+
+            // A newly available copy is new circulation capacity. Mirror the
+            // existing book-edit path: first repair blocked copy assignments,
+            // then promote the next eligible wait-list entry.
+            if ($stato === 'disponibile') {
+                $reassignmentService = new ReservationReassignmentService($db);
+                $reassignmentService->setExternalTransaction(true);
+                $reassignmentService->reassignOnNewCopy($bookId, $newCopyId);
+
+                $reservationManager = new ReservationManager($db);
+                $reservationManager->setExternalTransaction(true);
+                $reservationManager->processBookAvailability($bookId);
+            }
+
+            $integrity = new DataIntegrity($db);
+            if (!$integrity->recalculateBookAvailability($bookId, insideTransaction: true)) {
+                throw new \RuntimeException('Unable to recalculate book availability.');
+            }
+
+            $db->commit();
+            $transactionStarted = false;
         } catch (\Throwable $e) {
+            if ($transactionStarted) {
+                $db->rollback();
+            }
             SecureLogger::error('[CopyController] createCopy failed', ['book' => $bookId, 'error' => $e->getMessage()]);
-            $_SESSION['error_message'] = __('Impossibile aggiungere la copia.');
+            $_SESSION['error_message'] = (int) $e->getCode() === 1062
+                ? __('Esiste già una copia con questo numero di inventario.')
+                : __('Impossibile aggiungere la copia.');
             return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
         }
 
-        (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($bookId);
+        // Notifications are deliberately emitted only after the transaction that
+        // made the new assignment/promotion durable.
+        try {
+            $reassignmentService?->flushDeferredNotifications();
+            $reservationManager?->flushDeferredNotifications();
+        } catch (\Throwable $e) {
+            SecureLogger::warning(__('Invio notifica nuova copia fallito'), ['error' => $e->getMessage()]);
+        }
 
         $_SESSION['success_message'] = __('Copia aggiunta con successo.');
         return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -9,6 +9,7 @@ use App\Controllers\ReservationManager;
 use App\Models\CopyRepository;
 use App\Services\ReservationReassignmentService;
 use App\Support\DataIntegrity;
+use App\Support\RouteTranslator;
 use App\Support\SecureLogger;
 use mysqli;
 
@@ -17,12 +18,20 @@ class CopyController
     /**
      * SECURITY: Validate and sanitize HTTP_REFERER to prevent open redirect
      */
-    private function safeReferer(string $default = '/admin/books'): string
+    private function safeReferer(?string $default = null): string
     {
         // Delegate to the single audited implementation. localPath() uses only
         // the referer's path (never its scheme/host), which is strictly safer
         // than the previous same-host comparison and port-agnostic.
-        return \App\Support\RefererGuard::localPath((string) ($_SERVER['HTTP_REFERER'] ?? ''), $default);
+        return \App\Support\RefererGuard::localPath(
+            (string) ($_SERVER['HTTP_REFERER'] ?? ''),
+            $default ?? RouteTranslator::route('admin_books')
+        );
+    }
+
+    private function adminBookPath(int $bookId): string
+    {
+        return str_replace('{id}', (string) $bookId, RouteTranslator::route('admin_book'));
     }
 
     /**
@@ -60,7 +69,8 @@ class CopyController
     public function byCode(Request $request, Response $response, mysqli $db): Response
     {
         $params = $request->getQueryParams();
-        $code = trim((string) ($params['code'] ?? ''));
+        $rawCode = $params['code'] ?? '';
+        $code = is_string($rawCode) ? trim($rawCode) : '';
 
         if ($code === '') {
             $response->getBody()->write((string) json_encode(['found' => false]));
@@ -111,14 +121,20 @@ class CopyController
         $data = (array) $request->getParsedBody();
         // CSRF validated by CsrfMiddleware
 
-        $stato = $data['stato'] ?? 'disponibile';
-        $note = $data['note'] ?? '';
+        $statoInput = $data['stato'] ?? 'disponibile';
+        $noteInput = $data['note'] ?? '';
+        if (!is_string($statoInput) || !is_string($noteInput)) {
+            $_SESSION['error_message'] = __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
+            return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
+        }
+        $stato = $statoInput;
+        $note = $noteInput;
 
         // Validazione stato (deve corrispondere all'enum in copie.stato)
         $statiValidi = ['disponibile', 'prestato', 'prenotato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
-        if (!in_array($stato, $statiValidi)) {
+        if (!in_array($stato, $statiValidi, true)) {
             $_SESSION['error_message'] = __('Stato non valido.');
-            return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+            return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
         }
 
         // Recupera la copia per ottenere il libro_id
@@ -131,7 +147,7 @@ class CopyController
 
         if (!$copy) {
             $_SESSION['error_message'] = __('Copia non trovata.');
-            return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+            return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
         }
 
         $libroId = (int) $copy['libro_id'];
@@ -159,7 +175,7 @@ class CopyController
         // Non permettere cambio diretto a "prestato", deve usare il sistema prestiti
         if ($stato === 'prestato' && $statoCorrente !== 'prestato') {
             $_SESSION['error_message'] = __('Per prestare una copia, utilizza il sistema Prestiti dalla sezione dedicata. Non è possibile impostare manualmente lo stato "Prestato".');
-            return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+            return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
         }
 
         // GESTIONE CAMBIO STATO DA "PRESTATO" A "DISPONIBILE"
@@ -177,7 +193,7 @@ class CopyController
             $delegated = $request->withParsedBody([
                 'stato' => 'restituito',
                 'note' => $returnNote,
-                'redirect_to' => "/admin/books/{$libroId}",
+                'redirect_to' => $this->adminBookPath($libroId),
                 'csrf_token' => $data['csrf_token'] ?? '',
             ]);
             return (new PrestitiController())->processReturn($delegated, $response, $db, (int) $prestito['id']);
@@ -188,7 +204,7 @@ class CopyController
             // copy still in the library may instead be reassigned atomically below.
             if ($copyHeld && $prestito) {
                 $_SESSION['error_message'] = __('La copia è fisicamente in prestito: registra prima la restituzione o l’esito perso/danneggiato dal sistema Prestiti.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
 
             // L'aggiornamento avviene sotto lock del libro (ordine di lock canonico,
@@ -207,7 +223,7 @@ class CopyController
                 if (!$bookLocked) {
                     $db->rollback();
                     $_SESSION['error_message'] = __('Libro non trovato o non più disponibile.');
-                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                    return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
                 }
 
                 // Recheck only physical possession after the book lock. Scheduled
@@ -220,7 +236,7 @@ class CopyController
                 if ($physicallyOut) {
                     $db->rollback();
                     $_SESSION['error_message'] = __('La copia è fisicamente in prestito: usa il flusso di restituzione.');
-                    return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                    return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
                 }
 
                 $stmt = $db->prepare("UPDATE copie SET stato = ?, note = ?, updated_at = NOW() WHERE id = ?");
@@ -275,7 +291,7 @@ class CopyController
                     'error' => $e->getMessage()
                 ]);
                 $_SESSION['error_message'] = __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
 
             try {
@@ -291,7 +307,7 @@ class CopyController
         if (!isset($_SESSION['success_message'])) {
             $_SESSION['success_message'] = __('Stato della copia aggiornato con successo.');
         }
-        return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+        return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
     }
 
     /**
@@ -311,13 +327,20 @@ class CopyController
 
         // Only physical statuses a copy can be created in — loan states are
         // managed by the Prestiti system, never set here.
-        $stato = (string) ($data['stato'] ?? 'disponibile');
+        $statoInput = $data['stato'] ?? 'disponibile';
+        $noteInput = $data['note'] ?? '';
+        $numeroInput = $data['numero_inventario'] ?? '';
+        if (!is_string($statoInput) || !is_string($noteInput) || !is_string($numeroInput)) {
+            $_SESSION['error_message'] = __('Impossibile aggiungere la copia.');
+            return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
+        }
+        $stato = $statoInput;
         $statiValidi = ['disponibile', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
         if (!in_array($stato, $statiValidi, true)) {
             $_SESSION['error_message'] = __('Stato non valido.');
-            return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+            return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
         }
-        $note = trim((string) ($data['note'] ?? ''));
+        $note = trim($noteInput);
         if ($note !== '') {
             // Consistency with numero_inventario below: drop control characters
             // (keeping tab/newline for multi-line notes) and cap the length
@@ -330,7 +353,7 @@ class CopyController
 
         // Inventory code: honour an explicit value (must be unique), otherwise
         // auto-allocate the next collision-free "{base}-C{N}" like book creation.
-        $numero = trim((string) ($data['numero_inventario'] ?? ''));
+        $numero = trim($numeroInput);
         if ($numero !== '') {
             $numero = trim((string) preg_replace('/[\x00-\x1F]/', '', $numero));
             if (mb_strlen($numero) > 100) {
@@ -359,7 +382,7 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Libro non trovato.');
-                return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+                return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
             }
 
             // Re-evaluate after sanitisation: an explicit value made only of
@@ -376,7 +399,7 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Esiste già una copia con questo numero di inventario.');
-                return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
             } else {
                 $newCopyId = $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
             }
@@ -413,7 +436,7 @@ class CopyController
             $_SESSION['error_message'] = (int) $e->getCode() === 1062
                 ? __('Esiste già una copia con questo numero di inventario.')
                 : __('Impossibile aggiungere la copia.');
-            return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+            return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
         }
 
         // Notifications are deliberately emitted only after the transaction that
@@ -426,7 +449,7 @@ class CopyController
         }
 
         $_SESSION['success_message'] = __('Copia aggiunta con successo.');
-        return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+        return $response->withHeader('Location', url($this->adminBookPath($bookId)))->withStatus(302);
     }
 
     /**
@@ -445,7 +468,7 @@ class CopyController
         $stmt->close();
         if (!$copy) {
             $_SESSION['error_message'] = __('Copia non trovata.');
-            return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+            return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
         }
 
         $libroId = (int) $copy['libro_id'];
@@ -465,7 +488,7 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Libro non trovato o non più disponibile.');
-                return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+                return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
             }
 
             // Re-read under lock: state and commitments may have changed since
@@ -479,7 +502,7 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Copia non trovata.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
 
             // A copy with any current/future commitment or historical loan is
@@ -488,13 +511,13 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Impossibile eliminare una copia attualmente impegnata in un prestito o una prenotazione.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
             if (!in_array($lockedCopy['stato'], ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
 
             $stmt = $db->prepare('SELECT 1 FROM prestiti WHERE copia_id = ? LIMIT 1 FOR UPDATE');
@@ -506,7 +529,7 @@ class CopyController
                 $db->rollback();
                 $transactionStarted = false;
                 $_SESSION['error_message'] = __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.');
-                return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+                return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
             }
 
             $stmt = $db->prepare('DELETE FROM copie WHERE id = ?');
@@ -537,10 +560,10 @@ class CopyController
             $_SESSION['error_message'] = (int) $e->getCode() === 1451
                 ? __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.')
                 : __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
-            return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+            return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
         }
 
         $_SESSION['success_message'] = __('Copia eliminata con successo.');
-        return $response->withHeader('Location', url("/admin/books/{$libroId}"))->withStatus(302);
+        return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
     }
 }

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -133,7 +133,11 @@ class CopyController
         $note = $this->sanitizeNote($noteInput);
 
         // Validazione stato (deve corrispondere all'enum in copie.stato)
-        $statiValidi = ['disponibile', 'prestato', 'prenotato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
+        // 'prestato'/'prenotato' are owned by the loan/reservation system and must
+        // never be set directly here. 'prestato' is still listed so the explicit
+        // guard below can emit its dedicated message; 'prenotato' is not settable
+        // at all and is rejected as an invalid state.
+        $statiValidi = ['disponibile', 'prestato', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
         if (!in_array($stato, $statiValidi, true)) {
             $_SESSION['error_message'] = __('Stato non valido.');
             return $response->withHeader('Location', $this->safeReferer())->withStatus(302);
@@ -363,7 +367,9 @@ class CopyController
             // Keep the same canonical lock order used by circulation writes:
             // book first, then copies/loans. Copy creation, queue processing and
             // derived counters must become visible as one atomic change.
-            $db->begin_transaction();
+            if (!$db->begin_transaction()) {
+                throw new \RuntimeException('Unable to begin the physical-copy creation transaction.');
+            }
             $transactionStarted = true;
 
             $stmt = $db->prepare("SELECT id, numero_inventario FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE");
@@ -569,7 +575,7 @@ class CopyController
             SecureLogger::error('[CopyController] deleteCopy failed', ['copy' => $copyId, 'error' => $e->getMessage()]);
             $_SESSION['error_message'] = (int) $e->getCode() === 1451
                 ? __('Impossibile eliminare la copia: ha uno storico prestiti. Puoi metterla fuori circolazione cambiandone lo stato.')
-                : __('Impossibile aggiornare la copia senza lasciare dati incoerenti. Nessuna modifica è stata salvata.');
+                : __('Impossibile eliminare la copia.');
             return $response->withHeader('Location', url($this->adminBookPath($libroId)))->withStatus(302);
         }
 

--- a/app/Controllers/CopyController.php
+++ b/app/Controllers/CopyController.php
@@ -291,6 +291,73 @@ class CopyController
     }
 
     /**
+     * Crea una nuova copia fisica per un libro, direttamente dalla scheda.
+     *
+     * Loan states ('prestato'/'prenotato') are never created here — those belong
+     * to the Prestiti system. A lost/damaged/maintenance copy is allowed: the
+     * availability recalculation then excludes it from copie_totali, so marking a
+     * copy lost reduces the book's total on its own.
+     */
+    public function createCopy(Request $request, Response $response, mysqli $db, int $bookId): Response
+    {
+        $data = (array) $request->getParsedBody();
+        // CSRF validated by CsrfMiddleware
+
+        $stmt = $db->prepare("SELECT id, numero_inventario FROM libri WHERE id = ? AND deleted_at IS NULL");
+        $stmt->bind_param('i', $bookId);
+        $stmt->execute();
+        $book = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if (!$book) {
+            $_SESSION['error_message'] = __('Libro non trovato.');
+            return $response->withHeader('Location', $this->safeReferer('/admin/books'))->withStatus(302);
+        }
+
+        // Only physical statuses a copy can be created in — loan states are
+        // managed by the Prestiti system, never set here.
+        $stato = (string) ($data['stato'] ?? 'disponibile');
+        $statiValidi = ['disponibile', 'manutenzione', 'in_restauro', 'perso', 'danneggiato', 'in_trasferimento'];
+        if (!in_array($stato, $statiValidi, true)) {
+            $_SESSION['error_message'] = __('Stato non valido.');
+            return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+        }
+        $note = trim((string) ($data['note'] ?? ''));
+
+        $repo = new \App\Models\CopyRepository($db);
+
+        // Inventory code: honour an explicit value (must be unique), otherwise
+        // auto-allocate the next collision-free "{base}-C{N}" like book creation.
+        $numero = trim((string) ($data['numero_inventario'] ?? ''));
+        if ($numero !== '') {
+            $numero = preg_replace('/[\x00-\x1F]/', '', $numero);
+            if (mb_strlen($numero) > 100) {
+                $numero = mb_substr($numero, 0, 100);
+            }
+            if ($repo->inventoryCodeExists($numero)) {
+                $_SESSION['error_message'] = __('Esiste già una copia con questo numero di inventario.');
+                return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+            }
+        } else {
+            $base = !empty($book['numero_inventario']) ? (string) $book['numero_inventario'] : "LIB-{$bookId}";
+            $codes = $repo->allocateInventoryCodes($base, 1);
+            $numero = $codes[0] ?? ($base . '-C1');
+        }
+
+        try {
+            $repo->create($bookId, $numero, $stato, $note !== '' ? $note : null);
+        } catch (\Throwable $e) {
+            SecureLogger::error('[CopyController] createCopy failed', ['book' => $bookId, 'error' => $e->getMessage()]);
+            $_SESSION['error_message'] = __('Impossibile aggiungere la copia.');
+            return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+        }
+
+        (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($bookId);
+
+        $_SESSION['success_message'] = __('Copia aggiunta con successo.');
+        return $response->withHeader('Location', url("/admin/books/{$bookId}"))->withStatus(302);
+    }
+
+    /**
      * Elimina una singola copia
      */
     public function deleteCopy(Request $request, Response $response, mysqli $db, int $copyId): Response

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -844,8 +844,8 @@ class LibriController
         $fields['sottogenere_id'] = empty($fields['sottogenere_id']) || $fields['sottogenere_id'] == 0 ? null : (int) $fields['sottogenere_id'];
         $fields['copie_totali'] = (int) $fields['copie_totali'];
         // Add bounds checking to prevent integer overflow
-        if ($fields['copie_totali'] < 1) {
-            $fields['copie_totali'] = 1;
+        if ($fields['copie_totali'] < 0) {
+            $fields['copie_totali'] = 0;
         } elseif ($fields['copie_totali'] > 9999) {
             $fields['copie_totali'] = 9999;
         }
@@ -1195,14 +1195,19 @@ class LibriController
                 ? $fields['numero_inventario']
                 : "LIB-{$id}";
 
-            // Uniform "-C{N}" codes for every copy (#238): even a single copy is
-            // "{base}-C1", so later adding a 2nd copy yields a consistent C1/C2 pair
-            // instead of a bare base plus a "-C2". allocateInventoryCodes guarantees
-            // no collision with any existing numero_inventario.
-            $codes = $copyRepo->allocateInventoryCodes($baseInventario, $copieTotali);
-            foreach ($codes as $i => $numeroInventario) {
-                $note = "Copia " . ($i + 1) . " di {$copieTotali}";
-                $copyRepo->create($id, $numeroInventario, 'disponibile', $note);
+            // Create the requested holding set with one atomic multi-row INSERT:
+            // a request for three copies must never leave a partial 1/3 or 2/3
+            // result if one inventory code fails. Codes stay uniform (-C1, -C2,
+            // ...) and collision-free through the repository allocator.
+            $createdCopies = $copyRepo->createManyForBook(
+                $id,
+                $baseInventario,
+                $copieTotali,
+                'disponibile',
+                __('Copia %d di %d')
+            );
+            if ($createdCopies !== $copieTotali) {
+                throw new \RuntimeException('Unable to create the requested physical copies.');
             }
 
             // Ricalcola disponibilità dopo aver generato le copie, come fa il
@@ -1448,11 +1453,12 @@ class LibriController
         $fields['editore_id'] = empty($fields['editore_id']) || $fields['editore_id'] == 0 ? null : (int) $fields['editore_id'];
         $fields['genere_id'] = empty($fields['genere_id']) || $fields['genere_id'] == 0 ? null : (int) $fields['genere_id'];
         $fields['sottogenere_id'] = empty($fields['sottogenere_id']) || $fields['sottogenere_id'] == 0 ? null : (int) $fields['sottogenere_id'];
-        // Clamp to the same 1..9999 range as store(): an unbounded value would build
+        // Clamp to the same 0..9999 range as store(): zero is a valid catalogue
+        // record with no physical holdings yet; an unbounded value would build
         // a huge allocation loop / copy set. (#252 CodeRabbit)
         $fields['copie_totali'] = (int) $fields['copie_totali'];
-        if ($fields['copie_totali'] < 1) {
-            $fields['copie_totali'] = 1;
+        if ($fields['copie_totali'] < 0) {
+            $fields['copie_totali'] = 0;
         } elseif ($fields['copie_totali'] > 9999) {
             $fields['copie_totali'] = 9999;
         }

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -1453,15 +1453,15 @@ class LibriController
         $fields['editore_id'] = empty($fields['editore_id']) || $fields['editore_id'] == 0 ? null : (int) $fields['editore_id'];
         $fields['genere_id'] = empty($fields['genere_id']) || $fields['genere_id'] == 0 ? null : (int) $fields['genere_id'];
         $fields['sottogenere_id'] = empty($fields['sottogenere_id']) || $fields['sottogenere_id'] == 0 ? null : (int) $fields['sottogenere_id'];
-        // Clamp to the same 0..9999 range as store(): zero is a valid catalogue
-        // record with no physical holdings yet; an unbounded value would build
-        // a huge allocation loop / copy set. (#252 CodeRabbit)
-        $fields['copie_totali'] = (int) $fields['copie_totali'];
-        if ($fields['copie_totali'] < 0) {
-            $fields['copie_totali'] = 0;
-        } elseif ($fields['copie_totali'] > 9999) {
-            $fields['copie_totali'] = 9999;
-        }
+        // Copies are managed individually from the book summary (#physical-copies);
+        // the edit form's "Copie in circolazione" field is read-only. Ignore any
+        // submitted copie_totali — derive it from the copie table — so a crafted
+        // POST that bypasses the client-side readonly cannot drive the copy
+        // reconciliation below to silently add or delete copies. The derived value
+        // matches libri.copie_totali (same out-of-circulation exclusion as
+        // DataIntegrity), so the add/remove branches become guaranteed no-ops.
+        $copyRepoCount = new \App\Models\CopyRepository($db);
+        $fields['copie_totali'] = $copyRepoCount->countInCirculationByBookId($id);
 
         // Validazione copie: verifica che sia possibile ridurre il numero di copie.
         // Usa lo stesso conteggio "in circolazione" della gestione copie più sotto

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -1180,7 +1180,60 @@ class LibriController
             // Plugin hook: Before book save
             \App\Support\Hooks::do('book.save.before', [$fields, null]);
 
-            $id = $repo->createBasic($fields);
+            // Atomic create: the book row and its initial physical copies must
+            // persist together or not at all — a copy-creation failure used to
+            // leave an orphan book with no/partial holdings. The transaction
+            // wraps ONLY createBasic() + createManyForBook(): neither starts
+            // its own transaction (createBasic detects the open one via its
+            // savepoint probe and nests with SAVEPOINT), and no plugin hook
+            // fires inside it — book.save.after handlers (e.g. book-club)
+            // run their own begin_transaction(), which under mysqli implicitly
+            // commits an enclosing transaction and would silently destroy this
+            // atomicity. Hooks, series/LT metadata and the availability recalc
+            // therefore run strictly after the commit.
+            if (!$db->begin_transaction()) {
+                throw new \RuntimeException('Database error: unable to begin book create transaction');
+            }
+            try {
+                $id = $repo->createBasic($fields);
+
+                // Genera copie fisiche del libro
+                $copyRepo = new \App\Models\CopyRepository($db);
+                $copieTotali = (int) $fields['copie_totali'];
+                $baseInventario = !empty($fields['numero_inventario'])
+                    ? $fields['numero_inventario']
+                    : "LIB-{$id}";
+
+                // Create the requested holding set with one atomic multi-row INSERT:
+                // a request for three copies must never leave a partial 1/3 or 2/3
+                // result if one inventory code fails. Codes stay uniform (-C1, -C2,
+                // ...) and collision-free through the repository allocator.
+                $createdCopies = $copyRepo->createManyForBook(
+                    $id,
+                    $baseInventario,
+                    $copieTotali,
+                    'disponibile',
+                    __('Copia %d di %d')
+                );
+                if ($createdCopies !== $copieTotali) {
+                    throw new \RuntimeException('Unable to create the requested physical copies.');
+                }
+
+                if (!$db->commit()) {
+                    throw new \RuntimeException('Database error: unable to commit book create transaction');
+                }
+            } catch (\Throwable $atomicCreateError) {
+                try {
+                    $db->rollback();
+                } catch (\Throwable $rollbackError) {
+                    // best-effort — a dropped connection must not mask the original error
+                }
+                \App\Support\SecureLogger::error('LibriController::store atomic book+copies create failed', [
+                    'error' => $atomicCreateError->getMessage(),
+                ]);
+                throw $atomicCreateError;
+            }
+
             $this->syncSeriesMetadataFromBookForm($db, $id, $fields, $data);
 
             // Handle LibraryThing fields visibility preferences
@@ -1191,28 +1244,6 @@ class LibriController
 
             // Plugin hook: After book save
             \App\Support\Hooks::do('book.save.after', [$id, $fields]);
-
-            // Genera copie fisiche del libro
-            $copyRepo = new \App\Models\CopyRepository($db);
-            $copieTotali = (int) $fields['copie_totali'];
-            $baseInventario = !empty($fields['numero_inventario'])
-                ? $fields['numero_inventario']
-                : "LIB-{$id}";
-
-            // Create the requested holding set with one atomic multi-row INSERT:
-            // a request for three copies must never leave a partial 1/3 or 2/3
-            // result if one inventory code fails. Codes stay uniform (-C1, -C2,
-            // ...) and collision-free through the repository allocator.
-            $createdCopies = $copyRepo->createManyForBook(
-                $id,
-                $baseInventario,
-                $copieTotali,
-                'disponibile',
-                __('Copia %d di %d')
-            );
-            if ($createdCopies !== $copieTotali) {
-                throw new \RuntimeException('Unable to create the requested physical copies.');
-            }
 
             // Ricalcola disponibilità dopo aver generato le copie, come fa il
             // percorso di update. Senza questo, copie_disponibili/copie_totali e

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -1501,45 +1501,6 @@ class LibriController
         $copyRepoCount = new \App\Models\CopyRepository($db);
         $fields['copie_totali'] = $copyRepoCount->countInCirculationByBookId($id);
 
-        // Validazione copie: verifica che sia possibile ridurre il numero di copie.
-        // Usa lo stesso conteggio "in circolazione" della gestione copie più sotto
-        // (e di libri.copie_totali via DataIntegrity): con il conteggio grezzo,
-        // un libro con copie fuori circolazione divergerebbe dalla logica reale e
-        // bloccherebbe il salvataggio con un messaggio errato.
-        $copyRepo = new \App\Models\CopyRepository($db);
-        $currentCopieCount = $copyRepo->countInCirculationByBookId($id);
-        $newCopieCount = $fields['copie_totali'];
-
-        if ($newCopieCount < $currentCopieCount) {
-            // Conta quante copie sono disponibili per la rimozione
-            $copie = $copyRepo->getByBookId($id);
-            $removableCopies = 0;
-
-            foreach ($copie as $copia) {
-                if ($copia['stato'] === 'disponibile' && empty($copia['prestito_id'])) {
-                    $removableCopies++;
-                }
-            }
-
-            $requiredReduction = $currentCopieCount - $newCopieCount;
-
-            if ($requiredReduction > $removableCopies) {
-                // The floor is the in-circulation count minus what we can remove.
-                // Deriving it from $currentCopieCount (which already excludes
-                // out-of-circulation copies) keeps the message consistent with the
-                // canonical libri.copie_totali, instead of counting perso/danneggiato
-                // copies that aren't part of that total at all.
-                $minimumCopies = $currentCopieCount - $removableCopies;
-                $_SESSION['error_message'] = sprintf(
-                    __('Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.'),
-                    $newCopieCount,
-                    $minimumCopies,
-                    $minimumCopies
-                );
-                return $response->withHeader('Location', url('/admin/books/edit/' . $id))->withStatus(302);
-            }
-        }
-
         // Non aggiorniamo disponibilità/stato dall'utente: sono derivati dalle copie.
         unset($fields['copie_disponibili']);
         unset($fields['stato']);
@@ -1901,79 +1862,6 @@ class LibriController
 
             // Plugin hook: After book save (update)
             \App\Support\Hooks::do('book.save.after', [$id, $fields]);
-
-            // Gestione copie: aggiorna il numero di copie se cambiato.
-            // Il conteggio di riferimento DEVE escludere le copie fuori
-            // circolazione (perso/danneggiato/manutenzione/in_restauro/
-            // in_trasferimento), perché `$fields['copie_totali']` arriva dal
-            // form pre-compilato con `libri.copie_totali`, che DataIntegrity
-            // calcola con la stessa esclusione. Con il conteggio grezzo
-            // (countByBookId) un libro con una copia fuori circolazione avrebbe
-            // current > form a ogni salvataggio e cancellerebbe una copia buona.
-            $copyRepo = new \App\Models\CopyRepository($db);
-            $currentCopieCount = $copyRepo->countInCirculationByBookId($id);
-            $newCopieCount = (int) $fields['copie_totali'];
-
-            if ($newCopieCount > $currentCopieCount) {
-                // Aggiungi nuove copie. #238: generate gap-filling, collision-free
-                // "-C{N}" codes instead of "-C{count+1}" (which duplicated an existing
-                // code after a copy had been removed). allocateInventoryCodes checks
-                // every candidate against the whole `copie` table.
-                $baseInventario = !empty($fields['numero_inventario'])
-                    ? $fields['numero_inventario']
-                    : "LIB-{$id}";
-
-                $howMany = $newCopieCount - $currentCopieCount;
-                $codes = $copyRepo->allocateInventoryCodes($baseInventario, $howMany);
-                foreach ($codes as $numeroInventario) {
-                    $note = "Copia {$numeroInventario}";
-                    $newCopyId = $copyRepo->create($id, $numeroInventario, 'disponibile', $note);
-
-                    // Case 1: Reassign pending reservations to this new copy
-                    try {
-                        $reassignmentService = new \App\Services\ReservationReassignmentService($db);
-                        $reassignmentService->reassignOnNewCopy($id, $newCopyId);
-                    } catch (\Throwable $e) {
-                        SecureLogger::error(__('Riassegnazione prenotazione nuova copia fallita') . ': ' . $e->getMessage(), [
-                            'copia_id' => $newCopyId,
-                        ]);
-                    }
-
-                    // Also process waitlist (prenotazioni -> prestiti) as we have more capacity now
-                    try {
-                        $reservationManager = new \App\Controllers\ReservationManager($db);
-                        $reservationManager->processBookAvailability($id);
-                    } catch (\Throwable $e) {
-                        SecureLogger::error(__('Elaborazione lista attesa fallita') . ': ' . $e->getMessage(), [
-                            'libro_id' => $id,
-                        ]);
-                    }
-                }
-            } elseif ($newCopieCount < $currentCopieCount) {
-                // Rimuovi copie in eccesso DALLA CODA (le ultime aggiunte), solo quelle
-                // disponibili e senza impegni (#238: prima si rimuoveva la PRIMA della
-                // lista ASC, lasciando codici col suffisso più alto → collisioni dopo).
-                $removable = $copyRepo->getRemovableCopiesNewestFirst($id);
-                $toRemove = $currentCopieCount - $newCopieCount;
-                $removed = 0;
-
-                foreach ($removable as $copia) {
-                    if ($removed >= $toRemove) {
-                        break;
-                    }
-                    // Conditional delete: only counts if the copy is still removable
-                    // (a loan may have claimed it since the SELECT). Miscounting is
-                    // thus impossible; the FK RESTRICT is the hard backstop.
-                    if ($copyRepo->deleteIfRemovable($copia['id'])) {
-                        $removed++;
-                    }
-                }
-
-                // Se non riusciamo a rimuovere abbastanza copie, avvisa l'utente
-                if ($removed < $toRemove) {
-                    $_SESSION['warning_message'] = __("Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.");
-                }
-            }
 
             // Ricalcola disponibilità dopo aver modificato le copie
             $integrity = new \App\Support\DataIntegrity($db);

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -1183,13 +1183,14 @@ class LibriController
             // Atomic create: the book row and its initial physical copies must
             // persist together or not at all — a copy-creation failure used to
             // leave an orphan book with no/partial holdings. The transaction
-            // wraps ONLY createBasic() + createManyForBook(): neither starts
-            // its own transaction (createBasic detects the open one via its
-            // savepoint probe and nests with SAVEPOINT), and no plugin hook
-            // fires inside it — book.save.after handlers (e.g. book-club)
-            // run their own begin_transaction(), which under mysqli implicitly
-            // commits an enclosing transaction and would silently destroy this
-            // atomicity. Hooks, series/LT metadata and the availability recalc
+            // wraps ONLY createBasic() + createManyForBook() + the SQL-only
+            // availability reconciliation. createBasic detects the open
+            // transaction via its savepoint probe and nests with SAVEPOINT;
+            // DataIntegrity is explicitly told that this transaction belongs
+            // to the caller. No plugin hook fires inside it — book.save.after
+            // handlers (e.g. book-club) can open their own transaction, which
+            // under mysqli would implicitly commit the enclosing transaction
+            // and silently destroy this atomicity. Hooks and series/LT metadata
             // therefore run strictly after the commit.
             if (!$db->begin_transaction()) {
                 throw new \RuntimeException('Database error: unable to begin book create transaction');
@@ -1219,6 +1220,16 @@ class LibriController
                     throw new \RuntimeException('Unable to create the requested physical copies.');
                 }
 
+                // Counters and canonical state are part of the same invariant as
+                // the book and its holdings. If reconciliation fails, rolling
+                // back here prevents a committed book whose summary/API fields
+                // disagree with the physical copies just created.
+                $availabilityUpdated = (new \App\Support\DataIntegrity($db))
+                    ->recalculateBookAvailability($id, true);
+                if (!$availabilityUpdated) {
+                    throw new \RuntimeException('Unable to recalculate availability for the new book.');
+                }
+
                 if (!$db->commit()) {
                     throw new \RuntimeException('Database error: unable to commit book create transaction');
                 }
@@ -1244,14 +1255,6 @@ class LibriController
 
             // Plugin hook: After book save
             \App\Support\Hooks::do('book.save.after', [$id, $fields]);
-
-            // Ricalcola disponibilità dopo aver generato le copie, come fa il
-            // percorso di update. Senza questo, copie_disponibili/copie_totali e
-            // lo stato canonico non vengono derivati dalle copie appena create:
-            // ogni superficie OPAC calcola la disponibilità da copie_disponibili,
-            // quindi un nuovo libro resterebbe con i contatori a zero (o con lo
-            // stato grezzo scritto dal form) finché non passa un altro salvataggio.
-            (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($id);
 
             // Persist all fields first, then apply an explicitly chosen cover
             // (file upload or scraped URL) on top so it isn't reverted by the

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -842,11 +842,15 @@ class LibriController
         $fields['editore_id'] = empty($fields['editore_id']) || $fields['editore_id'] == 0 ? null : (int) $fields['editore_id'];
         $fields['genere_id'] = empty($fields['genere_id']) || $fields['genere_id'] == 0 ? null : (int) $fields['genere_id'];
         $fields['sottogenere_id'] = empty($fields['sottogenere_id']) || $fields['sottogenere_id'] == 0 ? null : (int) $fields['sottogenere_id'];
-        $fields['copie_totali'] = (int) $fields['copie_totali'];
-        // Add bounds checking to prevent integer overflow
-        if ($fields['copie_totali'] < 0) {
-            $fields['copie_totali'] = 0;
-        } elseif ($fields['copie_totali'] > 9999) {
+        // Reject non-scalar or non-integer input BEFORE casting: (int) "abc" is 0
+        // and (int) (non-empty array) is 1, both of which would slip past the
+        // 0..9999 bounds as a silent, wrong copy count. Only a genuine integer
+        // string is honoured; anything else falls back to zero copies.
+        $rawCopie = $fields['copie_totali'] ?? 0;
+        $fields['copie_totali'] = (is_scalar($rawCopie) && preg_match('/^\d+$/', trim((string) $rawCopie)) === 1)
+            ? (int) trim((string) $rawCopie)
+            : 0;
+        if ($fields['copie_totali'] > 9999) {
             $fields['copie_totali'] = 9999;
         }
         // In creazione, copie_disponibili = copie_totali (le copie sono tutte nuove e disponibili)

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -868,12 +868,21 @@ class LibriController
         // scraped_cover_url; this flag lets the scraped-cover branch skip the
         // redundant second download that would orphan a file on disk (#F009).
         $scrapedCoverAlreadySaved = false;
+        // A localised external cover is written before the DB transaction. Keep
+        // its path so an atomic book/copies rollback can remove that request's
+        // file as well as its database rows.
+        $coverCreatedBeforeAtomicInsert = '';
         if ($fields['copertina_url'] === '' || $fields['copertina_url'] === null) {
             $fields['copertina_url'] = null;
         } else {
             // Auto-download external cover URLs
             $originalCoverUrl = (string) $fields['copertina_url'];
             $fields['copertina_url'] = $this->downloadExternalCover($fields['copertina_url']);
+            if (preg_match('#^https?://#i', $originalCoverUrl) === 1
+                && is_string($fields['copertina_url'])
+                && strpos($fields['copertina_url'], '/uploads/copertine/') === 0) {
+                $coverCreatedBeforeAtomicInsert = $fields['copertina_url'];
+            }
             if (is_string($fields['copertina_url'])
                 && strpos($fields['copertina_url'], '/uploads/copertine/') === 0
                 && isset($data['scraped_cover_url'])
@@ -1238,6 +1247,16 @@ class LibriController
                     $db->rollback();
                 } catch (\Throwable $rollbackError) {
                     // best-effort — a dropped connection must not mask the original error
+                }
+                // The cover download is filesystem I/O and cannot participate in
+                // mysqli's transaction. Delete only the file localised by this
+                // request; raw external URLs and pre-existing local files no-op.
+                try {
+                    $this->deleteLocalCoverFile($coverCreatedBeforeAtomicInsert);
+                } catch (\Throwable $coverCleanupError) {
+                    \App\Support\SecureLogger::warning('Unable to clean up cover after atomic book rollback', [
+                        'error' => $coverCleanupError->getMessage(),
+                    ]);
                 }
                 \App\Support\SecureLogger::error('LibriController::store atomic book+copies create failed', [
                     'error' => $atomicCreateError->getMessage(),

--- a/app/Controllers/PrestitiController.php
+++ b/app/Controllers/PrestitiController.php
@@ -1317,7 +1317,9 @@ class PrestitiController
             // delle prenotazioni: solo così copie_disponibili e libri.stato riflettono lo
             // stato finale e un libro restituito torna correttamente prestabile (TXN-002,
             // TXN-005, A2). insideTransaction:true mantiene l'atomicità della transazione.
-            $integrity->recalculateBookAvailability($libro_id, insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability($libro_id, insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after loan return.');
+            }
 
             $db->commit();
 

--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -189,12 +189,26 @@ class ReservationManager
                 FROM prenotazioni r
                 JOIN utenti u ON r.utente_id = u.id
                 WHERE r.libro_id = ? AND r.stato = 'attiva'
-                AND COALESCE(r.data_inizio_richiesta, DATE(r.data_scadenza_prenotazione)) IS NOT NULL
-                AND COALESCE(r.data_inizio_richiesta, DATE(r.data_scadenza_prenotazione)) <= ?
+                AND (
+                    -- Real requested start that has arrived. '1000-01-01' is
+                    -- MySQL's minimum valid DATE: the floor rejects 0000-00-00
+                    -- dump rows (which would otherwise be promoted back-dated)
+                    -- without embedding the literal '0000-00-00', which a
+                    -- NO_ZERO_DATE server refuses even at prepare time.
+                    (r.data_inizio_richiesta >= '1000-01-01' AND r.data_inizio_richiesta <= ?)
+                    -- Legacy row with no requested start: promote only while the
+                    -- reservation deadline is still valid (today or future). An
+                    -- already-expired deadline must be left for the expiry /
+                    -- cancellation path, never converted into a loan back-dated
+                    -- to the past.
+                    OR (r.data_inizio_richiesta IS NULL
+                        AND r.data_scadenza_prenotazione IS NOT NULL
+                        AND DATE(r.data_scadenza_prenotazione) >= ?)
+                )
                 ORDER BY r.queue_position ASC
                 LIMIT 1
             ");
-            $stmt->bind_param('is', $bookId, $today);
+            $stmt->bind_param('iss', $bookId, $today, $today);
             $stmt->execute();
             $result = $stmt->get_result();
             $nextReservation = $result->fetch_assoc();

--- a/app/Controllers/ReservationManager.php
+++ b/app/Controllers/ReservationManager.php
@@ -189,7 +189,8 @@ class ReservationManager
                 FROM prenotazioni r
                 JOIN utenti u ON r.utente_id = u.id
                 WHERE r.libro_id = ? AND r.stato = 'attiva'
-                AND r.data_inizio_richiesta <= ?
+                AND COALESCE(r.data_inizio_richiesta, DATE(r.data_scadenza_prenotazione)) IS NOT NULL
+                AND COALESCE(r.data_inizio_richiesta, DATE(r.data_scadenza_prenotazione)) <= ?
                 ORDER BY r.queue_position ASC
                 LIMIT 1
             ");
@@ -204,13 +205,19 @@ class ReservationManager
                 // R_END once: a legacy prenotazione may have data_fine_richiesta NULL but
                 // data_scadenza_prenotazione set — passing the raw NULL would make
                 // isDateRangeAvailable() return false and the row would never promote.
-                $startDate = $nextReservation['data_inizio_richiesta'];
+                $startDate = $nextReservation['data_inizio_richiesta']
+                    ?: (!empty($nextReservation['data_scadenza_prenotazione'])
+                        ? substr((string) $nextReservation['data_scadenza_prenotazione'], 0, 10)
+                        : null);
                 $endDate = $nextReservation['data_fine_richiesta']
                     ?: (!empty($nextReservation['data_scadenza_prenotazione'])
                         ? substr((string) $nextReservation['data_scadenza_prenotazione'], 0, 10)
                         : $startDate);
-                // Feed the resolved end to createLoanFromReservation() too (it reads
-                // $reservation['data_fine_richiesta'] for the loan period).
+                // Feed both resolved bounds to createLoanFromReservation() too.
+                // Legacy rows can have a NULL requested start but a valid legacy
+                // deadline; selecting them without normalising the start would
+                // still make isDateRangeAvailable() reject them forever.
+                $nextReservation['data_inizio_richiesta'] = $startDate;
                 $nextReservation['data_fine_richiesta'] = $endDate;
 
                 // #157: pass the promoted reservation's queue_position so the
@@ -246,7 +253,9 @@ class ReservationManager
                     // counted. Recalc again now that the reservation is 'completata', so the
                     // commitment is counted exactly once.
                     $integrity = new \App\Support\DataIntegrity($this->db);
-                    $integrity->recalculateBookAvailability($bookId, true);
+                    if (!$integrity->recalculateBookAvailability($bookId, true)) {
+                        throw new \RuntimeException('Failed to recalculate availability after reservation promotion.');
+                    }
 
                     // Update queue positions for remaining reservations.
                     // Pass the completed reservation's position: the converted
@@ -359,8 +368,10 @@ class ReservationManager
         $ownTransaction = $this->beginTransactionIfNeeded();
 
         try {
-            // Find an available copy for this date range (no overlapping loans)
-            // Consider 'disponibile' and 'prenotato' copies (exclude perso/danneggiato/manutenzione)
+            // Find an available copy for this date range (no overlapping loans).
+            // Promotion happens only when the requested start has arrived, so a
+            // physically-out ('prestato') copy is intentionally excluded here;
+            // it becomes eligible through the return/reassignment path.
             // The NOT EXISTS clause ensures no overlapping loans for the requested dates
             // Note: 'da_ritirare' copies are still 'disponibile' but have a loan reservation
             $copyStmt = $this->db->prepare("
@@ -452,7 +463,9 @@ class ReservationManager
 
             // Update book availability (inside transaction)
             $integrity = new \App\Support\DataIntegrity($this->db);
-            $integrity->recalculateBookAvailability($bookId, true);
+            if (!$integrity->recalculateBookAvailability($bookId, true)) {
+                throw new \RuntimeException('Failed to recalculate availability for the promoted reservation.');
+            }
 
             $this->commitIfOwned($ownTransaction);
             return $loanId;
@@ -883,7 +896,9 @@ class ReservationManager
             $integrity = new \App\Support\DataIntegrity($this->db);
             foreach ($affectedBooks as $bookId) {
                 $this->reorderQueuePositions($bookId);
-                $integrity->recalculateBookAvailability($bookId, true);
+                if (!$integrity->recalculateBookAvailability($bookId, true)) {
+                    throw new \RuntimeException('Failed to recalculate availability after reservation expiry.');
+                }
             }
 
             $this->commitIfOwned($ownTransaction);

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -280,7 +280,9 @@ class ReservationsAdminController
             }
 
             $integrity = new \App\Support\DataIntegrity($db);
-            $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after reservation update.');
+            }
 
             // Cancelling/completing an active reservation frees a slot: promote the next
             // queued reservation(s) right away, exactly like every other release path
@@ -535,7 +537,9 @@ class ReservationsAdminController
             $stmt->close();
 
             $integrity = new \App\Support\DataIntegrity($db);
-            $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after reservation creation.');
+            }
 
             $db->commit();
             return $response->withHeader('Location', url('/admin/reservations') . '?created=1')->withStatus(302);

--- a/app/Controllers/ReservationsController.php
+++ b/app/Controllers/ReservationsController.php
@@ -434,17 +434,27 @@ class ReservationsController
             }
             $dupReservationStmt->close();
 
+            // The pre-transaction eligibility check is only a fast fail. Lock
+            // and re-check the patron before creating the durable request so a
+            // concurrent suspension/card expiry cannot slip through the gap.
+            $userLockStmt = $this->db->prepare("SELECT id FROM utenti WHERE id = ? FOR UPDATE");
+            $userLockStmt->bind_param('i', $userId);
+            $userLockStmt->execute();
+            $userLockStmt->get_result();
+            $userLockStmt->close();
+            $eligibilityError = \App\Support\LoanEligibility::checkUser($this->db, $userId);
+            if ($eligibilityError !== null) {
+                $this->db->rollback();
+                $response->getBody()->write(json_encode([
+                    'success' => false,
+                    'message' => \App\Support\LoanEligibility::errorMessage($eligibilityError),
+                ]));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(403);
+            }
+
             // Enforce max active loans per user (admin setting; 0 = no limit)
             $maxLoans = (int) ((new \App\Models\SettingsRepository($this->db))->get('loans', 'max_active_loans_per_user', '0') ?? 0);
             if ($maxLoans > 0) {
-                // Serialize concurrent same-user requests on different books: the
-                // per-book libri lock taken earlier does not mutually-exclude them,
-                // so without this both could pass the limit check and both commit.
-                $userLockStmt = $this->db->prepare("SELECT id FROM utenti WHERE id = ? FOR UPDATE");
-                $userLockStmt->bind_param('i', $userId);
-                $userLockStmt->execute();
-                $userLockStmt->close();
-
                 $cntStmt = $this->db->prepare("SELECT COUNT(*) FROM prestiti WHERE utente_id = ? AND attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')");
                 $cntStmt->bind_param('i', $userId);
                 $cntStmt->execute();

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -232,7 +232,9 @@ class UserActionsController
             // siamo dentro la transazione aperta in questo metodo, evita il
             // commit implicito di una begin_transaction() annidata)
             $integrity = new \App\Support\DataIntegrity($db);
-            $integrity->recalculateBookAvailability((int) $loan['libro_id'], insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability((int) $loan['libro_id'], insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after loan cancellation.');
+            }
 
             $db->commit();
 
@@ -347,11 +349,27 @@ class UserActionsController
             $updatePos->close();
             $reorderStmt->close();
 
-            // Recalculate book availability
+            // Cancelling a queue reservation frees a promised capacity unit.
+            // Promote every now-eligible row in the same transaction, matching
+            // the admin cancellation and physical-copy release paths.
+            $reservationManager = new \App\Controllers\ReservationManager($db);
+            $reservationManager->setExternalTransaction(true);
+            for ($promoGuard = 0; $promoGuard < 1000 && $reservationManager->processBookAvailability($libroId); $promoGuard++) {
+                // promote until the newly-freed capacity is exhausted
+            }
+
             $integrity = new \App\Support\DataIntegrity($db);
-            $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after reservation cancellation.');
+            }
 
             $db->commit();
+
+            try {
+                $reservationManager->flushDeferredNotifications();
+            } catch (\Throwable $e) {
+                SecureLogger::warning('Failed to flush reservation notifications after user cancellation', ['error' => $e->getMessage()]);
+            }
 
             return $response->withHeader('Location', RouteTranslator::route('reservations') . '?canceled=1')->withStatus(302);
 
@@ -452,7 +470,9 @@ class UserActionsController
 
             // Recalculate book availability
             $integrity = new \App\Support\DataIntegrity($db);
-            $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
+            if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                throw new \RuntimeException('Failed to recalculate availability after reservation date change.');
+            }
 
             $db->commit();
 
@@ -568,19 +588,22 @@ class UserActionsController
             }
             $dupReservationStmt->close();
 
+            // Revalidate eligibility while holding the user row. The fast check
+            // before the transaction improves feedback, but an administrator can
+            // suspend the patron between that check and this INSERT.
+            $userLockStmt = $db->prepare("SELECT id FROM utenti WHERE id = ? FOR UPDATE");
+            $userLockStmt->bind_param('i', $utenteId);
+            $userLockStmt->execute();
+            $userLockStmt->get_result();
+            $userLockStmt->close();
+            if (\App\Support\LoanEligibility::checkUser($db, $utenteId) !== null) {
+                $db->rollback();
+                return $this->back($response, ['loan_error' => 'not_eligible']);
+            }
+
             // Enforce max active loans per user (admin setting; 0 = no limit)
             $maxLoans = (int) ((new \App\Models\SettingsRepository($db))->get('loans', 'max_active_loans_per_user', '0') ?? 0);
             if ($maxLoans > 0) {
-                // Serialize concurrent loan requests by the SAME user: the per-book
-                // libri lock taken earlier does not mutually exclude two requests
-                // for *different* books, so without this both could read the same
-                // activeCount below the limit and both insert, exceeding it.
-                // Locking the user row forces them to run one at a time.
-                $userLockStmt = $db->prepare("SELECT id FROM utenti WHERE id = ? FOR UPDATE");
-                $userLockStmt->bind_param('i', $utenteId);
-                $userLockStmt->execute();
-                $userLockStmt->close();
-
                 $cntStmt = $db->prepare("SELECT COUNT(*) FROM prestiti WHERE utente_id = ? AND attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')");
                 $cntStmt->bind_param('i', $utenteId);
                 $cntStmt->execute();
@@ -729,6 +752,18 @@ class UserActionsController
             }
             $dupLoanStmt->close();
 
+            // Revalidate under the user lock so a concurrent suspension/card
+            // expiry cannot race the pre-transaction eligibility check.
+            $userLockStmt = $db->prepare("SELECT id FROM utenti WHERE id = ? FOR UPDATE");
+            $userLockStmt->bind_param('i', $utenteId);
+            $userLockStmt->execute();
+            $userLockStmt->get_result();
+            $userLockStmt->close();
+            if (\App\Support\LoanEligibility::checkUser($db, $utenteId) !== null) {
+                $db->rollback();
+                return $this->back($response, ['reserve_error' => 'not_eligible']);
+            }
+
             // Canonical peak-capacity decision (same service as admin create,
             // approval, renew and audit), excluding this user defensively.
             $capacity = new \App\Services\CapacityService($db);
@@ -759,7 +794,9 @@ class UserActionsController
 
                 // Recalculate book availability after reservation
                 $integrity = new \App\Support\DataIntegrity($db);
-                $integrity->recalculateBookAvailability($libroId, insideTransaction: true);
+                if (!$integrity->recalculateBookAvailability($libroId, insideTransaction: true)) {
+                    throw new \RuntimeException('Failed to recalculate availability after reservation creation.');
+                }
 
                 $db->commit();
                 $params = ['reserve_success' => 1];

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -251,7 +251,7 @@ class CopyRepository
             $types = '';
             $params = [];
             foreach ($codes as $i => $code) {
-                $note = $total === 1
+                $note = $total === 1 && $singleNote !== null
                     ? $singleNote
                     : ($noteTemplate !== null ? sprintf($noteTemplate, $i + 1, $total) : null);
                 $types .= 'isss';

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -175,12 +175,12 @@ class CopyRepository
      * "{base}-C{N}" codes in memory, then batch-insert every row with one
      * prepared statement. A connection-level advisory lock serializes inventory
      * allocation even when a prefix's unique-index range is still empty (where
-     * gap locks alone can deadlock). A single allocator lock also respects the
-     * database's case/accent-insensitive uniqueness without trying to reproduce
-     * its collation rules in PHP. The locking current-read then sees rows
-     * committed after the transaction snapshot. A bounded duplicate-key retry
-     * remains as a final guard for external writers. A failed multi-row INSERT
-     * never leaves a partial batch. Replaces the per-copy
+     * gap locks alone can deadlock). Candidate membership is evaluated by SQL,
+     * using numero_inventario's case/accent-insensitive collation rather than a
+     * case-sensitive PHP array. The locking current-read then sees rows committed
+     * after the transaction snapshot. A bounded duplicate-key retry remains as a
+     * final guard for external writers. A failed multi-row INSERT never leaves a
+     * partial batch. Replaces the per-copy
      * inventoryCodeExists()+create() pair that turned a large copie_totali
      * import into thousands of queries.
      *
@@ -190,22 +190,48 @@ class CopyRepository
      */
     public function createManyForBook(int $bookId, string $base, int $howMany, string $stato = 'disponibile', ?string $noteTemplate = null): int
     {
+        return $this->createManyForBookResult($bookId, $base, $howMany, $stato, $noteTemplate, false)['count'];
+    }
+
+    /**
+     * Create a batch and return every generated copy id. Circulation callers use
+     * this variant so each new physical copy can repair a copy-less HOLDING row
+     * before the reservation queue consumes the remaining capacity.
+     *
+     * @return list<int>
+     */
+    public function createManyForBookWithIds(int $bookId, string $base, int $howMany, string $stato = 'disponibile', ?string $noteTemplate = null): array
+    {
+        $result = $this->createManyForBookResult($bookId, $base, $howMany, $stato, $noteTemplate, true);
+        return $result['ids'];
+    }
+
+    /**
+     * @return array{count: int, ids: list<int>}
+     */
+    private function createManyForBookResult(
+        int $bookId,
+        string $base,
+        int $howMany,
+        string $stato,
+        ?string $noteTemplate,
+        bool $resolveIds
+    ): array
+    {
         $howMany = max(0, $howMany);
         if ($howMany === 0) {
-            return 0;
+            return ['count' => 0, 'ids' => []];
         }
         // numero_inventario is VARCHAR(100); leave room for the "-C{N}" suffix.
         $base = mb_substr($base, 0, 90);
 
-        // GET_LOCK() is server-wide and connection-scoped. One short global
-        // allocator lock avoids mismatches with numero_inventario's
-        // case/accent-insensitive UNIQUE collation. It does not start, commit or
-        // roll back the caller's transaction and is released after the batch
-        // INSERT, not held for hooks or external services.
+        // GET_LOCK() is server-wide and connection-scoped. It does not start,
+        // commit or roll back the caller's transaction and is released after the
+        // INSERT and id lookup, never held for hooks or external services.
         $lockName = 'pinakes-copy-inventory-allocation';
         $this->acquireInventoryAllocatorLock($lockName);
         try {
-            $result = $this->insertAllocatedCopiesWhileLocked(
+            $inserted = $this->insertAllocatedCopiesWhileLocked(
                 $bookId,
                 $base,
                 $howMany,
@@ -213,7 +239,14 @@ class CopyRepository
                 $noteTemplate,
                 null
             );
-            return $result['count'];
+            $ids = [];
+            if ($resolveIds) {
+                $ids = $this->copyIdsForInventoryCodes($inserted['codes']);
+                if (count($ids) !== $inserted['count']) {
+                    throw new \RuntimeException('Unable to resolve every inserted physical-copy id.');
+                }
+            }
+            return ['count' => $inserted['count'], 'ids' => $ids];
         } finally {
             $this->releaseInventoryAllocatorLock($lockName);
         }
@@ -224,7 +257,7 @@ class CopyRepository
      * lock. Both book creation and the single-copy form use this path, so code
      * allocation, duplicate retries and INSERT behavior cannot drift apart.
      *
-     * @return array{count: int, first_id: int}
+     * @return array{count: int, first_id: int, codes: list<string>}
      */
     private function insertAllocatedCopiesWhileLocked(
         int $bookId,
@@ -280,7 +313,7 @@ class CopyRepository
             $stmt->close();
 
             if ($inserted) {
-                return ['count' => $total, 'first_id' => $firstInsertId];
+                return ['count' => $total, 'first_id' => $firstInsertId, 'codes' => $codes];
             }
             if ($errno === 1062 && $attempt < $maxAttempts) {
                 continue;
@@ -327,7 +360,7 @@ class CopyRepository
     {
         // A locking current-read sees rows committed after this transaction's
         // snapshot and locks matching unique-index rows/ranges until commit.
-        $taken = [];
+        $existingCount = 0;
         $sel = $this->db->prepare(
             'SELECT numero_inventario FROM copie WHERE numero_inventario LIKE ? FOR UPDATE'
         );
@@ -341,20 +374,111 @@ class CopyRepository
             throw new \RuntimeException('Unable to load inventory codes: ' . $error);
         }
         $res = $sel->get_result();
-        while ($row = $res->fetch_assoc()) {
-            $taken[$row['numero_inventario']] = true;
+        while ($res->fetch_assoc()) {
+            $existingCount++;
         }
         $sel->close();
 
         $codes = [];
-        for ($index = 1; count($codes) < $howMany; $index++) {
-            $candidate = "{$base}-C{$index}";
-            if (!isset($taken[$candidate])) {
-                $taken[$candidate] = true;
+        $nextIndex = 1;
+        // Among existingCount + howMany candidates there must be at least
+        // howMany free values. Check them in bounded chunks so even a 9,999-copy
+        // import does not create an enormous UNION or one query per candidate.
+        $lastIndex = $existingCount + $howMany;
+        while (count($codes) < $howMany && $nextIndex <= $lastIndex) {
+            $candidates = [];
+            while (count($candidates) < 250 && $nextIndex <= $lastIndex) {
+                $candidates[] = "{$base}-C{$nextIndex}";
+                $nextIndex++;
+            }
+            foreach ($this->inventoryCodesMissingUnderDatabaseCollation($candidates) as $candidate) {
                 $codes[] = $candidate;
+                if (count($codes) === $howMany) {
+                    break;
+                }
             }
         }
+        if (count($codes) !== $howMany) {
+            throw new \RuntimeException('Unable to allocate the requested inventory-code batch.');
+        }
         return $codes;
+    }
+
+    /**
+     * Return candidates that do not compare equal to an existing inventory code.
+     * The JOIN deliberately delegates equality to the database column collation.
+     *
+     * @param list<string> $candidates
+     * @return list<string>
+     */
+    private function inventoryCodesMissingUnderDatabaseCollation(array $candidates): array
+    {
+        if ($candidates === []) {
+            return [];
+        }
+        $rows = [];
+        foreach (array_keys($candidates) as $ordinal) {
+            $rows[] = 'SELECT ? AS inventory_code, ' . (int) $ordinal . ' AS ordinal';
+        }
+        $sql = 'SELECT candidates.ordinal FROM (' . implode(' UNION ALL ', $rows) . ') candidates '
+            // FOR UPDATE is essential here: createBasic() may already have
+            // established an older transaction snapshot. A plain JOIN could
+            // miss a competing batch committed while GET_LOCK() was awaited
+            // and select C1 again; a locking read sees the latest committed row.
+            . 'JOIN copie c ON c.numero_inventario = candidates.inventory_code FOR UPDATE';
+        $stmt = $this->db->prepare($sql);
+        if ($stmt === false) {
+            throw new \RuntimeException('Unable to prepare collation-aware inventory lookup: ' . $this->db->error);
+        }
+        $stmt->bind_param(str_repeat('s', count($candidates)), ...$candidates);
+        if (!$stmt->execute()) {
+            $error = $stmt->error;
+            $stmt->close();
+            throw new \RuntimeException('Unable to compare inventory codes: ' . $error);
+        }
+        $taken = [];
+        foreach ($stmt->get_result()->fetch_all(MYSQLI_NUM) as $row) {
+            $taken[(int) $row[0]] = true;
+        }
+        $stmt->close();
+
+        $missing = [];
+        foreach ($candidates as $ordinal => $candidate) {
+            if (!isset($taken[$ordinal])) {
+                $missing[] = $candidate;
+            }
+        }
+        return $missing;
+    }
+
+    /**
+     * @param list<string> $codes
+     * @return list<int>
+     */
+    private function copyIdsForInventoryCodes(array $codes): array
+    {
+        if ($codes === []) {
+            return [];
+        }
+        $placeholders = implode(',', array_fill(0, count($codes), '?'));
+        $stmt = $this->db->prepare(
+            "SELECT id FROM copie WHERE numero_inventario IN ({$placeholders}) ORDER BY id"
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Unable to prepare inserted-copy lookup: ' . $this->db->error);
+        }
+        $stmt->bind_param(str_repeat('s', count($codes)), ...$codes);
+        if (!$stmt->execute()) {
+            $error = $stmt->error;
+            $stmt->close();
+            throw new \RuntimeException('Unable to resolve inserted-copy ids: ' . $error);
+        }
+        $ids = array_map(
+            static fn (array $row): int => (int) $row[0],
+            $stmt->get_result()->fetch_all(MYSQLI_NUM)
+        );
+        $stmt->close();
+        return $ids;
     }
 
     private function acquireInventoryAllocatorLock(string $lockName): void

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -171,11 +171,18 @@ class CopyRepository
 
     /**
      * Create $howMany copies for a book in a single round-trip: pre-load the
-     * existing codes of this base's family ONCE, generate collision-free
+     * existing codes of this base's family, generate collision-free
      * "{base}-C{N}" codes in memory, then batch-insert every row with one
-     * prepared statement. Replaces the per-copy inventoryCodeExists()+create()
-     * pair that turned a large copie_totali import into thousands of queries
-     * inside the per-row transaction (holding locks on `copie`).
+     * prepared statement. A connection-level advisory lock serializes inventory
+     * allocation even when a prefix's unique-index range is still empty (where
+     * gap locks alone can deadlock). A single allocator lock also respects the
+     * database's case/accent-insensitive uniqueness without trying to reproduce
+     * its collation rules in PHP. The locking current-read then sees rows
+     * committed after the transaction snapshot. A bounded duplicate-key retry
+     * remains as a final guard for external writers. A failed multi-row INSERT
+     * never leaves a partial batch. Replaces the per-copy
+     * inventoryCodeExists()+create() pair that turned a large copie_totali
+     * import into thousands of queries.
      *
      * @param string|null $noteTemplate already-translated sprintf template with
      *                                   two %d (index, total); null = no note.
@@ -190,10 +197,146 @@ class CopyRepository
         // numero_inventario is VARCHAR(100); leave room for the "-C{N}" suffix.
         $base = mb_substr($base, 0, 90);
 
-        // Pre-load, once, every existing code that could collide with this family.
-        $taken = [];
+        // GET_LOCK() is server-wide and connection-scoped. One short global
+        // allocator lock avoids mismatches with numero_inventario's
+        // case/accent-insensitive UNIQUE collation. It does not start, commit or
+        // roll back the caller's transaction and is released after the batch
+        // INSERT, not held for hooks or external services.
+        $lockName = 'pinakes-copy-inventory-allocation';
+        $this->acquireInventoryAllocatorLock($lockName);
+        try {
+            return $this->createManyForBookWhileLocked(
+                $bookId,
+                $base,
+                $howMany,
+                $stato,
+                $noteTemplate
+            );
+        } finally {
+            $this->releaseInventoryAllocatorLock($lockName);
+        }
+    }
+
+    /**
+     * Insert a copy batch while the caller holds the inventory allocator lock.
+     */
+    private function createManyForBookWhileLocked(int $bookId, string $base, int $howMany, string $stato, ?string $noteTemplate): int
+    {
         $likeParam = $base . '%';
-        $sel = $this->db->prepare("SELECT numero_inventario FROM copie WHERE numero_inventario LIKE ?");
+        $maxAttempts = 5;
+
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            $codes = $this->allocateInventoryCodesWithCurrentRead($base, $likeParam, $howMany);
+
+            // Single multi-row INSERT. MySQL/MariaDB roll back the entire
+            // statement if any unique inventory code collides.
+            $total = count($codes);
+            $placeholders = implode(',', array_fill(0, $total, '(?, ?, ?, ?)'));
+            $stmt = $this->db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES {$placeholders}");
+            if ($stmt === false) {
+                throw new \RuntimeException('Unable to prepare copy batch insert: ' . $this->db->error);
+            }
+            $types = '';
+            $params = [];
+            foreach ($codes as $i => $code) {
+                $note = ($noteTemplate !== null && $total > 1) ? sprintf($noteTemplate, $i + 1, $total) : null;
+                $types .= 'isss';
+                $params[] = $bookId;
+                $params[] = $code;
+                $params[] = $stato;
+                $params[] = $note;
+            }
+            $stmt->bind_param($types, ...$params);
+
+            try {
+                $inserted = $stmt->execute();
+                $errno = $stmt->errno;
+                $error = $stmt->error;
+            } catch (\mysqli_sql_exception $e) {
+                $stmt->close();
+                if ($e->getCode() === 1062 && $attempt < $maxAttempts) {
+                    continue;
+                }
+                throw $e;
+            }
+            $stmt->close();
+
+            if ($inserted) {
+                return $total;
+            }
+            if ($errno === 1062 && $attempt < $maxAttempts) {
+                continue;
+            }
+            throw new \RuntimeException('Unable to insert copy batch: ' . $error);
+        }
+
+        throw new \RuntimeException('Unable to allocate unique inventory codes after concurrent retries.');
+    }
+
+    /**
+     * Create one copy with an automatically allocated inventory code and return
+     * its id. Allocation and INSERT share the same advisory-lock critical
+     * section, unlike allocateInventoryCodes() which is intentionally read-only.
+     */
+    public function createWithAllocatedInventoryCode(int $bookId, string $base, string $stato = 'disponibile', ?string $note = null): int
+    {
+        $base = mb_substr($base, 0, 90);
+        $likeParam = $base . '%';
+        $lockName = 'pinakes-copy-inventory-allocation';
+        $maxAttempts = 5;
+
+        $this->acquireInventoryAllocatorLock($lockName);
+        try {
+            for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+                $codes = $this->allocateInventoryCodesWithCurrentRead($base, $likeParam, 1);
+                $numeroInventario = $codes[0] ?? ($base . '-C1');
+                $stmt = $this->db->prepare(
+                    'INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES (?, ?, ?, ?)'
+                );
+                if ($stmt === false) {
+                    throw new \RuntimeException('Unable to prepare copy insert: ' . $this->db->error);
+                }
+                $stmt->bind_param('isss', $bookId, $numeroInventario, $stato, $note);
+                try {
+                    $inserted = $stmt->execute();
+                    $errno = $stmt->errno;
+                    $error = $stmt->error;
+                } catch (\mysqli_sql_exception $e) {
+                    $stmt->close();
+                    if ($e->getCode() === 1062 && $attempt < $maxAttempts) {
+                        continue;
+                    }
+                    throw $e;
+                }
+                $insertId = (int) $this->db->insert_id;
+                $stmt->close();
+
+                if ($inserted && $insertId > 0) {
+                    return $insertId;
+                }
+                if ($errno === 1062 && $attempt < $maxAttempts) {
+                    continue;
+                }
+                throw new \RuntimeException('Unable to insert allocated copy: ' . $error);
+            }
+        } finally {
+            $this->releaseInventoryAllocatorLock($lockName);
+        }
+
+        throw new \RuntimeException('Unable to allocate a unique inventory code after concurrent retries.');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allocateInventoryCodesWithCurrentRead(string $base, string $likeParam, int $howMany): array
+    {
+        // A locking current-read sees rows committed after this transaction's
+        // snapshot and locks matching unique-index rows/ranges until commit.
+        $taken = [];
+        $sel = $this->db->prepare(
+            'SELECT numero_inventario FROM copie WHERE numero_inventario LIKE ? FOR UPDATE'
+        );
         if ($sel === false) {
             throw new \RuntimeException('Unable to prepare inventory-code lookup: ' . $this->db->error);
         }
@@ -209,7 +352,6 @@ class CopyRepository
         }
         $sel->close();
 
-        // Generate collision-free codes in memory (walk up, filling gaps).
         $codes = [];
         for ($index = 1; count($codes) < $howMany; $index++) {
             $candidate = "{$base}-C{$index}";
@@ -218,33 +360,43 @@ class CopyRepository
                 $codes[] = $candidate;
             }
         }
+        return $codes;
+    }
 
-        // Single multi-row INSERT.
-        $total = count($codes);
-        $placeholders = implode(',', array_fill(0, $total, '(?, ?, ?, ?)'));
-        $stmt = $this->db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES {$placeholders}");
+    private function acquireInventoryAllocatorLock(string $lockName): void
+    {
+        $stmt = $this->db->prepare('SELECT GET_LOCK(?, 30)');
         if ($stmt === false) {
-            throw new \RuntimeException('Unable to prepare copy batch insert: ' . $this->db->error);
+            throw new \RuntimeException('Unable to prepare inventory allocator lock: ' . $this->db->error);
         }
-        $types = '';
-        $params = [];
-        foreach ($codes as $i => $code) {
-            $note = ($noteTemplate !== null && $total > 1) ? sprintf($noteTemplate, $i + 1, $total) : null;
-            $types .= 'isss';
-            $params[] = $bookId;
-            $params[] = $code;
-            $params[] = $stato;
-            $params[] = $note;
-        }
-        $stmt->bind_param($types, ...$params);
-        if (!$stmt->execute()) {
-            $error = $stmt->error;
+        $stmt->bind_param('s', $lockName);
+        try {
+            if (!$stmt->execute()) {
+                throw new \RuntimeException('Unable to acquire inventory allocator lock: ' . $stmt->error);
+            }
+            $acquired = (int) ($stmt->get_result()->fetch_row()[0] ?? 0);
+        } finally {
             $stmt->close();
-            throw new \RuntimeException('Unable to insert copy batch: ' . $error);
         }
-        $stmt->close();
+        if ($acquired !== 1) {
+            throw new \RuntimeException('Timed out while waiting to allocate inventory codes.');
+        }
+    }
 
-        return $total;
+    private function releaseInventoryAllocatorLock(string $lockName): void
+    {
+        try {
+            $stmt = $this->db->prepare('SELECT RELEASE_LOCK(?)');
+            if ($stmt === false) {
+                return;
+            }
+            $stmt->bind_param('s', $lockName);
+            $stmt->execute();
+            $stmt->close();
+        } catch (\Throwable $e) {
+            // A broken connection releases its advisory locks server-side. Do
+            // not hide the original copy-allocation error from the caller.
+        }
     }
 
     /**

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -205,23 +205,35 @@ class CopyRepository
         $lockName = 'pinakes-copy-inventory-allocation';
         $this->acquireInventoryAllocatorLock($lockName);
         try {
-            return $this->createManyForBookWhileLocked(
+            $result = $this->insertAllocatedCopiesWhileLocked(
                 $bookId,
                 $base,
                 $howMany,
                 $stato,
-                $noteTemplate
+                $noteTemplate,
+                null
             );
+            return $result['count'];
         } finally {
             $this->releaseInventoryAllocatorLock($lockName);
         }
     }
 
     /**
-     * Insert a copy batch while the caller holds the inventory allocator lock.
+     * Insert allocated copies while the caller holds the inventory allocator
+     * lock. Both book creation and the single-copy form use this path, so code
+     * allocation, duplicate retries and INSERT behavior cannot drift apart.
+     *
+     * @return array{count: int, first_id: int}
      */
-    private function createManyForBookWhileLocked(int $bookId, string $base, int $howMany, string $stato, ?string $noteTemplate): int
-    {
+    private function insertAllocatedCopiesWhileLocked(
+        int $bookId,
+        string $base,
+        int $howMany,
+        string $stato,
+        ?string $noteTemplate,
+        ?string $singleNote
+    ): array {
         $likeParam = $base . '%';
         $maxAttempts = 5;
 
@@ -239,7 +251,9 @@ class CopyRepository
             $types = '';
             $params = [];
             foreach ($codes as $i => $code) {
-                $note = ($noteTemplate !== null && $total > 1) ? sprintf($noteTemplate, $i + 1, $total) : null;
+                $note = $total === 1
+                    ? $singleNote
+                    : ($noteTemplate !== null ? sprintf($noteTemplate, $i + 1, $total) : null);
                 $types .= 'isss';
                 $params[] = $bookId;
                 $params[] = $code;
@@ -259,10 +273,11 @@ class CopyRepository
                 }
                 throw $e;
             }
+            $firstInsertId = (int) $this->db->insert_id;
             $stmt->close();
 
             if ($inserted) {
-                return $total;
+                return ['count' => $total, 'first_id' => $firstInsertId];
             }
             if ($errno === 1062 && $attempt < $maxAttempts) {
                 continue;
@@ -281,49 +296,25 @@ class CopyRepository
     public function createWithAllocatedInventoryCode(int $bookId, string $base, string $stato = 'disponibile', ?string $note = null): int
     {
         $base = mb_substr($base, 0, 90);
-        $likeParam = $base . '%';
         $lockName = 'pinakes-copy-inventory-allocation';
-        $maxAttempts = 5;
 
         $this->acquireInventoryAllocatorLock($lockName);
         try {
-            for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
-                $codes = $this->allocateInventoryCodesWithCurrentRead($base, $likeParam, 1);
-                $numeroInventario = $codes[0] ?? ($base . '-C1');
-                $stmt = $this->db->prepare(
-                    'INSERT INTO copie (libro_id, numero_inventario, stato, note) VALUES (?, ?, ?, ?)'
-                );
-                if ($stmt === false) {
-                    throw new \RuntimeException('Unable to prepare copy insert: ' . $this->db->error);
-                }
-                $stmt->bind_param('isss', $bookId, $numeroInventario, $stato, $note);
-                try {
-                    $inserted = $stmt->execute();
-                    $errno = $stmt->errno;
-                    $error = $stmt->error;
-                } catch (\mysqli_sql_exception $e) {
-                    $stmt->close();
-                    if ($e->getCode() === 1062 && $attempt < $maxAttempts) {
-                        continue;
-                    }
-                    throw $e;
-                }
-                $insertId = (int) $this->db->insert_id;
-                $stmt->close();
-
-                if ($inserted && $insertId > 0) {
-                    return $insertId;
-                }
-                if ($errno === 1062 && $attempt < $maxAttempts) {
-                    continue;
-                }
-                throw new \RuntimeException('Unable to insert allocated copy: ' . $error);
+            $result = $this->insertAllocatedCopiesWhileLocked(
+                $bookId,
+                $base,
+                1,
+                $stato,
+                null,
+                $note
+            );
+            if ($result['count'] === 1 && $result['first_id'] > 0) {
+                return $result['first_id'];
             }
+            throw new \RuntimeException('Allocated copy insert did not affect exactly one row.');
         } finally {
             $this->releaseInventoryAllocatorLock($lockName);
         }
-
-        throw new \RuntimeException('Unable to allocate a unique inventory code after concurrent retries.');
     }
 
     /**

--- a/app/Models/CopyRepository.php
+++ b/app/Models/CopyRepository.php
@@ -234,7 +234,10 @@ class CopyRepository
         ?string $noteTemplate,
         ?string $singleNote
     ): array {
-        $likeParam = $base . '%';
+        // Escape LIKE metacharacters in the base before appending the wildcard.
+        // A base ending in a backslash would otherwise escape the trailing '%',
+        // making the taken-set miss the whole -C{N} family and loop into 1062.
+        $likeParam = addcslashes($base, '%_\\') . '%';
         $maxAttempts = 5;
 
         for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
@@ -356,7 +359,7 @@ class CopyRepository
 
     private function acquireInventoryAllocatorLock(string $lockName): void
     {
-        $stmt = $this->db->prepare('SELECT GET_LOCK(?, 30)');
+        $stmt = $this->db->prepare('SELECT GET_LOCK(?, 10)');
         if ($stmt === false) {
             throw new \RuntimeException('Unable to prepare inventory allocator lock: ' . $this->db->error);
         }

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -278,7 +278,7 @@ class LoanRepository
             // have vanished (recalculateBookAvailability only returns false when the
             // book row is missing).
             if (!$integrity->recalculateBookAvailability($bookId, true)) {
-                throw new \RuntimeException(__('Impossibile ricalcolare la disponibilità finale del libro.'));
+                throw new \RuntimeException('Unable to recalculate final book availability.');
             }
 
             $this->db->commit();

--- a/app/Models/LoanRepository.php
+++ b/app/Models/LoanRepository.php
@@ -277,7 +277,9 @@ class LoanRepository
             // recalculated successfully above in this same transaction, so it cannot
             // have vanished (recalculateBookAvailability only returns false when the
             // book row is missing).
-            $integrity->recalculateBookAvailability($bookId, true);
+            if (!$integrity->recalculateBookAvailability($bookId, true)) {
+                throw new \RuntimeException(__('Impossibile ricalcolare la disponibilità finale del libro.'));
+            }
 
             $this->db->commit();
 

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -1494,6 +1494,12 @@ return function (App $app): void {
         return $controller->deleteCopy($request, $response, $db, (int) $args['id']);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
+    $app->post('/admin/books/{id:\d+}/copies/create', function ($request, $response, $args) use ($app) {
+        $controller = new \App\Controllers\CopyController();
+        $db = $app->getContainer()->get('db');
+        return $controller->createCopy($request, $response, $db, (int) $args['id']);
+    })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
+
     // Series (Series) management
     $app->get('/admin/series', function ($request, $response) use ($app) {
         $controller = new \App\Controllers\CollaneController();

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2422,39 +2422,65 @@ return function (App $app): void {
             return $response->withStatus(404)->withHeader('Content-Type', 'application/json');
         }
 
-        // Calculate new total
-        $currentCopieTotali = (int) $book['copie_totali'];
-        $newCopieTotali = $currentCopieTotali + $copiesToAdd;
-
-        // Update copie_totali counter in libri table
-        $stmt = $db->prepare('UPDATE libri SET copie_totali = ? WHERE id = ?');
-        $stmt->bind_param('ii', $newCopieTotali, $bookId);
-        $stmt->execute();
-        $stmt->close();
-
-        // Create physical copies in copie table
+        // Create the copies atomically and let DataIntegrity derive the counters,
+        // mirroring CopyController::createCopy(). The allocator produces
+        // collision-free "{base}-C{N}" codes: the previous "-C{copie_totali+i}"
+        // scheme collided with an existing code as soon as a copy was out of
+        // circulation (copie_totali excludes those), raising a 1062 that left the
+        // manually-inflated copie_totali and a partial copy set behind. No manual
+        // UPDATE, one transaction, rolled back on any failure.
         $copyRepo = new \App\Models\CopyRepository($db);
         $baseInventario = !empty($book['numero_inventario'])
             ? $book['numero_inventario']
             : "LIB-{$bookId}";
 
-        // Start from current total + 1 for new copies
-        for ($i = 1; $i <= $copiesToAdd; $i++) {
-            $copyNumber = $currentCopieTotali + $i;
-            $numeroInventario = $newCopieTotali > 1
-                ? "{$baseInventario}-C{$copyNumber}"
-                : $baseInventario;
+        try {
+            $db->begin_transaction();
 
-            $note = "Copia {$copyNumber} di {$newCopieTotali}";
-            $copyRepo->create($bookId, $numeroInventario, 'disponibile', $note);
+            // Canonical lock order: book row first, then copies.
+            $lock = $db->prepare('SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE');
+            $lock->bind_param('i', $bookId);
+            $lock->execute();
+            $stillExists = (bool) $lock->get_result()->fetch_assoc();
+            $lock->close();
+            if (!$stillExists) {
+                throw new \RuntimeException('Book not found.');
+            }
+
+            $created = $copyRepo->createManyForBook($bookId, $baseInventario, $copiesToAdd, 'disponibile', __('Copia %d di %d'));
+            if ($created !== $copiesToAdd) {
+                throw new \RuntimeException('Unable to create the requested physical copies.');
+            }
+
+            // New available copies are new circulation capacity: promote as many
+            // wait-list entries as they allow (same as createCopy()).
+            $reservationManager = new \App\Controllers\ReservationManager($db);
+            $reservationManager->setExternalTransaction(true);
+            for ($guard = 0; $guard < 1000 && $reservationManager->processBookAvailability($bookId); $guard++) {
+                // promote the next eligible reservation into a pending loan
+            }
+
+            $integrity = new \App\Support\DataIntegrity($db);
+            if (!$integrity->recalculateBookAvailability($bookId, true)) {
+                throw new \RuntimeException('Unable to recalculate book availability.');
+            }
+
+            $db->commit();
+        } catch (\Throwable $e) {
+            $db->rollback();
+            \App\Support\SecureLogger::error('[increase-copies] failed to add copies', [
+                'book' => $bookId,
+                'error' => $e->getMessage(),
+            ]);
+            $response->getBody()->write(json_encode([
+                'error' => true,
+                'message' => __('Impossibile aggiungere le copie.')
+            ], JSON_UNESCAPED_UNICODE));
+            return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
         }
 
-        // Recalculate availability using DataIntegrity
-        $integrity = new \App\Support\DataIntegrity($db);
-        $integrity->recalculateBookAvailability($bookId);
-
-        // Get updated availability
-        $stmt = $db->prepare('SELECT copie_disponibili FROM libri WHERE id = ? AND deleted_at IS NULL');
+        // Read the derived counters (post-commit) for the response.
+        $stmt = $db->prepare('SELECT copie_totali, copie_disponibili FROM libri WHERE id = ? AND deleted_at IS NULL');
         $stmt->bind_param('i', $bookId);
         $stmt->execute();
         $result = $stmt->get_result();
@@ -2463,8 +2489,8 @@ return function (App $app): void {
 
         $response->getBody()->write(json_encode([
             'success' => true,
-            'copie_totali' => $newCopieTotali,
-            'copie_disponibili' => (int) $updatedBook['copie_disponibili'],
+            'copie_totali' => (int) ($updatedBook['copie_totali'] ?? 0),
+            'copie_disponibili' => (int) ($updatedBook['copie_disponibili'] ?? 0),
             'added' => $copiesToAdd
         ], JSON_UNESCAPED_UNICODE));
 

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -2392,13 +2392,20 @@ return function (App $app): void {
 
         // Get request body
         $body = $request->getParsedBody();
-        if (!$body) {
-            $body = json_decode((string) $request->getBody(), true);
+        if (!is_array($body) || $body === []) {
+            $decodedBody = json_decode((string) $request->getBody(), true);
+            $body = is_array($decodedBody) ? $decodedBody : [];
         }
 
-        $copiesToAdd = (int) ($body['copies'] ?? 0);
+        // Keep the server-side contract aligned with the admin prompt. Avoid
+        // PHP's surprising casts ((int) ['anything'] === 1) and cap the batch so
+        // one request cannot build an unbounded multi-row INSERT.
+        $rawCopies = $body['copies'] ?? null;
+        $copiesToAdd = is_int($rawCopies)
+            ? $rawCopies
+            : (is_string($rawCopies) && preg_match('/^[1-9]\d*$/D', $rawCopies) === 1 ? (int) $rawCopies : 0);
 
-        if ($copiesToAdd < 1) {
+        if ($copiesToAdd < 1 || $copiesToAdd > 100) {
             $response->getBody()->write(json_encode([
                 'error' => true,
                 'message' => __('Numero di copie non valido.')
@@ -2434,8 +2441,14 @@ return function (App $app): void {
             ? $book['numero_inventario']
             : "LIB-{$bookId}";
 
+        $reassignmentService = null;
+        $reservationManager = null;
+        $transactionStarted = false;
         try {
-            $db->begin_transaction();
+            if (!$db->begin_transaction()) {
+                throw new \RuntimeException('Unable to begin the increase-copies transaction.');
+            }
+            $transactionStarted = true;
 
             // Canonical lock order: book row first, then copies.
             $lock = $db->prepare('SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE');
@@ -2447,13 +2460,20 @@ return function (App $app): void {
                 throw new \RuntimeException('Book not found.');
             }
 
-            $created = $copyRepo->createManyForBook($bookId, $baseInventario, $copiesToAdd, 'disponibile', __('Copia %d di %d'));
-            if ($created !== $copiesToAdd) {
+            $createdCopyIds = $copyRepo->createManyForBookWithIds($bookId, $baseInventario, $copiesToAdd, 'disponibile', __('Copia %d di %d'));
+            if (count($createdCopyIds) !== $copiesToAdd) {
                 throw new \RuntimeException('Unable to create the requested physical copies.');
             }
 
-            // New available copies are new circulation capacity: promote as many
-            // wait-list entries as they allow (same as createCopy()).
+            // First repair copy-less/blocked HOLDING assignments, exactly like
+            // CopyController::createCopy(). Only the capacity left after those
+            // repairs may promote wait-list rows from prenotazioni.
+            $reassignmentService = new \App\Services\ReservationReassignmentService($db);
+            $reassignmentService->setExternalTransaction(true);
+            foreach ($createdCopyIds as $createdCopyId) {
+                $reassignmentService->reassignOnNewCopy($bookId, $createdCopyId);
+            }
+
             $reservationManager = new \App\Controllers\ReservationManager($db);
             $reservationManager->setExternalTransaction(true);
             for ($guard = 0; $guard < 1000 && $reservationManager->processBookAvailability($bookId); $guard++) {
@@ -2465,9 +2485,18 @@ return function (App $app): void {
                 throw new \RuntimeException('Unable to recalculate book availability.');
             }
 
-            $db->commit();
+            if (!$db->commit()) {
+                throw new \RuntimeException('Unable to commit the increase-copies transaction.');
+            }
+            $transactionStarted = false;
         } catch (\Throwable $e) {
-            $db->rollback();
+            if ($transactionStarted) {
+                try {
+                    $db->rollback();
+                } catch (\Throwable $rollbackError) {
+                    // best-effort — preserve the original failure
+                }
+            }
             \App\Support\SecureLogger::error('[increase-copies] failed to add copies', [
                 'book' => $bookId,
                 'error' => $e->getMessage(),
@@ -2477,6 +2506,19 @@ return function (App $app): void {
                 'message' => __('Impossibile aggiungere le copie.')
             ], JSON_UNESCAPED_UNICODE));
             return $response->withStatus(500)->withHeader('Content-Type', 'application/json');
+        }
+
+        // Both services defer I/O while the transaction is open. Flush only
+        // after the assignment/promotion has become durable; notification errors
+        // must not turn a committed copy batch into an apparent API failure.
+        try {
+            $reassignmentService->flushDeferredNotifications();
+            $reservationManager->flushDeferredNotifications();
+        } catch (\Throwable $e) {
+            \App\Support\SecureLogger::warning('[increase-copies] deferred notification failed', [
+                'book' => $bookId,
+                'error' => $e->getMessage(),
+            ]);
         }
 
         // Read the derived counters (post-commit) for the response.

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -231,10 +231,12 @@ class ReservationReassignmentService
             $stmt->execute();
             $stmt->close();
 
-            // Block the copy for the reserved loan period
-            $copyRepo = new \App\Models\CopyRepository($this->db);
-            if (!$copyRepo->updateStatus($newCopiaId, 'prenotato')) {
-                throw new \RuntimeException("Failed to update copy status for copia_id={$newCopiaId}");
+            // Derive the physical-copy state from every commitment instead of
+            // forcing 'prenotato'. This matters when a copy has another,
+            // non-overlapping current loan: 'prestato' has priority until that
+            // loan is returned, while the future hold remains linked correctly.
+            if (!(new \App\Support\DataIntegrity($this->db))->recalculateBookAvailability($libroId, true)) {
+                throw new \RuntimeException("Failed to recalculate availability for libro_id={$libroId}");
             }
 
             // Se la prenotazione aveva una vecchia copia assegnata, dobbiamo verificare
@@ -304,11 +306,21 @@ class ReservationReassignmentService
         $resStart = (string) $reservation['data_prestito'];
         $resEnd = (string) $reservation['data_scadenza'];
         $excludedCopies = [$copiaId]; // Copie da escludere dalla ricerca
-        $maxRetries = 5; // Limite tentativi per evitare loop infiniti
+        // The allocator pre-filters overlaps, so retries are only needed when a
+        // concurrent transaction claims a candidate between lookup and lock.
+        // A fixed limit of five used to give up even when a sixth physical copy
+        // was free for the requested period.
+        $maxRetries = 1000;
 
         for ($attempt = 0; $attempt < $maxRetries; $attempt++) {
             // Cerca un'altra copia disponibile per questo libro
-            $nextCopyId = $this->findAvailableCopyExcluding($libroId, $excludedCopies);
+            $nextCopyId = $this->findAvailableCopyExcluding(
+                $libroId,
+                $excludedCopies,
+                $reservationId,
+                $resStart,
+                $resEnd
+            );
 
             if (!$nextCopyId) {
                 // Nessuna copia disponibile
@@ -351,8 +363,9 @@ class ReservationReassignmentService
                 $copyStatus = $stmt->get_result()->fetch_assoc();
                 $stmt->close();
 
-                // Verifica che la copia sia ancora disponibile (potrebbe essere cambiata)
-                if (!$copyStatus || !in_array($copyStatus['stato'], ['disponibile', 'prenotato'], true)) {
+                // A copy currently 'prestato' is a valid target for a disjoint
+                // future hold. Operationally unavailable states never are.
+                if (!$copyStatus || in_array($copyStatus['stato'], ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true)) {
                     $this->rollbackIfOwned($ownTransaction);
                     // Aggiungi questa copia alle escluse e riprova
                     $excludedCopies[] = $nextCopyId;
@@ -386,10 +399,11 @@ class ReservationReassignmentService
                 $stmt->execute();
                 $stmt->close();
 
-                // Block the copy for the reserved loan period
-                $copyRepo = new \App\Models\CopyRepository($this->db);
-                if (!$copyRepo->updateStatus($nextCopyId, 'prenotato')) {
-                    throw new \RuntimeException("Failed to update copy status for copia_id={$nextCopyId}");
+                // Recompute instead of forcing 'prenotato': if the replacement
+                // is physically out on a non-overlapping current loan it must
+                // remain 'prestato' until return.
+                if (!(new \App\Support\DataIntegrity($this->db))->recalculateBookAvailability($libroId, true)) {
+                    throw new \RuntimeException("Failed to recalculate availability for libro_id={$libroId}");
                 }
 
                 $this->commitIfOwned($ownTransaction);
@@ -522,27 +536,45 @@ class ReservationReassignmentService
      * @param int $libroId ID del libro
      * @param array<int> $excludeCopiaIds Array di ID copie da escludere
      */
-    private function findAvailableCopyExcluding(int $libroId, array $excludeCopiaIds): ?int
+    private function findAvailableCopyExcluding(
+        int $libroId,
+        array $excludeCopiaIds,
+        int $reservationId,
+        string $startDate,
+        string $endDate
+    ): ?int
     {
         $sql = "
-            SELECT id
-            FROM copie
-            WHERE libro_id = ?
-            AND stato IN ('disponibile', 'prenotato')
+            SELECT c.id
+            FROM copie c
+            WHERE c.libro_id = ?
+            AND c.stato NOT IN ('perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento')
+            AND NOT EXISTS (
+                SELECT 1
+                FROM prestiti p
+                WHERE p.copia_id = c.id
+                  AND p.id <> ?
+                  AND p.data_prestito <= ?
+                  AND (p.stato = 'in_ritardo' OR p.data_scadenza >= ?)
+                  AND (
+                      (p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
+                      OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL)
+                  )
+            )
         ";
-        $params = [$libroId];
-        $types = "i";
+        $params = [$libroId, $reservationId, $endDate, $startDate];
+        $types = 'iiss';
 
         if (!empty($excludeCopiaIds)) {
             $placeholders = implode(',', array_fill(0, count($excludeCopiaIds), '?'));
-            $sql .= " AND id NOT IN ($placeholders)";
+            $sql .= " AND c.id NOT IN ($placeholders)";
             foreach ($excludeCopiaIds as $id) {
                 $params[] = $id;
                 $types .= "i";
             }
         }
 
-        $sql .= " LIMIT 1";
+        $sql .= " ORDER BY c.id ASC LIMIT 1";
 
         $stmt = $this->db->prepare($sql);
         $stmt->bind_param($types, ...$params);

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -262,6 +262,8 @@ class DataIntegrity {
     /**
      * Ricalcola le copie disponibili per un singolo libro
      * Supports being called inside or outside a transaction
+     *
+     * @phpstan-impure Mutates and re-reads circulation state in the database.
      */
     public function recalculateBookAvailability(int $bookId, bool $insideTransaction = false, bool $skipCacheInvalidation = false): bool {
         // App-timezone "today" (see recalculateAllBookAvailability) — interpolated in place of

--- a/app/Support/LoanEligibility.php
+++ b/app/Support/LoanEligibility.php
@@ -32,6 +32,7 @@ class LoanEligibility
      *
      * @return string|null Codice errore ('user_not_found', 'user_suspended',
      *                     'card_expired') oppure null se l'utente è idoneo.
+     * @phpstan-impure Reads mutable database state; repeated calls can differ.
      */
     public static function checkUser(\mysqli $db, int $userId): ?string
     {

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -419,7 +419,9 @@ class MaintenanceService
 
                 // Recalculate book availability using DataIntegrity for consistency
                 // (da_ritirare counts as "slot occupied" even if copy is available)
-                $integrity->recalculateBookAvailability((int)$loan['libro_id'], true);
+                if (!$integrity->recalculateBookAvailability((int) $loan['libro_id'], true)) {
+                    throw new \RuntimeException('Failed to recalculate availability while activating a scheduled loan.');
+                }
 
                 $this->db->commit();
                 $activatedCount++;
@@ -471,7 +473,8 @@ class MaintenanceService
             FROM prenotazioni p
             JOIN utenti u ON p.utente_id = u.id
             WHERE p.stato = 'attiva'
-            AND p.data_inizio_richiesta <= ?
+            AND COALESCE(p.data_inizio_richiesta, DATE(p.data_scadenza_prenotazione)) IS NOT NULL
+            AND COALESCE(p.data_inizio_richiesta, DATE(p.data_scadenza_prenotazione)) <= ?
             ORDER BY p.libro_id, p.queue_position ASC
         ");
 
@@ -690,7 +693,9 @@ class MaintenanceService
                 }
 
                 // Recalculate book availability (inside transaction)
-                $integrity->recalculateBookAvailability($libroId, true);
+                if (!$integrity->recalculateBookAvailability($libroId, true)) {
+                    throw new \RuntimeException('Failed to recalculate availability after reservation expiry.');
+                }
 
                 $this->db->commit();
                 $expiredCount++;
@@ -872,7 +877,9 @@ class MaintenanceService
                 }
 
                 // Recalculate book availability (inside transaction)
-                $integrity->recalculateBookAvailability($libroId, true);
+                if (!$integrity->recalculateBookAvailability($libroId, true)) {
+                    throw new \RuntimeException('Failed to recalculate availability after pickup expiry.');
+                }
 
                 $this->db->commit();
                 $expiredCount++;

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -473,8 +473,22 @@ class MaintenanceService
             FROM prenotazioni p
             JOIN utenti u ON p.utente_id = u.id
             WHERE p.stato = 'attiva'
-            AND COALESCE(p.data_inizio_richiesta, DATE(p.data_scadenza_prenotazione)) IS NOT NULL
-            AND COALESCE(p.data_inizio_richiesta, DATE(p.data_scadenza_prenotazione)) <= ?
+            AND (
+                -- Real requested start that has arrived. '1000-01-01' is MySQL's
+                -- minimum valid DATE: the floor rejects 0000-00-00 dump rows
+                -- (which would otherwise be promoted back-dated) without
+                -- embedding the literal '0000-00-00', which a NO_ZERO_DATE
+                -- server refuses even at prepare time.
+                (p.data_inizio_richiesta >= '1000-01-01' AND p.data_inizio_richiesta <= ?)
+                -- Legacy row with no requested start: promote only while the
+                -- reservation deadline is still valid (today or future). An
+                -- already-expired deadline must be left for the expiry /
+                -- cancellation path, never converted into a loan back-dated to
+                -- the past.
+                OR (p.data_inizio_richiesta IS NULL
+                    AND p.data_scadenza_prenotazione IS NOT NULL
+                    AND DATE(p.data_scadenza_prenotazione) >= ?)
+            )
             ORDER BY p.libro_id, p.queue_position ASC
         ");
 
@@ -482,7 +496,7 @@ class MaintenanceService
             throw new \RuntimeException('Failed to prepare scheduled reservations query');
         }
 
-        $stmt->bind_param('s', $today);
+        $stmt->bind_param('ss', $today, $today);
         $stmt->execute();
         $result = $stmt->get_result();
         $reservations = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];

--- a/app/Support/RouteTranslator.php
+++ b/app/Support/RouteTranslator.php
@@ -59,8 +59,6 @@ class RouteTranslator
         'api_home' => '/api/home',
         'language_switch' => '/language',
         'bibframe.book'   => '/api/bibframe/book/{id}',
-        'admin_books' => '/admin/books',
-        'admin_book' => '/admin/books/{id}',
     ];
 
     /**

--- a/app/Support/RouteTranslator.php
+++ b/app/Support/RouteTranslator.php
@@ -59,6 +59,8 @@ class RouteTranslator
         'api_home' => '/api/home',
         'language_switch' => '/language',
         'bibframe.book'   => '/api/bibframe/book/{id}',
+        'admin_books' => '/admin/books',
+        'admin_book' => '/admin/books/{id}',
     ];
 
     /**

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -319,10 +319,8 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
               <option value="non_disponibile" <?php echo $statoCorrente === 'non_disponibile' ? 'selected' : ''; ?>><?= __("Non Disponibile") ?></option>
               <option value="prestato" <?php echo $statoCorrente === 'prestato' ? 'selected' : ''; ?>><?= __("Prestato") ?></option>
               <option value="prenotato" <?php echo $statoCorrente === 'prenotato' ? 'selected' : ''; ?>><?= __("Prenotato") ?></option>
-              <option value="danneggiato" <?php echo $statoCorrente === 'danneggiato' ? 'selected' : ''; ?>><?= __("Danneggiato") ?></option>
-              <option value="perso" <?php echo $statoCorrente === 'perso' ? 'selected' : ''; ?>><?= __("Perso") ?></option>
             </select>
-            <p class="text-xs text-gray-500 mt-1"><?= __("Status attuale di questa copia del libro") ?></p>
+            <p class="text-xs text-gray-500 mt-1"><?= __("La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.") ?></p>
           </div>
 
           <!-- Description -->
@@ -488,13 +486,24 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
           
           <div class="form-grid-3">
             <div>
-              <label for="copie_totali" class="form-label"><?= __("Copie Totali") ?> <span class="text-xs text-gray-500">(<?= __("Le copie disponibili vengono calcolate automaticamente") ?>)</span></label>
-              <input id="copie_totali" name="copie_totali" type="number" class="form-input" value="<?php echo (int)($book['copie_totali'] ?? 1); ?>" min="<?php echo $mode === 'edit' ? (int)($book['copie_totali'] ?? 1) : 1; ?>" />
-              <?php if ($mode === 'edit'): ?>
+              <label for="copie_totali" class="form-label">
+                <?= $mode === 'edit' ? __("Copie in circolazione") : __("Copie fisiche iniziali") ?>
+                <span class="text-xs text-gray-500">(<?= __("Le copie disponibili vengono calcolate automaticamente") ?>)</span>
+              </label>
+              <input id="copie_totali" name="copie_totali" type="number" class="form-input"
+                     value="<?php echo (int)($book['copie_totali'] ?? 1); ?>" min="0" max="9999"
+                     <?php echo $mode === 'edit' ? 'readonly aria-readonly="true"' : ''; ?> />
+              <?php if ($mode === 'edit' && !empty($book['id'])): ?>
               <p class="text-xs text-gray-600 mt-1">
                 <i class="fas fa-info-circle text-blue-500 mr-1"></i>
-                Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.
+                <?= __("Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.") ?>
+                <a class="text-blue-600 hover:text-blue-800 underline"
+                   href="<?= htmlspecialchars(url('/admin/books/' . (int)$book['id'] . '#physical-copies'), ENT_QUOTES, 'UTF-8') ?>">
+                  <?= __("Gestisci copie fisiche") ?>
+                </a>
               </p>
+              <?php else: ?>
+              <p class="text-xs text-gray-600 mt-1"><?= __("Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.") ?></p>
               <?php endif; ?>
             </div>
           </div>
@@ -511,8 +520,13 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
         <div class="card-body form-section">
           <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
             <div>
-              <label for="numero_inventario" class="form-label"><?= __("Numero Inventario") ?></label>
+              <label for="numero_inventario" class="form-label"><?= __("Prefisso inventario copie") ?></label>
               <input id="numero_inventario" name="numero_inventario" type="text" class="form-input" placeholder="<?= __('es. INV-2024-001') ?>" value="<?php echo HtmlHelper::e($book['numero_inventario'] ?? ''); ?>" />
+              <p class="text-xs text-gray-500 mt-1">
+                <?= $mode === 'edit'
+                  ? __("Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.")
+                  : __("Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.") ?>
+              </p>
             </div>
           </div>
 

--- a/app/Views/libri/partials/book_form.php
+++ b/app/Views/libri/partials/book_form.php
@@ -490,7 +490,8 @@ $selectedSeriesType = \App\Support\SeriesLabels::canonical($book['tipo_collana']
                 <?= $mode === 'edit' ? __("Copie in circolazione") : __("Copie fisiche iniziali") ?>
                 <span class="text-xs text-gray-500">(<?= __("Le copie disponibili vengono calcolate automaticamente") ?>)</span>
               </label>
-              <input id="copie_totali" name="copie_totali" type="number" class="form-input"
+              <input id="copie_totali" name="copie_totali" type="number"
+                     class="form-input <?php echo $mode === 'edit' ? 'bg-gray-100 cursor-not-allowed' : ''; ?>"
                      value="<?php echo (int)($book['copie_totali'] ?? 1); ?>" min="0" max="9999"
                      <?php echo $mode === 'edit' ? 'readonly aria-readonly="true"' : ''; ?> />
               <?php if ($mode === 'edit' && !empty($book['id'])): ?>
@@ -3465,7 +3466,7 @@ async function increaseCopies(book) {
                     title: __('Copie Aggiunte!'),
                     html: `
                         <p class="mb-2">${__('Hai aggiunto %s copie a "%s"').replace('%s', copiesToAdd).replace('%s', escapeHtml(book.title))}</p>
-                        <p class="text-sm text-gray-600">${__('Copie totali:')}: ${data.copie_totali}</p>
+                        <p class="text-sm text-gray-600">${__('Copie in circolazione')}: ${data.copie_totali}</p>
                         <p class="text-sm text-gray-600">${__('Copie disponibili:')}: ${data.copie_disponibili}</p>
                     `,
                     confirmButtonText: __('OK')

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -908,8 +908,8 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
   </div>
   <?php endif; ?>
 
-  <!-- Copies Section -->
-  <?php if (!empty($copie) && count($copie) > 0): ?>
+  <!-- Copies Section (always shown so copies can be added even to a book with none) -->
+  <?php $copie = $copie ?? []; ?>
   <div class="mt-6">
     <div class="card">
       <div class="card-header flex items-center justify-between gap-4 flex-wrap">
@@ -930,11 +930,19 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
             <?php endif; ?>
           </span>
         </h2>
-        <a href="<?= htmlspecialchars(url('/admin/books/' . (int)$libro['id'] . '/copy-labels-pdf'), ENT_QUOTES, 'UTF-8') ?>"
-           target="_blank" rel="noopener"
-           class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-800 text-white text-sm rounded-lg hover:bg-gray-900 transition-colors font-medium">
-          <i class="fas fa-tags"></i><?= __("Stampa etichette copie") ?>
-        </a>
+        <div class="flex items-center gap-2 flex-wrap">
+          <button type="button" onclick="openAddCopyModal()"
+                  class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-800 text-white text-sm rounded-lg hover:bg-gray-900 transition-colors font-medium">
+            <i class="fas fa-plus"></i><?= __("Aggiungi copia") ?>
+          </button>
+          <?php if (!empty($copie)): ?>
+          <a href="<?= htmlspecialchars(url('/admin/books/' . (int)$libro['id'] . '/copy-labels-pdf'), ENT_QUOTES, 'UTF-8') ?>"
+             target="_blank" rel="noopener"
+             class="inline-flex items-center gap-2 px-3 py-1.5 bg-gray-800 text-white text-sm rounded-lg hover:bg-gray-900 transition-colors font-medium">
+            <i class="fas fa-tags"></i><?= __("Stampa etichette copie") ?>
+          </a>
+          <?php endif; ?>
+        </div>
       </div>
       <div class="card-body p-0">
         <div class="overflow-x-auto">
@@ -951,6 +959,15 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
               </tr>
             </thead>
             <tbody class="bg-white divide-y divide-gray-200">
+              <?php if (empty($copie)): ?>
+              <tr>
+                <td colspan="7" class="px-6 py-8 text-center text-sm text-gray-500">
+                  <i class="fas fa-clone text-gray-300 text-2xl mb-2 block"></i>
+                  <?= __("Nessuna copia fisica registrata.") ?>
+                  <?= __("Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.") ?>
+                </td>
+              </tr>
+              <?php endif; ?>
               <?php foreach ($copie as $copia): ?>
               <tr class="hover:bg-gray-50 transition-colors">
                 <td class="px-6 py-4 whitespace-nowrap">
@@ -1120,7 +1137,6 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
       </div>
     </div>
   </div>
-  <?php endif; ?>
 
   <!-- Loan History Section -->
   <?php if (!empty($parentWork)): ?>
@@ -1865,6 +1881,77 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
       </form>
     </div>
   </div>
+
+  <!-- Modal Aggiungi Copia -->
+  <div id="add-copy-modal" class="fixed inset-0 z-50 hidden items-center justify-center bg-black bg-opacity-50">
+    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md mx-4">
+      <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
+        <h3 class="text-lg font-semibold text-gray-900">
+          <i class="fas fa-plus text-gray-600 mr-2"></i>
+          <?= __("Aggiungi Copia") ?>
+        </h3>
+        <button type="button" id="close-add-copy-modal" class="text-gray-500 hover:text-gray-700">
+          <i class="fas fa-times"></i>
+        </button>
+      </div>
+      <form method="post" id="add-copy-form"
+            action="<?= htmlspecialchars(url('/admin/books/' . (int)$libro['id'] . '/copies/create'), ENT_QUOTES, 'UTF-8') ?>"
+            class="px-6 py-5 space-y-4">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>">
+
+        <div>
+          <label for="add-copy-inventario" class="form-label"><?= __("Numero di inventario") ?> (<?= __("opzionale") ?>)</label>
+          <input type="text" id="add-copy-inventario" name="numero_inventario" class="form-input" maxlength="100"
+                 placeholder="<?= __('Lascia vuoto per assegnarlo automaticamente') ?>">
+        </div>
+
+        <div>
+          <label for="add-copy-stato" class="form-label"><?= __("Stato della copia") ?></label>
+          <select id="add-copy-stato" name="stato" class="form-input" required aria-required="true">
+            <option value="disponibile"><?= __("Disponibile") ?></option>
+            <option value="manutenzione"><?= __("In manutenzione") ?></option>
+            <option value="danneggiato"><?= __("Danneggiato") ?></option>
+            <option value="perso"><?= __("Perso") ?></option>
+            <option value="in_restauro"><?= __("In restauro") ?></option>
+          </select>
+          <p class="text-xs text-gray-600 mt-1">
+            <i class="fas fa-info-circle text-blue-500 mr-1"></i>
+            <strong><?= __("Nota:") ?></strong> <?= __("Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.") ?>
+          </p>
+        </div>
+
+        <div>
+          <label for="add-copy-note" class="form-label"><?= __("Note") ?> (<?= __("opzionale") ?>)</label>
+          <textarea id="add-copy-note" name="note" rows="3" class="form-input" placeholder="<?= __('Aggiungi eventuali note...') ?>"></textarea>
+        </div>
+
+        <div class="flex items-center justify-end gap-3 pt-2">
+          <button type="button" id="close-add-copy-modal-secondary" class="btn-secondary"><?= __("Annulla") ?></button>
+          <button type="submit" class="<?php echo $btnPrimary; ?> justify-center">
+            <i class="fas fa-plus mr-2"></i><?= __("Aggiungi copia") ?>
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <script>
+    // Modal aggiungi copia
+    const addCopyModal = document.getElementById('add-copy-modal');
+    function openAddCopyModal() {
+      const f = document.getElementById('add-copy-form');
+      if (f) f.reset();
+      addCopyModal.classList.remove('hidden');
+      addCopyModal.classList.add('flex');
+    }
+    function closeAddCopyModal() {
+      addCopyModal.classList.add('hidden');
+      addCopyModal.classList.remove('flex');
+    }
+    document.getElementById('close-add-copy-modal')?.addEventListener('click', closeAddCopyModal);
+    document.getElementById('close-add-copy-modal-secondary')?.addEventListener('click', closeAddCopyModal);
+    addCopyModal?.addEventListener('click', (e) => { if (e.target === addCopyModal) closeAddCopyModal(); });
+  </script>
 
   <script>
     // Modal gestione copia

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -910,7 +910,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
 
   <!-- Copies Section (always shown so copies can be added even to a book with none) -->
   <?php $copie = $copie ?? []; ?>
-  <div class="mt-6">
+  <div class="mt-6" id="physical-copies">
     <div class="card">
       <div class="card-header flex items-center justify-between gap-4 flex-wrap">
         <h2 class="text-lg font-semibold text-gray-900 flex items-center gap-2">
@@ -921,7 +921,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
             <?php if (isset($libro['copie_totali']) || isset($libro['copie_disponibili'])): ?>
               <?php if (isset($libro['copie_totali'])): ?>
                 <span class="mx-2">•</span>
-                <?= __("Copie totali") ?>: <strong><?php echo (int)$libro['copie_totali']; ?></strong>
+                <?= __("Copie in circolazione") ?>: <strong><?php echo (int)$libro['copie_totali']; ?></strong>
               <?php endif; ?>
               <?php if (isset($libro['copie_disponibili'])): ?>
                 <span class="mx-2">•</span>
@@ -1015,16 +1015,20 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
                           'prestato'    => __('Prestato'),
                           'prenotato'   => __('Prenotato'),
                           'manutenzione' => __('In manutenzione'),
+                          'in_restauro' => __('In restauro'),
                           'perso'       => __('Perso'),
                           'danneggiato' => __('Danneggiato'),
+                          'in_trasferimento' => __('In trasferimento'),
                       ];
                       $copiaStatusClasses = [
                           'disponibile' => 'bg-green-100 text-green-800',
                           'prestato'    => 'bg-red-100 text-red-800',
                           'prenotato'   => 'bg-purple-100 text-purple-800',
                           'manutenzione' => 'bg-yellow-100 text-yellow-800',
+                          'in_restauro' => 'bg-indigo-100 text-indigo-800',
                           'perso'       => 'bg-gray-100 text-gray-800',
                           'danneggiato' => 'bg-orange-100 text-orange-800',
+                          'in_trasferimento' => 'bg-blue-100 text-blue-800',
                       ];
                       $effectiveLabel = $copiaStatusLabels[$effectiveStatus] ?? ucfirst($effectiveStatus);
                       $effectiveClass = $copiaStatusClasses[$effectiveStatus] ?? 'bg-gray-100 text-gray-800';
@@ -1860,6 +1864,8 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
             <option value="manutenzione"><?= __("In manutenzione") ?></option>
             <option value="danneggiato"><?= __("Danneggiato") ?></option>
             <option value="perso"><?= __("Perso") ?></option>
+            <option value="in_restauro"><?= __("In restauro") ?></option>
+            <option value="in_trasferimento"><?= __("In trasferimento") ?></option>
           </select>
           <p class="text-xs text-gray-600 mt-1">
             <i class="fas fa-info-circle text-blue-500 mr-1"></i>
@@ -1913,10 +1919,11 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
             <option value="danneggiato"><?= __("Danneggiato") ?></option>
             <option value="perso"><?= __("Perso") ?></option>
             <option value="in_restauro"><?= __("In restauro") ?></option>
+            <option value="in_trasferimento"><?= __("In trasferimento") ?></option>
           </select>
           <p class="text-xs text-gray-600 mt-1">
             <i class="fas fa-info-circle text-blue-500 mr-1"></i>
-            <strong><?= __("Nota:") ?></strong> <?= __("Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.") ?>
+            <strong><?= __("Nota:") ?></strong> <?= __("Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.") ?>
           </p>
         </div>
 

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -1994,7 +1994,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
       toggleLoanOption(
         prenotatoOption,
         stato === 'prenotato',
-        __('Prenotato (imposta "Disponibile" per cancellare)'),
+        __('Prenotato (gestisci dal sistema Prestiti)'),
         __('Prenotato (prestito in attesa)')
       );
 

--- a/app/Views/libri/scheda_libro.php
+++ b/app/Views/libri/scheda_libro.php
@@ -917,7 +917,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
           <i class="fas fa-clone text-gray-900"></i>
           <?= __("Copie Fisiche") ?>
           <span class="ml-2 text-sm font-normal text-gray-500">
-            (<?php echo count($copie); ?> <?= count($copie) > 1 ? __("copie") : __("copia") ?>)
+            (<?php echo count($copie); ?> <?= count($copie) === 1 ? __("copia") : __("copie") ?>)
             <?php if (isset($libro['copie_totali']) || isset($libro['copie_disponibili'])): ?>
               <?php if (isset($libro['copie_totali'])): ?>
                 <span class="mx-2">•</span>
@@ -1099,7 +1099,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
                     $loanStatusVal = $copia['prestito_stato'] ?? null;
                     $bookAtLibrary = in_array($loanStatusVal, ['da_ritirare', 'prenotato'], true);
                     $canEdit = empty($copia['prestito_id']) || $bookAtLibrary;
-                    $canDelete = $canEdit && in_array($rawCopiaStatus, ['perso', 'danneggiato', 'manutenzione']);
+                    $canDelete = $canEdit && in_array($rawCopiaStatus, ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'], true);
                     ?>
                     <?php if ($canEdit): ?>
                     <button type="button"
@@ -1894,7 +1894,7 @@ $btnDanger  = 'inline-flex items-center gap-2 rounded-lg bg-red-600 px-5 py-2.5 
       <div class="flex items-center justify-between border-b border-gray-200 px-6 py-4">
         <h3 class="text-lg font-semibold text-gray-900">
           <i class="fas fa-plus text-gray-600 mr-2"></i>
-          <?= __("Aggiungi Copia") ?>
+          <?= __("Aggiungi copia") ?>
         </h3>
         <button type="button" id="close-add-copy-modal" class="text-gray-500 hover:text-gray-700">
           <i class="fas fa-times"></i>

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6794,5 +6794,17 @@
   "Impossibile aggiungere la copia.": "Kunne ikke tilføje eksemplaret.",
   "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Et mistet eller beskadiget eksemplar reducerer det samlede antal eksemplarer. Brug Udlån-sektionen til udlån.",
   "Esiste già una copia con questo numero di inventario.": "Der findes allerede et eksemplar med dette inventarnummer.",
-  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Brug \"Tilføj eksemplar\" til at oprette et og angive dets status."
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Brug \"Tilføj eksemplar\" til at oprette et og angive dets status.",
+  "In trasferimento": "Under overførsel",
+  "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.": "Bortkomne, beskadigede eksemplarer eller eksemplarer under vedligeholdelse, restaurering eller overførsel tælles ikke som cirkulerende. Brug sektionen Udlån til udlån.",
+  "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.": "Bogtilgængelighed beregnes automatisk ud fra fysiske eksemplarer og udlån.",
+  "Copie in circolazione": "Cirkulerende eksemplarer",
+  "Copie fisiche iniziali": "Indledende fysiske eksemplarer",
+  "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.": "Tilføj, rediger eller fjern enkelte eksemplarer i sektionen Fysiske eksemplarer på bogsiden.",
+  "Gestisci copie fisiche": "Administrer fysiske eksemplarer",
+  "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.": "Du kan oprette posten uden eksemplarer og tilføje dem senere fra bogsiden.",
+  "Prefisso inventario copie": "Inventarpræfiks for eksemplarer",
+  "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Bruges kun til automatisk at generere koder til nye eksemplarer; eksisterende koder ændres ikke.",
+  "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Indledende eksemplarer får fortløbende koder som PRÆFIKS-C1 og PRÆFIKS-C2.",
+  "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes"
 }

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -3530,7 +3530,6 @@
   "Prenota questo libro": "Reserver denne bog",
   "Prenotabile per date future": "Kan reserveres til fremtidige datoer",
   "Prenotato": "Reserveret",
-  "Prenotato (imposta \"Disponibile\" per cancellare)": "Reserveret (indstil til \"Tilgængelig\" for at annullere)",
   "Prenotato (prestito in attesa)": "Reserveret (lån afventer)",
   "Prenotazione": "Reservation",
   "Prenotazione Annullata": "Reservation annulleret",
@@ -6804,5 +6803,8 @@
   "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kan kun slette eksemplarer uden for cirkulation (mistede, beskadigede, under vedligeholdelse, under restaurering eller under overførsel). Ret først eksemplarets status.",
   "Impossibile aggiungere le copie.": "Kunne ikke tilføje eksemplarerne.",
-  "Impossibile eliminare la copia.": "Kunne ikke slette eksemplaret."
+  "Impossibile eliminare la copia.": "Kunne ikke slette eksemplaret.",
+  "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".": "Brug udlånssystemet for at reservere et eksemplar. Status \"Reserveret\" kan ikke angives manuelt.",
+  "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.": "Brug udlånssystemet for at annullere eller flytte en reservation.",
+  "Prenotato (gestisci dal sistema Prestiti)": "Reserveret (administrér fra udlånssystemet)"
 }

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6805,5 +6805,6 @@
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Bruges kun til automatisk at generere koder til nye eksemplarer; eksisterende koder ændres ikke.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Indledende eksemplarer får fortløbende koder som PRÆFIKS-C1 og PRÆFIKS-C2.",
   "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes",
-  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kan kun slette eksemplarer uden for cirkulation (mistede, beskadigede, under vedligeholdelse, under restaurering eller under overførsel). Ret først eksemplarets status."
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kan kun slette eksemplarer uden for cirkulation (mistede, beskadigede, under vedligeholdelse, under restaurering eller under overførsel). Ret først eksemplarets status.",
+  "Impossibile aggiungere le copie.": "Kunne ikke tilføje eksemplarerne."
 }

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -3672,7 +3672,6 @@
   "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo": "Knapperne \"Anmod om lån\" og \"Reserver\" i kataloget",
   "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate": "Du kan ændre denne indstilling når som helst under Indstillinger → Avanceret",
   "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.": "Du kan konfigurere eller ændre disse indstillinger senere i admin-sektionen for e-mailindstillinger.",
-  "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.": "Du kan kun slette tabte, beskadigede eller vedligeholdte eksemplarer. Ændr eksemplarets status først.",
   "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.": "Du kan til enhver tid ændre disse indstillinger i administrationens sektion Indstillinger.",
   "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.": "Du kan kun reducere eksemplarer, hvis de ikke er udlånt, tabt eller beskadiget.",
   "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.": "Du kan vælge et foreslået spejl eller vælge et brugerdefineret domæne.",
@@ -6785,7 +6784,6 @@
   "Rinnovo non riuscito. Riprova.": "Fornyelsen mislykkedes. Prøv igen.",
   "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Ændringen blev ikke gemt: Det tildelte eksemplar er allerede optaget af et andet lån i den nye periode.",
   "Aggiungi copia": "Tilføj eksemplar",
-  "Aggiungi Copia": "Tilføj eksemplar",
   "Numero di inventario": "Inventarnummer",
   "Lascia vuoto per assegnarlo automaticamente": "Lad stå tom for automatisk tildeling",
   "In restauro": "Under restaurering",
@@ -6806,5 +6804,6 @@
   "Prefisso inventario copie": "Inventarpræfiks for eksemplarer",
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Bruges kun til automatisk at generere koder til nye eksemplarer; eksisterende koder ændres ikke.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Indledende eksemplarer får fortløbende koder som PRÆFIKS-C1 og PRÆFIKS-C2.",
-  "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes"
+  "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes",
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kan kun slette eksemplarer uden for cirkulation (mistede, beskadigede, under vedligeholdelse, under restaurering eller under overførsel). Ret først eksemplarets status."
 }

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -363,7 +363,6 @@
   "Attenzione: %d prestiti in ritardo": "Advarsel: %d forsinkede udlån",
   "Attenzione: %d prestito in ritardo": "Advarsel: %d forsinket udlån",
   "Attenzione: Azione Manuale Richiesta": "Advarsel: Manuel handling påkrævet",
-  "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Advarsel: Det var ikke muligt at fjerne alle de ønskede eksemplarer. Nogle eksemplarer er i øjeblikket udlånt.",
   "Attiva": "Aktivér",
   "Attiva API key": "Aktivér API-nøgle",
   "Attiva Direttamente": "Aktivér direkte",
@@ -2321,7 +2320,6 @@
   "Impossibile revocare la sessione": "Kan ikke tilbagekalde sessionen",
   "Impossibile riaprire il file ZIP": "Kan ikke genåbne ZIP-filen",
   "Impossibile ricalcolare la disponibilità del libro.": "Bogtilgængelighed kan ikke genberegnes.",
-  "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.": "Kan ikke reducere eksemplarerne til %d. Der er %d utilgængelige eksemplarer (udlånte, tabte eller beskadigede). Minimumsantallet af samlede eksemplarer er %d.",
   "Impossibile rifiutare la recensione": "Anmeldelsen kunne ikke afvises",
   "Impossibile rigenerare la sitemap.": "Sitemap kan ikke genereres igen.",
   "Impossibile rigenerare la sitemap: %s": "Sitemap kunne ikke genereres igen: %s",
@@ -6790,7 +6788,6 @@
   "Nessuna copia fisica registrata.": "Ingen fysiske eksemplarer registreret.",
   "Copia aggiunta con successo.": "Eksemplar tilføjet.",
   "Impossibile aggiungere la copia.": "Kunne ikke tilføje eksemplaret.",
-  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Et mistet eller beskadiget eksemplar reducerer det samlede antal eksemplarer. Brug Udlån-sektionen til udlån.",
   "Esiste già una copia con questo numero di inventario.": "Der findes allerede et eksemplar med dette inventarnummer.",
   "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Brug \"Tilføj eksemplar\" til at oprette et og angive dets status.",
   "In trasferimento": "Under overførsel",
@@ -6806,5 +6803,6 @@
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Indledende eksemplarer får fortløbende koder som PRÆFIKS-C1 og PRÆFIKS-C2.",
   "Invio notifica nuova copia fallito": "Notifikation om nyt eksemplar mislykkedes",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kan kun slette eksemplarer uden for cirkulation (mistede, beskadigede, under vedligeholdelse, under restaurering eller under overførsel). Ret først eksemplarets status.",
-  "Impossibile aggiungere le copie.": "Kunne ikke tilføje eksemplarerne."
+  "Impossibile aggiungere le copie.": "Kunne ikke tilføje eksemplarerne.",
+  "Impossibile eliminare la copia.": "Kunne ikke slette eksemplaret."
 }

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6783,5 +6783,16 @@
   "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.": "Fejl: ugyldigt datoformat. Indtast datoerne i formatet YYYY-MM-DD.",
   "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.": "Ændringen blev ikke gemt: I den nye periode er alle eksemplarer allerede optaget af andre udlån eller reservationer.",
   "Rinnovo non riuscito. Riprova.": "Fornyelsen mislykkedes. Prøv igen.",
-  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Ændringen blev ikke gemt: Det tildelte eksemplar er allerede optaget af et andet lån i den nye periode."
+  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Ændringen blev ikke gemt: Det tildelte eksemplar er allerede optaget af et andet lån i den nye periode.",
+  "Aggiungi copia": "Tilføj eksemplar",
+  "Aggiungi Copia": "Tilføj eksemplar",
+  "Numero di inventario": "Inventarnummer",
+  "Lascia vuoto per assegnarlo automaticamente": "Lad stå tom for automatisk tildeling",
+  "In restauro": "Under restaurering",
+  "Nessuna copia fisica registrata.": "Ingen fysiske eksemplarer registreret.",
+  "Copia aggiunta con successo.": "Eksemplar tilføjet.",
+  "Impossibile aggiungere la copia.": "Kunne ikke tilføje eksemplaret.",
+  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Et mistet eller beskadiget eksemplar reducerer det samlede antal eksemplarer. Brug Udlån-sektionen til udlån.",
+  "Esiste già una copia con questo numero di inventario.": "Der findes allerede et eksemplar med dette inventarnummer.",
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Brug \"Tilføj eksemplar\" til at oprette et og angive dets status."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6805,5 +6805,6 @@
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Wird nur zur automatischen Erzeugung neuer Exemplarcodes verwendet; bestehende Codes bleiben unverändert.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Anfängliche Exemplare erhalten fortlaufende Codes wie PRÄFIX-C1 und PRÄFIX-C2.",
   "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen",
-  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kannst nur Exemplare außer Betrieb löschen (verloren, beschädigt, in Wartung, in Restaurierung oder im Transfer). Ändere zuerst den Status des Exemplars."
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kannst nur Exemplare außer Betrieb löschen (verloren, beschädigt, in Wartung, in Restaurierung oder im Transfer). Ändere zuerst den Status des Exemplars.",
+  "Impossibile aggiungere le copie.": "Exemplare konnten nicht hinzugefügt werden."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -3530,7 +3530,6 @@
   "Prenota questo libro": "Dieses Buch vormerken",
   "Prenotabile per date future": "Für zukünftige Termine vormerkbar",
   "Prenotato": "Vorgemerkt",
-  "Prenotato (imposta \"Disponibile\" per cancellare)": "Vorgemerkt (setzen Sie \"Verfügbar\" zum Stornieren)",
   "Prenotato (prestito in attesa)": "Vorgemerkt (Ausleihe ausstehend)",
   "Prenotazione": "Vormerkung",
   "Prenotazione Annullata": "Reservierung storniert",
@@ -6804,5 +6803,8 @@
   "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kannst nur Exemplare außer Betrieb löschen (verloren, beschädigt, in Wartung, in Restaurierung oder im Transfer). Ändere zuerst den Status des Exemplars.",
   "Impossibile aggiungere le copie.": "Exemplare konnten nicht hinzugefügt werden.",
-  "Impossibile eliminare la copia.": "Exemplar konnte nicht gelöscht werden."
+  "Impossibile eliminare la copia.": "Exemplar konnte nicht gelöscht werden.",
+  "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".": "Um ein Exemplar vorzumerken, verwende das Ausleihsystem. Der Status „Vorgemerkt\" kann nicht manuell gesetzt werden.",
+  "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.": "Um eine Vormerkung zu stornieren oder zu verschieben, verwende das Ausleihsystem.",
+  "Prenotato (gestisci dal sistema Prestiti)": "Vorgemerkt (über das Ausleihsystem verwalten)"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6794,5 +6794,17 @@
   "Impossibile aggiungere la copia.": "Exemplar konnte nicht hinzugefügt werden.",
   "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Ein verlorenes oder beschädigtes Exemplar verringert die Gesamtzahl der Exemplare. Für Ausleihen den Bereich Ausleihen verwenden.",
   "Esiste già una copia con questo numero di inventario.": "Ein Exemplar mit dieser Inventarnummer existiert bereits.",
-  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Mit „Exemplar hinzufügen\" eines anlegen und dessen Status setzen."
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Mit „Exemplar hinzufügen\" eines anlegen und dessen Status setzen.",
+  "In trasferimento": "Im Transfer",
+  "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.": "Verlorene, beschädigte, in Wartung, Restaurierung oder Transfer befindliche Exemplare zählen nicht zu den zirkulierenden Exemplaren. Für Ausleihen verwenden Sie den Bereich Ausleihen.",
+  "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.": "Die Verfügbarkeit des Buches wird automatisch aus physischen Exemplaren und Ausleihen berechnet.",
+  "Copie in circolazione": "Zirkulierende Exemplare",
+  "Copie fisiche iniziali": "Anfängliche physische Exemplare",
+  "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.": "Fügen Sie einzelne Exemplare im Bereich Physische Exemplare der Buchseite hinzu, bearbeiten oder entfernen Sie sie.",
+  "Gestisci copie fisiche": "Physische Exemplare verwalten",
+  "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.": "Sie können den Datensatz ohne Exemplare erstellen und diese später auf der Buchseite hinzufügen.",
+  "Prefisso inventario copie": "Inventarpräfix für Exemplare",
+  "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Wird nur zur automatischen Erzeugung neuer Exemplarcodes verwendet; bestehende Codes bleiben unverändert.",
+  "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Anfängliche Exemplare erhalten fortlaufende Codes wie PRÄFIX-C1 und PRÄFIX-C2.",
+  "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -3672,7 +3672,6 @@
   "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo": "Schaltflächen \"Ausleihe anfordern\" und \"Vormerken\" im Katalog",
   "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate": "Sie können diese Einstellung jederzeit unter Einstellungen → Erweitert ändern",
   "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.": "Sie können diese Einstellungen später im Bereich E-Mail-Einstellungen der Administration konfigurieren oder ändern.",
-  "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.": "Sie können nur verlorene, beschädigte oder in Wartung befindliche Exemplare löschen. Ändern Sie zuerst den Status des Exemplars.",
   "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.": "Sie können diese Einstellungen jederzeit im Bereich Einstellungen der Administration ändern.",
   "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.": "Sie können Exemplare nur reduzieren, wenn sie nicht ausgeliehen, verloren oder beschädigt sind.",
   "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.": "Sie können einen vorgeschlagenen Mirror auswählen oder eine benutzerdefinierte Domain wählen.",
@@ -6785,7 +6784,6 @@
   "Rinnovo non riuscito. Riprova.": "Verlängerung fehlgeschlagen. Bitte erneut versuchen.",
   "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Änderung nicht gespeichert: Das zugewiesene Exemplar ist im neuen Zeitraum bereits durch eine andere Ausleihe belegt.",
   "Aggiungi copia": "Exemplar hinzufügen",
-  "Aggiungi Copia": "Exemplar hinzufügen",
   "Numero di inventario": "Inventarnummer",
   "Lascia vuoto per assegnarlo automaticamente": "Leer lassen für automatische Zuweisung",
   "In restauro": "In Restaurierung",
@@ -6806,5 +6804,6 @@
   "Prefisso inventario copie": "Inventarpräfix für Exemplare",
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Wird nur zur automatischen Erzeugung neuer Exemplarcodes verwendet; bestehende Codes bleiben unverändert.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Anfängliche Exemplare erhalten fortlaufende Codes wie PRÄFIX-C1 und PRÄFIX-C2.",
-  "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen"
+  "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen",
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kannst nur Exemplare außer Betrieb löschen (verloren, beschädigt, in Wartung, in Restaurierung oder im Transfer). Ändere zuerst den Status des Exemplars."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -363,7 +363,6 @@
   "Attenzione: %d prestiti in ritardo": "Achtung: %d überfällige Ausleihen",
   "Attenzione: %d prestito in ritardo": "Achtung: %d überfällige Ausleihe",
   "Attenzione: Azione Manuale Richiesta": "Achtung: Manueller Eingriff erforderlich",
-  "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Achtung: Es konnten nicht alle angeforderten Exemplare entfernt werden. Einige Exemplare sind derzeit ausgeliehen.",
   "Attiva": "Aktiv",
   "Attiva API key": "API-Schlüssel aktivieren",
   "Attiva Direttamente": "Direkt aktivieren",
@@ -2321,7 +2320,6 @@
   "Impossibile revocare la sessione": "Sitzung kann nicht widerrufen werden",
   "Impossibile riaprire il file ZIP": "ZIP-Datei kann nicht erneut geöffnet werden",
   "Impossibile ricalcolare la disponibilità del libro.": "Buchverfügbarkeit kann nicht neu berechnet werden.",
-  "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.": "Die Exemplare können nicht auf %d reduziert werden. Es gibt %d nicht verfügbare Exemplare (ausgeliehen, verloren oder beschädigt). Die Mindestanzahl der Gesamtexemplare beträgt %d.",
   "Impossibile rifiutare la recensione": "Die Rezension konnte nicht abgelehnt werden",
   "Impossibile rigenerare la sitemap.": "Sitemap kann nicht neu generiert werden.",
   "Impossibile rigenerare la sitemap: %s": "Die Sitemap konnte nicht regeneriert werden: %s",
@@ -6790,7 +6788,6 @@
   "Nessuna copia fisica registrata.": "Keine physischen Exemplare erfasst.",
   "Copia aggiunta con successo.": "Exemplar erfolgreich hinzugefügt.",
   "Impossibile aggiungere la copia.": "Exemplar konnte nicht hinzugefügt werden.",
-  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Ein verlorenes oder beschädigtes Exemplar verringert die Gesamtzahl der Exemplare. Für Ausleihen den Bereich Ausleihen verwenden.",
   "Esiste già una copia con questo numero di inventario.": "Ein Exemplar mit dieser Inventarnummer existiert bereits.",
   "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Mit „Exemplar hinzufügen\" eines anlegen und dessen Status setzen.",
   "In trasferimento": "Im Transfer",
@@ -6806,5 +6803,6 @@
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Anfängliche Exemplare erhalten fortlaufende Codes wie PRÄFIX-C1 und PRÄFIX-C2.",
   "Invio notifica nuova copia fallito": "Benachrichtigung über neues Exemplar fehlgeschlagen",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Du kannst nur Exemplare außer Betrieb löschen (verloren, beschädigt, in Wartung, in Restaurierung oder im Transfer). Ändere zuerst den Status des Exemplars.",
-  "Impossibile aggiungere le copie.": "Exemplare konnten nicht hinzugefügt werden."
+  "Impossibile aggiungere le copie.": "Exemplare konnten nicht hinzugefügt werden.",
+  "Impossibile eliminare la copia.": "Exemplar konnte nicht gelöscht werden."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6783,5 +6783,16 @@
   "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.": "Fehler: ungültiges Datumsformat. Geben Sie die Daten im Format YYYY-MM-DD ein.",
   "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.": "Änderung nicht gespeichert: Im neuen Zeitraum sind alle Exemplare bereits durch andere Ausleihen oder Vormerkungen belegt.",
   "Rinnovo non riuscito. Riprova.": "Verlängerung fehlgeschlagen. Bitte erneut versuchen.",
-  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Änderung nicht gespeichert: Das zugewiesene Exemplar ist im neuen Zeitraum bereits durch eine andere Ausleihe belegt."
+  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Änderung nicht gespeichert: Das zugewiesene Exemplar ist im neuen Zeitraum bereits durch eine andere Ausleihe belegt.",
+  "Aggiungi copia": "Exemplar hinzufügen",
+  "Aggiungi Copia": "Exemplar hinzufügen",
+  "Numero di inventario": "Inventarnummer",
+  "Lascia vuoto per assegnarlo automaticamente": "Leer lassen für automatische Zuweisung",
+  "In restauro": "In Restaurierung",
+  "Nessuna copia fisica registrata.": "Keine physischen Exemplare erfasst.",
+  "Copia aggiunta con successo.": "Exemplar erfolgreich hinzugefügt.",
+  "Impossibile aggiungere la copia.": "Exemplar konnte nicht hinzugefügt werden.",
+  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Ein verlorenes oder beschädigtes Exemplar verringert die Gesamtzahl der Exemplare. Für Ausleihen den Bereich Ausleihen verwenden.",
+  "Esiste già una copia con questo numero di inventario.": "Ein Exemplar mit dieser Inventarnummer existiert bereits.",
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Mit „Exemplar hinzufügen\" eines anlegen und dessen Status setzen."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6805,5 +6805,6 @@
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Used only to generate codes for new copies automatically; existing codes do not change.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Initial copies receive sequential codes such as PREFIX-C1 and PREFIX-C2.",
   "Invio notifica nuova copia fallito": "New-copy notification failed",
-  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "You can only delete out-of-circulation copies (lost, damaged, under maintenance, under restoration or in transfer). Change the copy's status first."
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "You can only delete out-of-circulation copies (lost, damaged, under maintenance, under restoration or in transfer). Change the copy's status first.",
+  "Impossibile aggiungere le copie.": "Unable to add the copies."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6783,5 +6783,16 @@
   "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.": "Error: invalid date format. Enter dates in YYYY-MM-DD format.",
   "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.": "Change not saved: in the new period every copy is already taken by other loans or reservations.",
   "Rinnovo non riuscito. Riprova.": "Renewal failed. Please try again.",
-  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Change not saved: the assigned copy is already committed to another loan in the new period."
+  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Change not saved: the assigned copy is already committed to another loan in the new period.",
+  "Aggiungi copia": "Add copy",
+  "Aggiungi Copia": "Add Copy",
+  "Numero di inventario": "Inventory number",
+  "Lascia vuoto per assegnarlo automaticamente": "Leave empty to assign it automatically",
+  "In restauro": "Under restoration",
+  "Nessuna copia fisica registrata.": "No physical copies recorded.",
+  "Copia aggiunta con successo.": "Copy added successfully.",
+  "Impossibile aggiungere la copia.": "Unable to add the copy.",
+  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "A lost or damaged copy lowers the total-copies count. For loans, use the Loans section.",
+  "Esiste già una copia con questo numero di inventario.": "A copy with this inventory number already exists.",
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Use \"Add copy\" to create one and set its status."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -3530,7 +3530,6 @@
   "Prenota questo libro": "Reserve this book",
   "Prenotabile per date future": "Reservable for future dates",
   "Prenotato": "Reserved",
-  "Prenotato (imposta \"Disponibile\" per cancellare)": "Reserved (set \"Available\" to cancel)",
   "Prenotato (prestito in attesa)": "Reserved (loan pending)",
   "Prenotazione": "Reservation",
   "Prenotazione Annullata": "Reservation Cancelled",
@@ -6804,5 +6803,8 @@
   "Invio notifica nuova copia fallito": "New-copy notification failed",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "You can only delete out-of-circulation copies (lost, damaged, under maintenance, under restoration or in transfer). Change the copy's status first.",
   "Impossibile aggiungere le copie.": "Unable to add the copies.",
-  "Impossibile eliminare la copia.": "Unable to delete the copy."
+  "Impossibile eliminare la copia.": "Unable to delete the copy.",
+  "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".": "To reserve a copy, use the Loans system. The \"Reserved\" status cannot be set manually.",
+  "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.": "To cancel or move a reservation, use the Loans system.",
+  "Prenotato (gestisci dal sistema Prestiti)": "Reserved (manage from the Loans system)"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -3672,7 +3672,6 @@
   "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo": "\"Request Loan\" and \"Reserve\" buttons in the catalogue",
   "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate": "You can change this setting anytime from Settings → Advanced",
   "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.": "You can configure or modify these settings later from the admin Email Settings section.",
-  "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.": "You can only delete lost, damaged or in maintenance copies. First change the copy status.",
   "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.": "You can modify these settings at any time from the admin Settings section.",
   "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.": "You can reduce copies only if they are not on loan, lost or damaged.",
   "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.": "You can choose a suggested mirror or select a custom domain.",
@@ -6785,7 +6784,6 @@
   "Rinnovo non riuscito. Riprova.": "Renewal failed. Please try again.",
   "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Change not saved: the assigned copy is already committed to another loan in the new period.",
   "Aggiungi copia": "Add copy",
-  "Aggiungi Copia": "Add Copy",
   "Numero di inventario": "Inventory number",
   "Lascia vuoto per assegnarlo automaticamente": "Leave empty to assign it automatically",
   "In restauro": "Under restoration",
@@ -6806,5 +6804,6 @@
   "Prefisso inventario copie": "Copy inventory prefix",
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Used only to generate codes for new copies automatically; existing codes do not change.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Initial copies receive sequential codes such as PREFIX-C1 and PREFIX-C2.",
-  "Invio notifica nuova copia fallito": "New-copy notification failed"
+  "Invio notifica nuova copia fallito": "New-copy notification failed",
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "You can only delete out-of-circulation copies (lost, damaged, under maintenance, under restoration or in transfer). Change the copy's status first."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -363,7 +363,6 @@
   "Attenzione: %d prestiti in ritardo": "Warning: %d overdue loans",
   "Attenzione: %d prestito in ritardo": "Warning: %d overdue loan",
   "Attenzione: Azione Manuale Richiesta": "Warning: Manual Action Required",
-  "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Warning: Could not remove all requested copies. Some copies are currently on loan.",
   "Attiva": "Active",
   "Attiva API key": "Activate API key",
   "Attiva Direttamente": "Activate Directly",
@@ -2321,7 +2320,6 @@
   "Impossibile revocare la sessione": "Unable to revoke session",
   "Impossibile riaprire il file ZIP": "Unable to reopen ZIP file",
   "Impossibile ricalcolare la disponibilità del libro.": "Unable to recalculate book availability.",
-  "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.": "Cannot reduce the copies to %d. There are %d unavailable copies (on loan, lost, or damaged). The minimum total number of copies is %d.",
   "Impossibile rifiutare la recensione": "Unable to reject the review",
   "Impossibile rigenerare la sitemap.": "Unable to regenerate the sitemap.",
   "Impossibile rigenerare la sitemap: %s": "Unable to regenerate sitemap: %s",
@@ -6790,7 +6788,6 @@
   "Nessuna copia fisica registrata.": "No physical copies recorded.",
   "Copia aggiunta con successo.": "Copy added successfully.",
   "Impossibile aggiungere la copia.": "Unable to add the copy.",
-  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "A lost or damaged copy lowers the total-copies count. For loans, use the Loans section.",
   "Esiste già una copia con questo numero di inventario.": "A copy with this inventory number already exists.",
   "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Use \"Add copy\" to create one and set its status.",
   "In trasferimento": "In transfer",
@@ -6806,5 +6803,6 @@
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Initial copies receive sequential codes such as PREFIX-C1 and PREFIX-C2.",
   "Invio notifica nuova copia fallito": "New-copy notification failed",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "You can only delete out-of-circulation copies (lost, damaged, under maintenance, under restoration or in transfer). Change the copy's status first.",
-  "Impossibile aggiungere le copie.": "Unable to add the copies."
+  "Impossibile aggiungere le copie.": "Unable to add the copies.",
+  "Impossibile eliminare la copia.": "Unable to delete the copy."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6794,5 +6794,17 @@
   "Impossibile aggiungere la copia.": "Unable to add the copy.",
   "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "A lost or damaged copy lowers the total-copies count. For loans, use the Loans section.",
   "Esiste già una copia con questo numero di inventario.": "A copy with this inventory number already exists.",
-  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Use \"Add copy\" to create one and set its status."
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Use \"Add copy\" to create one and set its status.",
+  "In trasferimento": "In transfer",
+  "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.": "Lost, damaged, maintenance, restoration, or transfer copies are not counted as circulating copies. For loans, use the Loans section.",
+  "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.": "Book availability is calculated automatically from physical copies and loans.",
+  "Copie in circolazione": "Circulating copies",
+  "Copie fisiche iniziali": "Initial physical copies",
+  "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.": "Add, edit, or remove individual copies in the Physical Copies section of the book page.",
+  "Gestisci copie fisiche": "Manage physical copies",
+  "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.": "You can create the record with zero copies and add them later from the book page.",
+  "Prefisso inventario copie": "Copy inventory prefix",
+  "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Used only to generate codes for new copies automatically; existing codes do not change.",
+  "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Initial copies receive sequential codes such as PREFIX-C1 and PREFIX-C2.",
+  "Invio notifica nuova copia fallito": "New-copy notification failed"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6805,5 +6805,6 @@
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Utilisé uniquement pour générer les codes des nouvelles copies ; les codes existants ne changent pas.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Les copies initiales recevront des codes séquentiels comme PRÉFIXE-C1 et PRÉFIXE-C2.",
   "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie",
-  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Vous ne pouvez supprimer que les copies hors circulation (perdues, endommagées, en maintenance, en restauration ou en transfert). Modifiez d'abord l'état de la copie."
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Vous ne pouvez supprimer que les copies hors circulation (perdues, endommagées, en maintenance, en restauration ou en transfert). Modifiez d'abord l'état de la copie.",
+  "Impossibile aggiungere le copie.": "Impossible d'ajouter les copies."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6783,5 +6783,16 @@
   "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.": "Erreur : format de date non valide. Saisissez les dates au format YYYY-MM-DD.",
   "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.": "Modification non enregistrée : sur la nouvelle période, tous les exemplaires sont déjà occupés par d'autres prêts ou réservations.",
   "Rinnovo non riuscito. Riprova.": "Échec du renouvellement. Veuillez réessayer.",
-  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modification non enregistrée : l’exemplaire attribué est déjà affecté à un autre prêt pendant la nouvelle période."
+  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modification non enregistrée : l’exemplaire attribué est déjà affecté à un autre prêt pendant la nouvelle période.",
+  "Aggiungi copia": "Ajouter une copie",
+  "Aggiungi Copia": "Ajouter une copie",
+  "Numero di inventario": "Numéro d'inventaire",
+  "Lascia vuoto per assegnarlo automaticamente": "Laisser vide pour l'attribuer automatiquement",
+  "In restauro": "En restauration",
+  "Nessuna copia fisica registrata.": "Aucune copie physique enregistrée.",
+  "Copia aggiunta con successo.": "Copie ajoutée avec succès.",
+  "Impossibile aggiungere la copia.": "Impossible d'ajouter la copie.",
+  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Une copie perdue ou endommagée réduit le nombre total de copies. Pour les prêts, utilisez la section Prêts.",
+  "Esiste già una copia con questo numero di inventario.": "Une copie avec ce numéro d'inventaire existe déjà.",
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Utilisez « Ajouter une copie » pour en créer une et définir son état."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -363,7 +363,6 @@
   "Attenzione: %d prestiti in ritardo": "Attention : %d emprunts en retard",
   "Attenzione: %d prestito in ritardo": "Attention : %d emprunt en retard",
   "Attenzione: Azione Manuale Richiesta": "Attention : action manuelle requise",
-  "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Attention : impossible de supprimer tous les exemplaires demandés. Certains exemplaires sont actuellement empruntés.",
   "Attiva": "Actif",
   "Attiva API key": "Activer la clé API",
   "Attiva Direttamente": "Activer directement",
@@ -2321,7 +2320,6 @@
   "Impossibile revocare la sessione": "Impossible de révoquer la session",
   "Impossibile riaprire il file ZIP": "Impossible de rouvrir le fichier ZIP",
   "Impossibile ricalcolare la disponibilità del libro.": "Impossible de recalculer la disponibilité du livre.",
-  "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.": "Impossible de réduire les exemplaires à %d. Il y a %d exemplaires indisponibles (empruntés, perdus ou endommagés). Le nombre minimum d'exemplaires total est %d.",
   "Impossibile rifiutare la recensione": "Impossible de refuser l'avis",
   "Impossibile rigenerare la sitemap.": "Impossible de régénérer le sitemap.",
   "Impossibile rigenerare la sitemap: %s": "Impossible de régénérer le sitemap : %s",
@@ -6790,7 +6788,6 @@
   "Nessuna copia fisica registrata.": "Aucune copie physique enregistrée.",
   "Copia aggiunta con successo.": "Copie ajoutée avec succès.",
   "Impossibile aggiungere la copia.": "Impossible d'ajouter la copie.",
-  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Une copie perdue ou endommagée réduit le nombre total de copies. Pour les prêts, utilisez la section Prêts.",
   "Esiste già una copia con questo numero di inventario.": "Une copie avec ce numéro d'inventaire existe déjà.",
   "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Utilisez « Ajouter une copie » pour en créer une et définir son état.",
   "In trasferimento": "En transfert",
@@ -6806,5 +6803,6 @@
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Les copies initiales recevront des codes séquentiels comme PRÉFIXE-C1 et PRÉFIXE-C2.",
   "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Vous ne pouvez supprimer que les copies hors circulation (perdues, endommagées, en maintenance, en restauration ou en transfert). Modifiez d'abord l'état de la copie.",
-  "Impossibile aggiungere le copie.": "Impossible d'ajouter les copies."
+  "Impossibile aggiungere le copie.": "Impossible d'ajouter les copies.",
+  "Impossibile eliminare la copia.": "Impossible de supprimer la copie."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6794,5 +6794,17 @@
   "Impossibile aggiungere la copia.": "Impossible d'ajouter la copie.",
   "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Une copie perdue ou endommagée réduit le nombre total de copies. Pour les prêts, utilisez la section Prêts.",
   "Esiste già una copia con questo numero di inventario.": "Une copie avec ce numéro d'inventaire existe déjà.",
-  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Utilisez « Ajouter une copie » pour en créer une et définir son état."
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Utilisez « Ajouter une copie » pour en créer une et définir son état.",
+  "In trasferimento": "En transfert",
+  "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.": "Les copies perdues, endommagées, en maintenance, restauration ou transfert ne sont pas comptées parmi les copies en circulation. Pour les prêts, utilisez la section Prêts.",
+  "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.": "La disponibilité du livre est calculée automatiquement à partir des copies physiques et des prêts.",
+  "Copie in circolazione": "Copies en circulation",
+  "Copie fisiche iniziali": "Copies physiques initiales",
+  "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.": "Ajoutez, modifiez ou supprimez les copies dans la section Copies physiques de la fiche du livre.",
+  "Gestisci copie fisiche": "Gérer les copies physiques",
+  "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.": "Vous pouvez créer la notice sans copie et en ajouter ensuite depuis la fiche du livre.",
+  "Prefisso inventario copie": "Préfixe d’inventaire des copies",
+  "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Utilisé uniquement pour générer les codes des nouvelles copies ; les codes existants ne changent pas.",
+  "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Les copies initiales recevront des codes séquentiels comme PRÉFIXE-C1 et PRÉFIXE-C2.",
+  "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -3672,7 +3672,6 @@
   "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo": "Boutons \"Demander un emprunt\" et \"Réserver\" dans le catalogue",
   "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate": "Vous pouvez modifier ce paramètre à tout moment depuis Paramètres → Avancé",
   "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.": "Vous pouvez configurer ou modifier ces paramètres plus tard depuis la section Paramètres e-mail de l'admin.",
-  "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.": "Vous pouvez uniquement supprimer les exemplaires perdus, endommagés ou en maintenance. Changez d'abord le statut de l'exemplaire.",
   "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.": "Vous pouvez modifier ces paramètres à tout moment depuis la section Paramètres de l'admin.",
   "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.": "Vous pouvez réduire les exemplaires uniquement s'ils ne sont pas empruntés, perdus ou endommagés.",
   "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.": "Vous pouvez choisir un miroir suggéré ou sélectionner un domaine personnalisé.",
@@ -6785,7 +6784,6 @@
   "Rinnovo non riuscito. Riprova.": "Échec du renouvellement. Veuillez réessayer.",
   "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modification non enregistrée : l’exemplaire attribué est déjà affecté à un autre prêt pendant la nouvelle période.",
   "Aggiungi copia": "Ajouter une copie",
-  "Aggiungi Copia": "Ajouter une copie",
   "Numero di inventario": "Numéro d'inventaire",
   "Lascia vuoto per assegnarlo automaticamente": "Laisser vide pour l'attribuer automatiquement",
   "In restauro": "En restauration",
@@ -6806,5 +6804,6 @@
   "Prefisso inventario copie": "Préfixe d’inventaire des copies",
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Utilisé uniquement pour générer les codes des nouvelles copies ; les codes existants ne changent pas.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Les copies initiales recevront des codes séquentiels comme PRÉFIXE-C1 et PRÉFIXE-C2.",
-  "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie"
+  "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie",
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Vous ne pouvez supprimer que les copies hors circulation (perdues, endommagées, en maintenance, en restauration ou en transfert). Modifiez d'abord l'état de la copie."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -3530,7 +3530,6 @@
   "Prenota questo libro": "Réserver ce livre",
   "Prenotabile per date future": "Réservable pour des dates futures",
   "Prenotato": "Réservé",
-  "Prenotato (imposta \"Disponibile\" per cancellare)": "Réservé (définir \"Disponible\" pour annuler)",
   "Prenotato (prestito in attesa)": "Réservé (emprunt en attente)",
   "Prenotazione": "Réservation",
   "Prenotazione Annullata": "Réservation annulée",
@@ -6804,5 +6803,8 @@
   "Invio notifica nuova copia fallito": "Échec de la notification de nouvelle copie",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Vous ne pouvez supprimer que les copies hors circulation (perdues, endommagées, en maintenance, en restauration ou en transfert). Modifiez d'abord l'état de la copie.",
   "Impossibile aggiungere le copie.": "Impossible d'ajouter les copies.",
-  "Impossibile eliminare la copia.": "Impossible de supprimer la copie."
+  "Impossibile eliminare la copia.": "Impossible de supprimer la copie.",
+  "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".": "Pour réserver une copie, utilisez le système de prêts. L'état « Réservé » ne peut pas être défini manuellement.",
+  "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.": "Pour annuler ou déplacer une réservation, utilisez le système de prêts.",
+  "Prenotato (gestisci dal sistema Prestiti)": "Réservé (gérer depuis le système de prêts)"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -3530,7 +3530,6 @@
   "Prenota questo libro": "Prenota questo libro",
   "Prenotabile per date future": "Prenotabile per date future",
   "Prenotato": "Prenotato",
-  "Prenotato (imposta \"Disponibile\" per cancellare)": "Prenotato (imposta \"Disponibile\" per cancellare)",
   "Prenotato (prestito in attesa)": "Prenotato (prestito in attesa)",
   "Prenotazione": "Prenotazione",
   "Prenotazione Annullata": "Prenotazione Annullata",
@@ -6804,5 +6803,8 @@
   "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.",
   "Impossibile aggiungere le copie.": "Impossibile aggiungere le copie.",
-  "Impossibile eliminare la copia.": "Impossibile eliminare la copia."
+  "Impossibile eliminare la copia.": "Impossibile eliminare la copia.",
+  "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".": "Per prenotare una copia, utilizza il sistema Prestiti. Non è possibile impostare manualmente lo stato \"Prenotato\".",
+  "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.": "Per annullare o spostare una prenotazione, utilizza il sistema Prestiti.",
+  "Prenotato (gestisci dal sistema Prestiti)": "Prenotato (gestisci dal sistema Prestiti)"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6794,5 +6794,17 @@
   "Impossibile aggiungere la copia.": "Impossibile aggiungere la copia.",
   "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.",
   "Esiste già una copia con questo numero di inventario.": "Esiste già una copia con questo numero di inventario.",
-  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato."
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.",
+  "In trasferimento": "In trasferimento",
+  "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.": "Le copie perse, danneggiate, in manutenzione, restauro o trasferimento non sono conteggiate tra le copie in circolazione. Per i prestiti usa la sezione Prestiti.",
+  "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.": "La disponibilità del libro è calcolata automaticamente dalle copie fisiche e dai prestiti.",
+  "Copie in circolazione": "Copie in circolazione",
+  "Copie fisiche iniziali": "Copie fisiche iniziali",
+  "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.": "Aggiungi, modifica o rimuovi le singole copie dalla sezione Copie Fisiche della scheda libro.",
+  "Gestisci copie fisiche": "Gestisci copie fisiche",
+  "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.": "Puoi creare il record con zero copie e aggiungerle in seguito dalla scheda libro.",
+  "Prefisso inventario copie": "Prefisso inventario copie",
+  "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.",
+  "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.",
+  "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6805,5 +6805,6 @@
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.",
   "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito",
-  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia."
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.",
+  "Impossibile aggiungere le copie.": "Impossibile aggiungere le copie."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -3672,7 +3672,6 @@
   "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo": "Pulsanti \"Richiedi Prestito\" e \"Prenota\" nel catalogo",
   "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate": "Puoi cambiare questa impostazione in qualsiasi momento da Impostazioni → Avanzate",
   "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.": "Puoi configurare o modificare queste impostazioni in seguito dalla sezione Impostazioni Email dell'admin.",
-  "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.": "Puoi eliminare solo copie perse, danneggiate o in manutenzione. Prima modifica lo stato della copia.",
   "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.": "Puoi modificare queste impostazioni in qualsiasi momento dalla sezione Impostazioni dell'admin.",
   "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.": "Puoi ridurre le copie solo se non sono in prestito, perse o danneggiate.",
   "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.": "Puoi scegliere un mirror suggerito oppure selezionare dominio personalizzato.",
@@ -6785,7 +6784,6 @@
   "Rinnovo non riuscito. Riprova.": "Rinnovo non riuscito. Riprova.",
   "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.",
   "Aggiungi copia": "Aggiungi copia",
-  "Aggiungi Copia": "Aggiungi Copia",
   "Numero di inventario": "Numero di inventario",
   "Lascia vuoto per assegnarlo automaticamente": "Lascia vuoto per assegnarlo automaticamente",
   "In restauro": "In restauro",
@@ -6806,5 +6804,6 @@
   "Prefisso inventario copie": "Prefisso inventario copie",
   "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.": "Viene usato solo per generare automaticamente i codici delle nuove copie; i codici esistenti non cambiano.",
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.",
-  "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito"
+  "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito",
+  "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -363,7 +363,6 @@
   "Attenzione: %d prestiti in ritardo": "Attenzione: %d prestiti in ritardo",
   "Attenzione: %d prestito in ritardo": "Attenzione: %d prestito in ritardo",
   "Attenzione: Azione Manuale Richiesta": "Attenzione: Azione Manuale Richiesta",
-  "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.": "Attenzione: Non è stato possibile rimuovere tutte le copie richieste. Alcune copie sono attualmente in prestito.",
   "Attiva": "Attiva",
   "Attiva API key": "Attiva API key",
   "Attiva Direttamente": "Attiva Direttamente",
@@ -2321,7 +2320,6 @@
   "Impossibile revocare la sessione": "Impossibile revocare la sessione",
   "Impossibile riaprire il file ZIP": "Impossibile riaprire il file ZIP",
   "Impossibile ricalcolare la disponibilità del libro.": "Impossibile ricalcolare la disponibilità del libro.",
-  "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.": "Impossibile ridurre le copie a %d. Ci sono %d copie non disponibili (in prestito, perse o danneggiate). Il numero minimo di copie totali è %d.",
   "Impossibile rifiutare la recensione": "Impossibile rifiutare la recensione",
   "Impossibile rigenerare la sitemap.": "Impossibile rigenerare la sitemap.",
   "Impossibile rigenerare la sitemap: %s": "Impossibile rigenerare la sitemap: %s",
@@ -6790,7 +6788,6 @@
   "Nessuna copia fisica registrata.": "Nessuna copia fisica registrata.",
   "Copia aggiunta con successo.": "Copia aggiunta con successo.",
   "Impossibile aggiungere la copia.": "Impossibile aggiungere la copia.",
-  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.",
   "Esiste già una copia con questo numero di inventario.": "Esiste già una copia con questo numero di inventario.",
   "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.",
   "In trasferimento": "In trasferimento",
@@ -6806,5 +6803,6 @@
   "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.": "Le copie iniziali riceveranno codici progressivi come PREFISSO-C1, PREFISSO-C2.",
   "Invio notifica nuova copia fallito": "Invio notifica nuova copia fallito",
   "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.": "Puoi eliminare solo copie fuori circolazione (perse, danneggiate, in manutenzione, in restauro o in trasferimento). Prima modifica lo stato della copia.",
-  "Impossibile aggiungere le copie.": "Impossibile aggiungere le copie."
+  "Impossibile aggiungere le copie.": "Impossibile aggiungere le copie.",
+  "Impossibile eliminare la copia.": "Impossibile eliminare la copia."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6783,5 +6783,16 @@
   "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.": "Errore: formato data non valido. Inserisci le date nel formato YYYY-MM-DD.",
   "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.": "Modifica non salvata: nel nuovo periodo tutte le copie sono già impegnate da altri prestiti o prenotazioni.",
   "Rinnovo non riuscito. Riprova.": "Rinnovo non riuscito. Riprova.",
-  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo."
+  "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.": "Modifica non salvata: la copia assegnata è già impegnata da un altro prestito nel nuovo periodo.",
+  "Aggiungi copia": "Aggiungi copia",
+  "Aggiungi Copia": "Aggiungi Copia",
+  "Numero di inventario": "Numero di inventario",
+  "Lascia vuoto per assegnarlo automaticamente": "Lascia vuoto per assegnarlo automaticamente",
+  "In restauro": "In restauro",
+  "Nessuna copia fisica registrata.": "Nessuna copia fisica registrata.",
+  "Copia aggiunta con successo.": "Copia aggiunta con successo.",
+  "Impossibile aggiungere la copia.": "Impossibile aggiungere la copia.",
+  "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.": "Una copia persa o danneggiata riduce il conteggio delle copie totali. Per i prestiti usa la sezione Prestiti.",
+  "Esiste già una copia con questo numero di inventario.": "Esiste già una copia con questo numero di inventario.",
+  "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato.": "Usa \"Aggiungi copia\" per crearne una e poterne impostare lo stato."
 }

--- a/tests/accessibility-cross-browser.spec.js
+++ b/tests/accessibility-cross-browser.spec.js
@@ -34,10 +34,8 @@ async function assertHealthyAndAccessible(page, route) {
 
     // Scan the stable visual state. WebKit can otherwise sample text midway
     // through a fade-in and report the transient blended color as a violation.
-    await page.addStyleTag({
-      content: '*, *::before, *::after { animation: none !important; transition: none !important; }',
-    });
-    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
+    // The longest entrance animation on these pages is 600 ms.
+    await page.waitForTimeout(750);
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])

--- a/tests/accessibility-cross-browser.spec.js
+++ b/tests/accessibility-cross-browser.spec.js
@@ -32,10 +32,12 @@ async function assertHealthyAndAccessible(page, route) {
     expect(response.status(), `${route} returned HTTP ${response.status()}`).toBeLessThan(400);
     await expect(page.locator('body')).toBeVisible();
 
-    // Scan the stable visual state. WebKit can otherwise sample text midway
-    // through a fade-in and report the transient blended color as a violation.
-    // The longest entrance animation on these pages is 600 ms.
-    await page.waitForTimeout(750);
+    // Scan the stable visual state. Headless WebKit can pause animations and
+    // otherwise expose a transient blended text color to axe indefinitely.
+    await page.evaluate(() => {
+      document.getAnimations().forEach((animation) => animation.cancel());
+    });
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
 
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])

--- a/tests/accessibility-cross-browser.spec.js
+++ b/tests/accessibility-cross-browser.spec.js
@@ -24,19 +24,23 @@ async function assertHealthyAndAccessible(page, route) {
   const onPageError = (error) => pageErrors.push(error.message);
   page.on('pageerror', onPageError);
 
-  const response = await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle' });
-  expect(response, `${route} did not return a response`).not.toBeNull();
-  expect(response.status(), `${route} returned HTTP ${response.status()}`).toBeLessThan(400);
-  await expect(page.locator('body')).toBeVisible();
+  try {
+    // DOMContentLoaded is the relevant readiness boundary for axe. Waiting for
+    // networkidle is unsafe here because admin pages perform background polling.
+    const response = await page.goto(`${BASE}${route}`, { waitUntil: 'domcontentloaded' });
+    expect(response, `${route} did not return a response`).not.toBeNull();
+    expect(response.status(), `${route} returned HTTP ${response.status()}`).toBeLessThan(400);
+    await expect(page.locator('body')).toBeVisible();
 
-  const results = await new AxeBuilder({ page })
-    .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
-    .analyze();
-  const blocking = results.violations.filter(({ impact }) => impact === 'critical' || impact === 'serious');
-  expect(blocking, `Accessibility violations on ${route}:\n${formatViolations(blocking)}`).toEqual([]);
-  expect(pageErrors, `Unhandled browser errors on ${route}`).toEqual([]);
-
-  page.off('pageerror', onPageError);
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
+      .analyze();
+    const blocking = results.violations.filter(({ impact }) => impact === 'critical' || impact === 'serious');
+    expect(blocking, `Accessibility violations on ${route}:\n${formatViolations(blocking)}`).toEqual([]);
+    expect(pageErrors, `Unhandled browser errors on ${route}`).toEqual([]);
+  } finally {
+    page.off('pageerror', onPageError);
+  }
 }
 
 test.describe('critical pages across supported browser engines', () => {
@@ -55,6 +59,10 @@ test.describe('critical pages across supported browser engines', () => {
       await page.locator('input[name="password"]').fill(ADMIN_PASS);
       await page.locator('button[type="submit"]').click();
       await page.waitForURL((url) => url.pathname.startsWith('/admin'), { timeout: 30_000 });
+
+      // Use a clean authenticated page so late errors from the login redirect or
+      // dashboard cannot be misattributed to the route under test.
+      await page.goto('about:blank');
       await assertHealthyAndAccessible(page, route);
     });
   }

--- a/tests/accessibility-cross-browser.spec.js
+++ b/tests/accessibility-cross-browser.spec.js
@@ -32,6 +32,13 @@ async function assertHealthyAndAccessible(page, route) {
     expect(response.status(), `${route} returned HTTP ${response.status()}`).toBeLessThan(400);
     await expect(page.locator('body')).toBeVisible();
 
+    // Scan the stable visual state. WebKit can otherwise sample text midway
+    // through a fade-in and report the transient blended color as a violation.
+    await page.addStyleTag({
+      content: '*, *::before, *::after { animation: none !important; transition: none !important; }',
+    });
+    await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve())));
+
     const results = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'])
       .analyze();

--- a/tests/accessibility-cross-browser.spec.js
+++ b/tests/accessibility-cross-browser.spec.js
@@ -50,20 +50,46 @@ test.describe('critical pages across supported browser engines', () => {
     });
   }
 
-  for (const route of adminRoutes) {
-    test(`admin ${route} has no serious WCAG violations or runtime errors`, async ({ page }) => {
-      test.skip(!ADMIN_EMAIL || !ADMIN_PASS, 'admin credentials are required');
+  test.describe('authenticated admin pages', () => {
+    let adminContext;
 
-      await page.goto(`${BASE}/accedi`);
-      await page.locator('input[name="email"]').fill(ADMIN_EMAIL);
-      await page.locator('input[name="password"]').fill(ADMIN_PASS);
-      await page.locator('button[type="submit"]').click();
-      await page.waitForURL((url) => url.pathname.startsWith('/admin'), { timeout: 30_000 });
+    test.beforeAll(async ({ browser }) => {
+      if (!ADMIN_EMAIL || !ADMIN_PASS) return;
 
-      // Use a clean authenticated page so late errors from the login redirect or
-      // dashboard cannot be misattributed to the route under test.
-      await page.goto('about:blank');
-      await assertHealthyAndAccessible(page, route);
+      // Authenticate once per browser project. Repeating the login for every
+      // route can exhaust the application rate limit after the package tests.
+      adminContext = await browser.newContext();
+      const loginPage = await adminContext.newPage();
+      try {
+        await loginPage.goto(`${BASE}/accedi`, { waitUntil: 'domcontentloaded' });
+        await loginPage.locator('input[name="email"]').fill(ADMIN_EMAIL);
+        await loginPage.locator('input[name="password"]').fill(ADMIN_PASS);
+        await Promise.all([
+          loginPage.waitForURL((url) => url.pathname.startsWith('/admin'), { timeout: 30_000 }),
+          loginPage.locator('button[type="submit"]').click(),
+        ]);
+      } finally {
+        await loginPage.close();
+      }
     });
-  }
+
+    test.afterAll(async () => {
+      await adminContext?.close();
+    });
+
+    for (const route of adminRoutes) {
+      test(`admin ${route} has no serious WCAG violations or runtime errors`, async () => {
+        test.skip(!adminContext, 'admin credentials are required');
+
+        // A new page avoids attributing late errors from the previous route to
+        // the route currently under audit while retaining the authenticated session.
+        const auditPage = await adminContext.newPage();
+        try {
+          await assertHealthyAndAccessible(auditPage, route);
+        } finally {
+          await auditPage.close();
+        }
+      });
+    }
+  });
 });

--- a/tests/atomic-book-create-356.spec.js
+++ b/tests/atomic-book-create-356.spec.js
@@ -1,0 +1,286 @@
+// @ts-check
+//
+// E2E proof for the atomic book+copies create in LibriController::store()
+// (PR #356): the book row and its initial physical copies now persist in ONE
+// transaction, committed before any plugin hook fires. Driven through the
+// REAL admin create form + controller + DB:
+//
+//   1. creating with 1 copy persists exactly one copie row and derived
+//      counters (DataIntegrity) of 1:1:disponibile;
+//   2. creating with 3 copies persists exactly three uniform -C1/-C2/-C3 codes;
+//   3. creating with 0 copies persists a valid zero-holding record;
+//   4. ROLLBACK PROOF: a forced copy-insert failure (SIGNAL trigger on copie)
+//      makes the real POST fail AND leaves no orphan book, no partial copies,
+//      and no orphan series (collane) metadata;
+//   5. a non-integer copie_totali still falls back to zero copies;
+//   6. copie_totali is still clamped to the 9999 upper bound;
+//   7. book.save.after still fires post-commit: with the book-club plugin
+//      active, an external club proposal with the same ISBN is reconciled
+//      (acquired_libro_id set) by the hook handler — which runs its own
+//      transaction — without corrupting the created book or its copies.
+//
+// Reusable: marker-scoped to titles `ZZ_ATOMIC356_%`, cleans up in afterAll.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_HOST = process.env.E2E_DB_HOST || '';
+const DB_PORT = process.env.E2E_DB_PORT || '';
+const DB_USER = process.env.E2E_DB_USER || '';
+const DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_NAME = process.env.E2E_DB_NAME || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+
+test.skip(
+  !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME,
+  'E2E credentials not configured',
+);
+
+/** Run a MySQL statement, return trimmed stdout. */
+function dbQuery(sql) {
+  const args = ['-N', '-B', '-e', sql];
+  if (DB_HOST) args.push('-h', DB_HOST);
+  if (DB_PORT) args.push('-P', DB_PORT);
+  if (!DB_HOST && DB_SOCKET) args.push('-S', DB_SOCKET);
+  args.push('-u', DB_USER, DB_NAME);
+  return execFileSync('mysql', args, {
+    encoding: 'utf-8', timeout: 20000,
+    env: { ...process.env, MYSQL_PWD: DB_PASS },
+  }).trim();
+}
+
+const RUN = Date.now().toString(36);
+const MARKER = 'ZZ_ATOMIC356_';
+const TITLE_ONE = `${MARKER}ONE_${RUN}`;
+const TITLE_THREE = `${MARKER}THREE_${RUN}`;
+const TITLE_ZERO = `${MARKER}ZERO_${RUN}`;
+const TITLE_FAIL = `${MARKER}FAIL_${RUN}`;
+const TITLE_NONINT = `${MARKER}NONINT_${RUN}`;
+const TITLE_CLAMP = `${MARKER}CLAMP_${RUN}`;
+const TITLE_HOOK = `${MARKER}HOOK_${RUN}`;
+const PREFIX_ONE = `A356A-${RUN}`;
+const PREFIX_THREE = `A356B-${RUN}`;
+const PREFIX_FAIL = `A356F-${RUN}`;
+const SERIES_FAIL = `${MARKER}SERIES_${RUN}`;
+const CLUB_SLUG = `zz-atomic356-${RUN}`;
+const TRIGGER = 'zz_atomic356_fail_copy';
+
+/** Valid ISBN-13 unique to this run (per-run digits + computed check digit). */
+function makeIsbn13() {
+  const body = ('978' + Date.now().toString().slice(-10)).slice(0, 12);
+  let sum = 0;
+  for (let i = 0; i < 12; i++) sum += Number(body[i]) * (i % 2 === 0 ? 1 : 3);
+  return body + String((10 - (sum % 10)) % 10);
+}
+const HOOK_ISBN = makeIsbn13();
+
+function cleanup() {
+  try { dbQuery(`DROP TRIGGER IF EXISTS ${TRIGGER}`); } catch { /* best-effort */ }
+  // Book-club fixture rows (ignore errors if the plugin tables are absent).
+  try {
+    dbQuery(`DELETE FROM bookclub_books WHERE club_id IN (SELECT id FROM bookclub_clubs WHERE slug='${CLUB_SLUG}')`);
+    dbQuery(`DELETE FROM bookclub_external_books WHERE club_id IN (SELECT id FROM bookclub_clubs WHERE slug='${CLUB_SLUG}')`);
+    dbQuery(`DELETE FROM bookclub_clubs WHERE slug='${CLUB_SLUG}'`);
+  } catch { /* plugin tables may not exist */ }
+  dbQuery(`DELETE FROM collane WHERE nome LIKE '${MARKER}%'`);
+  // copie rows cascade with the book (FK ON DELETE CASCADE).
+  dbQuery(`DELETE FROM libri WHERE titolo LIKE '${MARKER}%'`);
+}
+
+const bookIdByTitle = (title) =>
+  Number(dbQuery(`SELECT id FROM libri WHERE titolo='${title}' AND deleted_at IS NULL LIMIT 1`) || '0');
+const copieCount = (id) => Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${id}`));
+const copieCodes = (id) => dbQuery(`SELECT numero_inventario FROM copie WHERE libro_id=${id} ORDER BY id`)
+  .split('\n').filter(Boolean);
+
+async function loginAsAdmin(page) {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    await page.goto(`${BASE}/accedi`);
+    await page.waitForLoadState('domcontentloaded');
+    const email = page.locator('input[name="email"]');
+    if (await email.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await email.fill(ADMIN_EMAIL);
+      await page.fill('input[name="password"]', ADMIN_PASS);
+      await page.locator('button[type="submit"]').click();
+      try {
+        await page.waitForURL(u => u.toString().includes('/admin'), { timeout: 30000 });
+        return;
+      } catch {
+        if (attempt === 0) continue;
+        throw new Error('loginAsAdmin: not redirected to /admin');
+      }
+    } else if (page.url().includes('/admin')) {
+      return;
+    }
+  }
+}
+
+/**
+ * Submit #bookForm (SweetAlert confirm) and wait for the store() response.
+ * Returns the HTTP status of the POST, without assuming success.
+ */
+async function submitBookForm(page) {
+  const responsePromise = page.waitForResponse(
+    (r) => r.url().includes('/admin/books/create') && r.request().method() === 'POST',
+    { timeout: 60000 },
+  );
+  await page.locator('#bookForm button[type="submit"]').click();
+  const confirm = page.locator('.swal2-confirm:visible');
+  if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await confirm.click();
+  }
+  const response = await responsePromise;
+  return response.status();
+}
+
+async function openCreateForm(page, title) {
+  await page.goto(`${BASE}/admin/books/create`);
+  await expect(page.locator('#titolo')).toBeVisible({ timeout: 10000 });
+  await page.fill('#titolo', title);
+}
+
+test.describe.serial('atomic book+copies create (#356)', () => {
+  test.beforeAll(() => {
+    // Pre-clean leftovers from a previous aborted run.
+    dbQuery(`DELETE FROM libri WHERE titolo LIKE '${MARKER}%'`);
+    try { dbQuery(`DROP TRIGGER IF EXISTS ${TRIGGER}`); } catch { /* best-effort */ }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test.afterAll(() => cleanup());
+
+  test('1) create with 1 copy persists exactly one copie row + derived counters', async ({ page }) => {
+    await openCreateForm(page, TITLE_ONE);
+    await page.fill('#copie_totali', '1');
+    await page.fill('#numero_inventario', PREFIX_ONE);
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_ONE);
+    expect(id).toBeGreaterThan(0);
+    expect(copieCodes(id)).toEqual([`${PREFIX_ONE}-C1`]);
+    // DataIntegrity ran post-commit and derived the canonical counters.
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id=${id}`))
+      .toBe('1:1:disponibile');
+  });
+
+  test('2) create with 3 copies persists exactly three uniform -C1/-C2/-C3 codes', async ({ page }) => {
+    await openCreateForm(page, TITLE_THREE);
+    await page.fill('#copie_totali', '3');
+    await page.fill('#numero_inventario', PREFIX_THREE);
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_THREE);
+    expect(id).toBeGreaterThan(0);
+    expect(copieCodes(id)).toEqual([`${PREFIX_THREE}-C1`, `${PREFIX_THREE}-C2`, `${PREFIX_THREE}-C3`]);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('3:3');
+  });
+
+  test('3) create with 0 copies persists a valid zero-holding record', async ({ page }) => {
+    await openCreateForm(page, TITLE_ZERO);
+    await page.fill('#copie_totali', '0');
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_ZERO);
+    expect(id).toBeGreaterThan(0);
+    expect(copieCount(id)).toBe(0);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('0:0');
+  });
+
+  test('4) ROLLBACK: forced copy failure leaves no orphan book, copies or series rows', async ({ page }) => {
+    // Force the multi-row copie INSERT to fail server-side, exactly like a
+    // production insert error would, through the REAL controller path.
+    dbQuery(`CREATE TRIGGER ${TRIGGER} BEFORE INSERT ON copie FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced copy failure (e2e)'`);
+    try {
+      await openCreateForm(page, TITLE_FAIL);
+      await page.fill('#copie_totali', '2');
+      await page.fill('#numero_inventario', PREFIX_FAIL);
+      // Series metadata travels with the same submit: on rollback it must
+      // never be persisted either (it now runs only after the commit).
+      await page.evaluate((name) => {
+        const el = document.getElementById('collana');
+        if (el) el.value = name;
+      }, SERIES_FAIL);
+      const status = await submitBookForm(page);
+      expect(status).toBeGreaterThanOrEqual(500);
+    } finally {
+      dbQuery(`DROP TRIGGER IF EXISTS ${TRIGGER}`);
+    }
+
+    // No orphan book (not even soft-deleted), no partial copies, no series.
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM libri WHERE titolo='${TITLE_FAIL}'`))).toBe(0);
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE numero_inventario LIKE '${PREFIX_FAIL}%'`))).toBe(0);
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM collane WHERE nome='${SERIES_FAIL}'`))).toBe(0);
+  });
+
+  test('5) non-integer copie_totali still falls back to zero copies', async ({ page }) => {
+    await openCreateForm(page, TITLE_NONINT);
+    // Bypass the number input to deliver a genuinely non-integer POST value
+    // (the form is novalidate; the controller must reject it, not the browser).
+    await page.evaluate(() => {
+      const el = document.getElementById('copie_totali');
+      el.type = 'text';
+      el.value = 'abc';
+    });
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_NONINT);
+    expect(id).toBeGreaterThan(0);
+    expect(copieCount(id)).toBe(0);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('0:0');
+  });
+
+  test('6) copie_totali above the bound is clamped to 9999', async ({ page }) => {
+    test.setTimeout(120000); // 9999 copie rows: one multi-row INSERT + recalc
+    await openCreateForm(page, TITLE_CLAMP);
+    await page.evaluate(() => {
+      const el = document.getElementById('copie_totali');
+      el.removeAttribute('max');
+      el.value = '10000';
+    });
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_CLAMP);
+    expect(id).toBeGreaterThan(0);
+    expect(copieCount(id)).toBe(9999);
+    expect(Number(dbQuery(`SELECT copie_totali FROM libri WHERE id=${id}`))).toBe(9999);
+  });
+
+  test('7) book.save.after fires post-commit: book-club reconciles by ISBN without corrupting the create', async ({ page }) => {
+    const bookClubActive = dbQuery(`SELECT is_active FROM plugins WHERE name='book-club'`) === '1';
+    test.skip(!bookClubActive, 'book-club plugin not active in this environment');
+
+    // Fixture: a club with an outstanding external proposal for HOOK_ISBN.
+    const ics = RUN.padEnd(32, '0').slice(0, 32);
+    dbQuery(`INSERT INTO bookclub_clubs (slug, name, ics_token) VALUES ('${CLUB_SLUG}', 'ZZ Atomic356 Club', '${ics}')`);
+    const clubId = Number(dbQuery(`SELECT id FROM bookclub_clubs WHERE slug='${CLUB_SLUG}'`));
+    dbQuery(`INSERT INTO bookclub_external_books (club_id, titolo, isbn) VALUES (${clubId}, '${TITLE_HOOK}', '${HOOK_ISBN}')`);
+    const extId = Number(dbQuery(`SELECT id FROM bookclub_external_books WHERE club_id=${clubId}`));
+    dbQuery(`INSERT INTO bookclub_books (club_id, external_book_id, state) VALUES (${clubId}, ${extId}, 'proposed')`);
+
+    await openCreateForm(page, TITLE_HOOK);
+    await page.fill('#isbn13', HOOK_ISBN);
+    await page.fill('#copie_totali', '1');
+    const status = await submitBookForm(page);
+    expect(status).toBeLessThan(400);
+
+    const id = bookIdByTitle(TITLE_HOOK);
+    expect(id).toBeGreaterThan(0);
+    // The hook handler ran (its own transaction, post-commit) and linked the
+    // external proposal to the new catalogue book…
+    expect(Number(dbQuery(`SELECT acquired_libro_id FROM bookclub_external_books WHERE id=${extId}`))).toBe(id);
+    // …without corrupting the atomic create: the copy and the derived
+    // counters are exactly what the form requested.
+    expect(copieCount(id)).toBe(1);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('1:1');
+  });
+});

--- a/tests/atomic-book-create-356.spec.js
+++ b/tests/atomic-book-create-356.spec.js
@@ -294,7 +294,12 @@ test.describe.serial('atomic book+copies create (#356)', () => {
   });
 
   test('8) book.save.after fires post-commit: book-club reconciles by ISBN without corrupting the create', async ({ page }) => {
-    const bookClubActive = dbQuery(`SELECT is_active FROM plugins WHERE name='book-club'`) === '1';
+    let bookClubActive = false;
+    try {
+      bookClubActive = dbQuery(`SELECT is_active FROM plugins WHERE name='book-club'`) === '1';
+    } catch {
+      // Optional plugin infrastructure is absent in some supported installs.
+    }
     test.skip(!bookClubActive, 'book-club plugin not active in this environment');
 
     // Fixture: a club with an outstanding external proposal for HOOK_ISBN.

--- a/tests/atomic-book-create-356.spec.js
+++ b/tests/atomic-book-create-356.spec.js
@@ -2,22 +2,27 @@
 //
 // E2E proof for the atomic book+copies create in LibriController::store()
 // (PR #356): the book row and its initial physical copies now persist in ONE
-// transaction, committed before any plugin hook fires. Driven through the
+// transaction, including availability reconciliation and committed before any
+// plugin hook fires. Driven through the
 // REAL admin create form + controller + DB:
 //
 //   1. creating with 1 copy persists exactly one copie row and derived
 //      counters (DataIntegrity) of 1:1:disponibile;
 //   2. creating with 3 copies persists exactly three uniform -C1/-C2/-C3 codes;
 //   3. creating with 0 copies persists a valid zero-holding record;
-//   4. ROLLBACK PROOF: a forced copy-insert failure (SIGNAL trigger on copie)
+//   4. ROLLBACK PROOF: a forced copy-insert failure (DB trigger on copie)
 //      makes the real POST fail AND leaves no orphan book, no partial copies,
 //      and no orphan series (collane) metadata;
-//   5. a non-integer copie_totali still falls back to zero copies;
-//   6. copie_totali is still clamped to the 9999 upper bound;
-//   7. book.save.after still fires post-commit: with the book-club plugin
+//   5. ROLLBACK PROOF: a forced availability-recalc failure removes the book
+//      and the physical copies that had already been inserted;
+//   6. a non-integer copie_totali still falls back to zero copies;
+//   7. copie_totali is still clamped to the 9999 upper bound;
+//   8. book.save.after still fires post-commit: with the book-club plugin
 //      active, an external club proposal with the same ISBN is reconciled
 //      (acquired_libro_id set) by the hook handler — which runs its own
 //      transaction — without corrupting the created book or its copies.
+//   9. two concurrent creates sharing an inventory prefix both succeed and
+//      receive four globally unique, gap-free physical-copy codes.
 //
 // Reusable: marker-scoped to titles `ZZ_ATOMIC356_%`, cleans up in afterAll.
 const { test, expect } = require('@playwright/test');
@@ -57,15 +62,22 @@ const TITLE_ONE = `${MARKER}ONE_${RUN}`;
 const TITLE_THREE = `${MARKER}THREE_${RUN}`;
 const TITLE_ZERO = `${MARKER}ZERO_${RUN}`;
 const TITLE_FAIL = `${MARKER}FAIL_${RUN}`;
+const TITLE_RECALC_FAIL = `${MARKER}RECALC_FAIL_${RUN}`;
 const TITLE_NONINT = `${MARKER}NONINT_${RUN}`;
 const TITLE_CLAMP = `${MARKER}CLAMP_${RUN}`;
 const TITLE_HOOK = `${MARKER}HOOK_${RUN}`;
+const TITLE_RACE_A = `${MARKER}RACE_A_${RUN}`;
+const TITLE_RACE_B = `${MARKER}RACE_B_${RUN}`;
 const PREFIX_ONE = `A356A-${RUN}`;
 const PREFIX_THREE = `A356B-${RUN}`;
 const PREFIX_FAIL = `A356F-${RUN}`;
+const PREFIX_RECALC_FAIL = `A356R-${RUN}`;
+const PREFIX_RACE = `A356C-${RUN}`;
 const SERIES_FAIL = `${MARKER}SERIES_${RUN}`;
 const CLUB_SLUG = `zz-atomic356-${RUN}`;
 const TRIGGER = 'zz_atomic356_fail_copy';
+const RECALC_TRIGGER = 'zz_atomic356_fail_recalc';
+const SLOW_COPY_TRIGGER = 'zz_atomic356_slow_copy';
 
 /** Valid ISBN-13 unique to this run (per-run digits + computed check digit). */
 function makeIsbn13() {
@@ -78,6 +90,8 @@ const HOOK_ISBN = makeIsbn13();
 
 function cleanup() {
   try { dbQuery(`DROP TRIGGER IF EXISTS ${TRIGGER}`); } catch { /* best-effort */ }
+  try { dbQuery(`DROP TRIGGER IF EXISTS ${RECALC_TRIGGER}`); } catch { /* best-effort */ }
+  try { dbQuery(`DROP TRIGGER IF EXISTS ${SLOW_COPY_TRIGGER}`); } catch { /* best-effort */ }
   // Book-club fixture rows (ignore errors if the plugin tables are absent).
   try {
     dbQuery(`DELETE FROM bookclub_books WHERE club_id IN (SELECT id FROM bookclub_clubs WHERE slug='${CLUB_SLUG}')`);
@@ -146,6 +160,8 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     // Pre-clean leftovers from a previous aborted run.
     dbQuery(`DELETE FROM libri WHERE titolo LIKE '${MARKER}%'`);
     try { dbQuery(`DROP TRIGGER IF EXISTS ${TRIGGER}`); } catch { /* best-effort */ }
+    try { dbQuery(`DROP TRIGGER IF EXISTS ${RECALC_TRIGGER}`); } catch { /* best-effort */ }
+    try { dbQuery(`DROP TRIGGER IF EXISTS ${SLOW_COPY_TRIGGER}`); } catch { /* best-effort */ }
   });
 
   test.beforeEach(async ({ page }) => {
@@ -164,7 +180,7 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     const id = bookIdByTitle(TITLE_ONE);
     expect(id).toBeGreaterThan(0);
     expect(copieCodes(id)).toEqual([`${PREFIX_ONE}-C1`]);
-    // DataIntegrity ran post-commit and derived the canonical counters.
+    // DataIntegrity ran inside the transaction and derived canonical counters.
     expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id=${id}`))
       .toBe('1:1:disponibile');
   });
@@ -191,13 +207,16 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     const id = bookIdByTitle(TITLE_ZERO);
     expect(id).toBeGreaterThan(0);
     expect(copieCount(id)).toBe(0);
-    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('0:0');
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id=${id}`))
+      .toBe('0:0:non_disponibile');
   });
 
   test('4) ROLLBACK: forced copy failure leaves no orphan book, copies or series rows', async ({ page }) => {
     // Force the multi-row copie INSERT to fail server-side, exactly like a
     // production insert error would, through the REAL controller path.
-    dbQuery(`CREATE TRIGGER ${TRIGGER} BEFORE INSERT ON copie FOR EACH ROW SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced copy failure (e2e)'`);
+    // A single-statement trigger stays marker-scoped, so this spec remains safe
+    // when Playwright runs other files against the same database in parallel.
+    dbQuery(`CREATE TRIGGER ${TRIGGER} BEFORE INSERT ON copie FOR EACH ROW SET NEW.numero_inventario=IF(NEW.numero_inventario LIKE '${PREFIX_FAIL}%', NULL, NEW.numero_inventario)`);
     try {
       await openCreateForm(page, TITLE_FAIL);
       await page.fill('#copie_totali', '2');
@@ -220,7 +239,26 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     expect(Number(dbQuery(`SELECT COUNT(*) FROM collane WHERE nome='${SERIES_FAIL}'`))).toBe(0);
   });
 
-  test('5) non-integer copie_totali still falls back to zero copies', async ({ page }) => {
+  test('5) ROLLBACK: forced availability-recalc failure removes book and copies', async ({ page }) => {
+    // Fail only the marked book's DataIntegrity UPDATE. Assigning NULL to the
+    // non-null primary key is a portable one-statement trigger failure and does
+    // not disturb parallel specs updating unrelated books.
+    dbQuery(`CREATE TRIGGER ${RECALC_TRIGGER} BEFORE UPDATE ON libri FOR EACH ROW SET NEW.id=IF(NEW.titolo='${TITLE_RECALC_FAIL}', NULL, NEW.id)`);
+    try {
+      await openCreateForm(page, TITLE_RECALC_FAIL);
+      await page.fill('#copie_totali', '2');
+      await page.fill('#numero_inventario', PREFIX_RECALC_FAIL);
+      const status = await submitBookForm(page);
+      expect(status).toBeGreaterThanOrEqual(500);
+    } finally {
+      dbQuery(`DROP TRIGGER IF EXISTS ${RECALC_TRIGGER}`);
+    }
+
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM libri WHERE titolo='${TITLE_RECALC_FAIL}'`))).toBe(0);
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE numero_inventario LIKE '${PREFIX_RECALC_FAIL}%'`))).toBe(0);
+  });
+
+  test('6) non-integer copie_totali still falls back to zero copies', async ({ page }) => {
     await openCreateForm(page, TITLE_NONINT);
     // Bypass the number input to deliver a genuinely non-integer POST value
     // (the form is novalidate; the controller must reject it, not the browser).
@@ -238,7 +276,7 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('0:0');
   });
 
-  test('6) copie_totali above the bound is clamped to 9999', async ({ page }) => {
+  test('7) copie_totali above the bound is clamped to 9999', async ({ page }) => {
     test.setTimeout(120000); // 9999 copie rows: one multi-row INSERT + recalc
     await openCreateForm(page, TITLE_CLAMP);
     await page.evaluate(() => {
@@ -255,7 +293,7 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     expect(Number(dbQuery(`SELECT copie_totali FROM libri WHERE id=${id}`))).toBe(9999);
   });
 
-  test('7) book.save.after fires post-commit: book-club reconciles by ISBN without corrupting the create', async ({ page }) => {
+  test('8) book.save.after fires post-commit: book-club reconciles by ISBN without corrupting the create', async ({ page }) => {
     const bookClubActive = dbQuery(`SELECT is_active FROM plugins WHERE name='book-club'`) === '1';
     test.skip(!bookClubActive, 'book-club plugin not active in this environment');
 
@@ -282,5 +320,44 @@ test.describe.serial('atomic book+copies create (#356)', () => {
     // counters are exactly what the form requested.
     expect(copieCount(id)).toBe(1);
     expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili) FROM libri WHERE id=${id}`)).toBe('1:1');
+  });
+
+  test('9) concurrent creates sharing an inventory prefix allocate unique physical copies', async ({ page, browser }) => {
+    test.setTimeout(90000);
+    const secondContext = await browser.newContext();
+    const secondPage = await secondContext.newPage();
+    try {
+      await loginAsAdmin(secondPage);
+      await Promise.all([
+        openCreateForm(page, TITLE_RACE_A),
+        openCreateForm(secondPage, TITLE_RACE_B),
+      ]);
+      await page.fill('#copie_totali', '2');
+      await page.fill('#numero_inventario', PREFIX_RACE);
+      await secondPage.fill('#copie_totali', '2');
+      await secondPage.fill('#numero_inventario', PREFIX_RACE);
+
+      // Keep both INSERT statements overlapped. Without locking/retry, both
+      // requests can select the same free C1/C2 codes and one fails on UNIQUE.
+      dbQuery(`CREATE TRIGGER ${SLOW_COPY_TRIGGER} BEFORE INSERT ON copie FOR EACH ROW DO IF(NEW.numero_inventario LIKE '${PREFIX_RACE}%', SLEEP(0.35), 0)`);
+      const firstSubmit = submitBookForm(page);
+      await page.waitForTimeout(100);
+      const secondSubmit = submitBookForm(secondPage);
+      const statuses = await Promise.all([firstSubmit, secondSubmit]);
+      expect(statuses.every((status) => status < 400)).toBe(true);
+    } finally {
+      dbQuery(`DROP TRIGGER IF EXISTS ${SLOW_COPY_TRIGGER}`);
+      await secondContext.close();
+    }
+
+    const firstId = bookIdByTitle(TITLE_RACE_A);
+    const secondId = bookIdByTitle(TITLE_RACE_B);
+    expect(firstId).toBeGreaterThan(0);
+    expect(secondId).toBeGreaterThan(0);
+    const allCodes = [...copieCodes(firstId), ...copieCodes(secondId)].sort();
+    expect(allCodes).toEqual([
+      `${PREFIX_RACE}-C1`, `${PREFIX_RACE}-C2`,
+      `${PREFIX_RACE}-C3`, `${PREFIX_RACE}-C4`,
+    ]);
   });
 });

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -342,11 +342,25 @@ try {
     $copyRepo->create($idCollation, $existingCollationCode, 'disponibile');
     $createdCollationIds = $copyRepo->createManyForBookWithIds($idCollation, $baseCollation, 2, 'disponibile', null);
     $collationCodes = $copyCodes($idCollation);
+    // Bind the returned ids to the actual -C2/-C3 rows: a regression returning two
+    // distinct-but-wrong ids would otherwise slip past the count/uniqueness checks.
+    $expectedCollationIds = [];
+    $resCollationIds = $db->query(
+        "SELECT id FROM copie WHERE libro_id = {$idCollation}"
+        . " AND numero_inventario IN ('{$baseCollation}-C2', '{$baseCollation}-C3')"
+    );
+    while ($row = $resCollationIds->fetch_assoc()) {
+        $expectedCollationIds[] = (int) $row['id'];
+    }
+    $gotCollationIds = array_map('intval', $createdCollationIds);
+    sort($gotCollationIds);
+    sort($expectedCollationIds);
     $check(
         count($createdCollationIds) === 2
             && count(array_unique($createdCollationIds)) === 2
-            && $collationCodes === [$existingCollationCode, "{$baseCollation}-C2", "{$baseCollation}-C3"],
-        '9. allocator follows utf8mb4_unicode_ci and returns both inserted copy ids'
+            && $collationCodes === [$existingCollationCode, "{$baseCollation}-C2", "{$baseCollation}-C3"]
+            && $gotCollationIds === $expectedCollationIds,
+        '9. allocator follows utf8mb4_unicode_ci and returns the -C2/-C3 copy ids'
     );
 
     /* ---------------------------------------------------------------------

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -144,6 +144,8 @@ try {
     $db->commit();
     $check($createdA === 1 && $bookCount($titleA) === 1, '1. committed create persists the book row');
     $check($copyCodes($idA) === ["{$baseA}-C1"], '1. exactly one copie row with the uniform -C1 code');
+    $singleNote = (string) $db->query("SELECT note FROM copie WHERE libro_id = {$idA} LIMIT 1")->fetch_row()[0];
+    $check($singleNote === 'Copy 1 of 1', '1. single-copy batch preserves its formatted note');
 
     /* ---------------------------------------------------------------------
      * 2. Three copies: uniform -C1/-C2/-C3 codes

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -22,7 +22,9 @@ declare(strict_types=1);
  *   7. source-order guard: recalc happens before commit, while the
  *      book.save.after hook stays after commit, so plugin handlers that open
  *      their own transaction (book-club) cannot destroy the atomicity;
- *   8. two books sharing the same inventory base get collision-free codes.
+ *   8. two books sharing the same inventory base get collision-free codes;
+ *   9. allocation follows the DB collation and returns every inserted copy id;
+ *  10. a localised external cover is cleaned up on atomic rollback.
  *
  * Run: php tests/atomic-book-create-356.unit.php   (exit 0 = pass)
  */
@@ -326,6 +328,36 @@ try {
             && $copyCodes($idS1) === ["{$baseS}-C1", "{$baseS}-C2"]
             && $copyCodes($idS2) === ["{$baseS}-C3", "{$baseS}-C4"],
         '8. two books on the same base get collision-free -C1..-C4 codes'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 9. DB COLLATION — PHP comparisons are case-sensitive, while the unique
+     *    inventory index is utf8mb4_unicode_ci. A differently-cased/accented C1
+     *    must be detected and the new batch must start at C2.
+     * ------------------------------------------------------------------- */
+    $titleCollation = "{$prefix}_collation";
+    $baseCollation = "{$prefix}-CAFÉ";
+    $idCollation = $repo->createBasic(['titolo' => $titleCollation, 'copie_totali' => 1, 'copie_disponibili' => 1]);
+    $existingCollationCode = strtolower(str_replace('É', 'e', $baseCollation)) . '-c1';
+    $copyRepo->create($idCollation, $existingCollationCode, 'disponibile');
+    $createdCollationIds = $copyRepo->createManyForBookWithIds($idCollation, $baseCollation, 2, 'disponibile', null);
+    $collationCodes = $copyCodes($idCollation);
+    $check(
+        count($createdCollationIds) === 2
+            && count(array_unique($createdCollationIds)) === 2
+            && $collationCodes === [$existingCollationCode, "{$baseCollation}-C2", "{$baseCollation}-C3"],
+        '9. allocator follows utf8mb4_unicode_ci and returns both inserted copy ids'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 10. FILESYSTEM ROLLBACK GUARD — the local cover created before the DB
+     *     transaction must be removed in the atomic catch before rethrow.
+     * ------------------------------------------------------------------- */
+    $posCoverCleanup = strpos($store, 'deleteLocalCoverFile($coverCreatedBeforeAtomicInsert)');
+    $posAtomicRethrow = strpos($store, 'throw $atomicCreateError;');
+    $check(
+        $posCoverCleanup !== false && $posAtomicRethrow !== false && $posCoverCleanup < $posAtomicRethrow,
+        '10. atomic rollback cleans the request-localised cover before rethrow'
     );
 
     $exitCode = $failed === 0 ? 0 : 1;

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -1,0 +1,295 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural proof for the atomic book+copies create (PR #356).
+ *
+ * LibriController::store() wraps BookRepository::createBasic() and
+ * CopyRepository::createManyForBook() in ONE mysqli transaction, committed
+ * BEFORE any plugin hook / series sync / availability recalc runs. These
+ * tests drive the exact same sequence against the real database and prove:
+ *
+ *   1. commit persists book + exactly 1 copy together;
+ *   2. 3 copies get uniform, ordered -C1/-C2/-C3 codes;
+ *   3. a zero-holding record commits with 0 copie rows;
+ *   4. DataIntegrity derives copie_totali/copie_disponibili post-commit;
+ *   5. a REAL forced copy-insert failure (SIGNAL trigger) rolls back the
+ *      book row — no orphan book, no orphan author links, no copies;
+ *   6. createBasic() nests via SAVEPOINT inside the open transaction — an
+ *      internal begin_transaction() would implicitly COMMIT the outer one
+ *      (the mysqli nested-transaction trap) and this test would fail;
+ *   7. source-order guard: in store() the commit happens BEFORE the
+ *      book.save.after hook and the availability recalc, so plugin handlers
+ *      that open their own transaction (book-club) can never destroy the
+ *      atomicity by construction;
+ *   8. two books sharing the same inventory base get collision-free codes.
+ *
+ * Run: php tests/atomic-book-create-356.unit.php   (exit 0 = pass)
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+$user = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$pass = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+$name = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+$host = getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1');
+$port = (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306));
+
+try {
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $user, $pass, $name, 0, $socket)
+        : new mysqli($host, $user, $pass, $name, $port);
+    $db->set_charset('utf8mb4');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — atomic-create proof is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+        return;
+    }
+    $failed++;
+    echo "FAIL  {$label}\n";
+};
+
+$prefix = 'U356_' . bin2hex(random_bytes(4));
+$trigger = 'zz_u356_fail_copy';
+
+/** Count libri rows by exact title, INCLUDING soft-deleted ones. */
+$bookCount = static function (string $title) use ($db): int {
+    $stmt = $db->prepare('SELECT COUNT(*) FROM libri WHERE titolo = ?');
+    $stmt->bind_param('s', $title);
+    $stmt->execute();
+    $n = (int) $stmt->get_result()->fetch_row()[0];
+    $stmt->close();
+    return $n;
+};
+
+/** Copy codes for a book, ordered by id. @return list<string> */
+$copyCodes = static function (int $bookId) use ($db): array {
+    $stmt = $db->prepare('SELECT numero_inventario FROM copie WHERE libro_id = ? ORDER BY id');
+    $stmt->bind_param('i', $bookId);
+    $stmt->execute();
+    $codes = [];
+    foreach ($stmt->get_result()->fetch_all(MYSQLI_NUM) as $row) {
+        $codes[] = (string) $row[0];
+    }
+    $stmt->close();
+    return $codes;
+};
+
+$scalar = static function (string $sql, string $types = '', array $params = []) use ($db) {
+    $stmt = $db->prepare($sql);
+    if ($types !== '') {
+        $stmt->bind_param($types, ...$params);
+    }
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_row();
+    $stmt->close();
+    return $row[0] ?? null;
+};
+
+$cleanup = static function () use ($db, $prefix, $trigger): void {
+    try {
+        $db->query("DROP TRIGGER IF EXISTS {$trigger}");
+    } catch (Throwable) {
+        // best-effort
+    }
+    try {
+        // copie rows cascade with the book (FK ON DELETE CASCADE).
+        $stmt = $db->prepare("DELETE FROM libri WHERE titolo LIKE CONCAT(?, '%')");
+        $stmt->bind_param('s', $prefix);
+        $stmt->execute();
+        $stmt->close();
+    } catch (Throwable) {
+        // best-effort
+    }
+};
+
+$repo = new \App\Models\BookRepository($db);
+$copyRepo = new \App\Models\CopyRepository($db);
+
+$exitCode = 1;
+try {
+    /* ---------------------------------------------------------------------
+     * 1. Atomic commit: book + exactly 1 copy persist together
+     * ------------------------------------------------------------------- */
+    $titleA = "{$prefix}_one";
+    $baseA = "{$prefix}-A";
+    $db->begin_transaction();
+    $idA = $repo->createBasic(['titolo' => $titleA, 'copie_totali' => 1, 'copie_disponibili' => 1]);
+    $createdA = $copyRepo->createManyForBook($idA, $baseA, 1, 'disponibile', 'Copy %d of %d');
+    $db->commit();
+    $check($createdA === 1 && $bookCount($titleA) === 1, '1. committed create persists the book row');
+    $check($copyCodes($idA) === ["{$baseA}-C1"], '1. exactly one copie row with the uniform -C1 code');
+
+    /* ---------------------------------------------------------------------
+     * 2. Three copies: uniform -C1/-C2/-C3 codes
+     * ------------------------------------------------------------------- */
+    $titleB = "{$prefix}_three";
+    $baseB = "{$prefix}-B";
+    $db->begin_transaction();
+    $idB = $repo->createBasic(['titolo' => $titleB, 'copie_totali' => 3, 'copie_disponibili' => 3]);
+    $createdB = $copyRepo->createManyForBook($idB, $baseB, 3, 'disponibile', 'Copy %d of %d');
+    $db->commit();
+    $check(
+        $createdB === 3 && $copyCodes($idB) === ["{$baseB}-C1", "{$baseB}-C2", "{$baseB}-C3"],
+        '2. three copies committed with uniform -C1/-C2/-C3 codes'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 3. Zero copies: valid zero-holding record
+     * ------------------------------------------------------------------- */
+    $titleC = "{$prefix}_zero";
+    $db->begin_transaction();
+    $idC = $repo->createBasic(['titolo' => $titleC, 'copie_totali' => 0, 'copie_disponibili' => 0]);
+    $createdC = $copyRepo->createManyForBook($idC, "{$prefix}-C0", 0, 'disponibile', null);
+    $db->commit();
+    $check(
+        $createdC === 0 && $bookCount($titleC) === 1 && $copyCodes($idC) === [],
+        '3. zero-copy create commits the book with 0 copie rows'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 4. DataIntegrity derives the counters from the committed copies
+     * ------------------------------------------------------------------- */
+    (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idB);
+    $derived = $scalar(
+        "SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id = ? AND deleted_at IS NULL",
+        'i',
+        [$idB]
+    );
+    $check($derived === '3:3:disponibile', "4. recalc derives copie_totali/disponibili/stato from copies (got: {$derived})");
+
+    /* ---------------------------------------------------------------------
+     * 5. ROLLBACK PROOF — a real forced mysqli failure during copy creation
+     *    leaves NO orphan book. The SIGNAL trigger makes the multi-row copy
+     *    INSERT fail exactly like a production-side insert error would.
+     * ------------------------------------------------------------------- */
+    $titleF = "{$prefix}_fail";
+    $failBase = "{$prefix}-FAIL";
+    $db->query("DROP TRIGGER IF EXISTS {$trigger}");
+    // DDL implicitly commits, so the trigger is installed BEFORE the tx opens.
+    $db->query(
+        "CREATE TRIGGER {$trigger} BEFORE INSERT ON copie FOR EACH ROW " .
+        "BEGIN IF NEW.numero_inventario LIKE '{$failBase}%' THEN " .
+        "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced copy failure (test)'; " .
+        "END IF; END"
+    );
+    $db->begin_transaction();
+    $idF = $repo->createBasic(['titolo' => $titleF, 'copie_totali' => 2, 'copie_disponibili' => 2]);
+    $threw = false;
+    try {
+        $copyRepo->createManyForBook($idF, $failBase, 2, 'disponibile', null);
+    } catch (Throwable) {
+        $threw = true;
+    }
+    // Mirror the controller's error path: rollback, then the book must be gone.
+    try {
+        $db->rollback();
+    } catch (Throwable) {
+        // best-effort
+    }
+    $db->query("DROP TRIGGER IF EXISTS {$trigger}");
+    $check($threw, '5. forced copy-insert failure actually throws (test can fail)');
+    $check($bookCount($titleF) === 0, '5. rollback removes the book row — no orphan book');
+    $check(
+        (int) $scalar('SELECT COUNT(*) FROM libri_autori WHERE libro_id = ?', 'i', [$idF]) === 0,
+        '5. rollback leaves no orphan author links'
+    );
+    $check(
+        (int) $scalar("SELECT COUNT(*) FROM copie WHERE numero_inventario LIKE CONCAT(?, '%')", 's', [$failBase]) === 0,
+        '5. rollback leaves no partial copie rows'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 6. NESTED-TRANSACTION TRAP PROOF — createBasic() must nest via
+     *    SAVEPOINT. If it called begin_transaction() internally, mysqli
+     *    would implicitly COMMIT the outer transaction and the row would
+     *    survive the outer rollback below.
+     * ------------------------------------------------------------------- */
+    $titleT = "{$prefix}_trap";
+    $db->begin_transaction();
+    $idT = $repo->createBasic(['titolo' => $titleT, 'copie_totali' => 1, 'copie_disponibili' => 1]);
+    $visibleInsideTx = $bookCount($titleT) === 1;
+    $db->rollback();
+    $check(
+        $visibleInsideTx && $bookCount($titleT) === 0,
+        '6. createBasic nests via SAVEPOINT: outer rollback removes the row (no implicit commit)'
+    );
+
+    /* ---------------------------------------------------------------------
+     * 7. SOURCE-ORDER GUARD — in store() the transaction must close BEFORE
+     *    the book.save.after hook (whose handlers, e.g. book-club, open
+     *    their own transaction) and before the availability recalc.
+     * ------------------------------------------------------------------- */
+    $controller = (string) file_get_contents($root . '/app/Controllers/LibriController.php');
+    $storeStart = strpos($controller, 'public function store(');
+    $storeEnd = strpos($controller, 'public function editForm(');
+    $store = ($storeStart !== false && $storeEnd !== false && $storeEnd > $storeStart)
+        ? substr($controller, $storeStart, $storeEnd - $storeStart)
+        : '';
+    $posBegin = strpos($store, '$db->begin_transaction()');
+    $posCreate = strpos($store, 'createBasic($fields)');
+    $posCopies = strpos($store, '$copyRepo->createManyForBook(');
+    $posCommit = strpos($store, '$db->commit()');
+    $posHook = strpos($store, "Hooks::do('book.save.after'");
+    $posRecalc = strpos($store, 'recalculateBookAvailability(');
+    $ordered = $posBegin !== false && $posCreate !== false && $posCopies !== false
+        && $posCommit !== false && $posHook !== false && $posRecalc !== false
+        && $posBegin < $posCreate && $posCreate < $posCopies && $posCopies < $posCommit
+        && $posCommit < $posHook && $posCommit < $posRecalc;
+    $check($ordered, '7. store(): begin < createBasic < createManyForBook < commit < book.save.after hook & recalc');
+
+    /* ---------------------------------------------------------------------
+     * 8. Shared inventory base across two books: collision-free codes
+     * ------------------------------------------------------------------- */
+    $titleS1 = "{$prefix}_share1";
+    $titleS2 = "{$prefix}_share2";
+    $baseS = "{$prefix}-S";
+    $db->begin_transaction();
+    $idS1 = $repo->createBasic(['titolo' => $titleS1, 'copie_totali' => 2, 'copie_disponibili' => 2]);
+    $copyRepo->createManyForBook($idS1, $baseS, 2, 'disponibile', null);
+    $db->commit();
+    $db->begin_transaction();
+    $idS2 = $repo->createBasic(['titolo' => $titleS2, 'copie_totali' => 2, 'copie_disponibili' => 2]);
+    $copyRepo->createManyForBook($idS2, $baseS, 2, 'disponibile', null);
+    $db->commit();
+    $allCodes = array_merge($copyCodes($idS1), $copyCodes($idS2));
+    $check(
+        count($allCodes) === 4 && count(array_unique($allCodes)) === 4
+            && $copyCodes($idS1) === ["{$baseS}-C1", "{$baseS}-C2"]
+            && $copyCodes($idS2) === ["{$baseS}-C3", "{$baseS}-C4"],
+        '8. two books on the same base get collision-free -C1..-C4 codes'
+    );
+
+    $exitCode = $failed === 0 ? 0 : 1;
+} catch (Throwable $e) {
+    $failed++;
+    echo 'FAIL  unexpected exception: ' . $e->getMessage() . "\n";
+    $exitCode = 1;
+} finally {
+    $cleanup();
+}
+
+echo "\n{$passed} passed, {$failed} failed\n";
+exit($exitCode);

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -282,11 +282,15 @@ try {
      *    book.save.after hook (whose handlers, e.g. book-club, can open their
      *    own transaction) must remain after commit.
      * ------------------------------------------------------------------- */
-    $controller = (string) file_get_contents($root . '/app/Controllers/LibriController.php');
-    $storeStart = strpos($controller, 'public function store(');
-    $storeEnd = strpos($controller, 'public function editForm(');
-    $store = ($storeStart !== false && $storeEnd !== false && $storeEnd > $storeStart)
-        ? substr($controller, $storeStart, $storeEnd - $storeStart)
+    $controllerPath = $root . '/app/Controllers/LibriController.php';
+    $controllerLines = file($controllerPath);
+    $storeMethod = new \ReflectionMethod(\App\Controllers\LibriController::class, 'store');
+    $store = is_array($controllerLines)
+        ? implode('', array_slice(
+            $controllerLines,
+            $storeMethod->getStartLine() - 1,
+            $storeMethod->getEndLine() - $storeMethod->getStartLine() + 1
+        ))
         : '';
     $posBegin = strpos($store, '$db->begin_transaction()');
     $posCreate = strpos($store, 'createBasic($fields)');

--- a/tests/atomic-book-create-356.unit.php
+++ b/tests/atomic-book-create-356.unit.php
@@ -4,24 +4,24 @@ declare(strict_types=1);
 /**
  * Behavioural proof for the atomic book+copies create (PR #356).
  *
- * LibriController::store() wraps BookRepository::createBasic() and
- * CopyRepository::createManyForBook() in ONE mysqli transaction, committed
- * BEFORE any plugin hook / series sync / availability recalc runs. These
- * tests drive the exact same sequence against the real database and prove:
+ * LibriController::store() wraps BookRepository::createBasic(),
+ * CopyRepository::createManyForBook() and the SQL-only availability recalc in
+ * ONE mysqli transaction, committed BEFORE any plugin hook / series sync runs.
+ * These tests drive the exact same sequence against the real database and prove:
  *
  *   1. commit persists book + exactly 1 copy together;
  *   2. 3 copies get uniform, ordered -C1/-C2/-C3 codes;
  *   3. a zero-holding record commits with 0 copie rows;
- *   4. DataIntegrity derives copie_totali/copie_disponibili post-commit;
+ *   4. DataIntegrity derives copie_totali/copie_disponibili before commit;
  *   5. a REAL forced copy-insert failure (SIGNAL trigger) rolls back the
  *      book row — no orphan book, no orphan author links, no copies;
+ *   5b. a forced availability-recalc failure rolls the entire create back;
  *   6. createBasic() nests via SAVEPOINT inside the open transaction — an
  *      internal begin_transaction() would implicitly COMMIT the outer one
  *      (the mysqli nested-transaction trap) and this test would fail;
- *   7. source-order guard: in store() the commit happens BEFORE the
- *      book.save.after hook and the availability recalc, so plugin handlers
- *      that open their own transaction (book-club) can never destroy the
- *      atomicity by construction;
+ *   7. source-order guard: recalc happens before commit, while the
+ *      book.save.after hook stays after commit, so plugin handlers that open
+ *      their own transaction (book-club) cannot destroy the atomicity;
  *   8. two books sharing the same inventory base get collision-free codes.
  *
  * Run: php tests/atomic-book-create-356.unit.php   (exit 0 = pass)
@@ -73,6 +73,7 @@ $check = static function (bool $condition, string $label) use (&$passed, &$faile
 
 $prefix = 'U356_' . bin2hex(random_bytes(4));
 $trigger = 'zz_u356_fail_copy';
+$recalcTrigger = 'zz_u356_fail_recalc';
 
 /** Count libri rows by exact title, INCLUDING soft-deleted ones. */
 $bookCount = static function (string $title) use ($db): int {
@@ -108,9 +109,10 @@ $scalar = static function (string $sql, string $types = '', array $params = []) 
     return $row[0] ?? null;
 };
 
-$cleanup = static function () use ($db, $prefix, $trigger): void {
+$cleanup = static function () use ($db, $prefix, $trigger, $recalcTrigger): void {
     try {
         $db->query("DROP TRIGGER IF EXISTS {$trigger}");
+        $db->query("DROP TRIGGER IF EXISTS {$recalcTrigger}");
     } catch (Throwable) {
         // best-effort
     }
@@ -138,6 +140,7 @@ try {
     $db->begin_transaction();
     $idA = $repo->createBasic(['titolo' => $titleA, 'copie_totali' => 1, 'copie_disponibili' => 1]);
     $createdA = $copyRepo->createManyForBook($idA, $baseA, 1, 'disponibile', 'Copy %d of %d');
+    (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idA, true);
     $db->commit();
     $check($createdA === 1 && $bookCount($titleA) === 1, '1. committed create persists the book row');
     $check($copyCodes($idA) === ["{$baseA}-C1"], '1. exactly one copie row with the uniform -C1 code');
@@ -150,6 +153,7 @@ try {
     $db->begin_transaction();
     $idB = $repo->createBasic(['titolo' => $titleB, 'copie_totali' => 3, 'copie_disponibili' => 3]);
     $createdB = $copyRepo->createManyForBook($idB, $baseB, 3, 'disponibile', 'Copy %d of %d');
+    (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idB, true);
     $db->commit();
     $check(
         $createdB === 3 && $copyCodes($idB) === ["{$baseB}-C1", "{$baseB}-C2", "{$baseB}-C3"],
@@ -163,6 +167,7 @@ try {
     $db->begin_transaction();
     $idC = $repo->createBasic(['titolo' => $titleC, 'copie_totali' => 0, 'copie_disponibili' => 0]);
     $createdC = $copyRepo->createManyForBook($idC, "{$prefix}-C0", 0, 'disponibile', null);
+    (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idC, true);
     $db->commit();
     $check(
         $createdC === 0 && $bookCount($titleC) === 1 && $copyCodes($idC) === [],
@@ -170,9 +175,8 @@ try {
     );
 
     /* ---------------------------------------------------------------------
-     * 4. DataIntegrity derives the counters from the committed copies
+     * 4. DataIntegrity derived the counters inside the create transaction
      * ------------------------------------------------------------------- */
-    (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idB);
     $derived = $scalar(
         "SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id = ? AND deleted_at IS NULL",
         'i',
@@ -222,6 +226,42 @@ try {
     );
 
     /* ---------------------------------------------------------------------
+     * 5b. ROLLBACK PROOF — failure while deriving availability must also
+     *     remove the new book and its already-inserted physical copies.
+     * ------------------------------------------------------------------- */
+    $titleR = "{$prefix}_recalc_fail";
+    $recalcBase = "{$prefix}-RECALC";
+    $db->query("DROP TRIGGER IF EXISTS {$recalcTrigger}");
+    $escapedTitleR = $db->real_escape_string($titleR);
+    $db->query(
+        "CREATE TRIGGER {$recalcTrigger} BEFORE UPDATE ON libri FOR EACH ROW " .
+        "BEGIN IF NEW.titolo = '{$escapedTitleR}' THEN " .
+        "SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = 'forced recalc failure (test)'; " .
+        "END IF; END"
+    );
+    $db->begin_transaction();
+    $idR = $repo->createBasic(['titolo' => $titleR, 'copie_totali' => 2, 'copie_disponibili' => 2]);
+    $copyRepo->createManyForBook($idR, $recalcBase, 2, 'disponibile', null);
+    $recalcThrew = false;
+    try {
+        (new \App\Support\DataIntegrity($db))->recalculateBookAvailability($idR, true);
+    } catch (Throwable) {
+        $recalcThrew = true;
+    }
+    try {
+        $db->rollback();
+    } catch (Throwable) {
+        // best-effort
+    }
+    $db->query("DROP TRIGGER IF EXISTS {$recalcTrigger}");
+    $check($recalcThrew, '5b. forced availability-recalc failure actually throws');
+    $check(
+        $bookCount($titleR) === 0
+            && (int) $scalar("SELECT COUNT(*) FROM copie WHERE numero_inventario LIKE CONCAT(?, '%')", 's', [$recalcBase]) === 0,
+        '5b. rollback removes both the book and its already-inserted copies'
+    );
+
+    /* ---------------------------------------------------------------------
      * 6. NESTED-TRANSACTION TRAP PROOF — createBasic() must nest via
      *    SAVEPOINT. If it called begin_transaction() internally, mysqli
      *    would implicitly COMMIT the outer transaction and the row would
@@ -238,9 +278,9 @@ try {
     );
 
     /* ---------------------------------------------------------------------
-     * 7. SOURCE-ORDER GUARD — in store() the transaction must close BEFORE
-     *    the book.save.after hook (whose handlers, e.g. book-club, open
-     *    their own transaction) and before the availability recalc.
+     * 7. SOURCE-ORDER GUARD — recalc must happen before commit, while the
+     *    book.save.after hook (whose handlers, e.g. book-club, can open their
+     *    own transaction) must remain after commit.
      * ------------------------------------------------------------------- */
     $controller = (string) file_get_contents($root . '/app/Controllers/LibriController.php');
     $storeStart = strpos($controller, 'public function store(');
@@ -256,9 +296,9 @@ try {
     $posRecalc = strpos($store, 'recalculateBookAvailability(');
     $ordered = $posBegin !== false && $posCreate !== false && $posCopies !== false
         && $posCommit !== false && $posHook !== false && $posRecalc !== false
-        && $posBegin < $posCreate && $posCreate < $posCopies && $posCopies < $posCommit
-        && $posCommit < $posHook && $posCommit < $posRecalc;
-    $check($ordered, '7. store(): begin < createBasic < createManyForBook < commit < book.save.after hook & recalc');
+        && $posBegin < $posCreate && $posCreate < $posCopies && $posCopies < $posRecalc
+        && $posRecalc < $posCommit && $posCommit < $posHook;
+    $check($ordered, '7. store(): begin < createBasic < createManyForBook < recalc < commit < book.save.after hook');
 
     /* ---------------------------------------------------------------------
      * 8. Shared inventory base across two books: collision-free codes

--- a/tests/book-field-types-static.spec.js
+++ b/tests/book-field-types-static.spec.js
@@ -127,13 +127,13 @@ test.describe('book field-type consistency', () => {
     expect(messages['Restituito — copia in restauro']).toBe('Restituito — copia in restauro');
   });
 
-  test('15) loan edge-case suite labels match the expanded 60-test coverage', () => {
+  test('15) loan edge-case suite labels match the expanded 64-test coverage', () => {
     const loanEdges = read('tests/loan-edge-cases.unit.php');
 
-    expect(loanEdges).toContain('Exit:  0 only if all 60 pass');
+    expect(loanEdges).toContain('Exit:  0 only if all 64 pass');
     expect(loanEdges).toContain('* 41-48  Mixed / availability math');
     expect(loanEdges).toContain('* 49-52  Misc invariants');
-    expect(loanEdges).toContain('* 53-60  Canonical capacity, schedules, integrity and calendars');
-    expect(loanEdges).toContain('printf("[%02d/60] PASS: %s\\n", $TESTNO, $desc);');
+    expect(loanEdges).toContain('* 53-64  Canonical capacity, schedules, integrity, calendars and reservation queues');
+    expect(loanEdges).toContain('printf("[%02d/64] PASS: %s\\n", $TESTNO, $desc);');
   });
 });

--- a/tests/book-fields-form.spec.js
+++ b/tests/book-fields-form.spec.js
@@ -12,6 +12,9 @@
 //      derived libri.stato — LibriController unset()s it, the loan engine owns it;
 //   3. the book-detail badge renders a localized, underscore-free label for the
 //      new `non_disponibile` state with its own (non-fallback) colour.
+//   4. copy counts are managed from the book page after creation, while a new
+//      catalogue record creates exactly the requested initial physical copies
+//      (including the legitimate zero-copy case).
 //
 // Reusable: marker-scoped to titles `ZZ_BFTFORM_%`, cleans up in afterAll.
 
@@ -30,6 +33,9 @@ const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
 
 const RUN_ID = Date.now().toString(36);
 const TITLE = `ZZ_BFTFORM_${RUN_ID}`;
+const ZERO_TITLE = `ZZ_BFTFORM_ZERO_${RUN_ID}`;
+const THREE_TITLE = `ZZ_BFTFORM_THREE_${RUN_ID}`;
+const THREE_PREFIX = `ZZ3-${RUN_ID}`;
 
 test.skip(
   !ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_NAME,
@@ -139,11 +145,16 @@ test.describe.serial('book fields + derived status — form/controller behavior'
 
     await page.goto(`${BASE}/admin/books/edit/${bookId}`);
     // #stato lives in a non-active form section, so it's attached but not
-    // "visible". We're testing the CONTROLLER (does it honour a submitted
-    // stato?), so set the hidden field's value directly and submit — the form
-    // POSTs stato=perso regardless of which tab is showing.
+    // "visible". We're testing the CONTROLLER (does it honour a crafted
+    // submitted stato?), so enable it, inject the per-copy value and submit.
     await page.locator('#stato').waitFor({ state: 'attached', timeout: 10000 });
     await page.locator('#stato').evaluate((el, v) => {
+      // The UI intentionally exposes only canonical BOOK states; inject an
+      // invalid per-copy state to verify that a crafted POST is still ignored.
+      if (![...el.options].some((option) => option.value === v)) {
+        el.add(new Option(v, v));
+      }
+      el.disabled = false;
       el.value = v;
       el.dispatchEvent(new Event('change', { bubbles: true }));
     }, 'perso');
@@ -175,5 +186,41 @@ test.describe.serial('book fields + derived status — form/controller behavior'
     // Its colour is the dedicated non_disponibile shade, not the slate-500 fallback.
     const html = await page.content();
     expect(html).toContain('bg-gray-600');
+  });
+
+  test('4) edit delegates copy management; create persists exactly zero or three physical copies', async ({ page }) => {
+    expect(bookId).toBeGreaterThan(0);
+    await page.goto(`${BASE}/admin/books/edit/${bookId}`);
+    const editCopies = page.locator('#copie_totali');
+    await expect(editCopies).toHaveAttribute('readonly', '');
+    await expect(page.locator(`a[href$="/admin/books/${bookId}#physical-copies"]`)).toBeAttached();
+    await expect(page.locator('label[for="numero_inventario"]')).toContainText('Prefisso inventario copie');
+
+    await page.goto(`${BASE}/admin/books/create`);
+    const createCopies = page.locator('#copie_totali');
+    await expect(createCopies).not.toHaveAttribute('readonly', '');
+    await expect(createCopies).toHaveAttribute('min', '0');
+    await createCopies.fill('0');
+    expect(await createCopies.inputValue()).toBe('0');
+    await page.fill('#titolo', ZERO_TITLE);
+    await saveBookForm(page);
+
+    const zeroBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${ZERO_TITLE}' AND deleted_at IS NULL LIMIT 1`));
+    expect(zeroBookId).toBeGreaterThan(0);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id=${zeroBookId}`)).toBe('0:0:non_disponibile');
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${zeroBookId}`))).toBe(0);
+
+    await page.goto(`${BASE}/admin/books/create`);
+    await page.fill('#titolo', THREE_TITLE);
+    await page.fill('#copie_totali', '3');
+    await page.fill('#numero_inventario', THREE_PREFIX);
+    await saveBookForm(page);
+
+    const threeBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${THREE_TITLE}' AND deleted_at IS NULL LIMIT 1`));
+    expect(threeBookId).toBeGreaterThan(0);
+    expect(dbQuery(`SELECT CONCAT(copie_totali, ':', copie_disponibili, ':', stato) FROM libri WHERE id=${threeBookId}`)).toBe('3:3:disponibile');
+    expect(Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${threeBookId}`))).toBe(3);
+    expect(dbQuery(`SELECT GROUP_CONCAT(numero_inventario ORDER BY id SEPARATOR ',') FROM copie WHERE libro_id=${threeBookId}`))
+      .toBe(`${THREE_PREFIX}-C1,${THREE_PREFIX}-C2,${THREE_PREFIX}-C3`);
   });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -1,0 +1,218 @@
+// E2E: manage physical copies from the book summary page (admin).
+//
+// New capability: /admin/books/{id} always shows the "Copie Fisiche" section
+// with an "Aggiungi copia" button (even when the book has no copies), a create
+// modal, and per-copy status editing. A lost/damaged/maintenance copy is
+// excluded from libri.copie_totali (DataIntegrity::recalculateBookAvailability),
+// so marking a copy lost lowers the total.
+//
+// Real browser flow (per project rule): drives the actual modals and asserts the
+// effect in the DB.
+const { test, expect } = require('@playwright/test');
+const { execFileSync } = require('child_process');
+
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
+const ADMIN_PASS = process.env.E2E_ADMIN_PASS || '';
+const DB_USER = process.env.E2E_DB_USER || '';
+const DB_PASS = process.env.E2E_DB_PASS || '';
+const DB_SOCKET = process.env.E2E_DB_SOCKET || '';
+const DB_HOST = process.env.E2E_DB_HOST || '';
+const DB_PORT = process.env.E2E_DB_PORT || '';
+const DB_NAME = process.env.E2E_DB_NAME || '';
+
+test.skip(!ADMIN_EMAIL || !ADMIN_PASS || !DB_USER || !DB_PASS || !DB_NAME, 'E2E credentials not configured');
+
+const sqlEscape = (s) => String(s).replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+function dbQuery(sql) {
+  const args = ['-u', DB_USER, `-p${DB_PASS}`, DB_NAME, '-N', '-B', '-e', sql];
+  if (DB_HOST) { args.splice(3, 0, '-h', DB_HOST); if (DB_PORT) args.splice(5, 0, '-P', DB_PORT); }
+  else if (DB_SOCKET) { args.splice(3, 0, '-S', DB_SOCKET); }
+  return execFileSync('mysql', args, { encoding: 'utf-8', timeout: 10000 }).trim();
+}
+
+const RUN = Date.now().toString(36);
+const TITLE = `CopyMgmt ${RUN}`;             // book that starts with one copy
+const TITLE_EMPTY = `CopyMgmtEmpty ${RUN}`;  // book with zero copie rows
+let bookId = 0;
+let emptyBookId = 0;
+
+function cleanupByTitle() {
+  // copie cascade on libri delete (FK ON DELETE CASCADE).
+  dbQuery(`DELETE FROM libri WHERE titolo IN ('${sqlEscape(TITLE)}','${sqlEscape(TITLE_EMPTY)}')`);
+}
+const copieCount = (id) => Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${id}`));
+const copieTotali = (id) => Number(dbQuery(`SELECT copie_totali FROM libri WHERE id=${id}`));
+const bookStato = (id) => dbQuery(`SELECT stato FROM libri WHERE id=${id}`);
+
+async function loginAsAdmin(page) {
+  await page.goto(`${BASE}/admin/dashboard`);
+  const email = page.locator('input[name="email"]');
+  if (await email.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await email.fill(ADMIN_EMAIL);
+    await page.fill('input[name="password"]', ADMIN_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/.*(?:dashboard|admin).*/, { timeout: 15000 });
+  }
+}
+
+// Open the "Aggiungi copia" modal, fill it, submit, wait for the reload.
+async function addCopy(page, { inventario = '', stato = 'disponibile', note = '' } = {}) {
+  await page.evaluate(() => window.openAddCopyModal());
+  await expect(page.locator('#add-copy-modal')).toBeVisible();
+  await page.fill('#add-copy-inventario', inventario);
+  await page.selectOption('#add-copy-stato', stato);
+  if (note) await page.fill('#add-copy-note', note);
+  await Promise.all([
+    page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+    page.click('#add-copy-form button[type="submit"]'),
+  ]);
+}
+
+// Edit a copy's status via its row modal (with the SweetAlert confirm).
+async function editCopyStatus(page, copyId, stato) {
+  await page.evaluate((id) => window.openEditCopyModal(id, 'disponibile', ''), copyId);
+  await expect(page.locator('#edit-copy-modal')).toBeVisible();
+  await page.selectOption('#edit-copy-stato', stato);
+  await page.click('#edit-copy-form button[type="submit"]');
+  const confirm = page.locator('.swal2-confirm');
+  if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      confirm.click(),
+    ]);
+  }
+}
+
+test.describe.serial('Copy management from the book summary (#238/#351)', () => {
+  test.beforeAll(async () => {
+    cleanupByTitle();
+    dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(TITLE)}', 1, 1, NOW(), NOW())`);
+    bookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(TITLE)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at) VALUES (${bookId}, 'CM-${RUN}-C1', 'disponibile', NOW())`);
+    // A second book with NO copie rows (legacy/never-loaned) for the empty-state test.
+    dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(TITLE_EMPTY)}', 1, 1, NOW(), NOW())`);
+    emptyBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(TITLE_EMPTY)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+  });
+  test.afterAll(() => cleanupByTitle());
+
+  test('1. book summary shows the Copie Fisiche section and Aggiungi copia button', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await expect(page.locator('text=Copie Fisiche')).toBeVisible();
+    await expect(page.locator('button:has-text("Aggiungi copia")').first()).toBeVisible();
+  });
+
+  test('2. a book with no copies shows the empty-state and the add button', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${emptyBookId}`);
+    await expect(page.locator('text=Nessuna copia fisica')).toBeVisible();
+    await expect(page.locator('button:has-text("Aggiungi copia")').first()).toBeVisible();
+    expect(copieCount(emptyBookId)).toBe(0);
+  });
+
+  test('3. add a copy with auto-assigned inventory → +1 copy, copie_totali +1', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const before = copieCount(bookId);
+    await addCopy(page, { stato: 'disponibile', note: 'auto' });
+    expect(copieCount(bookId)).toBe(before + 1);
+    expect(copieTotali(bookId)).toBe(before + 1);
+    // auto code follows the {base}-C{N} family
+    expect(dbQuery(`SELECT numero_inventario FROM copie WHERE libro_id=${bookId} AND note='auto' LIMIT 1`)).toMatch(/-C\d+$/);
+  });
+
+  test('4. add a copy with an explicit inventory number', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const code = `CM-${RUN}-EXPLICIT`;
+    await addCopy(page, { inventario: code, stato: 'disponibile', note: 'explicit' });
+    expect(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${bookId} AND numero_inventario='${code}'`)).toBe('1');
+  });
+
+  test('5. a duplicate inventory number is rejected (no new copy)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const dup = `CM-${RUN}-EXPLICIT`; // created in test 4
+    const before = copieCount(bookId);
+    await addCopy(page, { inventario: dup, stato: 'disponibile', note: 'dup' });
+    expect(copieCount(bookId)).toBe(before); // unchanged
+    await expect(page.locator('text=Esiste già una copia con questo numero di inventario')).toBeVisible();
+  });
+
+  test('6. a copy created as "danneggiato" does NOT raise copie_totali', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const beforeCount = copieCount(bookId);
+    const beforeTotal = copieTotali(bookId);
+    await addCopy(page, { stato: 'danneggiato', note: 'born-damaged' });
+    expect(copieCount(bookId)).toBe(beforeCount + 1);      // the row exists
+    expect(copieTotali(bookId)).toBe(beforeTotal);          // but total unchanged
+  });
+
+  test('7. editing a copy to "perso" lowers copie_totali', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const targetId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${bookId} AND stato='disponibile' ORDER BY id DESC LIMIT 1`));
+    const beforeTotal = copieTotali(bookId);
+    await editCopyStatus(page, targetId, 'perso');
+    expect(dbQuery(`SELECT stato FROM copie WHERE id=${targetId}`)).toBe('perso');
+    expect(copieTotali(bookId)).toBe(beforeTotal - 1);
+  });
+
+  test('8. damaged then available round-trips copie_totali', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const targetId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${bookId} AND stato='disponibile' ORDER BY id DESC LIMIT 1`));
+    const start = copieTotali(bookId);
+    await editCopyStatus(page, targetId, 'danneggiato');
+    expect(copieTotali(bookId)).toBe(start - 1);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await editCopyStatus(page, targetId, 'disponibile');
+    expect(copieTotali(bookId)).toBe(start);
+  });
+
+  test('9. an available copy is protected from deletion; an out-of-circulation one is deletable', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const targetId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${bookId} AND stato='disponibile' ORDER BY id DESC LIMIT 1`));
+
+    // Guard: an available copy cannot be deleted directly.
+    await page.evaluate((id) => window.confirmDeleteCopy(id, 'X'), targetId);
+    let confirm = page.locator('.swal2-confirm');
+    await expect(confirm).toBeVisible({ timeout: 3000 });
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      confirm.click(),
+    ]);
+    expect(dbQuery(`SELECT COUNT(*) FROM copie WHERE id=${targetId}`)).toBe('1'); // still there
+    await expect(page.locator('text=Puoi eliminare solo copie perse')).toBeVisible();
+
+    // Mark it damaged, then it can be deleted → the row count drops by one.
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await editCopyStatus(page, targetId, 'danneggiato');
+    const beforeCount = copieCount(bookId);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await page.evaluate((id) => window.confirmDeleteCopy(id, 'X'), targetId);
+    confirm = page.locator('.swal2-confirm');
+    await expect(confirm).toBeVisible({ timeout: 3000 });
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      confirm.click(),
+    ]);
+    expect(copieCount(bookId)).toBe(beforeCount - 1);
+    expect(dbQuery(`SELECT COUNT(*) FROM copie WHERE id=${targetId}`)).toBe('0');
+  });
+
+  test('10. when every copy is out of circulation the book becomes non_disponibile', async ({ page }) => {
+    await loginAsAdmin(page);
+    // Reduce to a single available copy, then lose it.
+    dbQuery(`DELETE FROM copie WHERE libro_id=${bookId}`);
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at) VALUES (${bookId}, 'CM-${RUN}-LAST', 'disponibile', NOW())`);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const targetId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${bookId} ORDER BY id DESC LIMIT 1`));
+    await editCopyStatus(page, targetId, 'perso');
+    expect(copieTotali(bookId)).toBe(0);
+    expect(bookStato(bookId)).toBe('non_disponibile');
+  });
+});

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -200,7 +200,7 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
       confirm.click(),
     ]);
     expect(dbQuery(`SELECT COUNT(*) FROM copie WHERE id=${targetId}`)).toBe('1'); // still there
-    await expect(page.locator('text=Puoi eliminare solo copie perse')).toBeVisible();
+    await expect(page.locator('text=Puoi eliminare solo copie fuori circolazione')).toBeVisible();
 
     // Mark it damaged, then it can be deleted → the row count drops by one.
     await page.goto(`${BASE}/admin/books/${bookId}`);
@@ -270,5 +270,121 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
     expect(linked).toMatch(new RegExp(`^\\d+:${queueBookId}:prenotazione:pendente$`));
     expect(copieTotali(queueBookId)).toBe(1);
     expect(Number(dbQuery(`SELECT copie_disponibili FROM libri WHERE id=${queueBookId}`))).toBe(0);
+  });
+
+  // ---- PR #356 review fixes ---------------------------------------------
+
+  // #2: in_restauro / in_trasferimento are out-of-circulation states and must be
+  // deletable from the UI (with no loan history), like perso/danneggiato/manutenzione.
+  test('14. copies in_restauro and in_trasferimento are deletable from the UI (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    const delTitle = `CopyMgmtDel ${RUN}`;
+    dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(delTitle)}', 0, 0, NOW(), NOW())`);
+    const delBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(delTitle)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    try {
+      for (const stato of ['in_restauro', 'in_trasferimento']) {
+        dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at) VALUES (${delBookId}, 'DEL-${RUN}-${stato}', '${stato}', NOW())`);
+        const copyId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${delBookId} AND stato='${stato}' ORDER BY id DESC LIMIT 1`));
+        await page.goto(`${BASE}/admin/books/${delBookId}`);
+        // The row exposes a delete button (view $canDelete now includes the state).
+        await expect(page.locator(`button[onclick^="confirmDeleteCopy(${copyId}"]`)).toBeVisible();
+        await page.evaluate((id) => window.confirmDeleteCopy(id, 'X'), copyId);
+        const confirm = page.locator('.swal2-confirm');
+        await expect(confirm).toBeVisible({ timeout: 3000 });
+        await Promise.all([
+          page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+          confirm.click(),
+        ]);
+        // The controller allow-list now permits the delete → the row is gone.
+        expect(dbQuery(`SELECT COUNT(*) FROM copie WHERE id=${copyId}`)).toBe('0');
+      }
+    } finally {
+      dbQuery(`DELETE FROM libri WHERE id=${delBookId}`);
+    }
+  });
+
+  // #3: a zero-copy book (now a valid state) must pluralise the header as "0 copie".
+  test('15. a zero-copy book pluralises the header count as "0 copie" (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    const zeroTitle = `CopyMgmtZero ${RUN}`;
+    dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(zeroTitle)}', 0, 0, NOW(), NOW())`);
+    const zeroId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(zeroTitle)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    try {
+      await page.goto(`${BASE}/admin/books/${zeroId}`);
+      const header = page.locator('#physical-copies');
+      await expect(header).toContainText('0 copie');
+      expect(await header.innerText()).not.toContain('0 copia');
+    } finally {
+      dbQuery(`DELETE FROM libri WHERE id=${zeroId}`);
+    }
+  });
+
+  // #5: copie_totali is read-only + visibly disabled on edit, editable on create.
+  test('16. copie_totali is read-only and greyed on edit, editable on create (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/edit/${bookId}`);
+    const input = page.locator('#copie_totali');
+    await expect(input).toHaveAttribute('readonly', '');
+    expect(await input.getAttribute('class')).toContain('cursor-not-allowed');
+    await page.goto(`${BASE}/admin/books/create`);
+    expect(await page.locator('#copie_totali').getAttribute('readonly')).toBeNull();
+  });
+
+  // #6: the Add-copy modal title matches the button label ("Aggiungi copia").
+  test('17. the Add-copy modal title matches the button label (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    await page.evaluate(() => window.openAddCopyModal());
+    await expect(page.locator('#add-copy-modal')).toBeVisible();
+    expect((await page.locator('#add-copy-modal h3').first().innerText()).trim()).toBe('Aggiungi copia');
+    // The old mixed-case "Aggiungi Copia" string is gone from the modal.
+    expect(await page.locator('#add-copy-modal').innerText()).not.toContain('Aggiungi Copia');
+  });
+
+  // #1: copie_totali is derived server-side on edit — a crafted POST that bypasses
+  // the client-side readonly and sends 0 must NOT delete the book's copies.
+  test('18. a tampered copie_totali=0 on edit does not delete copies (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    const tamperTitle = `CopyMgmtTamper ${RUN}`;
+    dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(tamperTitle)}', 2, 2, NOW(), NOW())`);
+    const tId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(tamperTitle)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at) VALUES (${tId}, 'TMP-${RUN}-C1', 'disponibile', NOW()), (${tId}, 'TMP-${RUN}-C2', 'disponibile', NOW())`);
+    try {
+      await page.goto(`${BASE}/admin/books/edit/${tId}`);
+      const marker = `${tamperTitle} EDITED`;
+      // Simulate a crafted POST: strip the readonly guard and zero the field, plus
+      // a benign title change so we can prove the update ran to completion.
+      await page.evaluate((title) => {
+        const el = document.getElementById('copie_totali');
+        el.removeAttribute('readonly');
+        el.value = '0';
+        const t = document.querySelector('input[name="titolo"]');
+        if (t) t.value = title;
+      }, marker);
+      await page.click('#bookForm button[type="submit"]');
+      const confirm = page.locator('.swal2-confirm');
+      if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await Promise.all([
+          page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+          confirm.click(),
+        ]);
+      }
+      // The benign edit persisted (update ran) …
+      expect(dbQuery(`SELECT titolo FROM libri WHERE id=${tId}`)).toBe(marker);
+      // … but the copies survived and the derived total is intact.
+      expect(copieCount(tId)).toBe(2);
+      expect(copieTotali(tId)).toBe(2);
+    } finally {
+      dbQuery(`DELETE FROM libri WHERE id=${tId}`);
+    }
+  });
+
+  // #7: the bulk-import success dialog uses the new "Copie in circolazione" wording.
+  test('19. the copies-added dialog uses the "Copie in circolazione" wording (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/create`);
+    const html = await page.content();
+    expect(html).toContain("__('Copie in circolazione')");
+    expect(html).not.toContain("__('Copie totali:')");
   });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -409,4 +409,22 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
       if (badId > 0) dbQuery(`DELETE FROM libri WHERE id=${badId}`);
     }
   });
+
+  test('21. add-copy rejects array-shaped status, note and inventory inputs (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    for (const field of ['stato', 'note', 'numero_inventario']) {
+      await page.goto(`${BASE}/admin/books/${emptyBookId}`);
+      const before = copieCount(emptyBookId);
+      await page.evaluate(() => window.openAddCopyModal());
+      await expect(page.locator('#add-copy-modal')).toBeVisible();
+      await page.locator(`#add-copy-form [name="${field}"]`).evaluate((el) => {
+        el.name = `${el.name}[]`;
+      });
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+        page.click('#add-copy-form button[type="submit"]'),
+      ]);
+      expect(copieCount(emptyBookId)).toBe(before);
+    }
+  });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -456,4 +456,37 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
     }
     expect(dbQuery(`SELECT note FROM copie WHERE id=${targetId}`)).toBe('x'.repeat(500));
   });
+
+  // M2: /api/libri/{id}/increase-copies must allocate collision-free codes and stay
+  // atomic. With an out-of-circulation copy present, copie_totali excludes it, so the
+  // old "{base}-C{copie_totali+i}" scheme reused an existing code → 1062 → 500 with an
+  // inflated counter. The allocator + transaction fix that.
+  test('23. increase-copies allocates collision-free codes with an out-of-circulation copy (M2)', async ({ page }) => {
+    await loginAsAdmin(page);
+    const base = `M2-${RUN}`;
+    const title = `CopyMgmtM2 ${RUN}`;
+    // Book whose inventory base matches its copies; C2 is "perso" so copie_totali=1
+    // while the code -C2 already exists — the exact collision precondition.
+    dbQuery(`INSERT INTO libri (titolo, numero_inventario, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(title)}', '${base}', 1, 1, NOW(), NOW())`);
+    const id = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(title)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato, created_at) VALUES (${id}, '${base}-C1', 'disponibile', NOW()), (${id}, '${base}-C2', 'perso', NOW())`);
+    try {
+      await page.goto(`${BASE}/admin/books/edit/${id}`);
+      const csrf = await page.locator('#bookForm input[name="csrf_token"]').first().inputValue();
+      const resp = await page.request.post(`${BASE}/api/libri/${id}/increase-copies`, {
+        headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' },
+        data: { copies: 1 },
+      });
+      // Old code raised an unhandled 1062 → 500; the fix returns 200.
+      expect(resp.status()).toBe(200);
+      // The new copy skipped the colliding -C2 and took the next free code.
+      expect(copieCount(id)).toBe(3);
+      expect(dbQuery(`SELECT numero_inventario FROM copie WHERE libro_id=${id} AND stato='disponibile' AND numero_inventario NOT IN ('${base}-C1') ORDER BY id DESC LIMIT 1`)).toBe(`${base}-C3`);
+      // No duplicate codes, and the counter is derived (C1 + C3 available; C2 excluded).
+      expect(Number(dbQuery(`SELECT COUNT(*) - COUNT(DISTINCT numero_inventario) FROM copie WHERE libro_id=${id}`))).toBe(0);
+      expect(copieTotali(id)).toBe(2);
+    } finally {
+      dbQuery(`DELETE FROM libri WHERE id=${id}`);
+    }
+  });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -34,12 +34,20 @@ function dbQuery(sql) {
 const RUN = Date.now().toString(36);
 const TITLE = `CopyMgmt ${RUN}`;             // book that starts with one copy
 const TITLE_EMPTY = `CopyMgmtEmpty ${RUN}`;  // book with zero copie rows
+const TITLE_QUEUE = `CopyMgmtQueue ${RUN}`;  // zero-copy book with an active wait-list entry
+const QUEUE_EMAIL = `copy-mgmt-${RUN}@example.test`;
 let bookId = 0;
 let emptyBookId = 0;
+let queueBookId = 0;
+let queueUserId = 0;
 
 function cleanupByTitle() {
-  // copie cascade on libri delete (FK ON DELETE CASCADE).
-  dbQuery(`DELETE FROM libri WHERE titolo IN ('${sqlEscape(TITLE)}','${sqlEscape(TITLE_EMPTY)}')`);
+  const titles = [TITLE, TITLE_EMPTY, TITLE_QUEUE].map((title) => `'${sqlEscape(title)}'`).join(',');
+  // Loans/reservations restrict book deletion; copies cascade with the book.
+  dbQuery(`DELETE FROM prestiti WHERE libro_id IN (SELECT id FROM libri WHERE titolo IN (${titles}))`);
+  dbQuery(`DELETE FROM prenotazioni WHERE libro_id IN (SELECT id FROM libri WHERE titolo IN (${titles}))`);
+  dbQuery(`DELETE FROM libri WHERE titolo IN (${titles})`);
+  dbQuery(`DELETE FROM utenti WHERE email='${sqlEscape(QUEUE_EMAIL)}'`);
 }
 const copieCount = (id) => Number(dbQuery(`SELECT COUNT(*) FROM copie WHERE libro_id=${id}`));
 const copieTotali = (id) => Number(dbQuery(`SELECT copie_totali FROM libri WHERE id=${id}`));
@@ -70,8 +78,8 @@ async function addCopy(page, { inventario = '', stato = 'disponibile', note = ''
 }
 
 // Edit a copy's status via its row modal (with the SweetAlert confirm).
-async function editCopyStatus(page, copyId, stato) {
-  await page.evaluate((id) => window.openEditCopyModal(id, 'disponibile', ''), copyId);
+async function editCopyStatus(page, copyId, stato, currentStato = 'disponibile') {
+  await page.evaluate(({ id, current }) => window.openEditCopyModal(id, current, ''), { id: copyId, current: currentStato });
   await expect(page.locator('#edit-copy-modal')).toBeVisible();
   await page.selectOption('#edit-copy-stato', stato);
   await page.click('#edit-copy-form button[type="submit"]');
@@ -93,6 +101,12 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
     // A second book with NO copie rows (legacy/never-loaned) for the empty-state test.
     dbQuery(`INSERT INTO libri (titolo, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(TITLE_EMPTY)}', 1, 1, NOW(), NOW())`);
     emptyBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(TITLE_EMPTY)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+
+    dbQuery(`INSERT INTO libri (titolo, stato, copie_totali, copie_disponibili, created_at, updated_at) VALUES ('${sqlEscape(TITLE_QUEUE)}', 'non_disponibile', 0, 0, NOW(), NOW())`);
+    queueBookId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(TITLE_QUEUE)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO utenti (codice_tessera, nome, cognome, email, password, stato, tipo_utente, email_verificata, privacy_accettata) VALUES ('CM-${RUN}', 'Copy', 'Queue', '${sqlEscape(QUEUE_EMAIL)}', 'not-used', 'attivo', 'standard', 1, 1)`);
+    queueUserId = Number(dbQuery(`SELECT id FROM utenti WHERE email='${sqlEscape(QUEUE_EMAIL)}' LIMIT 1`));
+    dbQuery(`INSERT INTO prenotazioni (libro_id, utente_id, data_inizio_richiesta, data_fine_richiesta, data_scadenza_prenotazione, queue_position, stato) VALUES (${queueBookId}, ${queueUserId}, CURDATE(), DATE_ADD(CURDATE(), INTERVAL 14 DAY), DATE_ADD(NOW(), INTERVAL 14 DAY), 1, 'attiva')`);
   });
   test.afterAll(() => cleanupByTitle());
 
@@ -214,5 +228,47 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
     await editCopyStatus(page, targetId, 'perso');
     expect(copieTotali(bookId)).toBe(0);
     expect(bookStato(bookId)).toBe('non_disponibile');
+  });
+
+  test('11. restoration and transfer states round-trip through add/edit and render readable badges', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${emptyBookId}`);
+
+    await addCopy(page, { stato: 'in_restauro', note: 'restoration-roundtrip' });
+    const restorationId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${emptyBookId} AND note='restoration-roundtrip' LIMIT 1`));
+    await expect(page.locator('#physical-copies')).toContainText('In restauro');
+    await editCopyStatus(page, restorationId, 'disponibile', 'in_restauro');
+    expect(dbQuery(`SELECT stato FROM copie WHERE id=${restorationId}`)).toBe('disponibile');
+
+    await page.goto(`${BASE}/admin/books/${emptyBookId}`);
+    await addCopy(page, { stato: 'in_trasferimento', note: 'transfer-readable' });
+    expect(dbQuery(`SELECT stato FROM copie WHERE libro_id=${emptyBookId} AND note='transfer-readable' LIMIT 1`)).toBe('in_trasferimento');
+    await expect(page.locator('#physical-copies')).toContainText('In trasferimento');
+  });
+
+  test('12. an inventory value emptied by sanitisation falls back to an automatic code', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${emptyBookId}`);
+    await page.evaluate(() => window.openAddCopyModal());
+    await page.locator('#add-copy-inventario').evaluate((el) => { el.value = '\u0001\u0002'; });
+    await page.fill('#add-copy-note', 'sanitized-auto');
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+      page.click('#add-copy-form button[type="submit"]'),
+    ]);
+    const code = dbQuery(`SELECT numero_inventario FROM copie WHERE libro_id=${emptyBookId} AND note='sanitized-auto' LIMIT 1`);
+    expect(code).toMatch(/-C\d+$/);
+  });
+
+  test('13. adding an available copy promotes the wait-list and links the loan to that physical copy', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${queueBookId}`);
+    await addCopy(page, { stato: 'disponibile', note: 'queue-capacity' });
+
+    expect(dbQuery(`SELECT stato FROM prenotazioni WHERE libro_id=${queueBookId} AND utente_id=${queueUserId}`)).toBe('completata');
+    const linked = dbQuery(`SELECT CONCAT(p.copia_id, ':', c.libro_id, ':', p.origine, ':', p.stato) FROM prestiti p JOIN copie c ON c.id=p.copia_id WHERE p.libro_id=${queueBookId} AND p.utente_id=${queueUserId} ORDER BY p.id DESC LIMIT 1`);
+    expect(linked).toMatch(new RegExp(`^\\d+:${queueBookId}:prenotazione:pendente$`));
+    expect(copieTotali(queueBookId)).toBe(1);
+    expect(Number(dbQuery(`SELECT copie_disponibili FROM libri WHERE id=${queueBookId}`))).toBe(0);
   });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -387,4 +387,26 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
     expect(html).toContain("__('Copie in circolazione')");
     expect(html).not.toContain("__('Copie totali:')");
   });
+
+  // CodeRabbit follow-up: store() must reject a non-integer copie_totali before
+  // casting — "7abc" must NOT be coerced to 7 copies (nor an array to 1).
+  test('20. store() rejects a non-integer copie_totali → zero copies, not coerced (#356)', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/create`);
+    const csrf = await page.locator('#bookForm input[name="csrf_token"]').first().inputValue();
+    const badTitle = `CopyMgmtBadCount ${RUN}`;
+    // A crafted POST that bypasses the numeric input and sends a non-integer.
+    const resp = await page.request.post(`${BASE}/admin/books/create`, {
+      form: { csrf_token: csrf, titolo: badTitle, copie_totali: '7abc' },
+    });
+    expect(resp.status()).toBeLessThan(400);
+    const badId = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(badTitle)}' AND deleted_at IS NULL ORDER BY id DESC LIMIT 1`));
+    try {
+      expect(badId).toBeGreaterThan(0);          // the book was created …
+      expect(copieCount(badId)).toBe(0);         // … with ZERO copies (not 7)
+      expect(copieTotali(badId)).toBe(0);
+    } finally {
+      if (badId > 0) dbQuery(`DELETE FROM libri WHERE id=${badId}`);
+    }
+  });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -489,4 +489,107 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
       dbQuery(`DELETE FROM libri WHERE id=${id}`);
     }
   });
+
+  test('24. increase-copies respects the case/accent-insensitive inventory collation', async ({ page }) => {
+    await loginAsAdmin(page);
+    const base = `COLL-${RUN}-CAFÉ`;
+    const existingCode = `coll-${RUN}-cafe-c1`;
+    const title = `CopyMgmtCollation ${RUN}`;
+    dbQuery(`INSERT INTO libri (titolo, numero_inventario, copie_totali, copie_disponibili) VALUES ('${sqlEscape(title)}', '${sqlEscape(base)}', 1, 1)`);
+    const id = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(title)}' ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (${id}, '${sqlEscape(existingCode)}', 'disponibile')`);
+    try {
+      await page.goto(`${BASE}/admin/books/edit/${id}`);
+      const csrf = await page.locator('#bookForm input[name="csrf_token"]').first().inputValue();
+      const resp = await page.request.post(`${BASE}/api/libri/${id}/increase-copies`, {
+        headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' },
+        data: { copies: 1 },
+      });
+      expect(resp.status()).toBe(200);
+      expect(dbQuery(`SELECT numero_inventario FROM copie WHERE libro_id=${id} ORDER BY id`)).toBe(`${existingCode}\n${base}-C2`);
+    } finally {
+      dbQuery(`DELETE FROM libri WHERE id=${id}`);
+    }
+  });
+
+  test('25. increase-copies assigns a blocked copy-less HOLDING before exposing capacity', async ({ page }) => {
+    await loginAsAdmin(page);
+    const title = `CopyMgmtBlockedHold ${RUN}`;
+    const email = `copy-mgmt-blocked-${RUN}@example.test`;
+    dbQuery(`INSERT INTO libri (titolo, numero_inventario, stato, copie_totali, copie_disponibili) VALUES ('${sqlEscape(title)}', 'BH-${RUN}', 'non_disponibile', 0, 0)`);
+    const id = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(title)}' ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO utenti (codice_tessera, nome, cognome, email, password, stato, tipo_utente, email_verificata, privacy_accettata) VALUES ('BH-${RUN}', 'Blocked', 'Holder', '${sqlEscape(email)}', 'not-used', 'attivo', 'standard', 1, 1)`);
+    const userId = Number(dbQuery(`SELECT id FROM utenti WHERE email='${sqlEscape(email)}'`));
+    dbQuery(`INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo) VALUES (${id}, NULL, ${userId}, CURDATE(), DATE_ADD(CURDATE(), INTERVAL 14 DAY), 'prenotato', 'prenotazione', 1)`);
+    const loanId = Number(dbQuery(`SELECT id FROM prestiti WHERE libro_id=${id} AND utente_id=${userId} ORDER BY id DESC LIMIT 1`));
+    try {
+      await page.goto(`${BASE}/admin/books/edit/${id}`);
+      const csrf = await page.locator('#bookForm input[name="csrf_token"]').first().inputValue();
+      const resp = await page.request.post(`${BASE}/api/libri/${id}/increase-copies`, {
+        headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' },
+        data: { copies: 1 },
+      });
+      expect(resp.status()).toBe(200);
+      const linked = dbQuery(`SELECT CONCAT(p.copia_id, ':', c.libro_id, ':', c.stato) FROM prestiti p JOIN copie c ON c.id=p.copia_id WHERE p.id=${loanId}`);
+      expect(linked).toMatch(new RegExp(`^\\d+:${id}:prenotato$`));
+      expect(Number(dbQuery(`SELECT copie_disponibili FROM libri WHERE id=${id}`))).toBe(0);
+    } finally {
+      dbQuery(`DELETE FROM prestiti WHERE libro_id=${id}`);
+      dbQuery(`DELETE FROM libri WHERE id=${id}`);
+      dbQuery(`DELETE FROM utenti WHERE id=${userId}`);
+    }
+  });
+
+  test('26. increase-copies rejects non-scalar, fractional and oversized batches', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/edit/${emptyBookId}`);
+    const csrf = await page.locator('#bookForm input[name="csrf_token"]').first().inputValue();
+    const before = copieCount(emptyBookId);
+    for (const copies of [['1'], '1.5', 101]) {
+      const resp = await page.request.post(`${BASE}/api/libri/${emptyBookId}/increase-copies`, {
+        headers: { 'X-CSRF-Token': csrf, 'Content-Type': 'application/json' },
+        data: { copies },
+      });
+      expect(resp.status()).toBe(400);
+    }
+    expect(copieCount(emptyBookId)).toBe(before);
+  });
+
+  test('27. a reserved copy accepts note edits but cannot cancel its HOLDING via copy status', async ({ page }) => {
+    await loginAsAdmin(page);
+    const title = `CopyMgmtReservedNote ${RUN}`;
+    const email = `copy-mgmt-reserved-${RUN}@example.test`;
+    dbQuery(`INSERT INTO libri (titolo, stato, copie_totali, copie_disponibili) VALUES ('${sqlEscape(title)}', 'prenotato', 1, 0)`);
+    const id = Number(dbQuery(`SELECT id FROM libri WHERE titolo='${sqlEscape(title)}' ORDER BY id DESC LIMIT 1`));
+    dbQuery(`INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (${id}, 'RN-${RUN}-C1', 'prenotato')`);
+    const copyId = Number(dbQuery(`SELECT id FROM copie WHERE libro_id=${id}`));
+    dbQuery(`INSERT INTO utenti (codice_tessera, nome, cognome, email, password, stato, tipo_utente, email_verificata, privacy_accettata) VALUES ('RN-${RUN}', 'Reserved', 'Holder', '${sqlEscape(email)}', 'not-used', 'attivo', 'standard', 1, 1)`);
+    const userId = Number(dbQuery(`SELECT id FROM utenti WHERE email='${sqlEscape(email)}'`));
+    dbQuery(`INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo) VALUES (${id}, ${copyId}, ${userId}, CURDATE(), DATE_ADD(CURDATE(), INTERVAL 14 DAY), 'prenotato', 'prenotazione', 1)`);
+    try {
+      await page.goto(`${BASE}/admin/books/${id}`);
+      await page.evaluate((copy) => window.openEditCopyModal(copy, 'prenotato', ''), copyId);
+      await expect(page.locator('#edit-copy-modal')).toBeVisible();
+      await page.fill('#edit-copy-note', 'reserved-note-saved');
+      await page.click('#edit-copy-form button[type="submit"]');
+      let confirm = page.locator('.swal2-confirm');
+      if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await Promise.all([
+          page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+          confirm.click(),
+        ]);
+      }
+      expect(dbQuery(`SELECT CONCAT(stato, ':', note) FROM copie WHERE id=${copyId}`)).toBe('prenotato:reserved-note-saved');
+
+      await page.goto(`${BASE}/admin/books/${id}`);
+      await editCopyStatus(page, copyId, 'disponibile', 'prenotato');
+      expect(dbQuery(`SELECT stato FROM copie WHERE id=${copyId}`)).toBe('prenotato');
+      expect(Number(dbQuery(`SELECT copia_id FROM prestiti WHERE libro_id=${id} AND utente_id=${userId} AND attivo=1`))).toBe(copyId);
+      await expect(page.getByRole('alert')).toContainText('utilizza il sistema Prestiti');
+    } finally {
+      dbQuery(`DELETE FROM prestiti WHERE libro_id=${id}`);
+      dbQuery(`DELETE FROM libri WHERE id=${id}`);
+      dbQuery(`DELETE FROM utenti WHERE id=${userId}`);
+    }
+  });
 });

--- a/tests/copy-management-scheda.spec.js
+++ b/tests/copy-management-scheda.spec.js
@@ -424,7 +424,36 @@ test.describe.serial('Copy management from the book summary (#238/#351)', () => 
         page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
         page.click('#add-copy-form button[type="submit"]'),
       ]);
+      const errorAlert = page.getByRole('alert');
+      await expect(errorAlert).toBeVisible();
+      await expect(errorAlert).toContainText('Impossibile aggiungere la copia');
       expect(copieCount(emptyBookId)).toBe(before);
     }
+  });
+
+  test('22. edit-copy normalizes control characters and caps notes at 500 characters', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto(`${BASE}/admin/books/${bookId}`);
+    const target = dbQuery(`SELECT id, stato FROM copie WHERE libro_id=${bookId} ORDER BY id LIMIT 1`).split('\t');
+    const targetId = Number(target[0]);
+    const currentStatus = target[1];
+    await page.evaluate(
+      ({ id, status }) => window.openEditCopyModal(id, status, ''),
+      { id: targetId, status: currentStatus }
+    );
+    await expect(page.locator('#edit-copy-modal')).toBeVisible();
+    await page.locator('#edit-copy-note').evaluate((element) => {
+      element.value = `  ${'x'.repeat(510)}\u0001  `;
+      element.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.click('#edit-copy-form button[type="submit"]');
+    const confirm = page.locator('.swal2-confirm');
+    if (await confirm.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await Promise.all([
+        page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => {}),
+        confirm.click(),
+      ]);
+    }
+    expect(dbQuery(`SELECT note FROM copie WHERE id=${targetId}`)).toBe('x'.repeat(500));
   });
 });

--- a/tests/email-notifications.spec.js
+++ b/tests/email-notifications.spec.js
@@ -76,119 +76,45 @@ async function mailpitJson(urlPath, timeoutMs = 5000) {
   }
 }
 
-/** Delete all messages in Mailpit */
+/** Delete existing Mailpit messages without starting an asynchronous global purge. */
 async function clearMailpit() {
   if (!mailpitAvailable) return;
-  let lastError;
-  for (let attempt = 1; attempt <= 2; attempt++) {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 5000);
-    try {
-      const res = await fetch(`${MAILPIT_API}/messages`, { method: 'DELETE', signal: controller.signal });
-      if (!res.ok) throw new Error(`Mailpit clear failed: HTTP ${res.status}`);
-      lastError = undefined;
-      break;
-    } catch (err) {
-      lastError = err;
-    } finally {
-      clearTimeout(timer);
-    }
-  }
-
-  if (lastError) {
-    mailpitAvailable = false;
-    throw lastError;
-  }
-
-  // Mailpit can acknowledge DELETE before its recipient/full-text indexes have
-  // settled. Submitting the next form immediately can race the outstanding
-  // purge and delete the newly accepted message. Require two consecutive empty
-  // snapshots before the next test is allowed to send mail.
+  // DELETE without IDs starts a global purge that Mailpit may acknowledge
+  // before it has finished. A newly accepted SMTP message can then be removed
+  // by that outstanding purge. Delete only the IDs observed in each snapshot;
+  // targeted deletes do not remain active and cannot consume the next test's
+  // message. Loop because the listing is paginated and may change while the
+  // suite's notification workers finish.
   let consecutiveEmpty = 0;
-  const deadline = Date.now() + 5000;
-  let stablyEmpty = false;
+  const deadline = Date.now() + 10000;
   while (Date.now() < deadline) {
     const data = await mailpitJson('/messages');
-    const count = Number(data.total ?? data.messages_count ?? data.messages?.length ?? 0);
-    if (count === 0) {
+    const messages = Array.isArray(data.messages) ? data.messages : [];
+    const ids = messages.map(message => message.ID).filter(Boolean);
+
+    if (ids.length === 0) {
       consecutiveEmpty++;
-      if (consecutiveEmpty === 2) { stablyEmpty = true; break; }
+      if (consecutiveEmpty === 2) return;
     } else {
       consecutiveEmpty = 0;
-    }
-    await new Promise(resolve => setTimeout(resolve, 150));
-  }
-  if (!stablyEmpty) {
-    throw new Error('Mailpit inbox did not become stably empty within 5000ms');
-  }
-
-  // A stably-empty LISTING still does not prove the purge fully settled: in CI
-  // (deep-regression shard 4/4, runs 31657224674 and 31689284087 attempt 1)
-  // B.13's contact email was SMTP-accepted ~1s after the DELETE was
-  // acknowledged, yet never became visible — swallowed by the still-settling
-  // purge — so waitForMail timed out and only the serial-block retry passed.
-  // Prove Mailpit is accepting AND RETAINING new mail again before returning:
-  // store a sentinel via the HTTP send API, require it to stay retrievable in
-  // two consecutive reads, then delete just that sentinel by ID (a targeted
-  // delete — no second full purge to re-open the race).
-  const sentinelDeadline = Date.now() + 10000;
-  let sentinelId = null;
-  while (sentinelId === null && Date.now() < sentinelDeadline) {
-    let id = null;
-    try {
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 5000);
       try {
-        const res = await fetch(`${MAILPIT_API}/send`, {
-          method: 'POST',
+        const res = await fetch(`${MAILPIT_API}/messages`, {
+          method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
           signal: controller.signal,
-          body: JSON.stringify({
-            From: { Email: 'purge-sentinel@pinakes.invalid' },
-            To: [{ Email: 'purge-sentinel@pinakes.invalid' }],
-            Subject: `clearMailpit retention sentinel ${Date.now()}`,
-            Text: 'Proves the delete-all purge has settled. Deleted by clearMailpit().',
-          }),
+          body: JSON.stringify({ IDs: ids }),
         });
-        if (!res.ok) throw new Error(`Mailpit send failed: HTTP ${res.status}`);
-        id = (await res.json()).ID;
+        if (!res.ok) throw new Error(`Mailpit targeted clear failed: HTTP ${res.status}`);
       } finally {
         clearTimeout(timer);
       }
-    } catch { /* Mailpit busy — try a fresh sentinel below */ }
-
-    if (id) {
-      let retainedReads = 0;
-      while (retainedReads < 2 && Date.now() < sentinelDeadline) {
-        const retained = await mailpitJson(`/message/${id}`).then(() => true).catch(() => false);
-        if (!retained) { retainedReads = -1; break; } // swallowed → purge still active
-        retainedReads++;
-        if (retainedReads < 2) await new Promise(resolve => setTimeout(resolve, 200));
-      }
-      if (retainedReads === 2) { sentinelId = id; break; }
     }
-    await new Promise(resolve => setTimeout(resolve, 250));
-  }
-  if (sentinelId === null) {
-    throw new Error('Mailpit purge did not settle: sentinel messages kept disappearing within 10000ms');
+    await new Promise(resolve => setTimeout(resolve, 150));
   }
 
-  const delController = new AbortController();
-  const delTimer = setTimeout(() => delController.abort(), 5000);
-  let delRes;
-  try {
-    delRes = await fetch(`${MAILPIT_API}/messages`, {
-      method: 'DELETE',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ IDs: [sentinelId] }),
-      signal: delController.signal,
-    });
-  } finally {
-    clearTimeout(delTimer);
-  }
-  if (!delRes.ok) {
-    throw new Error(`Mailpit sentinel cleanup failed: HTTP ${delRes.status}`);
-  }
+  throw new Error('Mailpit inbox did not become stably empty within 10000ms');
 }
 
 function clearConfigCache() {

--- a/tests/email-notifications.spec.js
+++ b/tests/email-notifications.spec.js
@@ -207,7 +207,7 @@ function clearConfigCache() {
  * @param {number} timeoutMs - Max wait time
  * @returns {Promise<object>} - The matching message summary
  */
-async function waitForMail(query, timeoutMs = 15000) {
+async function waitForMail(query, timeoutMs = 30000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {

--- a/tests/helpers/e2e-fixtures.js
+++ b/tests/helpers/e2e-fixtures.js
@@ -219,6 +219,7 @@ module.exports = {
   BASE_URL,
   createTempAdminUser,
   createTempBook,
+  dbQuery,
   dbExec,
   deleteTempAdminUser,
   deleteTempBook,

--- a/tests/issues-333-336-338.spec.js
+++ b/tests/issues-333-336-338.spec.js
@@ -1,0 +1,215 @@
+// @ts-check
+//
+// End-to-end regression coverage for the three user-visible fixes shipped in
+// v0.7.59. The existing PHP guards pin the implementation structure; these
+// tests prove the real admin routes, rendered pages and persisted data agree.
+//
+// Run:
+//   /tmp/run-e2e.sh tests/issues-333-336-338.spec.js \
+//     --config=tests/playwright.config.js --workers=1
+
+const { test, expect } = require('@playwright/test');
+const {
+  BASE_URL,
+  createTempAdminUser,
+  createTempBook,
+  dbExec,
+  dbQuery,
+  deleteTempAdminUser,
+  deleteTempBook,
+} = require('./helpers/e2e-fixtures');
+const { appDateOffsetISO } = require('./helpers/app-date');
+
+test.describe.serial('issues #333, #336 and #338', () => {
+  /** @type {import('@playwright/test').BrowserContext} */
+  let context;
+  /** @type {import('@playwright/test').Page} */
+  let page;
+  /** @type {{id: number, email: string, password: string, locale: string}} */
+  let admin;
+  /** @type {{id: number, email: string, password: string, locale: string}} */
+  let reservationUser;
+  /** @type {{id: number, title: string}} */
+  let book;
+
+  let cancelledLoanId = 0;
+  let editableLoanId = 0;
+  const seriesName = `Issue338Series${Date.now()}`;
+  const originalDueDate = appDateOffsetISO(10);
+  const shortenedDueDate = appDateOffsetISO(8);
+
+  test.beforeAll(async ({ browser }) => {
+    admin = createTempAdminUser('it_IT');
+    reservationUser = createTempAdminUser('it_IT');
+    book = createTempBook('Issues 333 336');
+
+    cancelledLoanId = Number(dbQuery(`
+      INSERT INTO prestiti (
+        libro_id, utente_id, data_prestito, data_scadenza,
+        stato, attivo, note, created_at, updated_at
+      ) VALUES (
+        ${book.id}, ${admin.id}, '${appDateOffsetISO(-20)}', '${appDateOffsetISO(-5)}',
+        'annullato', 0, '[User] Annullato dall utente', NOW(), NOW()
+      );
+      SELECT LAST_INSERT_ID();
+    `));
+
+    editableLoanId = Number(dbQuery(`
+      INSERT INTO prestiti (
+        libro_id, utente_id, data_prestito, data_scadenza,
+        stato, origine, attivo, created_at, updated_at
+      ) VALUES (
+        ${book.id}, ${admin.id}, '${appDateOffsetISO(0)}', '${originalDueDate}',
+        'in_corso', 'diretto', 1, NOW(), NOW()
+      );
+      SELECT LAST_INSERT_ID();
+    `));
+
+    // This reservation already coexists with the loan's current window. Before
+    // #336, update() rechecked the whole edited window, counted this commitment
+    // against the one-copy capacity and rejected even a shortening operation.
+    dbExec(`
+      INSERT INTO prenotazioni (
+        libro_id, utente_id, data_prenotazione,
+        data_inizio_richiesta, data_fine_richiesta,
+        queue_position, stato, created_at, updated_at
+      ) VALUES (
+        ${book.id}, ${reservationUser.id}, NOW(),
+        '${appDateOffsetISO(2)}', '${appDateOffsetISO(4)}',
+        1, 'attiva', NOW(), NOW()
+      )
+    `);
+
+    // Seed only the pre-existing column: if the #338 migration is missing, the
+    // dedicated test fails on the absent checkbox instead of preventing the
+    // unrelated #333/#336 cases from running at all.
+    dbExec(`INSERT INTO collane (nome) VALUES ('${seriesName}')`);
+
+    expect(cancelledLoanId).toBeGreaterThan(0);
+    expect(editableLoanId).toBeGreaterThan(0);
+
+    context = await browser.newContext();
+    page = await context.newPage();
+    await page.goto(`${BASE_URL}/accedi`);
+    await page.getByRole('textbox', { name: 'Email' }).fill(admin.email);
+    await page.getByRole('textbox', { name: 'Password' }).fill(admin.password);
+    await page.getByRole('button', { name: 'Accedi' }).click();
+    await page.waitForURL('**/admin/dashboard');
+  });
+
+  test.afterAll(async () => {
+    await context?.close();
+
+    if (book) {
+      // deleteTempAdminUser and deleteTempBook are intentionally redundant for
+      // loan/reservation rows, making cleanup safe after a partially-run suite.
+      try { dbExec(`DELETE FROM prenotazioni WHERE libro_id = ${book.id}`); } catch {}
+      try { dbExec(`DELETE FROM prestiti WHERE libro_id = ${book.id}`); } catch {}
+    }
+    try { dbExec(`DELETE FROM collane WHERE nome = '${seriesName}'`); } catch {}
+    if (reservationUser) {
+      try { deleteTempAdminUser(reservationUser.id); } catch {}
+    }
+    if (admin) {
+      try { deleteTempAdminUser(admin.id); } catch {}
+    }
+    if (book) {
+      try { deleteTempBook(book.id); } catch {}
+    }
+  });
+
+  test('#333 renders a cancelled loan as Annullato, not Unknown or still pending return', async () => {
+    await page.goto(`${BASE_URL}/admin/loans/details/${cancelledLoanId}`);
+
+    const statusRow = page.getByText('Stato:', { exact: true }).locator('..');
+    await expect(statusRow).toContainText('Annullato');
+    await expect(statusRow).not.toContainText(/Sconosciuto|Unknown/i);
+
+    const returnDateRow = page.getByText('Data Restituzione:', { exact: true }).locator('..');
+    await expect(returnDateRow).toContainText('—');
+    await expect(returnDateRow).not.toContainText('Non ancora restituito');
+  });
+
+  test('#336 allows shortening a loan when an existing reservation overlaps only held days', async () => {
+    await page.goto(`${BASE_URL}/admin/loans/edit/${editableLoanId}`);
+
+    const form = page.locator(`form[action$="/admin/loans/update/${editableLoanId}"]`);
+    const dueDateInput = form.locator('input[name="data_scadenza"]');
+    await expect(dueDateInput).toHaveValue(originalDueDate);
+    // The shared Flatpickr initializer hides the original ISO input and exposes
+    // a localized alternate input. Drive the real widget API so both values and
+    // its change event match a user selection.
+    await dueDateInput.evaluate((element, value) => {
+      const input = /** @type {HTMLInputElement & {_flatpickr?: {setDate: Function}}} */ (element);
+      if (input._flatpickr) {
+        input._flatpickr.setDate(value, true, 'Y-m-d');
+      } else {
+        input.value = value;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }, shortenedDueDate);
+    await expect(dueDateInput).toHaveValue(shortenedDueDate);
+
+    await Promise.all([
+      page.waitForURL((url) => url.pathname.endsWith('/admin/loans')),
+      form.getByRole('button', { name: 'Salva modifiche' }).click(),
+    ]);
+
+    expect(new URL(page.url()).searchParams.has('error')).toBe(false);
+    expect(dbQuery(`SELECT data_scadenza FROM prestiti WHERE id = ${editableLoanId}`))
+      .toBe(shortenedDueDate);
+    expect(dbQuery(`
+      SELECT COUNT(*)
+        FROM prenotazioni
+       WHERE libro_id = ${book.id}
+         AND stato = 'attiva'
+         AND data_inizio_richiesta <= '${shortenedDueDate}'
+         AND data_fine_richiesta >= '${appDateOffsetISO(0)}'
+    `)).toBe('1');
+  });
+
+  test('#338 persists and displays the complete-series flag, then clears it', async () => {
+    const detailUrl = `${BASE_URL}/admin/series/detail?nome=${encodeURIComponent(seriesName)}`;
+    await page.goto(detailUrl);
+
+    const form = page.locator('form[action$="/admin/series/description"]');
+    const checkbox = form.locator('input[name="is_completa"]');
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.check();
+    await Promise.all([
+      page.waitForURL((url) => (
+        url.pathname.endsWith('/admin/series/detail')
+          && url.searchParams.get('nome') === seriesName
+      )),
+      form.getByRole('button', { name: 'Salva modifiche' }).click(),
+    ]);
+
+    await expect(checkbox).toBeChecked();
+    expect(dbQuery(`SELECT is_completa FROM collane WHERE nome = '${seriesName}'`)).toBe('1');
+    await expect(page.locator('h1')).toContainText('Serie completa');
+
+    await page.goto(`${BASE_URL}/admin/series`);
+    const seriesRow = page.locator('tbody tr').filter({ hasText: seriesName });
+    await expect(seriesRow).toHaveCount(1);
+    await expect(seriesRow.locator('[role="img"][aria-label="Serie completa"]')).toBeVisible();
+
+    await page.goto(detailUrl);
+    const clearForm = page.locator('form[action$="/admin/series/description"]');
+    const clearCheckbox = clearForm.locator('input[name="is_completa"]');
+    await clearCheckbox.uncheck();
+    await Promise.all([
+      page.waitForURL((url) => (
+        url.pathname.endsWith('/admin/series/detail')
+          && url.searchParams.get('nome') === seriesName
+      )),
+      clearForm.getByRole('button', { name: 'Salva modifiche' }).click(),
+    ]);
+
+    await expect(clearCheckbox).not.toBeChecked();
+    expect(dbQuery(`SELECT is_completa FROM collane WHERE nome = '${seriesName}'`)).toBe('0');
+
+    await page.goto(`${BASE_URL}/admin/series`);
+    const clearedRow = page.locator('tbody tr').filter({ hasText: seriesName });
+    await expect(clearedRow.locator('[role="img"][aria-label="Serie completa"]')).toHaveCount(0);
+  });
+});

--- a/tests/loan-edge-cases.unit.php
+++ b/tests/loan-edge-cases.unit.php
@@ -2,7 +2,7 @@
 declare(strict_types=1);
 
 /**
- * Behavioral integration suite — 60 loan ("prestiti") edge cases for Pinakes.
+ * Behavioral integration suite — 64 loan ("prestiti") edge cases for Pinakes.
  *
  * Runs against the LIVE local MySQL but only ever touches data it creates,
  * marked with: book titles `ZZ_LOANEDGE_%`, copy numero_inventario `ZZLE-%`,
@@ -17,15 +17,19 @@ declare(strict_types=1);
  *   - installer/database/triggers.sql (copy-occupancy invariants)
  *
  * Run:   php tests/loan-edge-cases.unit.php
- * Exit:  0 only if all 60 pass; prints "ALL 60 PASS".
+ * Exit:  0 only if all 64 pass; prints "ALL 64 PASS".
  */
 
 use App\Models\CopyRepository;
+use App\Controllers\ReservationManager;
+use App\Controllers\UserActionsController;
 use App\Services\CapacityService;
 use App\Services\ReservationReassignmentService;
 use App\Support\DataIntegrity;
 use App\Support\DateHelper;
 use App\Support\IcsGenerator;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response as SlimResponse;
 
 $root = dirname(__DIR__);
 require $root . '/vendor/autoload.php';
@@ -135,7 +139,7 @@ function pass(string $desc): void
 {
     global $TESTNO;
     $TESTNO++;
-    printf("[%02d/60] PASS: %s\n", $TESTNO, $desc);
+    printf("[%02d/64] PASS: %s\n", $TESTNO, $desc);
 }
 
 function assertEq($exp, $got, string $msg): void
@@ -794,9 +798,124 @@ foreach ($issues as $issue) {
 assertEq(true, $foundOverbook, 'integrity report must detect overbooking that involves overdue loans');
 pass('integrity: overbooked period with overdue loans is reported');
 
+// 61: copy-loss reassignment must inspect every viable physical copy, not give
+// up after five overlapping candidates while a later copy is free.
+$b = mkBook('reassign_after_five_conflicts');
+$copies = mkCopies($b, 7);
+$damagedCopy = array_shift($copies);
+$periodStart = date('Y-m-d', strtotime('+90 days'));
+$periodEnd = date('Y-m-d', strtotime('+100 days'));
+for ($i = 0; $i < 5; $i++) {
+    loan($b, $copies[$i], mkUser(), $periodStart, $periodEnd, 'prenotato', 1);
+}
+$freeReplacement = $copies[5];
+$hold = loan($b, $damagedCopy, mkUser(), $periodStart, $periodEnd, 'prenotato', 1);
+(new CopyRepository($db))->updateStatus($damagedCopy, 'danneggiato');
+(new ReservationReassignmentService($db))->reassignOnCopyLost($damagedCopy);
+$assignedCopy = (int) $db->query("SELECT COALESCE(copia_id, 0) FROM prestiti WHERE id = {$hold}")->fetch_row()[0];
+assertEq($freeReplacement, $assignedCopy, 'allocator must reach the free physical copy after five conflicts');
+pass('copies: reassignment searches beyond five overlapping candidates');
+
+// 62: a copy physically out today can still host a disjoint future hold. The
+// derived status must stay 'prestato' until the current loan is returned.
+$b = mkBook('reassign_to_currently_loaned_copy');
+[$damagedCopy, $loanedReplacement] = mkCopies($b, 2);
+$currentStart = date('Y-m-d', strtotime('-2 days'));
+$currentEnd = date('Y-m-d', strtotime('+5 days'));
+loan($b, $loanedReplacement, mkUser(), $currentStart, $currentEnd, 'in_corso', 1);
+(new CopyRepository($db))->updateStatus($loanedReplacement, 'prestato');
+$futureStart = date('Y-m-d', strtotime('+10 days'));
+$futureEnd = date('Y-m-d', strtotime('+20 days'));
+$futureHold = loan($b, $damagedCopy, mkUser(), $futureStart, $futureEnd, 'prenotato', 1);
+(new CopyRepository($db))->updateStatus($damagedCopy, 'danneggiato');
+(new ReservationReassignmentService($db))->reassignOnCopyLost($damagedCopy);
+$futureCopy = (int) $db->query("SELECT COALESCE(copia_id, 0) FROM prestiti WHERE id = {$futureHold}")->fetch_row()[0];
+assertEq($loanedReplacement, $futureCopy, 'disjoint future hold must reuse the currently loaned physical copy');
+assertEq('prestato', copyStato($loanedReplacement), 'current physical loan must retain status priority after future reassignment');
+pass('copies: disjoint future hold reuses a loaned copy without corrupting its current status');
+
+// 63: legacy reservations with NULL data_inizio_richiesta use the canonical
+// deadline fallback and must still promote to a copy-linked pending loan.
+$b = mkBook('legacy_null_start_promotion');
+$copy = mkCopies($b, 1)[0];
+$u = mkUser();
+$legacyStart = DateHelper::today();
+$legacyEnd = (new \DateTimeImmutable($legacyStart))->modify('+7 days')->format('Y-m-d');
+$legacyDeadline = $legacyStart . ' 23:59:59';
+$stmt = $db->prepare(
+    "INSERT INTO prenotazioni
+        (libro_id, utente_id, data_prenotazione, data_inizio_richiesta, data_fine_richiesta,
+         data_scadenza_prenotazione, queue_position, stato)
+     VALUES (?, ?, NOW(), NULL, ?, ?, 1, 'attiva')"
+);
+$stmt->bind_param('iiss', $b, $u, $legacyEnd, $legacyDeadline);
+$stmt->execute();
+$legacyReservation = (int) $db->insert_id;
+$stmt->close();
+$db->begin_transaction();
+$manager = new ReservationManager($db);
+$manager->setExternalTransaction(true);
+$promoted = $manager->processBookAvailability($b);
+$db->commit();
+$legacyState = (string) $db->query("SELECT stato FROM prenotazioni WHERE id = {$legacyReservation}")->fetch_row()[0];
+$legacyLoan = $db->query(
+    "SELECT stato, copia_id, data_prestito FROM prestiti
+     WHERE libro_id = {$b} AND utente_id = {$u} AND origine = 'prenotazione'
+     ORDER BY id DESC LIMIT 1"
+)->fetch_assoc();
+assertEq(true, $promoted, 'legacy NULL-start reservation must be selected for promotion');
+assertEq('completata', $legacyState, 'legacy reservation must become completed');
+assertEq($copy, (int) ($legacyLoan['copia_id'] ?? 0), 'promoted legacy reservation must link the physical copy');
+assertEq($legacyStart, (string) ($legacyLoan['data_prestito'] ?? ''), 'legacy fallback must become the loan start date');
+pass('reservations: legacy NULL start promotes into a physical-copy-linked loan');
+
+// 64: cancelling a queue reservation from the user frontend must immediately
+// promote the next eligible row and link the freed physical capacity.
+$b = mkBook('user_cancel_promotes_queue');
+$copy = mkCopies($b, 1)[0];
+$cancelUser = mkUser();
+$nextUser = mkUser();
+$queueStart = DateHelper::today();
+$queueEnd = (new \DateTimeImmutable($queueStart))->modify('+7 days')->format('Y-m-d');
+$queueStartDt = $queueStart . ' 00:00:00';
+$queueEndDt = $queueEnd . ' 23:59:59';
+$insertReservation = $db->prepare(
+    "INSERT INTO prenotazioni
+        (libro_id, utente_id, data_prenotazione, data_scadenza_prenotazione,
+         data_inizio_richiesta, data_fine_richiesta, queue_position, stato)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'attiva')"
+);
+$firstPosition = 1;
+$insertReservation->bind_param('iissssi', $b, $cancelUser, $queueStartDt, $queueEndDt, $queueStart, $queueEnd, $firstPosition);
+$insertReservation->execute();
+$cancelReservationId = (int) $db->insert_id;
+$secondPosition = 2;
+$insertReservation->bind_param('iissssi', $b, $nextUser, $queueStartDt, $queueEndDt, $queueStart, $queueEnd, $secondPosition);
+$insertReservation->execute();
+$nextReservationId = (int) $db->insert_id;
+$insertReservation->close();
+$_SESSION['user'] = ['id' => $cancelUser, 'tipo_utente' => 'standard'];
+$cancelRequest = (new ServerRequestFactory())
+    ->createServerRequest('POST', '/reservation/cancel')
+    ->withParsedBody(['reservation_id' => $cancelReservationId]);
+$cancelResponse = (new UserActionsController())->cancelReservation($cancelRequest, new SlimResponse(), $db);
+unset($_SESSION['user']);
+$cancelledState = (string) $db->query("SELECT stato FROM prenotazioni WHERE id = {$cancelReservationId}")->fetch_row()[0];
+$nextState = (string) $db->query("SELECT stato FROM prenotazioni WHERE id = {$nextReservationId}")->fetch_row()[0];
+$promotedLoan = $db->query(
+    "SELECT copia_id, stato FROM prestiti
+     WHERE libro_id = {$b} AND utente_id = {$nextUser} AND origine = 'prenotazione'
+     ORDER BY id DESC LIMIT 1"
+)->fetch_assoc();
+assertEq(302, $cancelResponse->getStatusCode(), 'user cancellation must complete with the normal redirect');
+assertEq('annullata', $cancelledState, 'cancelled reservation must be terminal');
+assertEq('completata', $nextState, 'next eligible reservation must be promoted immediately');
+assertEq($copy, (int) ($promotedLoan['copia_id'] ?? 0), 'promoted queue row must link the freed physical copy');
+pass('reservations: user cancellation immediately promotes and links the next queue row');
+
 /* ==========================================================================
  * Done
  * ====================================================================== */
 cleanup($db);
-echo "ALL 60 PASS\n";
+echo "ALL 64 PASS\n";
 $db->close();

--- a/tests/loan-edge-cases.unit.php
+++ b/tests/loan-edge-cases.unit.php
@@ -677,7 +677,7 @@ assertEq('disponibile', bookStato($b), 'recalc overwrites manually-wrong libri.s
 pass('misc: libri.stato is derived (recalc overwrites wrong value)');
 
 /* ==========================================================================
- * 53-60  Canonical capacity, schedules, integrity and calendars
+ * 53-64  Canonical capacity, schedules, integrity, calendars and reservation queues
  * ====================================================================== */
 // 53: an unreturned overdue loan is open-ended for future capacity decisions.
 $b = mkBook('capacity_overdue_open');

--- a/tests/mobile-api.spec.js
+++ b/tests/mobile-api.spec.js
@@ -85,6 +85,18 @@ function dbExec(sql) {
     });
 }
 
+/**
+ * Direct SQL writes bypass SettingsRepository, so invalidate ConfigStore's
+ * cross-request file cache before asserting API-visible settings.
+ */
+function clearConfigCache() {
+    execFileSync(
+        'php',
+        ['-r', 'require "vendor/autoload.php"; \\App\\Support\\ConfigStore::clearCache();'],
+        { cwd: process.cwd(), encoding: 'utf-8', timeout: 15000, env: process.env }
+    );
+}
+
 function tableExists(name) {
     const n = parseInt(dbQuery(
         `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '${name.replace(/'/g, "''")}'`
@@ -335,6 +347,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
                  ON DUPLICATE KEY UPDATE setting_value='0'`
             );
         }
+        clearConfigCache();
         dbExec(
             `INSERT INTO registrazione_campi (etichetta, tipo, obbligatorio, attivo, ordine)
              SELECT '${CUSTOM_FIELD_LABEL}', 'text', 1, 1, ordering.next_order
@@ -393,6 +406,7 @@ test.describe.serial('Mobile API plugin — E2E suite', () => {
                     );
                 }
             }
+            clearConfigCache();
         } catch (_) { /* best-effort */ }
     });
 


### PR DESCRIPTION
## Why

A book's availability is a value **derived from its physical copies** (#351): to mark a book lost/damaged you change the status of a copy, not the book. But the per-copy status editor only appeared when the book already had `copie` rows — and those are created on loan or import, never for a manually-created book that was never loaned. There was also no way to **add** a copy from the UI. So a book like that had nowhere to set the status.

## What

Copy management on the book summary (`/admin/books/{id}`):

- The **"Copie Fisiche"** section is now **always shown**. When the book has no copies it shows an empty state and the **"Aggiungi copia"** button.
- An **"Aggiungi copia"** modal (cloned from the existing "Modifica Stato Copia" modal, same style) creates a physical copy: optional inventory number (auto-allocated as the next collision-free `{base}-C{N}` when left blank), initial status, and a note.
- Backend: `CopyController::createCopy` + `POST /admin/books/{id}/copies/create`, reusing `CopyRepository` and recalculating availability.

The availability recalculation already **excludes** lost/damaged/maintenance copies from `copie_totali`, so marking a copy lost lowers the total on its own — no extra logic needed.

## Tests

`tests/copy-management-scheda.spec.js` — **10 real browser E2E, all green**: section + button visible, empty-state, add (auto + explicit inventory), duplicate inventory rejected, a copy born "danneggiato" not counted in the total, edit to lost/damaged lowering the total and round-tripping to available, delete guard (available copies protected) + delete of an out-of-circulation copy, and "every copy out of circulation → `non_disponibile`".

New UI strings added to **all five locales** (parity check green). PHPStan level 5 clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * È possibile creare copie fisiche dalla scheda del libro, con codice inventario automatico o personalizzato, stato iniziale e note.
  * Aggiunti gli stati “In restauro” e “In trasferimento”.
  * Le nuove copie possono riassegnare automaticamente le prenotazioni in attesa.

* **Miglioramenti**
  * La sezione copie è visibile anche quando è vuota.
  * Il numero di copie può essere zero e la disponibilità viene calcolata automaticamente.
  * Le copie non più in circolazione possono essere eliminate quando consentito.
  * Rafforzati controlli, aggiornamenti della disponibilità e gestione delle operazioni.
  * Aggiunte traduzioni per la gestione delle copie fisiche in tutte le lingue supportate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->