### PR TITLE
Localize `Sesso` rendering on `/admin/users/details/<id>` 

### DIFF
--- a/app/Views/utenti/dettagli_utente.php
+++ b/app/Views/utenti/dettagli_utente.php
@@ -35,6 +35,15 @@ $roleLabels = [
     'standard' => __('Standard')
 ];
 
+$genderLabels = [
+    'M' => __('Maschio'),
+    'F' => __('Femmina'),
+    'Altro' => __('Altro'),
+];
+
+$sessoKey = trim((string)$sesso);
+$sessoLabel = $genderLabels[$sessoKey] ?? $sessoKey;
+
 $display = static function (?string $value, string $placeholder = '—'): string {
     $value = trim((string)$value);
     return $value !== '' ? HtmlHelper::e($value) : $placeholder;
@@ -147,7 +156,7 @@ $display = static function (?string $value, string $placeholder = '—'): string
       </div>
       <div>
         <dt class="text-sm text-gray-500"><?= __("Sesso") ?></dt>
-        <dd class="text-sm text-gray-900 mt-1"><?= $display($sesso); ?></dd>
+        <dd class="text-sm text-gray-900 mt-1"><?= $display($sessoLabel); ?></dd>
       </div>
       <div>
         <dt class="text-sm text-gray-500"><?= __("Codice Fiscale") ?></dt>

--- a/tests/issue-255-registration.spec.js
+++ b/tests/issue-255-registration.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * Issue #255 — configurable registration fields. 29-check E2E suite.
+ * Issue #255 — configurable registration fields. 30-check E2E suite.
  *
  * Coverage (all through the real browser):
  *   1-4    defaults + SERVER-side enforcement of each built-in requirement
@@ -18,7 +18,7 @@
  *   23-24  sanitization: a tag-carrying label is neutralised on save; a
  *          script-carrying VALUE is escaped when rendered back (admin detail).
  *   25     an inactive (attivo=0) field disappears from the public form.
- *   26-29 profile/admin-detail regressions and destructive type-change guard.
+ *   26-30 profile/admin-detail regressions and destructive type-change guard.
  */
 
 const { test, expect } = require('@playwright/test');
@@ -117,7 +117,7 @@ function userCount(email) {
   return Number(dbQuery(`SELECT COUNT(*) FROM utenti WHERE email='${email}'`));
 }
 
-test.describe.serial('Issue #255 — configurable registration fields (29 checks)', () => {
+test.describe.serial('Issue #255 — configurable registration fields (30 checks)', () => {
   /** @type {import('@playwright/test').Page} */
   let admin;
   /** @type {Map<string, string>} setting key -> original HEX(setting_value) */
@@ -510,5 +510,25 @@ test.describe.serial('Issue #255 — configurable registration fields (29 checks
     ]);
     expect(dbQuery(`SELECT tipo FROM registrazione_campi WHERE id=${id}`)).toBe('text');
     await expect(admin.locator('body')).toContainText(/non puoi cambiare il tipo|cannot change the type|ne pouvez pas modifier le type|Typ eines Feldes/i);
+  });
+
+  test('30. admin user details localize the stored sesso enum value', async ({ page }) => {
+    await setToggles(admin, false, false, false);
+    const email = `zz-255-sesso-${TOKEN}@example.test`;
+    await fillRegistration(page, {
+      fields: { nome: 'Sesso30', email, password: 'Password255!ok', password_confirm: 'Password255!ok' },
+    });
+    await submitNoValidate(page);
+    expect(userCount(email)).toBe(1);
+
+    dbQuery(`UPDATE utenti SET sesso='M' WHERE email='${email}'`);
+    const uid = dbQuery(`SELECT id FROM utenti WHERE email='${email}'`);
+
+    await admin.goto(`${BASE}/registrati`);
+    const expectedLabel = (await admin.locator('select[name="sesso"] option[value="M"]').innerText()).trim();
+
+    await admin.goto(`${BASE}/admin/users/details/${uid}`);
+    const sessoValue = admin.locator('dt:has-text("Sesso") + dd');
+    await expect(sessoValue).toHaveText(expectedLabel);
   });
 });


### PR DESCRIPTION
The admin user details page was rendering raw enum values for `sesso` (`M`, `F`, `Altro`) instead of the localized labels already used by registration/profile flows. This change updates display-only behavior while preserving stored DB values and resilient handling of empty/legacy data.

- **Presentation mapping on admin details view**
  - Updated `/app/Views/utenti/dettagli_utente.php` to map:
    - `M` → `__("Maschio")`
    - `F` → `__("Femmina")`
    - `Altro` → `__("Altro")`
  - Kept this as a view-layer transformation only; no controller/model/schema changes.

- **Fallback and escaping behavior**
  - Empty/null values continue to render as the existing placeholder (`—`).
  - Unexpected legacy values continue to render as escaped text (no notices/errors).
  - Output still flows through existing escaping conventions (`$display(...)` / `HtmlHelper::e(...)`).

- **Focused regression coverage**
  - Extended existing E2E suite (`tests/issue-255-registration.spec.js`) with a targeted assertion that admin details show the localized label for stored `sesso='M'`, aligned with the registration form’s locale-specific option text.

```php
$genderLabels = [
    'M' => __('Maschio'),
    'F' => __('Femmina'),
    'Altro' => __('Altro'),
];

$sessoKey = trim((string)$sesso);
$sessoLabel = $genderLabels[$sessoKey] ?? $sessoKey;

// ...
<dd><?= $display($sessoLabel); ?></dd>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Miglioramenti**
  * La pagina dei dettagli utente ora mostra un’etichetta localizzata per il campo sesso, inclusi i valori standard e quelli non riconosciuti.

* **Test**
  * Aggiunta una verifica end-to-end per confermare la coerenza dell’etichetta visualizzata tra registrazione pubblica e area amministrativa.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->