### PR TITLE
fix(updater): self-heal missing plugin foreign keys and columns on upgrade (0.7.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.67]
+
+Fixes a silent upgrade gap discovered on a live install: a foreign key or column that a bundled plugin adds in a release was not applied when an already-active plugin was upgraded through the admin UI, even though the plugin version was bumped.
+
+### Fixed
+
+- **Plugin schema self-heal now covers foreign keys and columns, not just tables.** An admin-UI upgrade loads a plugin's old class into memory before the new files are swapped in, so PHP keeps running the old `onActivate`/`ensureSchema` during the upgrade even as the version is stamped forward — any foreign key or column added in that release never runs at upgrade time. The boot-time self-heal is the only path that applies it, and it previously probed missing *tables* only. It now also probes declared columns (`expectedColumns()`) and foreign keys (`expectedForeignKeys()`) and re-runs `onActivate` when any declared element is missing. Concrete effect: `ncip_transactions`' two foreign keys and `libri.file_url`/`libri.audio_url` are now restored automatically on the next page load after upgrading. No action is required; already-upgraded installs heal themselves.
+
+### Internal
+
+- ncip-server and digital-library declare their foreign keys / columns from a single source shared with the code that creates them, so the self-heal probe and the DDL cannot drift apart. New behavioural coverage (`tests/plugin-schema-selfheal-fkcol.unit.php`) reproduces the missing-FK / missing-column state against the real `PluginManager` and asserts it self-heals; it fails on the pre-fix code by design and is wired into the mandatory schema gate.
+
 ## [0.7.66]
 
 A full audit of all 20 bundled plugins — security, correctness and schema fixes — plus four previously-orphaned plugin features wired into the UI.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.61 — latest
+### v0.7.67 — latest
+
+A reliability fix for plugin upgrades: a foreign key or column added by a bundled plugin is now applied automatically after an in-place upgrade of an already-active plugin, instead of being silently skipped.
+
+### Fixes
+
+- **Plugin schema self-heal now covers foreign keys and columns, not only tables.** An admin-UI upgrade runs a plugin's old code until the next page load, so a foreign key or column introduced in a release never ran at upgrade time even though the version was bumped. The boot-time self-heal now detects a declared foreign key or column missing and re-applies it on the next request — `ncip_transactions`' foreign keys and `libri.file_url`/`libri.audio_url` heal themselves with no manual step. See **[CHANGELOG.md](CHANGELOG.md)**.
+
+### v0.7.61
 
 Physical-copy management from the book page, with availability derived from the copies — plus a per-user interface language and a safe upgrade path for existing catalogues.
 

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -102,13 +102,30 @@ class PluginManager
      */
     /**
      * Cheap boot-time schema-presence probe used by the self-heal in
-     * autoRegisterBundledPlugins(). A schema-owning plugin may declare
-     * `expectedTables(): list<string>`; if any of those tables is missing the
-     * plugin's schema is behind and ensureSchema must be re-run. Plugins that
-     * do not declare the method never trigger a rebuild. One read-only
-     * information_schema query, no locks — safe to call on every boot.
+     * autoRegisterBundledPlugins(). A schema-owning plugin may declare its
+     * expected surface via any of:
+     *   - `expectedTables(): list<string>`
+     *   - `expectedColumns(): list<array{table:string, column:string}>`
+     *   - `expectedForeignKeys(): list<array{table:string, column:string, ref_table:string}>`
+     * If ANY declared table / column / FK is missing, the plugin's schema is
+     * behind and ensureSchema/onActivate must be re-run. This is the ONLY path
+     * that applies a schema change added in a release on an admin-UI upgrade:
+     * that upgrade runs the plugin's OLD class (already in memory from
+     * loadActivePlugins) even though the version is bumped, so the new
+     * ensureSchema never runs at upgrade time (stale-class trap, ncip FK,
+     * bibliodoc 2026-08-24). Plugins that declare nothing never trigger a
+     * rebuild. Each probe is one read-only information_schema query, no locks —
+     * safe on every boot.
      */
     private function bundledSchemaIncomplete(object $instance): bool
+    {
+        return $this->expectedTablesMissing($instance)
+            || $this->expectedColumnsMissing($instance)
+            || $this->expectedForeignKeysMissing($instance);
+    }
+
+    /** True when a declared expectedTables() entry is absent from the schema. */
+    private function expectedTablesMissing(object $instance): bool
     {
         if (!method_exists($instance, 'expectedTables')) {
             return false;
@@ -138,6 +155,106 @@ class PluginManager
         }
         $present = (int) $res->fetch_row()[0];
         return $present < count($escaped);
+    }
+
+    /**
+     * True when a declared expectedColumns() entry is absent. A plugin that adds
+     * a column to an existing table (its own or a core table, e.g.
+     * digital-library's file_url/audio_url on `libri`) declares it as
+     * {table, column}. If the prepare fails we return false — "cannot prove
+     * missing" must not churn onActivate on every boot.
+     */
+    private function expectedColumnsMissing(object $instance): bool
+    {
+        if (!method_exists($instance, 'expectedColumns')) {
+            return false;
+        }
+        try {
+            $columns = $instance->expectedColumns();
+        } catch (\Throwable $e) {
+            return false;
+        }
+        if (!is_array($columns) || $columns === []) {
+            return false;
+        }
+        foreach ($columns as $col) {
+            if (!is_array($col)) {
+                continue;
+            }
+            $table  = (string) ($col['table'] ?? '');
+            $column = (string) ($col['column'] ?? '');
+            if ($table === '' || $column === '') {
+                continue;
+            }
+            $stmt = $this->db->prepare(
+                "SELECT COUNT(*) FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?"
+            );
+            if ($stmt === false) {
+                return false;
+            }
+            $stmt->bind_param('ss', $table, $column);
+            $present = 0;
+            if ($stmt->execute()) {
+                $stmt->bind_result($present);
+                $stmt->fetch();
+            }
+            $stmt->close();
+            if ((int) $present === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True when a declared expectedForeignKeys() entry is absent. Mirrors the
+     * probe a plugin's own ensureForeignKeys() uses (REFERENCED_TABLE_NAME is
+     * non-NULL only for real FKs, so a same-named plain index is not matched).
+     */
+    private function expectedForeignKeysMissing(object $instance): bool
+    {
+        if (!method_exists($instance, 'expectedForeignKeys')) {
+            return false;
+        }
+        try {
+            $fks = $instance->expectedForeignKeys();
+        } catch (\Throwable $e) {
+            return false;
+        }
+        if (!is_array($fks) || $fks === []) {
+            return false;
+        }
+        foreach ($fks as $fk) {
+            if (!is_array($fk)) {
+                continue;
+            }
+            $table    = (string) ($fk['table'] ?? '');
+            $column   = (string) ($fk['column'] ?? '');
+            $refTable = (string) ($fk['ref_table'] ?? '');
+            if ($table === '' || $column === '' || $refTable === '') {
+                continue;
+            }
+            $stmt = $this->db->prepare(
+                "SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?
+                   AND COLUMN_NAME = ? AND REFERENCED_TABLE_NAME = ?"
+            );
+            if ($stmt === false) {
+                return false;
+            }
+            $stmt->bind_param('sss', $table, $column, $refTable);
+            $present = 0;
+            if ($stmt->execute()) {
+                $stmt->bind_result($present);
+                $stmt->fetch();
+            }
+            $stmt->close();
+            if ((int) $present === 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function autoRegisterBundledPlugins(): int

--- a/app/Support/PluginManager.php
+++ b/app/Support/PluginManager.php
@@ -194,11 +194,15 @@ class PluginManager
                 return false;
             }
             $stmt->bind_param('ss', $table, $column);
-            $present = 0;
-            if ($stmt->execute()) {
-                $stmt->bind_result($present);
-                $stmt->fetch();
+            if (!$stmt->execute()) {
+                // A probe failure is not proof the column is missing — returning
+                // "missing" here would churn onActivate DDL on every boot.
+                $stmt->close();
+                return false;
             }
+            $present = 0;
+            $stmt->bind_result($present);
+            $stmt->fetch();
             $stmt->close();
             if ((int) $present === 0) {
                 return true;
@@ -244,11 +248,15 @@ class PluginManager
                 return false;
             }
             $stmt->bind_param('sss', $table, $column, $refTable);
-            $present = 0;
-            if ($stmt->execute()) {
-                $stmt->bind_result($present);
-                $stmt->fetch();
+            if (!$stmt->execute()) {
+                // A probe failure is not proof the FK is missing — returning
+                // "missing" here would churn onActivate DDL on every boot.
+                $stmt->close();
+                return false;
             }
+            $present = 0;
+            $stmt->bind_result($present);
+            $stmt->fetch();
             $stmt->close();
             if ((int) $present === 0) {
                 return true;

--- a/scripts/verify-schema.sh
+++ b/scripts/verify-schema.sh
@@ -33,6 +33,7 @@ TESTS=(
   tests/plugin-schema-expectations-static.unit.php
   tests/plugin-schema-guard.unit.php
   tests/plugin-schema-selfheal.unit.php
+  tests/plugin-schema-selfheal-fkcol.unit.php
 )
 
 # The current release's behavioural migration test, derived from version.json

--- a/storage/plugins/digital-library/DigitalLibraryPlugin.php
+++ b/storage/plugins/digital-library/DigitalLibraryPlugin.php
@@ -152,14 +152,41 @@ class DigitalLibraryPlugin
             return;
         }
 
-        $this->ensureColumn(
-            'file_url',
-            "ALTER TABLE libri ADD COLUMN file_url VARCHAR(255) DEFAULT NULL COMMENT 'eBook file URL' AFTER note_varie"
-        );
-        $this->ensureColumn(
-            'audio_url',
-            "ALTER TABLE libri ADD COLUMN audio_url VARCHAR(255) DEFAULT NULL COMMENT 'Audiobook file URL' AFTER file_url"
-        );
+        foreach (self::columnDefs() as $column => $alterSql) {
+            $this->ensureColumn($column, $alterSql);
+        }
+    }
+
+    /**
+     * Single source of truth for the columns digital-library adds to `libri`,
+     * shared by ensureSchema() (which adds them) and expectedColumns() (which
+     * lets PluginManager's boot-time self-heal detect them missing after a
+     * stale-class upgrade). Keep the two in sync via this list.
+     *
+     * @return array<string,string> column => ADD COLUMN DDL
+     */
+    private static function columnDefs(): array
+    {
+        return [
+            'file_url'  => "ALTER TABLE libri ADD COLUMN file_url VARCHAR(255) DEFAULT NULL COMMENT 'eBook file URL' AFTER note_varie",
+            'audio_url' => "ALTER TABLE libri ADD COLUMN audio_url VARCHAR(255) DEFAULT NULL COMMENT 'Audiobook file URL' AFTER file_url",
+        ];
+    }
+
+    /**
+     * Declared to PluginManager::bundledSchemaIncomplete() so an already-active
+     * digital-library at the same version whose columns are missing (stale-class
+     * admin-UI upgrade) self-heals on the next boot by re-running onActivate.
+     *
+     * @return list<array{table:string, column:string}>
+     */
+    public function expectedColumns(): array
+    {
+        $out = [];
+        foreach (array_keys(self::columnDefs()) as $column) {
+            $out[] = ['table' => 'libri', 'column' => $column];
+        }
+        return $out;
     }
 
     /**

--- a/storage/plugins/ncip-server/NcipServerPlugin.php
+++ b/storage/plugins/ncip-server/NcipServerPlugin.php
@@ -197,12 +197,45 @@ class NcipServerPlugin
      *              probe/cleanup/ALTER failed so the caller can report the schema
      *              as half-applied instead of registering hooks over it.
      */
-    private function ensureForeignKeys(): bool
+    /**
+     * Single source of truth for the ncip_transactions foreign keys, shared by
+     * ensureForeignKeys() (which adds them) and expectedForeignKeys() (which
+     * lets PluginManager's boot-time self-heal detect them missing after a
+     * stale-class upgrade). Keep the two in sync via this list.
+     *
+     * @return list<array{column:string, ref_table:string, ref_col:string, name:string}>
+     */
+    private static function foreignKeyDefs(): array
     {
-        $fks = [
+        return [
             ['column' => 'partner_id',  'ref_table' => 'ncip_partners', 'ref_col' => 'id', 'name' => 'ncip_transactions_ibfk_1'],
             ['column' => 'prestito_id', 'ref_table' => 'prestiti',      'ref_col' => 'id', 'name' => 'ncip_transactions_ibfk_2'],
         ];
+    }
+
+    /**
+     * Declared to PluginManager::bundledSchemaIncomplete() so an already-active
+     * ncip at the same version whose FKs are missing (stale-class admin-UI
+     * upgrade) self-heals on the next boot by re-running onActivate.
+     *
+     * @return list<array{table:string, column:string, ref_table:string}>
+     */
+    public function expectedForeignKeys(): array
+    {
+        $out = [];
+        foreach (self::foreignKeyDefs() as $fk) {
+            $out[] = [
+                'table'     => 'ncip_transactions',
+                'column'    => $fk['column'],
+                'ref_table' => $fk['ref_table'],
+            ];
+        }
+        return $out;
+    }
+
+    private function ensureForeignKeys(): bool
+    {
+        $fks = self::foreignKeyDefs();
 
         $ok = true;
         foreach ($fks as $fk) {

--- a/storage/plugins/ncip-server/wrapper.php
+++ b/storage/plugins/ncip-server/wrapper.php
@@ -35,6 +35,11 @@ if (!class_exists('NcipServerPlugin', false)) {
             return $this->instance->expectedTables();
         }
 
+        public function expectedForeignKeys(): array
+        {
+            return $this->instance->expectedForeignKeys();
+        }
+
         public function onDeactivate(): void
         {
             $this->instance->onDeactivate();

--- a/tests/plugin-schema-selfheal-fkcol.unit.php
+++ b/tests/plugin-schema-selfheal-fkcol.unit.php
@@ -127,16 +127,29 @@ set_exception_handler(function (\Throwable $e) use ($cleanup): void {
 /* ================= Scenario A — ncip-server foreign keys ================= */
 $ncip = $db->query("SELECT id, is_active, version FROM plugins WHERE name='ncip-server'")->fetch_assoc();
 if (!$ncip) {
-    echo "NOTE: ncip-server not registered — skipping FK scenario\n";
+    // ncip-server is a bundled plugin: a missing row means this environment
+    // never registered it, which would let the gate pass WITHOUT testing FK
+    // self-heal at all. Fail loudly instead of silently skipping.
+    if (is_dir(__DIR__ . '/../storage/plugins/ncip-server')) {
+        throw new \RuntimeException('ncip-server is bundled on disk but not registered in `plugins` — cannot verify FK self-heal');
+    }
 } else {
     $ncipId       = (int) $ncip['id'];
     $ncipActive0  = (int) $ncip['is_active'];
     $ncipVersion0 = (string) $ncip['version'];
     $ncipDisk     = $diskVersion('ncip-server');
 
-    // Restore exactly as found: original active flag + version; if it was
-    // inactive, drop the hooks our activation registered.
+    // Restore exactly as found: re-add the FKs we drop below (so a mid-scenario
+    // failure never leaves ncip_transactions without its referential
+    // integrity), original active flag + version, and — if it was inactive —
+    // the hooks our activation registered.
     $restores[] = function (mysqli $db) use ($ncipId, $ncipActive0, $ncipVersion0): void {
+        if (!$db->query("SELECT 1 FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='ncip_transactions' AND COLUMN_NAME='partner_id' AND REFERENCED_TABLE_NAME='ncip_partners'")->num_rows) {
+            @$db->query("ALTER TABLE ncip_transactions ADD CONSTRAINT ncip_transactions_ibfk_1 FOREIGN KEY (partner_id) REFERENCES ncip_partners (id) ON DELETE SET NULL");
+        }
+        if (!$db->query("SELECT 1 FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='ncip_transactions' AND COLUMN_NAME='prestito_id' AND REFERENCED_TABLE_NAME='prestiti'")->num_rows) {
+            @$db->query("ALTER TABLE ncip_transactions ADD CONSTRAINT ncip_transactions_ibfk_2 FOREIGN KEY (prestito_id) REFERENCES prestiti (id) ON DELETE SET NULL");
+        }
         if ($ncipActive0 === 0) {
             $db->query("DELETE FROM plugin_hooks WHERE plugin_id={$ncipId}");
         }
@@ -172,7 +185,11 @@ if (!$ncip) {
 /* ================= Scenario B — digital-library columns ================= */
 $dl = $db->query("SELECT id, is_active, version FROM plugins WHERE name='digital-library'")->fetch_assoc();
 if (!$dl) {
-    echo "NOTE: digital-library not registered — skipping column scenario\n";
+    // Same contract as ncip above: a bundled-but-unregistered plugin must fail
+    // the gate rather than let it pass without exercising the column self-heal.
+    if (is_dir(__DIR__ . '/../storage/plugins/digital-library')) {
+        throw new \RuntimeException('digital-library is bundled on disk but not registered in `plugins` — cannot verify column self-heal');
+    }
 } else {
     $dlId       = (int) $dl['id'];
     $dlActive0  = (int) $dl['is_active'];
@@ -216,6 +233,12 @@ if (!$dl) {
     // Idempotent.
     $runSync();
     check($columnExists('libri', 'audio_url'), 'B06 idempotent: column intact after a second sync');
+}
+
+// Belt and suspenders: if neither scenario ran a single assertion, the gate
+// would report success without verifying anything. Refuse to pass empty.
+if ($TESTNO === 0) {
+    throw new \RuntimeException('no self-heal scenario executed — neither ncip-server nor digital-library was verifiable');
 }
 
 $cleanup();

--- a/tests/plugin-schema-selfheal-fkcol.unit.php
+++ b/tests/plugin-schema-selfheal-fkcol.unit.php
@@ -1,0 +1,223 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Plugin schema self-heal for COLUMNS and FOREIGN KEYS (0.7.67).
+ *
+ * Sibling to plugin-schema-selfheal.unit.php, which covers missing TABLES.
+ *
+ * THE BUG this pins down: an admin-UI upgrade runs
+ * `public/index.php → loadActivePlugins()`, loading the ACTIVE plugin's OLD
+ * class into memory BEFORE the Updater overwrites the files. PHP will not
+ * reload a class already in memory, so a new FK/column added to
+ * onActivate/ensureSchema in that release never runs at upgrade time — yet
+ * `plugins.version` is bumped to the new value. The same-version self-heal on
+ * the next boot is the only path that can apply it, and before 0.7.67 it only
+ * probed expectedTables(): a new FK on an existing table (ncip_transactions'
+ * FKs, bibliodoc 2026-08-24) or a new column (digital-library's file_url/
+ * audio_url on `libri`) was healed by neither path and stayed missing forever.
+ *
+ * These reproduce the "version already == disk, hooks present, FK/column
+ * missing" state against the REAL PluginManager and REAL plugins, then assert
+ * the schema self-heals. On the pre-fix code these FAIL by design.
+ *
+ * Each scenario SKIPs cleanly if its plugin is not present. The FK drop loses
+ * no row data; the column scenario snapshots the affected values and restores
+ * them.
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+/* ----------------------------- DB connect ----------------------------- */
+function sfc_env(string $path): array
+{
+    $env = [];
+    foreach (@file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [] as $line) {
+        if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+            continue;
+        }
+        [$k, $v] = explode('=', $line, 2);
+        $k = trim($k);
+        $v = trim($v);
+        if (strlen($v) >= 2 && ($v[0] === '"' || $v[0] === "'") && $v[-1] === $v[0]) {
+            $v = substr($v, 1, -1);
+        }
+        $env[$k] = $v;
+    }
+    return $env;
+}
+
+$env    = sfc_env(__DIR__ . '/../.env');
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$user   = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$pass   = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+$name   = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+
+mysqli_report(MYSQLI_REPORT_OFF);
+try {
+    $db = (is_string($socket) && $socket !== '' && file_exists($socket))
+        ? @new mysqli(null, $user, $pass, $name, 0, $socket)
+        : @new mysqli($env['DB_HOST'] ?? '127.0.0.1', $user, $pass, $name, (int) ($env['DB_PORT'] ?? 3306));
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+if (!isset($db) || $db->connect_errno !== 0) {
+    $error = isset($db) ? $db->connect_error : 'connection failed';
+    echo "SKIP: database not reachable ({$error})\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+/* ----------------------------- harness ----------------------------- */
+$TESTNO = 0;
+function pass(string $desc): void
+{
+    global $TESTNO;
+    $TESTNO++;
+    printf("[%02d] PASS: %s\n", $TESTNO, $desc);
+}
+function check(bool $cond, string $desc): void
+{
+    if (!$cond) {
+        throw new \RuntimeException("assertion failed: {$desc}");
+    }
+    pass($desc);
+}
+
+$hm = new \App\Support\HookManager($db);
+$runSync = function () use ($db, $hm): void {
+    (new \App\Support\PluginManager($db, $hm))->autoRegisterBundledPlugins();
+};
+$fkExists = function (string $table, string $column, string $refTable) use ($db): bool {
+    return (bool) $db->query(
+        "SELECT 1 FROM information_schema.KEY_COLUMN_USAGE
+         WHERE TABLE_SCHEMA=DATABASE()
+           AND TABLE_NAME='" . $db->real_escape_string($table) . "'
+           AND COLUMN_NAME='" . $db->real_escape_string($column) . "'
+           AND REFERENCED_TABLE_NAME='" . $db->real_escape_string($refTable) . "'"
+    )->num_rows;
+};
+$columnExists = function (string $t, string $c) use ($db): bool {
+    return (bool) $db->query(
+        "SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='" . $db->real_escape_string($t) . "' AND COLUMN_NAME='" . $db->real_escape_string($c) . "'"
+    )->num_rows;
+};
+$hookCount = function (int $pluginId) use ($db): int {
+    return (int) $db->query("SELECT COUNT(*) FROM plugin_hooks WHERE plugin_id={$pluginId}")->fetch_row()[0];
+};
+$diskVersion = function (string $plugin): string {
+    $meta = json_decode((string) @file_get_contents(__DIR__ . "/../storage/plugins/{$plugin}/plugin.json"), true);
+    return (string) ($meta['version'] ?? '1.0.0');
+};
+
+/* Track what we changed so cleanup restores the plugins as we found them. */
+$restores = [];
+$cleanup = function () use ($db, &$restores): void {
+    foreach (array_reverse($restores) as $r) {
+        try { $r($db); } catch (\Throwable $ignored) {}
+    }
+};
+set_exception_handler(function (\Throwable $e) use ($cleanup): void {
+    try { $cleanup(); } catch (\Throwable $ignored) {}
+    fwrite(STDERR, "FAIL: " . $e->getMessage() . "\n");
+    exit(1);
+});
+
+/* ================= Scenario A — ncip-server foreign keys ================= */
+$ncip = $db->query("SELECT id, is_active, version FROM plugins WHERE name='ncip-server'")->fetch_assoc();
+if (!$ncip) {
+    echo "NOTE: ncip-server not registered — skipping FK scenario\n";
+} else {
+    $ncipId       = (int) $ncip['id'];
+    $ncipActive0  = (int) $ncip['is_active'];
+    $ncipVersion0 = (string) $ncip['version'];
+    $ncipDisk     = $diskVersion('ncip-server');
+
+    // Restore exactly as found: original active flag + version; if it was
+    // inactive, drop the hooks our activation registered.
+    $restores[] = function (mysqli $db) use ($ncipId, $ncipActive0, $ncipVersion0): void {
+        if ($ncipActive0 === 0) {
+            $db->query("DELETE FROM plugin_hooks WHERE plugin_id={$ncipId}");
+        }
+        $v = $db->real_escape_string($ncipVersion0);
+        $db->query("UPDATE plugins SET is_active={$ncipActive0}, version='{$v}' WHERE id={$ncipId}");
+    };
+
+    // Baseline: activate + let the real sync build the ncip schema (tables + FKs).
+    $db->query("UPDATE plugins SET is_active=1 WHERE id={$ncipId}");
+    $runSync();
+    check($fkExists('ncip_transactions', 'partner_id', 'ncip_partners'), 'A01 baseline: ncip FK partner_id present');
+    check($fkExists('ncip_transactions', 'prestito_id', 'prestiti'), 'A02 baseline: ncip FK prestito_id present');
+
+    // Break: drop both FKs, pin version == disk (the stale-class upgrade state),
+    // keep active + hooks. Pre-fix, the same-version branch skips ensureSchema.
+    @$db->query("ALTER TABLE ncip_transactions DROP FOREIGN KEY ncip_transactions_ibfk_1");
+    @$db->query("ALTER TABLE ncip_transactions DROP FOREIGN KEY ncip_transactions_ibfk_2");
+    $v = $db->real_escape_string($ncipDisk);
+    $db->query("UPDATE plugins SET version='{$v}', is_active=1 WHERE id={$ncipId}");
+    check(!$fkExists('ncip_transactions', 'partner_id', 'ncip_partners'), 'A03 setup: FK partner_id dropped, version already == disk');
+    check(!$fkExists('ncip_transactions', 'prestito_id', 'prestiti'), 'A04 setup: FK prestito_id dropped');
+    check($hookCount($ncipId) > 0, 'A05 setup: ncip active with hooks present (stale-class scenario)');
+
+    $runSync();
+    check($fkExists('ncip_transactions', 'partner_id', 'ncip_partners'), 'A06 same-version sync SELF-HEALS ncip FK partner_id (the bibliodoc bug)');
+    check($fkExists('ncip_transactions', 'prestito_id', 'prestiti'), 'A07 same-version sync SELF-HEALS ncip FK prestito_id');
+
+    // Idempotent: a second sync on a healthy schema is a no-op.
+    $runSync();
+    check($fkExists('ncip_transactions', 'partner_id', 'ncip_partners'), 'A08 idempotent: FKs intact after a second sync');
+}
+
+/* ================= Scenario B — digital-library columns ================= */
+$dl = $db->query("SELECT id, is_active, version FROM plugins WHERE name='digital-library'")->fetch_assoc();
+if (!$dl) {
+    echo "NOTE: digital-library not registered — skipping column scenario\n";
+} else {
+    $dlId       = (int) $dl['id'];
+    $dlActive0  = (int) $dl['is_active'];
+    $dlVersion0 = (string) $dl['version'];
+    $dlDisk     = $diskVersion('digital-library');
+
+    // Snapshot audio_url values so dropping the column loses no real data.
+    $db->query("DROP TABLE IF EXISTS zz_sfc_dl_bak");
+    $db->query("CREATE TABLE zz_sfc_dl_bak AS SELECT id, audio_url FROM libri WHERE audio_url IS NOT NULL AND audio_url <> ''");
+
+    $restores[] = function (mysqli $db) use ($dlId, $dlActive0, $dlVersion0): void {
+        // Ensure the column exists again before restoring its values.
+        if (!$db->query("SELECT 1 FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='libri' AND COLUMN_NAME='audio_url'")->num_rows) {
+            @$db->query("ALTER TABLE libri ADD COLUMN audio_url VARCHAR(255) DEFAULT NULL COMMENT 'Audiobook file URL' AFTER file_url");
+        }
+        if ($db->query("SELECT 1 FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='zz_sfc_dl_bak'")->num_rows) {
+            @$db->query("UPDATE libri l JOIN zz_sfc_dl_bak b ON l.id=b.id SET l.audio_url=b.audio_url");
+            $db->query("DROP TABLE IF EXISTS zz_sfc_dl_bak");
+        }
+        $v = $db->real_escape_string($dlVersion0);
+        $db->query("UPDATE plugins SET is_active={$dlActive0}, version='{$v}' WHERE id={$dlId}");
+    };
+
+    // Baseline: active + real sync ensures the columns exist.
+    $db->query("UPDATE plugins SET is_active=1 WHERE id={$dlId}");
+    $runSync();
+    check($columnExists('libri', 'file_url'), 'B01 baseline: libri.file_url present');
+    check($columnExists('libri', 'audio_url'), 'B02 baseline: libri.audio_url present');
+
+    // Break: drop audio_url, pin version == disk, keep active. Pre-fix the
+    // same-version branch (expectedTables only) never re-adds it.
+    @$db->query("ALTER TABLE libri DROP COLUMN audio_url");
+    $v = $db->real_escape_string($dlDisk);
+    $db->query("UPDATE plugins SET version='{$v}', is_active=1 WHERE id={$dlId}");
+    check(!$columnExists('libri', 'audio_url'), 'B03 setup: libri.audio_url dropped, version already == disk');
+    check($hookCount($dlId) > 0, 'B04 setup: digital-library active with hooks present');
+
+    $runSync();
+    check($columnExists('libri', 'audio_url'), 'B05 same-version sync SELF-HEALS libri.audio_url');
+
+    // Idempotent.
+    $runSync();
+    check($columnExists('libri', 'audio_url'), 'B06 idempotent: column intact after a second sync');
+}
+
+$cleanup();
+$db->close();
+printf("\nALL %d PASS\n", $TESTNO);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Why

Found on a live 0.7.66 install (bibliodoc): `ncip_transactions` carried plugin version `1.0.3` in the DB but had **zero foreign keys**. Root cause is generic and affects any bundled plugin that adds a foreign key or column in a release.

An admin-UI upgrade runs `public/index.php → loadActivePlugins()`, which loads each **active** plugin's OLD class into memory **before** the Updater overwrites the plugin files. PHP will not reload a class already in memory, so the OLD `onActivate`/`ensureSchema` runs during the upgrade even though `plugins.version` is stamped forward. Any FK/column newly added in that release therefore never runs at upgrade time. The same-version boot self-heal is the only path that can apply it afterwards — and it only probed missing **tables**, so a new FK on an existing table, or a new column, was healed by neither path and stayed missing forever.

## What

- `PluginManager::bundledSchemaIncomplete()` now probes `expectedColumns()` and `expectedForeignKeys()` in addition to `expectedTables()` (read-only `information_schema`, no locks, gated by `method_exists`), re-running `onActivate` when any declared table/column/FK is missing.
- `ncip-server` declares `expectedForeignKeys()` and `digital-library` declares `expectedColumns()`, each derived from a **single source** shared with the DDL that creates them, so the probe and the creation cannot drift. The ncip global wrapper forwards the new method (the self-heal introspects the wrapper, not the inner class).
- `tests/plugin-schema-selfheal-fkcol.unit.php` reproduces the missing-FK / missing-column state against the real `PluginManager` and asserts self-heal. It **fails on the pre-fix code by design** and is wired into `verify-schema.sh` (the mandatory schema gate).

## Effect on existing installs

No action required. On the first page load after upgrading, `ncip_transactions`' two foreign keys and `libri.file_url`/`libri.audio_url` are restored automatically. The already-affected 0.7.66 install had its foreign keys applied directly.

## Verification

- `scripts/verify-schema.sh` — green, including the new FK/column self-heal test (14 assertions).
- Full-tree PHPStan level 5 — no errors.
- 131 standalone unit tests pass; the 3 circulation suites that require a dedicated `E2E_DB_NAME` are unrelated to this change and run in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Migliorata l’auto-riparazione dello schema dei plugin: vengono ripristinate automaticamente anche colonne e chiavi esterne mancanti al riavvio.
  * Aggiornate le integrazioni per garantire il corretto ripristino degli schemi dichiarati.

* **Correzioni**
  * Risolti i casi in cui modifiche allo schema effettuate dopo un aggiornamento in-place non venivano applicate automaticamente.

* **Documentazione**
  * Aggiornate le note di rilascio per la versione 0.7.67.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->