### PR TITLE
fix(release): export TAG_NAME so create-release.sh preflight stops aborting

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -50,7 +50,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$ ]]; th
     fail "invalid version '$VERSION'; expected X.Y.Z or X.Y.Z-(alpha|beta|rc).N"
 fi
 
-readonly TAG_NAME="v${VERSION}"
+declare -rx TAG_NAME="v${VERSION}"
 IS_PRERELEASE=false
 if [[ "$VERSION" == *-* ]]; then
     IS_PRERELEASE=true
@@ -144,7 +144,6 @@ if [[ "$IS_PRERELEASE" == false ]]; then
 fi
 
 release_token="$(gh auth token)"
-TAG_NAME="$TAG_NAME" \
 GITHUB_SHA="$head_sha" \
 GITHUB_REPOSITORY="$REPOSITORY" \
 GH_TOKEN="$release_token" \


### PR DESCRIPTION
`create-release.sh` declared `readonly TAG_NAME` and then passed it to `ci-verify-release-source.sh` as a command env-prefix (`TAG_NAME="$TAG_NAME" … bash scripts/ci-verify-release-source.sh`). bash refuses a temporary assignment to a readonly variable, so the 0.7.66 release aborted in preflight with `line 147: TAG_NAME: readonly variable` on every run.

Fix: declare it `declare -rx` (readonly **and** exported) and drop the redundant prefix — the sub-shell now inherits `TAG_NAME` from the environment. `bash -n` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Migliorata la gestione delle informazioni di versione durante la creazione delle release.
  * Verificata la corretta disponibilità del tag di release nei controlli automatici.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->