### PR TITLE
fix(loans): approving a request that can't allocate a copy returns 400, not 500 (#384)

### DIFF
--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -538,7 +538,21 @@ class LoanApprovalController
             // non è assegnabile in approvazione (double-issue, vedi confirmPickup).
             $invalidStates = ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento', 'prestato'];
             if (!$copyResult || in_array($copyResult['stato'], $invalidStates, true)) {
-                throw new \RuntimeException(__('Copia non disponibile per il prestito'));
+                // #384: the copy-selection query legitimately hands back a copy
+                // that is physically out ('prestato') when it is assignable for a
+                // date-DISJOINT future window (future scheduling on a currently-out
+                // copy). Flipping such a copy to 'prenotato' now would corrupt the
+                // active loan still holding it, so this terminal check rejects it —
+                // but it must do so with a graceful 400 (the same canonical outcome
+                // as the capacity/overlap gates above), NOT an uncaught throw that
+                // surfaces as HTTP 500 "Internal error during approval". The request
+                // then degrades to pending_approval instead of erroring.
+                $db->rollback();
+                $response->getBody()->write(json_encode([
+                    'success' => false,
+                    'message' => __('Nessuna copia disponibile per il periodo richiesto')
+                ]));
+                return $response->withHeader('Content-Type', 'application/json')->withStatus(400);
             }
 
             $copyRepo = new \App\Models\CopyRepository($db);


### PR DESCRIPTION
Fixes #384 (most serious).

A single-copy book already on loan could have a loan request auto-approved, and approving it returned **HTTP 500** `{"success":false,"message":"Internal error during approval"}`.

## Root cause (adversarially verified + CI-confirmed)

For a date-**disjoint future window**, the copy-selection query (`getAvailableByBookIdForDateRange` / Step 2d) legitimately hands back the physical copy even though it is still out (`prestato`) today — this is the deliberate "schedule a future loan on a currently-out copy" behaviour, asserted by `loan-review-0764.unit.php` (B1/B5). But the terminal copy-state check in `approveLoan` lists `prestato` among the invalid states and rejected it with an **uncaught `RuntimeException`** → caught → 500.

## Fix (deliberately minimal)

Convert that terminal `throw` into the same **graceful 400** ("Nessuna copia disponibile per il periodo richiesto") the capacity/overlap gates already return. Flipping a still-out copy to `prenotato` would corrupt the active loan, so the rejection is correct — it just must not 500. The request then degrades to `pending_approval` instead of erroring, and the copy is left untouched.

> Earlier iterations also (a) excluded `prestato` from the copy-selection denylist and (b) rejected such requests at the request gate. Both were reverted: (a) broke the future-scheduling design (`loan-review-0764` B1/B5), and (b) broke the deliberate `pending_approval` degradation for legacy books with no `copie` rows (`loan-auto-approval-301`). The CI matrix caught both — the remaining single-line change is the safe, verified fix.

## Verification (real UI, live dev server)
- Reporter state (single copy `prestato` + active loan + future-window `pendente`): approval returns **400** (not 500), copy stays `prestato`, request stays `pendente`.
- **Regression:** a genuinely available book is still approved normally.

PHPStan level 5 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * Corretta la gestione delle approvazioni di prestito quando la copia selezionata non è prestabile.
  * Restituito un errore HTTP 400 con dettagli in formato JSON, anziché un errore interno HTTP 500.
  * La transazione viene annullata correttamente e la richiesta prosegue nel flusso di approvazione in sospeso.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->