### PR TITLE
fix: cancel waiting-for-pickup loans (#381) + download author photo URLs (#382)

### DIFF
--- a/app/Controllers/AutoriController.php
+++ b/app/Controllers/AutoriController.php
@@ -275,6 +275,10 @@ class AutoriController
                 'ssrf_guard'   => true,
                 'https_only'   => true,
                 'max_redirects' => 3,
+                // Abort mid-transfer past the photo size cap so an oversized or
+                // endless response can't exhaust memory before storeAuthorPhotoBytes.
+                'max_bytes'    => 5 * 1024 * 1024,
+                'timeout'      => 15,
             ]);
             if (empty($res['ok']) || (int) $res['status'] < 200 || (int) $res['status'] >= 300 || (string) $res['body'] === '') {
                 return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,

--- a/app/Controllers/AutoriController.php
+++ b/app/Controllers/AutoriController.php
@@ -223,7 +223,8 @@ class AutoriController
      * `error` so the caller can surface it instead of silently saving no photo.
      *
      * @return array{foto: string, deleteOnSuccess: ?string, deleteOnFailure: ?string, error?: string}
-     *         foto = stored value (`/uploads/...` path, external `https?://` URL, or '')
+     *         foto = stored value (a local `/uploads/autori/...` path or '' — a
+     *         pasted URL is downloaded server-side, #382, never stored verbatim)
      */
     private function resolveAuthorPhoto(Request $request, array $data, string $existing): array
     {
@@ -245,48 +246,41 @@ class AutoriController
             } catch (\Throwable $e) {
                 $bytes = '';
             }
-            // SECURITY: never trust the client-supplied MIME — validate the real
-            // bytes and derive the extension from the detected type.
-            $info = ($bytes !== '' && strlen($bytes) <= 5 * 1024 * 1024)
-                ? @getimagesizefromstring($bytes) : false;
-            $detected = is_array($info) ? (string) $info['mime'] : '';
-            $allowed = ['image/png' => 'png', 'image/jpeg' => 'jpg', 'image/webp' => 'webp', 'image/gif' => 'gif'];
-            if (!isset($allowed[$detected])) {
-                return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
-                        'error' => __('Formato immagine non supportato. Usa PNG, JPG, WebP o GIF.')];
-            }
-            $dir = dirname(__DIR__, 2) . '/public/uploads/autori';
-            if (!is_dir($dir)) {
-                @mkdir($dir, 0775, true);
-            }
-            $name = 'autore_' . bin2hex(random_bytes(8)) . '.' . $allowed[$detected];
-            $dest = $dir . '/' . $name;
-            // Re-encode through GD to strip any embedded payload (mirrors cover handling).
-            if (!$this->reencodeAuthorPhoto($bytes, $detected, $dest)) {
-                \App\Support\SecureLogger::error('Author photo re-encode failed (unsupported or corrupt image)');
-                return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
-                        'error' => __('Impossibile elaborare l\'immagine caricata.')];
-            }
-            @chmod($dest, 0644);
-            $stored = '/uploads/autori/' . $name;
-            return [
-                'foto' => $stored,
-                'deleteOnSuccess' => ($existing !== '' && $existing !== $stored) ? $existing : null,
-                'deleteOnFailure' => $stored, // remove this fresh upload if the DB write fails
-            ];
+            // SECURITY: never trust the client-supplied MIME. The shared helper
+            // validates the real bytes (size/format/pixels), re-encodes via GD to
+            // strip any embedded payload, and stores under /uploads/autori.
+            return $this->storeAuthorPhotoBytes($bytes, $existing);
         }
 
-        // 2) A pasted URL takes priority over the remove flag too.
+        // 2) A pasted URL. #382: download it server-side and store a local
+        //    /uploads/autori file. Storing the external URL verbatim left the
+        //    <img> blocked by the app CSP img-src (external hosts are not
+        //    allow-listed), so the photo never displayed. Serving it same-origin
+        //    also fixes mixed-content (http image on an https page) and remote
+        //    hotlink protection.
         $urlRaw = trim((string) ($data['foto_url'] ?? ''));
         if ($urlRaw !== '') {
             if (!filter_var($urlRaw, FILTER_VALIDATE_URL)) {
                 $urlRaw = 'https://' . ltrim($urlRaw, '/');
             }
-            if (filter_var($urlRaw, FILTER_VALIDATE_URL) && preg_match('#^https?://#i', $urlRaw) === 1) {
-                // Switching from a local file to a URL: drop the file only after the DB write.
-                $deleteOld = ($urlRaw !== $existing) ? $existing : null;
-                return ['foto' => $urlRaw, 'deleteOnSuccess' => $deleteOld, 'deleteOnFailure' => null];
+            if (!filter_var($urlRaw, FILTER_VALIDATE_URL) || preg_match('#^https://#i', $urlRaw) !== 1) {
+                return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                        'error' => __('Inserisci un URL immagine valido (https://).')];
             }
+            // Full SSRF guard via HttpClient: the host must resolve to a public
+            // IP, the connection is pinned to it (CURLOPT_RESOLVE, DNS-rebind
+            // safe), and cross-host/scheme/port redirects are rejected. HTTPS-only,
+            // mirroring the book-cover download boundary.
+            $res = \App\Support\HttpClient::get($urlRaw, [], [
+                'ssrf_guard'   => true,
+                'https_only'   => true,
+                'max_redirects' => 3,
+            ]);
+            if (empty($res['ok']) || (int) $res['status'] < 200 || (int) $res['status'] >= 300 || (string) $res['body'] === '') {
+                return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                        'error' => __('Impossibile scaricare l\'immagine dall\'URL indicato.')];
+            }
+            return $this->storeAuthorPhotoBytes((string) $res['body'], $existing);
         }
 
         // 3) No new photo data → apply the remove flag as a fallback.
@@ -295,6 +289,57 @@ class AutoriController
         }
 
         return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null]; // unchanged
+    }
+
+    /**
+     * Validate raw image bytes (real MIME, size, pixel count), re-encode through
+     * GD to public/uploads/autori, and return the resolveAuthorPhoto() result
+     * shape. Shared by the upload branch and the download-by-URL branch (#382) so
+     * a pasted URL is stored as a same-origin local file with the SAME guards as
+     * an upload. A rejected image returns an `error` (never a silent no-photo).
+     *
+     * @return array{foto: string, deleteOnSuccess: ?string, deleteOnFailure: ?string, error?: string}
+     */
+    private function storeAuthorPhotoBytes(string $bytes, string $existing): array
+    {
+        if ($bytes === '' || strlen($bytes) > 5 * 1024 * 1024) {
+            return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                    'error' => __('La foto supera la dimensione massima di 5 MB.')];
+        }
+        // SECURITY: derive the type from the real bytes, never a client-supplied MIME.
+        $info = @getimagesizefromstring($bytes);
+        $detected = is_array($info) ? (string) $info['mime'] : '';
+        $allowed = ['image/png' => 'png', 'image/jpeg' => 'jpg', 'image/webp' => 'webp', 'image/gif' => 'gif'];
+        if (!isset($allowed[$detected])) {
+            return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                    'error' => __('Formato immagine non supportato. Usa PNG, JPG, WebP o GIF.')];
+        }
+        // Reject oversized images BEFORE the GD decode (OOM/DoS guard, mirrors
+        // covers). Reaching here implies $info is the getimagesizefromstring array.
+        $w = (int) $info[0];
+        $h = (int) $info[1];
+        if ($w <= 0 || $h <= 0 || ($w * $h) > 20_000_000) {
+            return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                    'error' => __('Immagine troppo grande da processare.')];
+        }
+        $dir = dirname(__DIR__, 2) . '/public/uploads/autori';
+        if (!is_dir($dir)) {
+            @mkdir($dir, 0775, true);
+        }
+        $name = 'autore_' . bin2hex(random_bytes(8)) . '.' . $allowed[$detected];
+        $dest = $dir . '/' . $name;
+        if (!$this->reencodeAuthorPhoto($bytes, $detected, $dest)) {
+            \App\Support\SecureLogger::error('Author photo re-encode failed (unsupported or corrupt image)');
+            return ['foto' => $existing, 'deleteOnSuccess' => null, 'deleteOnFailure' => null,
+                    'error' => __('Impossibile elaborare l\'immagine.')];
+        }
+        @chmod($dest, 0644);
+        $stored = '/uploads/autori/' . $name;
+        return [
+            'foto' => $stored,
+            'deleteOnSuccess' => ($existing !== '' && $existing !== $stored) ? $existing : null,
+            'deleteOnFailure' => $stored, // remove this fresh file if the DB write fails
+        ];
     }
 
     /**

--- a/app/Controllers/UserActionsController.php
+++ b/app/Controllers/UserActionsController.php
@@ -140,13 +140,16 @@ class UserActionsController
         // — stesso pattern di cancelReservation qui sotto. Lockare prima la
         // riga prestiti incrocerebbe i lock con i percorsi di creazione/
         // approvazione (che vanno libri -> prestiti) causando deadlock.
-        // Note: 'pendente' has attivo=0, 'prenotato' has attivo=1
+        // Note: 'pendente' has attivo=0, 'prenotato'/'da_ritirare' have attivo=1.
+        // 'da_ritirare' (approved, waiting for pickup) must be user-cancellable too
+        // (#381): its copy is held in copie.stato='prenotato' exactly like a
+        // 'prenotato' loan, so the same release path below applies.
         $lookupStmt = $db->prepare("
             SELECT libro_id
             FROM prestiti
             WHERE id = ? AND utente_id = ? AND (
                 (attivo = 0 AND stato = 'pendente')
-                OR (attivo = 1 AND stato = 'prenotato')
+                OR (attivo = 1 AND stato IN ('prenotato', 'da_ritirare'))
             )
         ");
         $lookupStmt->bind_param('ii', $loanId, $uid);
@@ -179,7 +182,7 @@ class UserActionsController
                 FROM prestiti
                 WHERE id = ? AND utente_id = ? AND (
                     (attivo = 0 AND stato = 'pendente')
-                    OR (attivo = 1 AND stato = 'prenotato')
+                    OR (attivo = 1 AND stato IN ('prenotato', 'da_ritirare'))
                 )
                 FOR UPDATE
             ");
@@ -196,9 +199,12 @@ class UserActionsController
 
             // Mark as cancelled
             $cancelNote = "\n[User] Annullato dall'utente";
+            // pickup_deadline = NULL: a 'da_ritirare' loan carries a deadline;
+            // clear it on cancel so the expiry cron / PickupDeadlineBackfill (#366)
+            // cannot act on a dead deadline.
             $updateStmt = $db->prepare("
                 UPDATE prestiti
-                SET stato = 'annullato', attivo = 0, updated_at = NOW(), note = CONCAT(COALESCE(note, ''), ?)
+                SET stato = 'annullato', attivo = 0, pickup_deadline = NULL, updated_at = NOW(), note = CONCAT(COALESCE(note, ''), ?)
                 WHERE id = ?
             ");
             $updateStmt->bind_param('si', $cancelNote, $loanId);
@@ -209,11 +215,13 @@ class UserActionsController
             // 'pendente' promosso dalla coda (attivo=0 con copia_id): prima solo
             // il ramo 'prenotato' riassegnava subito e la copia del pendente
             // annullato restava in attesa dello sweep di manutenzione.
-            if ($loan['copia_id'] && in_array((string) $loan['stato'], ['prenotato', 'pendente'], true)) {
+            if ($loan['copia_id'] && in_array((string) $loan['stato'], ['prenotato', 'pendente', 'da_ritirare'], true)) {
                 $copiaId = (int) $loan['copia_id'];
 
-                // Update copy status to available (if it was 'prenotato'; la copia
-                // di un pendente promosso resta 'disponibile' e l'UPDATE è no-op)
+                // Update copy status to available. Both 'prenotato' and 'da_ritirare'
+                // hold the copy in copie.stato='prenotato', so this guarded UPDATE
+                // frees it; a promoted 'pendente' keeps its copy 'disponibile' and
+                // the UPDATE is a no-op.
                 $copyStmt = $db->prepare("UPDATE copie SET stato = 'disponibile' WHERE id = ? AND stato = 'prenotato'");
                 $copyStmt->bind_param('i', $copiaId);
                 $copyStmt->execute();

--- a/app/Support/HttpClient.php
+++ b/app/Support/HttpClient.php
@@ -47,7 +47,8 @@ final class HttpClient
      * @param array<string,mixed>  $options Overrides: timeout, connect_timeout,
      *                                       user_agent, max_redirects, verify,
      *                                       query (array), https_only (bool),
-     *                                       ssrf_guard (bool)
+     *                                       ssrf_guard (bool), max_bytes (int —
+     *                                       abort the download past this size)
      * @return array{ok:bool,status:int,body:string}
      */
     public static function get(string $url, array $headers = [], array $options = []): array
@@ -210,6 +211,27 @@ final class HttpClient
         }
         if (isset($options[RequestOptions::BODY])) {
             $guzzleOptions[RequestOptions::BODY] = $options[RequestOptions::BODY];
+        }
+
+        // Hard download cap (DoS guard for caller-configurable endpoints): abort
+        // as soon as the body exceeds max_bytes, so a huge or endless response
+        // cannot exhaust memory before a post-download size check. Content-Length
+        // is advisory (server-controlled), so it is only an early-out; the
+        // progress cap during transfer is the real boundary. A breach throws,
+        // which the catch below turns into an ok=false result.
+        $maxBytes = (int) ($options['max_bytes'] ?? 0);
+        if ($maxBytes > 0) {
+            $guzzleOptions[RequestOptions::ON_HEADERS] = static function (\Psr\Http\Message\ResponseInterface $response) use ($maxBytes): void {
+                $declared = $response->getHeaderLine('Content-Length');
+                if ($declared !== '' && (int) $declared > $maxBytes) {
+                    throw new \RuntimeException('HttpClient: response Content-Length exceeds max_bytes');
+                }
+            };
+            $guzzleOptions[RequestOptions::PROGRESS] = static function ($downloadTotal, $downloadedBytes) use ($maxBytes): void {
+                if ((int) $downloadedBytes > $maxBytes) {
+                    throw new \RuntimeException('HttpClient: downloaded body exceeds max_bytes');
+                }
+            };
         }
 
         try {

--- a/app/Views/admin/pending_loans.php
+++ b/app/Views/admin/pending_loans.php
@@ -183,9 +183,16 @@
                                     <i class="fas fa-times mr-1"></i><?= __("Annulla Prestito Scaduto") ?>
                                 </button>
                                 <?php else: ?>
-                                <button type="button" class="inline-flex items-center justify-center w-full bg-gray-800 hover:bg-gray-700 text-white font-medium py-2 px-3 rounded-lg transition-colors confirm-pickup-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
-                                    <i class="fas fa-check-circle mr-1"></i><?= __("Conferma Ritiro") ?>
-                                </button>
+                                <?php // Non ancora scaduto: il ritiro si può confermare O annullare
+                                      // (#381) — prima l'annullamento compariva solo dopo la scadenza. ?>
+                                <div class="flex gap-2">
+                                    <button type="button" class="inline-flex items-center justify-center flex-1 bg-gray-800 hover:bg-gray-700 text-white font-medium py-2 px-3 rounded-lg transition-colors confirm-pickup-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                        <i class="fas fa-check-circle mr-1"></i><?= __("Conferma Ritiro") ?>
+                                    </button>
+                                    <button type="button" class="inline-flex items-center justify-center flex-1 bg-red-600 hover:bg-red-500 text-white font-medium py-2 px-3 rounded-lg transition-colors cancel-pickup-btn shadow-sm text-sm" data-loan-id="<?= $loan['id'] ?>">
+                                        <i class="fas fa-times mr-1"></i><?= __("Annulla Ritiro") ?>
+                                    </button>
+                                </div>
                                 <?php endif; ?>
                             </div>
                         </div>

--- a/app/Views/partials/loan-actions-swal.php
+++ b/app/Views/partials/loan-actions-swal.php
@@ -24,7 +24,10 @@ $loanActionTranslations = array_merge([
     'cancelPickupTitle' => __('Annullare il ritiro?'),
     'cancelPickupText' => __('La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?'),
     'cancelPickupButton' => __('Annulla Prestito'),
-    'cancelPickupReason' => __('Ritiro non effettuato entro il termine previsto'),
+    // Neutral reason (emailed via sendPickupCancelledNotification): the same
+    // handler now cancels non-expired pickups too (#381), so it must not assert
+    // the pickup deadline was missed.
+    'cancelPickupReason' => __('Ritiro annullato'),
     'successCancelPickupTitle' => __('Prestito annullato!'),
     // Add missing translations for the Swal dialogs in prestiti/index.php
     'Approva Prestito?' => __('Approva Prestito?'),

--- a/app/Views/partials/loan-actions-swal.php
+++ b/app/Views/partials/loan-actions-swal.php
@@ -19,8 +19,10 @@ $loanActionTranslations = array_merge([
     'confirmPickupText' => __('Questa azione conferma che l\'utente ha ritirato il libro.'),
     'pickupButton' => __('Conferma Ritiro'),
     'successPickupTitle' => __('Ritiro confermato!'),
-    'cancelPickupTitle' => __('Annullare il prestito scaduto?'),
-    'cancelPickupText' => __('Il termine per il ritiro è scaduto. Vuoi annullare questo prestito?'),
+    // Neutral wording: the cancel-pickup action now also serves a not-yet-expired
+    // pickup (#381), so the dialog must not assert the deadline has passed.
+    'cancelPickupTitle' => __('Annullare il ritiro?'),
+    'cancelPickupText' => __('La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?'),
     'cancelPickupButton' => __('Annulla Prestito'),
     'cancelPickupReason' => __('Ritiro non effettuato entro il termine previsto'),
     'successCancelPickupTitle' => __('Prestito annullato!'),

--- a/app/Views/user_dashboard/prenotazioni.php
+++ b/app/Views/user_dashboard/prenotazioni.php
@@ -686,8 +686,9 @@ function accountLineIcon(string $name): string {
                 <span><?= $hasReview ? __('Già recensito') : __('Lascia una recensione') ?></span>
               </button>
               <?php // Annullabile dall'utente solo finché il prestito non è partito:
-                    // 'prenotato' (attivo=1) qui, 'pendente' nella sezione richieste (M13). ?>
-              <?php if ($stato === 'prenotato'): ?>
+                    // 'prenotato' (attivo=1) e 'da_ritirare' (approvato, in attesa di
+                    // ritiro — #381) qui, 'pendente' nella sezione richieste (M13). ?>
+              <?php if (in_array($stato, ['prenotato', 'da_ritirare'], true)): ?>
               <form method="post" action="<?= htmlspecialchars(url('/loan/cancel'), ENT_QUOTES, 'UTF-8') ?>"
                     data-swal-confirm="<?= htmlspecialchars(__('Annullare questo prestito programmato?'), ENT_QUOTES, 'UTF-8') ?>"
                     data-swal-confirm-button="<?= htmlspecialchars(__('Annulla prestito'), ENT_QUOTES, 'UTF-8') ?>">

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -6971,5 +6971,11 @@
   "Revisore": "Revisor",
   "Salva espressione": "Gem udtryk",
   "Eliminare questa espressione?": "Slet dette udtryk?",
-  "Aggiungi espressione": "Tilføj udtryk"
+  "Aggiungi espressione": "Tilføj udtryk",
+  "Annulla Ritiro": "Annullér afhentning",
+  "Annullare il ritiro?": "Vil du annullere afhentningen?",
+  "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?": "Eksemplaret bliver tilgængeligt igen for andre brugere. Vil du annullere dette udlån?",
+  "Inserisci un URL immagine valido (https://).": "Indtast en gyldig billed-URL (https://).",
+  "Impossibile scaricare l'immagine dall'URL indicato.": "Billedet kunne ikke hentes fra den angivne URL.",
+  "Impossibile elaborare l'immagine.": "Billedet kunne ikke behandles."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -6971,5 +6971,11 @@
   "Revisore": "Bearbeiter",
   "Salva espressione": "Expression speichern",
   "Eliminare questa espressione?": "Diese Expression löschen?",
-  "Aggiungi espressione": "Expression hinzufügen"
+  "Aggiungi espressione": "Expression hinzufügen",
+  "Annulla Ritiro": "Abholung stornieren",
+  "Annullare il ritiro?": "Abholung stornieren?",
+  "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?": "Das Exemplar wird wieder für andere Benutzer verfügbar. Möchten Sie diese Ausleihe stornieren?",
+  "Inserisci un URL immagine valido (https://).": "Geben Sie eine gültige Bild-URL ein (https://).",
+  "Impossibile scaricare l'immagine dall'URL indicato.": "Das Bild konnte von der angegebenen URL nicht heruntergeladen werden.",
+  "Impossibile elaborare l'immagine.": "Das Bild konnte nicht verarbeitet werden."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -6971,5 +6971,11 @@
   "Revisore": "Reviser",
   "Salva espressione": "Save expression",
   "Eliminare questa espressione?": "Delete this expression?",
-  "Aggiungi espressione": "Add expression"
+  "Aggiungi espressione": "Add expression",
+  "Annulla Ritiro": "Cancel Pickup",
+  "Annullare il ritiro?": "Cancel the pickup?",
+  "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?": "The copy will become available again for other users. Do you want to cancel this loan?",
+  "Inserisci un URL immagine valido (https://).": "Enter a valid image URL (https://).",
+  "Impossibile scaricare l'immagine dall'URL indicato.": "Could not download the image from the given URL.",
+  "Impossibile elaborare l'immagine.": "Could not process the image."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -6971,5 +6971,11 @@
   "Revisore": "Réviseur",
   "Salva espressione": "Enregistrer l'expression",
   "Eliminare questa espressione?": "Supprimer cette expression ?",
-  "Aggiungi espressione": "Ajouter une expression"
+  "Aggiungi espressione": "Ajouter une expression",
+  "Annulla Ritiro": "Annuler la récupération",
+  "Annullare il ritiro?": "Annuler la récupération ?",
+  "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?": "L'exemplaire redeviendra disponible pour les autres utilisateurs. Voulez-vous annuler cet emprunt ?",
+  "Inserisci un URL immagine valido (https://).": "Saisissez une URL d'image valide (https://).",
+  "Impossibile scaricare l'immagine dall'URL indicato.": "Impossible de télécharger l'image depuis l'URL indiquée.",
+  "Impossibile elaborare l'immagine.": "Impossible de traiter l'image."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -6971,5 +6971,11 @@
   "Revisore": "Revisore",
   "Salva espressione": "Salva espressione",
   "Eliminare questa espressione?": "Eliminare questa espressione?",
-  "Aggiungi espressione": "Aggiungi espressione"
+  "Aggiungi espressione": "Aggiungi espressione",
+  "Annulla Ritiro": "Annulla Ritiro",
+  "Annullare il ritiro?": "Annullare il ritiro?",
+  "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?": "La copia tornerà disponibile per gli altri utenti. Vuoi annullare questo prestito?",
+  "Inserisci un URL immagine valido (https://).": "Inserisci un URL immagine valido (https://).",
+  "Impossibile scaricare l'immagine dall'URL indicato.": "Impossibile scaricare l'immagine dall'URL indicato.",
+  "Impossibile elaborare l'immagine.": "Impossibile elaborare l'immagine."
 }

--- a/tests/issue-163-author-photo.spec.js
+++ b/tests/issue-163-author-photo.spec.js
@@ -6,7 +6,9 @@
 //   - replacing a local photo drops the OLD file only AFTER the DB write (deferred
 //     cleanup), never leaving the row pointing at a deleted file;
 //   - a non-image masquerading as .png is REJECTED (photo unchanged, no orphan);
-//   - an external https URL is stored verbatim (preview must not url()-wrap it);
+//   - an external https URL is DOWNLOADED server-side and stored as a local
+//     /uploads/autori path (#382: the app CSP img-src blocks external hosts, so
+//     the raw URL is never kept verbatim — it is served same-origin);
 //   - the "remove" action clears the photo and deletes the local file;
 //   - posting an update for a non-existent author returns 404 (no masked redirect).
 const { test, expect } = require('@playwright/test');
@@ -118,21 +120,28 @@ test.describe('#163 — author photo lifecycle (CodeRabbit-hardened)', () => {
     expect(afterCount).toBe(beforeCount); // no orphan written
   });
 
-  test('4. external https URL is stored verbatim and the local file is dropped', async () => {
+  test('4. external https URL is downloaded to /uploads/autori and served same-origin (#382)', async () => {
     const localBefore = fotoOf(authorId);
     const localDisk = diskPathOf(localBefore);
-    const ext = 'https://upload.wikimedia.org/wikipedia/commons/a/a0/example.jpg';
+    // A real, stable public HTTPS image (reachable from CI, like the ISBN-scrape
+    // phase). The pasted URL must be downloaded server-side, not kept verbatim:
+    // the app CSP img-src does not allow-list external hosts, so a raw external
+    // <img src> would silently not render.
+    const ext = 'https://raw.githubusercontent.com/fabiodalez-dev/Pinakes/main/docs/catalog.png';
     await openEdit();
     await page.fill('#foto_url', ext);
     await saveEdit();
-    expect(fotoOf(authorId)).toBe(ext);
-    if (localBefore.startsWith('/uploads/autori/')) {
-      expect(fs.existsSync(localDisk)).toBe(false); // switching to URL removed the local file
+    const stored = fotoOf(authorId);
+    expect(stored.startsWith('/uploads/autori/')).toBe(true); // downloaded, not the raw URL
+    expect(stored).not.toBe(ext);
+    if (localBefore.startsWith('/uploads/autori/') && localBefore !== stored) {
+      expect(fs.existsSync(localDisk)).toBe(false); // the previous local file was dropped
     }
-    // preview must use the URL directly, not url()-wrapped
+    // preview must render the stored LOCAL path (same-origin), never the external URL
     await openEdit();
     const src = await page.locator('#author-photo-current img').getAttribute('src');
-    expect(src).toBe(ext);
+    expect(src).toContain('/uploads/autori/');
+    expect(src).not.toBe(ext);
   });
 
   test('5. "remove photo" clears the stored value', async () => {


### PR DESCRIPTION
Fixes #381 and #382.

## #381 — Cannot cancel a loan in "Waiting for Pickup"

After a librarian approves a request the copy enters `da_ritirare`, and from that point neither the patron nor the librarian could cancel it. Two independent guards excluded `da_ritirare`:

- **Patron** — `UserActionsController::cancelLoan()` allowed only `pendente`/`prenotato`, and the loans view only rendered the cancel form for `prenotato`. Widened both status guards to include `da_ritirare`, clear `pickup_deadline` on cancel, and include `da_ritirare` in the copy-release branch. A `da_ritirare` copy is held in `copie.stato='prenotato'`, so the existing guarded release + queue-promotion block runs unchanged and stays trigger-safe (`annullato` + `attivo=0` bypasses the overlap SIGNAL).
- **Librarian** — `cancelPickup` already accepted a non-expired `da_ritirare`; the admin pickup card only exposed a cancel button **after** the deadline expired. It now shows **Annulla Ritiro** next to **Conferma Ritiro** for a not-yet-expired pickup. The shared cancel-pickup dialog wording is neutralised (no longer asserts the deadline passed).

## #382 — Author photo pasted as a URL never displays

The external `<img src>` was blocked by the app's own CSP `img-src` allow-list (external hosts are not listed) — not CORS. `resolveAuthorPhoto()` now downloads a pasted URL server-side via `HttpClient` with `ssrf_guard` + `https_only` (host must resolve to a public IP, connection pinned, cross-host/scheme/port redirects rejected) and stores a local `/uploads/autori` path served same-origin (also fixes mixed-content and remote hotlink protection). A shared `storeAuthorPhotoBytes()` helper (size/format/pixel guards + GD re-encode) backs **both** the upload and the URL branch and accepts the same PNG/JPEG/WebP/GIF set. A failed/rejected download surfaces a flash error instead of saving a broken URL.

## i18n
Every new user-facing string added across all locales (it/en/de/da/fr); parity gate green.

## Verification (real UI, live dev server)
- #381 patron cancel of a `da_ritirare` loan → `annullato`, `pickup_deadline` cleared, copy freed.
- #381 admin cancel of a **non-expired** pickup → button now present, neutral dialog, copy freed.
- #381 **interference case** (multi-copy): an unrelated active loan and its copy stay untouched, a queued reservation is promoted onto the freed copy, book availability recalculated correctly.
- #382 author photo **upload** → stored under `/uploads/autori`.
- #382 author photo **by URL** → downloaded to `/uploads/autori`, renders with **no CSP violation** (the reported symptom).
- #382 **SSRF rejection** of a private-IP URL → rejected, not saved.

PHPStan level 5 clean; i18n parity green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuove funzionalità**
  - Le immagini degli autori inserite tramite URL vengono scaricate e salvate localmente con controlli di sicurezza e validazione.
  - È possibile annullare anche i prestiti pronti per il ritiro, liberando automaticamente la copia associata.
  - Per i prestiti pronti al ritiro sono disponibili sia la conferma sia l’annullamento.

- **Correzioni**
  - Migliorata la gestione degli errori durante caricamento, download e elaborazione delle immagini.
  - Aggiornata la finestra di conferma dell’annullamento con messaggi più neutrali.

- **Localizzazione**
  - Aggiunte e aggiornate le traduzioni per italiano, inglese, francese, tedesco e danese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->