### PR TITLE
Release prep 0.7.66: CHANGELOG heading + robust plugin-integrity login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
-## [0.7.66] - 2026-08-24
-
+## [0.7.66]
 A full audit of all 20 bundled plugins — security, correctness and schema fixes — plus four previously-orphaned plugin features wired into the UI.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
 ## [0.7.66]
+
 A full audit of all 20 bundled plugins — security, correctness and schema fixes — plus four previously-orphaned plugin features wired into the UI.
 
 ### Security

--- a/tests/plugin-integrity.spec.js
+++ b/tests/plugin-integrity.spec.js
@@ -69,8 +69,15 @@ test.describe.serial('Plugin integrity regression (#101)', () => {
         context = await browser.newContext();
         page = await context.newPage();
         await page.goto(`${BASE}/login`);
-        await page.fill('input[name="email"]', ADMIN_EMAIL);
-        await page.fill('input[name="password"]', ADMIN_PASS);
+        // Wait for the form to be laid out before filling: filling immediately
+        // after goto occasionally races the render and Playwright's fill
+        // auto-verify (toHaveValue) fails on the freshly-loaded field. locator
+        // fills carry a stronger actionability wait than page.fill(selector).
+        await page.waitForLoadState('domcontentloaded');
+        const passwordField = page.locator('input[name="password"]');
+        await page.locator('input[name="email"]').fill(ADMIN_EMAIL);
+        await passwordField.fill(ADMIN_PASS);
+        await expect(passwordField).toHaveValue(ADMIN_PASS);
         await Promise.all([
             page.waitForURL(/\/admin\//, { timeout: 15000 }),
             page.click('button[type="submit"]'),


### PR DESCRIPTION
Two small fixes to unblock the 0.7.66 release:

- **CHANGELOG heading**: `create-release.sh` requires an exact `## [0.7.66]` line (the date is added post-tag, as in every prior entry); the version-bump commit carried the date inline and failed the preflight.
- **plugin-integrity login**: the beforeAll filled the password field before the form laid out, so Playwright's `fill` auto-verify occasionally failed at 0ms and aborted the suite. Added `waitForLoadState` + `locator().fill()` + an explicit value guard.

Everything else for 0.7.66 (the 20-plugin audit, 4 orphaned features, SSRF guard, the 5 plugin.json bumps so ensureSchema/hooks re-run on upgrade) is already on main via #376. reinstall-test Test A+B passed (real admin-UI upgrade verified: plugins overwritten + schema applied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentazione**
  * Aggiornato il changelog della versione 0.7.66 rimuovendo la data di rilascio dall’intestazione.

* **Test**
  * Migliorata la stabilità del test di integrità dei plugin durante il login.
  * Aggiunta una verifica per confermare il corretto inserimento della password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->