### PR TITLE
perf(cache): single-backend QueryCache + O(1) generation invalidation + instrumentation (#387)

### DIFF
--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -15,15 +15,16 @@ final class ContentCache
     private static bool $booksInvalidationDeferred = false;
 
     /**
-     * A book (or its availability) changed: clear catalog counts/facets,
+     * A book (or its availability) changed: invalidate catalog counts/facets,
      * every home entry (home_page_data_v1 and home_api_count_*), and the
-     * cached genre tree.
+     * cached genre tree. O(1) generation bumps — previously cached entries in
+     * these namespaces become unreachable immediately, no scan/delete storm.
      */
     public static function booksChanged(): void
     {
-        QueryCache::clearByPrefix('catalog_');
-        QueryCache::clearByPrefix('home_');
-        QueryCache::clearByPrefix('genre_tree_');
+        QueryCache::bumpGeneration('catalog_');
+        QueryCache::bumpGeneration('home_');
+        QueryCache::bumpGeneration('genre_tree_');
     }
 
     /**
@@ -31,7 +32,7 @@ final class ContentCache
      * in an outer transaction cannot safely invalidate immediately: another
      * request could rebuild the cache from pre-commit rows. Shutdown runs after
      * the controller has committed (or rolled back), and duplicate calls from a
-     * batch collapse into a single prefix sweep.
+     * batch collapse into a single invalidation.
      */
     public static function deferBooksChanged(): void
     {
@@ -51,6 +52,6 @@ final class ContentCache
      */
     public static function homeContentChanged(): void
     {
-        QueryCache::clearByPrefix('home_');
+        QueryCache::bumpGeneration('home_');
     }
 }

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -581,6 +581,12 @@ class QueryCache
         if (self::hasApcu()) {
             $iterator = new \APCUIterator('/^pinakes_/');
             foreach ($iterator as $item) {
+                // Never remove a live mutex: deleting it while its owner is
+                // computing would allow a second worker to acquire a new
+                // lock for the same key. The sentinel expires on its own.
+                if (str_starts_with($item['key'], 'pinakes_lock_')) {
+                    continue;
+                }
                 if (!apcu_delete($item['key'])) {
                     $successApcu = false;
                 }
@@ -594,11 +600,27 @@ class QueryCache
             $files = glob($cacheDir . '/pinakes_*');
             if ($files !== false) {
                 foreach ($files as $file) {
+                    $basename = basename($file);
+                    // Generation writer locks must keep the same inode for
+                    // their entire lifetime. Counter files are superseded by
+                    // the generation bumps below, rather than deleted while
+                    // another process may be updating them.
+                    if (str_ends_with($basename, '.lock')
+                        || str_starts_with($basename, 'pinakes_gen_')) {
+                        continue;
+                    }
                     if (!@unlink($file)) {
                         $successFiles = false;
                     }
                 }
             }
+        }
+
+        // Publish a generation newer than every value visible before the
+        // flush. An in-flight loader may still finish afterwards, but it will
+        // write under its captured old generation and remain unreachable.
+        foreach (self::NAMESPACE_PREFIXES as $namespace) {
+            self::bumpGeneration($namespace);
         }
 
         return $successApcu && $successFiles;
@@ -735,10 +757,12 @@ class QueryCache
     {
         $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
 
-        $handle = @fopen($path . '.lock', 'c');
+        $lockPath = $path . '.lock';
+        $handle = @fopen($lockPath, 'c');
         if ($handle === false) {
             return null;
         }
+        @chmod($lockPath, 0660);
 
         try {
             if (!flock($handle, LOCK_EX)) {
@@ -1034,13 +1058,15 @@ class QueryCache
                 continue;
             }
 
+            $locked = false;
             try {
                 // Ordinary entries are written in place under an exclusive
                 // lock (file_put_contents LOCK_EX); GC must take that same
                 // exclusive lock or it could mistake an in-progress write for
                 // corruption. Generation counters are replaced atomically via
                 // temp + rename, so any inode opened here is always complete.
-                if (!flock($handle, LOCK_EX)) {
+                $locked = flock($handle, LOCK_EX | LOCK_NB);
+                if (!$locked) {
                     continue;
                 }
 
@@ -1063,7 +1089,9 @@ class QueryCache
                     $count++;
                 }
             } finally {
-                flock($handle, LOCK_UN);
+                if ($locked) {
+                    flock($handle, LOCK_UN);
+                }
                 fclose($handle);
             }
         }

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -67,6 +67,15 @@ class QueryCache
     /** Avoid checking the GC marker more than once in the same request. */
     private static bool $gcCheckedThisRequest = false;
 
+    /**
+     * Monotonic per-process sequence for generation temp filenames. Combined
+     * with getmypid() it yields a collision-free name without any time- or
+     * random-based component (two live processes never share a PID; a stale
+     * leftover from a crashed same-PID process is only ever overwritten while
+     * holding the namespace writer lock, so it is safe to reuse).
+     */
+    private static int $generationTmpSeq = 0;
+
     /** @var int Instrumentation: total get() calls this request */
     private static int $statGets = 0;
 
@@ -703,12 +712,30 @@ class QueryCache
     /**
      * Initialize or atomically increment a namespace generation.
      *
+     * Crash/IO safety: the counter file itself is NEVER truncated or written
+     * in place. The new payload goes to a temp file in the same directory
+     * (flushed + fsynced) and is then rename()d over the counter path —
+     * atomic on POSIX — so a failed write leaves the previous counter intact
+     * and a reader can never observe an empty/partial file. An in-place
+     * ftruncate+fwrite scheme could leave the file empty on a mid-write
+     * failure, making the next initializer fall back to time() — potentially
+     * LOWER than a counter that had climbed past wall-clock, which would make
+     * invalidated-but-TTL-live entries reachable again.
+     *
+     * Writer serialization: because rename() swaps the inode, an flock held
+     * on the counter file itself would not serialize concurrent writers (the
+     * second writer would lock the OLD inode). Writers therefore serialize on
+     * a dedicated sibling lock file (<counter>.lock) that is never unlinked
+     * (gc() skips it), held across the whole read-current → write-temp →
+     * rename sequence, so concurrent bumps cannot lose an increment.
+     *
      * @param bool $increment true for invalidation, false for initialize-if-missing
      */
     private static function mutateGenerationFile(string $ns, bool $increment): ?int
     {
         $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
-        $handle = @fopen($path, 'c+');
+
+        $handle = @fopen($path . '.lock', 'c');
         if ($handle === false) {
             return null;
         }
@@ -718,7 +745,7 @@ class QueryCache
                 return null;
             }
 
-            $current = self::generationFromHandle($handle);
+            $current = self::readGenerationFile($ns);
             if ($current !== null && !$increment) {
                 return $current;
             }
@@ -730,22 +757,53 @@ class QueryCache
                 'created' => time(),
             ]);
 
-            rewind($handle);
-            if (!ftruncate($handle, 0)) {
+            if (!self::replaceGenerationFile($path, $payload)) {
                 return null;
             }
-
-            $written = fwrite($handle, $payload);
-            if ($written === false || $written !== strlen($payload) || !fflush($handle)) {
-                return null;
-            }
-            @chmod($path, 0660);
 
             return $next;
         } finally {
             flock($handle, LOCK_UN);
             fclose($handle);
         }
+    }
+
+    /**
+     * Atomically replace the counter file with $payload via temp + rename.
+     * Must be called while holding the namespace writer lock. Returns false
+     * (leaving the previous counter untouched) on any failure.
+     */
+    private static function replaceGenerationFile(string $path, string $payload): bool
+    {
+        $tmpPath = $path . '.tmp.' . getmypid() . '.' . self::$generationTmpSeq++;
+
+        $tmp = @fopen($tmpPath, 'w');
+        if ($tmp === false) {
+            return false;
+        }
+
+        $written = fwrite($tmp, $payload);
+        $flushed = $written === strlen($payload) && fflush($tmp);
+        // Persist the payload before publishing the name: a rename made
+        // durable before its data could surface an empty file after a crash.
+        if ($flushed && function_exists('fsync')) {
+            $flushed = fsync($tmp);
+        }
+        fclose($tmp);
+
+        if (!$flushed) {
+            @unlink($tmpPath);
+            return false;
+        }
+
+        @chmod($tmpPath, 0660);
+
+        if (!@rename($tmpPath, $path)) {
+            @unlink($tmpPath);
+            return false;
+        }
+
+        return true;
     }
 
     /** Parse a generation payload from an already locked file handle. */
@@ -954,6 +1012,20 @@ class QueryCache
                 continue;
             }
 
+            // Generation temp files (counter payloads awaiting their atomic
+            // rename) are not cache entries: never parse them, and only
+            // remove residue left behind by a crashed writer once it is
+            // unambiguously stale.
+            if (str_contains(basename($file), '.tmp.')) {
+                $tmpMtime = @filemtime($file);
+                if ($tmpMtime !== false
+                    && $tmpMtime < $now - self::LOCK_STALE_SECONDS
+                    && @unlink($file)) {
+                    $count++;
+                }
+                continue;
+            }
+
             $handle = @fopen($file, 'r');
             if ($handle === false) {
                 if (@unlink($file)) {
@@ -963,9 +1035,11 @@ class QueryCache
             }
 
             try {
-                // Generation counters and ordinary entries are written under an
-                // exclusive lock. GC must take that same exclusive lock or it
-                // could mistake an in-progress truncate/write for corruption.
+                // Ordinary entries are written in place under an exclusive
+                // lock (file_put_contents LOCK_EX); GC must take that same
+                // exclusive lock or it could mistake an in-progress write for
+                // corruption. Generation counters are replaced atomically via
+                // temp + rename, so any inode opened here is always complete.
                 if (!flock($handle, LOCK_EX)) {
                     continue;
                 }
@@ -998,6 +1072,14 @@ class QueryCache
         if ($lockFiles !== false) {
             $staleTime = $now - self::LOCK_STALE_SECONDS;
             foreach ($lockFiles as $lockFile) {
+                // Generation writer locks are deliberately persistent: writers
+                // flock() the same never-recreated file to serialize bumps.
+                // Unlinking one here would let a new writer create a second
+                // lock inode at the same path and race the current holder.
+                if (str_starts_with(basename($lockFile), 'pinakes_gen_')) {
+                    continue;
+                }
+
                 $lockMtime = @filemtime($lockFile);
                 if ($lockMtime !== false && $lockMtime < $staleTime) {
                     if (@unlink($lockFile)) {

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -6,19 +6,61 @@ namespace App\Support;
 /**
  * QueryCache - Simple caching layer for expensive database queries
  *
- * Uses APCu for in-memory caching when available, falls back to file-based
- * caching in storage/cache directory. Designed for caching dashboard stats,
- * aggregations, and other expensive queries that don't need real-time data.
+ * Uses a SINGLE backend per request: APCu when available and enabled,
+ * otherwise file-based caching in storage/cache. Designed for caching
+ * dashboard stats, aggregations, and other expensive queries that don't
+ * need real-time data.
+ *
+ * Invalidation of the known content namespaces (catalog_, home_, ...) is
+ * O(1) via generation counters (namespace versioning): the effective storage
+ * key embeds the namespace's current generation, so bumping the generation
+ * makes every prior entry unreachable without scanning or deleting anything.
+ * Unreachable entries are reclaimed lazily by gc() / APCu TTL expiry.
  *
  * @package App\Support
  */
 class QueryCache
 {
+    /**
+     * Namespace prefixes eligible for O(1) generation-based invalidation.
+     * A logical key starting with one of these prefixes has its storage key
+     * derived from (key, current generation of the namespace).
+     *
+     * Keep in sync with ContentCache and the clearByPrefix() callers.
+     */
+    private const NAMESPACE_PREFIXES = [
+        'catalog_',
+        'home_',
+        'genre_tree_',
+        'plugins_maintenance_',
+        'schema_table_',
+    ];
+
+    /**
+     * TTL for generation counter entries (~1 year). Must outlive any data TTL:
+     * if a generation counter is ever lost, it is re-initialized to time(),
+     * which is monotonic w.r.t. every previously issued generation, so stale
+     * entries can never be resurrected.
+     */
+    private const GENERATION_TTL = 31536000;
+
+    /** Stale threshold (seconds) shared by the file lock and the APCu lock sentinel */
+    private const LOCK_STALE_SECONDS = 300;
+
     /** @var string Base directory for file cache */
     private static string $cacheDir = '';
 
-    /** @var bool|null Whether APCu is available (cached check) */
+    /** @var bool|null Whether APCu is available (cached check = deterministic backend per request) */
     private static ?bool $apcuAvailable = null;
+
+    /** @var int Instrumentation: total get() calls this request */
+    private static int $statGets = 0;
+
+    /** @var int Instrumentation: get() calls served from cache this request */
+    private static int $statHits = 0;
+
+    /** @var int Instrumentation: get() calls that missed this request */
+    private static int $statMisses = 0;
 
     /**
      * Get the cache directory path
@@ -38,7 +80,9 @@ class QueryCache
     }
 
     /**
-     * Check if APCu is available and enabled
+     * Check if APCu is available and enabled.
+     *
+     * Memoized: the backend choice is deterministic for the whole request.
      */
     private static function hasApcu(): bool
     {
@@ -50,10 +94,30 @@ class QueryCache
     }
 
     /**
+     * Per-request cache statistics (lightweight instrumentation, no persistence).
+     *
+     * @return array{backend: string, gets: int, hits: int, misses: int, hit_ratio: float}
+     */
+    public static function stats(): array
+    {
+        $gets = self::$statGets;
+
+        return [
+            'backend' => self::hasApcu() ? 'apcu' : 'file',
+            'gets' => $gets,
+            'hits' => self::$statHits,
+            'misses' => self::$statMisses,
+            'hit_ratio' => $gets > 0 ? round(self::$statHits / $gets, 4) : 0.0,
+        ];
+    }
+
+    /**
      * Get a value from cache or execute callback to generate it
      *
      * Uses mutex locking to prevent cache stampede (thundering herd problem).
-     * Only one process computes the value while others wait.
+     * Only one process computes the value while others wait. The mutex lives
+     * in the selected backend: an apcu_add() sentinel when APCu holds the
+     * values (no filesystem I/O on the APCu hot path), a .lock file otherwise.
      *
      * @param string $key Unique cache key
      * @param callable $callback Function to generate value if not cached
@@ -68,6 +132,101 @@ class QueryCache
             return $cached;
         }
 
+        if (self::hasApcu()) {
+            return self::rememberWithApcuLock($key, $callback, $ttl);
+        }
+
+        return self::rememberWithFileLock($key, $callback, $ttl);
+    }
+
+    /**
+     * remember() body for the APCu backend: stampede protection via an
+     * apcu_add() sentinel instead of a filesystem lock. Mirrors the file-lock
+     * timeout/stale/graceful-degradation semantics:
+     *  - the sentinel's own TTL replaces the stale-mtime check;
+     *  - same 8s bounded wait, then the FIX F008 final-attempt pass and
+     *    SecureLogger warning before proceeding unprotected.
+     */
+    private static function rememberWithApcuLock(string $key, callable $callback, int $ttl): mixed
+    {
+        // Lock identity is the logical key (not the generation-resolved storage
+        // key) so concurrent callers agree on the mutex even across a bump.
+        $lockKey = 'pinakes_lock_' . md5($key);
+
+        $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+        $timedOut = false;
+
+        try {
+            if (!$lockAcquired) {
+                $start = microtime(true);
+                $maxWaitSeconds = 8.0;
+                $sleepMicros = 200000;
+
+                while (true) {
+                    usleep($sleepMicros);
+
+                    $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+                    if ($lockAcquired) {
+                        break;
+                    }
+
+                    if ((microtime(true) - $start) >= $maxWaitSeconds) {
+                        $timedOut = true;
+                        break;
+                    }
+                }
+
+                $cached = self::get($key);
+                if ($cached !== null) {
+                    return $cached;
+                }
+
+                // FIX F008 (mirrored from the file-lock path): after a timeout,
+                // attempt a short bounded retry so at most one caller proceeds
+                // unprotected; surface the bypass via SecureLogger either way.
+                // ($timedOut === true implies the lock was never acquired.)
+                if ($timedOut) {
+                    $finalAttempts = 5;
+                    for ($i = 0; $i < $finalAttempts; $i++) {
+                        if (apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS)) {
+                            $lockAcquired = true;
+                            break;
+                        }
+                        usleep(100000); // 100ms between attempts → up to ~500ms extra wait
+                    }
+
+                    if (!$lockAcquired) {
+                        SecureLogger::warning(
+                            'QueryCache: proceeding without mutex after lock timeout (stampede protection bypassed)',
+                            [
+                                'key_prefix' => substr($key, 0, 80),
+                                'wait_seconds' => round(microtime(true) - $start, 3),
+                            ]
+                        );
+                    }
+                }
+            }
+
+            // Execute callback to get fresh value
+            $value = $callback();
+
+            // Store in cache
+            self::set($key, $value, $ttl);
+
+            return $value;
+        } finally {
+            if ($lockAcquired) {
+                apcu_delete($lockKey);
+            }
+        }
+    }
+
+    /**
+     * remember() body for the file backend: the original flock()-based
+     * stampede protection, unchanged.
+     */
+    private static function rememberWithFileLock(string $key, callable $callback, int $ttl): mixed
+    {
         // Acquire mutex lock to prevent stampede
         $lockKey = self::hashKey($key) . '.lock';
         $lockFile = self::getCacheDir() . '/' . $lockKey;
@@ -89,7 +248,7 @@ class QueryCache
             $timedOut = false;
             $start = microtime(true);
             $maxWaitSeconds = 8.0;
-            $staleThreshold = 300;
+            $staleThreshold = self::LOCK_STALE_SECONDS;
             $sleepMicros = 200000;
 
             // Check if lock file was already stale before we opened it
@@ -184,24 +343,21 @@ class QueryCache
      */
     public static function get(string $key): mixed
     {
-        $hashedKey = self::hashKey($key);
+        self::$statGets++;
 
-        // Try APCu first
-        if (self::hasApcu()) {
-            $success = false;
-            $value = apcu_fetch($hashedKey, $success);
-            if ($success) {
-                return $value;
-            }
-            // APCu miss - fall through to file cache
+        $value = self::backendGet(self::hashKey($key));
+
+        if ($value !== null) {
+            self::$statHits++;
+        } else {
+            self::$statMisses++;
         }
 
-        // Fallback to file cache
-        return self::getFromFile($hashedKey);
+        return $value;
     }
 
     /**
-     * Set a value in cache
+     * Set a value in cache (in the selected backend only — no dual-write)
      *
      * @param string $key Cache key
      * @param mixed $value Value to cache
@@ -210,14 +366,7 @@ class QueryCache
      */
     public static function set(string $key, mixed $value, int $ttl = 300): bool
     {
-        $hashedKey = self::hashKey($key);
-
-        // Also write to APCu if available
-        $apcuOk = !self::hasApcu() || apcu_store($hashedKey, $value, $ttl);
-
-        $success = self::setToFile($hashedKey, $value, $ttl) && $apcuOk;
-
-        return $success;
+        return self::backendSet(self::hashKey($key), $value, $ttl);
     }
 
     /**
@@ -229,23 +378,67 @@ class QueryCache
     public static function delete(string $key): bool
     {
         $hashedKey = self::hashKey($key);
-        $success = self::deleteFromFile($hashedKey);
 
-        // Also delete from APCu if available
         if (self::hasApcu()) {
-            $success = apcu_delete($hashedKey) && $success;
+            return apcu_delete($hashedKey);
         }
 
-        return $success;
+        return self::deleteFromFile($hashedKey);
+    }
+
+    /**
+     * Bump the generation counter of a known namespace: O(1) invalidation of
+     * every entry whose key starts with that prefix (they become unreachable,
+     * no scan, no delete storm). Unknown prefixes fall back to the legacy scan
+     * so semantics stay correct for arbitrary callers.
+     *
+     * @param string $namespace Namespace prefix, with or without trailing '_'
+     *                          (e.g. 'catalog' or 'catalog_')
+     */
+    public static function bumpGeneration(string $namespace): void
+    {
+        $ns = str_ends_with($namespace, '_') ? $namespace : $namespace . '_';
+
+        if (!in_array($ns, self::NAMESPACE_PREFIXES, true)) {
+            // Not generation-tracked: only a scan can invalidate it correctly.
+            self::legacyClearByPrefix($ns);
+            return;
+        }
+
+        $genKey = self::generationStorageKey($ns);
+        $current = self::backendGet($genKey);
+        // max(current+1, time()): monotonic even if the counter was ever lost
+        // and re-initialized (init value is time(), see currentGeneration()).
+        $next = is_int($current) ? max($current + 1, time()) : time();
+        self::backendSet($genKey, $next, self::GENERATION_TTL);
     }
 
     /**
      * Clear all cache entries with a given prefix
      *
+     * For the known content namespaces this is an O(1) generation bump (the
+     * return value is 0 because nothing is enumerated — no caller consumes
+     * the count). Arbitrary prefixes keep the original scan behavior.
+     *
      * @param string $prefix Key prefix to match (e.g., 'dashboard_')
-     * @return int Number of entries cleared
+     * @return int Number of entries physically removed (0 for generation bumps)
      */
     public static function clearByPrefix(string $prefix): int
+    {
+        if (in_array($prefix, self::NAMESPACE_PREFIXES, true)) {
+            self::bumpGeneration($prefix);
+            return 0;
+        }
+
+        return self::legacyClearByPrefix($prefix);
+    }
+
+    /**
+     * Original O(n) prefix scan (APCUIterator + glob). Kept as fallback for
+     * prefixes outside the generation-tracked namespaces; scans BOTH stores so
+     * pre-upgrade leftovers from the old dual-write scheme are reclaimed too.
+     */
+    private static function legacyClearByPrefix(string $prefix): int
     {
         $hashedPrefix = 'pinakes_' . $prefix;
         $count = 0;
@@ -286,6 +479,8 @@ class QueryCache
      *
      * Only clears entries with the 'pinakes_' prefix to avoid clearing
      * other applications' cache entries that may share the same APCu instance.
+     * Intentionally clears BOTH stores (maintenance operation): prevents
+     * resurrection of pre-upgrade dual-written entries if the backend flips.
      *
      * @return bool Success status
      */
@@ -322,13 +517,96 @@ class QueryCache
     }
 
     /**
+     * Read a raw hashed key from the selected backend (no stats, no
+     * generation resolution — internal primitive).
+     */
+    private static function backendGet(string $hashedKey): mixed
+    {
+        if (self::hasApcu()) {
+            $success = false;
+            $value = apcu_fetch($hashedKey, $success);
+
+            return $success ? $value : null;
+        }
+
+        return self::getFromFile($hashedKey);
+    }
+
+    /**
+     * Write a raw hashed key to the selected backend (internal primitive).
+     */
+    private static function backendSet(string $hashedKey, mixed $value, int $ttl): bool
+    {
+        if (self::hasApcu()) {
+            return apcu_store($hashedKey, $value, $ttl);
+        }
+
+        return self::setToFile($hashedKey, $value, $ttl);
+    }
+
+    /**
+     * Namespace prefix of a logical key, or null if not generation-tracked.
+     */
+    private static function namespaceFor(string $key): ?string
+    {
+        foreach (self::NAMESPACE_PREFIXES as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                return $prefix;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Storage key of a namespace's generation counter. Deliberately outside
+     * every namespace prefix so it never resolves through itself.
+     */
+    private static function generationStorageKey(string $ns): string
+    {
+        $safe = preg_replace('/[^A-Za-z0-9_\-]/', '_', $ns);
+
+        return 'pinakes_gen_' . $safe . md5('__gen__' . $ns);
+    }
+
+    /**
+     * Current generation of a namespace. Missing counters are initialized to
+     * time(): monotonic w.r.t. every generation ever issued before, so a lost
+     * counter can never make previously invalidated entries reachable again.
+     */
+    private static function currentGeneration(string $ns): int
+    {
+        $genKey = self::generationStorageKey($ns);
+        $value = self::backendGet($genKey);
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $gen = time();
+        self::backendSet($genKey, $gen, self::GENERATION_TTL);
+
+        return $gen;
+    }
+
+    /**
      * Hash a cache key for storage
+     *
+     * The human-readable sanitized prefix is preserved (filesystem safety +
+     * the legacy prefix scan keeps matching); the hash suffix embeds the
+     * namespace generation for generation-tracked keys.
      */
     private static function hashKey(string $key): string
     {
         // Sanitize prefix for filesystem safety + append hash for uniqueness
         $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($key, 0, 80));
-        return 'pinakes_' . $prefix . '_' . md5($key);
+
+        $hashInput = $key;
+        $ns = self::namespaceFor($key);
+        if ($ns !== null) {
+            $hashInput .= '|gen:' . self::currentGeneration($ns);
+        }
+
+        return 'pinakes_' . $prefix . '_' . md5($hashInput);
     }
 
     /**
@@ -466,7 +744,7 @@ class QueryCache
 
         $lockFiles = glob($cacheDir . '/*.lock');
         if ($lockFiles !== false) {
-            $staleTime = $now - 300;
+            $staleTime = $now - self::LOCK_STALE_SECONDS;
             foreach ($lockFiles as $lockFile) {
                 $lockMtime = @filemtime($lockFile);
                 if ($lockMtime !== false && $lockMtime < $staleTime) {

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -37,21 +37,35 @@ class QueryCache
     ];
 
     /**
-     * TTL for generation counter entries (~1 year). Must outlive any data TTL:
-     * if a generation counter is ever lost, it is re-initialized to time(),
-     * which is monotonic w.r.t. every previously issued generation, so stale
-     * entries can never be resurrected.
+     * TTL for generation counter entries (~1 year). It intentionally outlives
+     * every data TTL, so all entries that referenced an expired counter are
+     * already expired before the counter can be initialized again.
      */
     private const GENERATION_TTL = 31536000;
 
     /** Stale threshold (seconds) shared by the file lock and the APCu lock sentinel */
     private const LOCK_STALE_SECONDS = 300;
 
+    /** Run file-cache garbage collection at most once per hour. */
+    private const GC_INTERVAL_SECONDS = 3600;
+
     /** @var string Base directory for file cache */
     private static string $cacheDir = '';
 
     /** @var bool|null Whether APCu is available (cached check = deterministic backend per request) */
     private static ?bool $apcuAvailable = null;
+
+    /**
+     * Request-local namespace generations. The canonical counters live on
+     * disk so FPM/APCu and CLI/file users observe the same invalidations; the
+     * memo avoids an extra filesystem read for every cache operation.
+     *
+     * @var array<string, int>
+     */
+    private static array $generationCache = [];
+
+    /** Avoid checking the GC marker more than once in the same request. */
+    private static bool $gcCheckedThisRequest = false;
 
     /** @var int Instrumentation: total get() calls this request */
     private static int $statGets = 0;
@@ -117,7 +131,9 @@ class QueryCache
      * Uses mutex locking to prevent cache stampede (thundering herd problem).
      * Only one process computes the value while others wait. The mutex lives
      * in the selected backend: an apcu_add() sentinel when APCu holds the
-     * values (no filesystem I/O on the APCu hot path), a .lock file otherwise.
+     * values, a .lock file otherwise. Generation-tracked keys read their small
+     * canonical generation file once per namespace/request so CLI and FPM stay
+     * coherent even when APCu is disabled for CLI.
      *
      * @param string $key Unique cache key
      * @param callable $callback Function to generate value if not cached
@@ -126,17 +142,26 @@ class QueryCache
      */
     public static function remember(string $key, callable $callback, int $ttl = 300): mixed
     {
-        // Try to get from cache first
-        $cached = self::get($key);
+        // Resolve the generation exactly once. If an invalidation happens while
+        // the callback is running, the result is written under this old storage
+        // key and therefore stays unreachable from the new generation.
+        $hashedKey = self::hashKey($key);
+
+        // This is the one logical lookup represented in stats(). Mutex
+        // double-checks below deliberately use backendGet() without counters.
+        self::$statGets++;
+        $cached = self::backendGet($hashedKey);
         if ($cached !== null) {
+            self::$statHits++;
             return $cached;
         }
+        self::$statMisses++;
 
         if (self::hasApcu()) {
-            return self::rememberWithApcuLock($key, $callback, $ttl);
+            return self::rememberWithApcuLock($key, $hashedKey, $callback, $ttl);
         }
 
-        return self::rememberWithFileLock($key, $callback, $ttl);
+        return self::rememberWithFileLock($key, $hashedKey, $callback, $ttl);
     }
 
     /**
@@ -147,25 +172,31 @@ class QueryCache
      *  - same 8s bounded wait, then the FIX F008 final-attempt pass and
      *    SecureLogger warning before proceeding unprotected.
      */
-    private static function rememberWithApcuLock(string $key, callable $callback, int $ttl): mixed
+    private static function rememberWithApcuLock(
+        string $key,
+        string $hashedKey,
+        callable $callback,
+        int $ttl
+    ): mixed
     {
-        // Lock identity is the logical key (not the generation-resolved storage
-        // key) so concurrent callers agree on the mutex even across a bump.
-        $lockKey = 'pinakes_lock_' . md5($key);
+        // The lock follows the resolved generation. A request for a new
+        // generation must not wait for (or consume) an old-generation loader.
+        $lockKey = 'pinakes_lock_' . md5($hashedKey);
+        $lockToken = random_int(1, PHP_INT_MAX);
 
-        $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+        $lockAcquired = apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS);
         $timedOut = false;
+        $start = microtime(true);
 
         try {
             if (!$lockAcquired) {
-                $start = microtime(true);
                 $maxWaitSeconds = 8.0;
                 $sleepMicros = 200000;
 
                 while (true) {
                     usleep($sleepMicros);
 
-                    $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+                    $lockAcquired = apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS);
                     if ($lockAcquired) {
                         break;
                     }
@@ -176,7 +207,7 @@ class QueryCache
                     }
                 }
 
-                $cached = self::get($key);
+                $cached = self::backendGet($hashedKey);
                 if ($cached !== null) {
                     return $cached;
                 }
@@ -188,7 +219,7 @@ class QueryCache
                 if ($timedOut) {
                     $finalAttempts = 5;
                     for ($i = 0; $i < $finalAttempts; $i++) {
-                        if (apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS)) {
+                        if (apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS)) {
                             $lockAcquired = true;
                             break;
                         }
@@ -207,17 +238,48 @@ class QueryCache
                 }
             }
 
+            // Always double-check after acquiring the sentinel. Another worker
+            // may have populated the value between our first miss and apcu_add(),
+            // or immediately before a final retry acquired the released lock.
+            if ($lockAcquired) {
+                $cached = self::backendGet($hashedKey);
+                if ($cached !== null) {
+                    return $cached;
+                }
+            }
+
             // Execute callback to get fresh value
             $value = $callback();
 
-            // Store in cache
-            self::set($key, $value, $ttl);
+            // Store under the generation resolved before the callback.
+            self::backendSet($hashedKey, $value, $ttl);
 
             return $value;
         } finally {
             if ($lockAcquired) {
+                self::releaseApcuLock($lockKey, $lockToken);
+            }
+        }
+    }
+
+    /** Release an APCu sentinel only when it is still owned by this caller. */
+    private static function releaseApcuLock(string $lockKey, int $lockToken): void
+    {
+        if (function_exists('apcu_cas')) {
+            // CAS keeps an expired/reacquired successor lock from being deleted
+            // by the previous owner. The temporary zero remains locked until
+            // this caller deletes it immediately below.
+            if (apcu_cas($lockKey, $lockToken, 0)) {
                 apcu_delete($lockKey);
             }
+            return;
+        }
+
+        // Compatibility fallback for unusual APCu builds without apcu_cas().
+        $success = false;
+        $current = apcu_fetch($lockKey, $success);
+        if ($success && $current === $lockToken) {
+            apcu_delete($lockKey);
         }
     }
 
@@ -225,10 +287,15 @@ class QueryCache
      * remember() body for the file backend: the original flock()-based
      * stampede protection, unchanged.
      */
-    private static function rememberWithFileLock(string $key, callable $callback, int $ttl): mixed
+    private static function rememberWithFileLock(
+        string $key,
+        string $hashedKey,
+        callable $callback,
+        int $ttl
+    ): mixed
     {
         // Acquire mutex lock to prevent stampede
-        $lockKey = self::hashKey($key) . '.lock';
+        $lockKey = $hashedKey . '.lock';
         $lockFile = self::getCacheDir() . '/' . $lockKey;
 
         // Check lock file mtime BEFORE fopen (fopen 'c' mode can update mtime)
@@ -278,7 +345,7 @@ class QueryCache
                 usleep($sleepMicros);
             }
 
-            $cached = self::get($key);
+            $cached = self::backendGet($hashedKey);
             if ($cached !== null) {
                 return $cached;
             }
@@ -319,8 +386,8 @@ class QueryCache
             // Execute callback to get fresh value
             $value = $callback();
 
-            // Store in cache
-            self::set($key, $value, $ttl);
+            // Store under the generation resolved before the callback.
+            self::backendSet($hashedKey, $value, $ttl);
 
             return $value;
         } finally {
@@ -378,12 +445,17 @@ class QueryCache
     public static function delete(string $key): bool
     {
         $hashedKey = self::hashKey($key);
+        $successFiles = self::deleteFromFile($hashedKey);
+        $successApcu = true;
 
+        // Invalidation intentionally reaches both stores when this SAPI can
+        // access APCu. This preserves web/FPM -> CLI/file coherence while data
+        // writes themselves remain single-backend.
         if (self::hasApcu()) {
-            return apcu_delete($hashedKey);
+            $successApcu = apcu_delete($hashedKey) || !apcu_exists($hashedKey);
         }
 
-        return self::deleteFromFile($hashedKey);
+        return $successFiles && $successApcu;
     }
 
     /**
@@ -405,12 +477,19 @@ class QueryCache
             return;
         }
 
-        $genKey = self::generationStorageKey($ns);
-        $current = self::backendGet($genKey);
-        // max(current+1, time()): monotonic even if the counter was ever lost
-        // and re-initialized (init value is time(), see currentGeneration()).
-        $next = is_int($current) ? max($current + 1, time()) : time();
-        self::backendSet($genKey, $next, self::GENERATION_TTL);
+        $next = self::mutateGenerationFile($ns, true);
+        if ($next === null) {
+            // If the canonical counter cannot be persisted, fall back to the
+            // physical invalidation used before namespace generations. Keep a
+            // request-local unique generation as an additional safety net so
+            // this process cannot reuse the old key after the invalidation.
+            self::legacyClearByPrefix($ns);
+            self::$generationCache[$ns] = -random_int(1, PHP_INT_MAX);
+            return;
+        }
+
+        self::$generationCache[$ns] = $next;
+        self::maybeGc();
     }
 
     /**
@@ -558,10 +637,7 @@ class QueryCache
         return null;
     }
 
-    /**
-     * Storage key of a namespace's generation counter. Deliberately outside
-     * every namespace prefix so it never resolves through itself.
-     */
+    /** Storage filename of a namespace's canonical generation counter. */
     private static function generationStorageKey(string $ns): string
     {
         $safe = preg_replace('/[^A-Za-z0-9_\-]/', '_', $ns);
@@ -570,22 +646,126 @@ class QueryCache
     }
 
     /**
-     * Current generation of a namespace. Missing counters are initialized to
-     * time(): monotonic w.r.t. every generation ever issued before, so a lost
-     * counter can never make previously invalidated entries reachable again.
+     * Current generation of a namespace.
+     *
+     * The canonical counter is deliberately file-backed even when APCu is the
+     * selected data backend. PHP-FPM and CLI commonly disagree on APCu
+     * availability (apc.enable_cli is normally off); one shared file keeps
+     * invalidation coherent across those SAPIs. The value is memoized for the
+     * remainder of this request, so each namespace costs at most one file read.
      */
     private static function currentGeneration(string $ns): int
     {
-        $genKey = self::generationStorageKey($ns);
-        $value = self::backendGet($genKey);
-        if (is_int($value)) {
-            return $value;
+        if (isset(self::$generationCache[$ns])) {
+            return self::$generationCache[$ns];
         }
 
-        $gen = time();
-        self::backendSet($genKey, $gen, self::GENERATION_TTL);
+        $gen = self::readGenerationFile($ns);
+        if ($gen === null) {
+            // Initialize under an exclusive lock. A concurrent initializer may
+            // win; mutateGenerationFile(false) then returns its value unchanged.
+            $gen = self::mutateGenerationFile($ns, false);
+        }
+
+        if ($gen === null) {
+            // Graceful degradation when the cache directory is unavailable:
+            // a process-unique negative generation prevents stale cross-request
+            // reuse while still allowing repeat lookups within this request.
+            $gen = -random_int(1, PHP_INT_MAX);
+        }
+
+        self::$generationCache[$ns] = $gen;
 
         return $gen;
+    }
+
+    /** Read a valid generation file under a shared lock. */
+    private static function readGenerationFile(string $ns): ?int
+    {
+        $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
+        $handle = @fopen($path, 'r');
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            if (!flock($handle, LOCK_SH)) {
+                return null;
+            }
+
+            return self::generationFromHandle($handle);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /**
+     * Initialize or atomically increment a namespace generation.
+     *
+     * @param bool $increment true for invalidation, false for initialize-if-missing
+     */
+    private static function mutateGenerationFile(string $ns, bool $increment): ?int
+    {
+        $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
+        $handle = @fopen($path, 'c+');
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                return null;
+            }
+
+            $current = self::generationFromHandle($handle);
+            if ($current !== null && !$increment) {
+                return $current;
+            }
+
+            $next = $current !== null ? max($current + 1, time()) : time();
+            $payload = serialize([
+                'value' => $next,
+                'expires' => time() + self::GENERATION_TTL,
+                'created' => time(),
+            ]);
+
+            rewind($handle);
+            if (!ftruncate($handle, 0)) {
+                return null;
+            }
+
+            $written = fwrite($handle, $payload);
+            if ($written === false || $written !== strlen($payload) || !fflush($handle)) {
+                return null;
+            }
+            @chmod($path, 0660);
+
+            return $next;
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /** Parse a generation payload from an already locked file handle. */
+    private static function generationFromHandle($handle): ?int
+    {
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        if ($content === false || $content === '') {
+            return null;
+        }
+
+        $data = @unserialize($content, ['allowed_classes' => false]);
+        if (!is_array($data)
+            || !isset($data['expires'], $data['value'])
+            || (int) $data['expires'] < time()
+            || !is_int($data['value'])) {
+            return null;
+        }
+
+        return $data['value'];
     }
 
     /**
@@ -678,9 +858,59 @@ class QueryCache
         $result = @file_put_contents($path, serialize($data), LOCK_EX);
         if ($result !== false) {
             @chmod($path, 0660);
+            self::maybeGc();
         }
 
         return $result !== false;
+    }
+
+    /**
+     * Run file-cache GC at most once per configured interval and never make a
+     * request wait behind another collector. Generation invalidation leaves
+     * old filenames unreachable, so TTL alone is insufficient: without this
+     * scheduled sweep those files would remain on disk forever.
+     */
+    private static function maybeGc(): void
+    {
+        if (self::$gcCheckedThisRequest) {
+            return;
+        }
+        self::$gcCheckedThisRequest = true;
+
+        $cacheDir = self::getCacheDir();
+        $marker = $cacheDir . '/.pinakes_gc';
+        clearstatcache(true, $marker);
+        $lastRun = @filemtime($marker);
+        if ($lastRun !== false && $lastRun >= time() - self::GC_INTERVAL_SECONDS) {
+            return;
+        }
+
+        $lockPath = $cacheDir . '/.pinakes_gc.lock';
+        $lock = @fopen($lockPath, 'c');
+        if ($lock === false) {
+            return;
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return;
+            }
+
+            // Recheck after acquiring the lock: another process may have run
+            // GC between the optimistic marker check and flock().
+            clearstatcache(true, $marker);
+            $lastRun = @filemtime($marker);
+            if ($lastRun !== false && $lastRun >= time() - self::GC_INTERVAL_SECONDS) {
+                return;
+            }
+
+            // Mark before scanning so a fatal error cannot trigger a GC storm.
+            @touch($marker);
+            self::gc();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
     }
 
     /**
@@ -724,21 +954,43 @@ class QueryCache
                 continue;
             }
 
-            $content = @file_get_contents($file);
-            if ($content === false) {
+            $handle = @fopen($file, 'r');
+            if ($handle === false) {
                 if (@unlink($file)) {
                     $count++;
                 }
                 continue;
             }
 
-            // Use safe unserialize to prevent object injection attacks
-            $data = @unserialize($content, ['allowed_classes' => false]);
-            // Delete if: not an array, missing 'expires' key (corrupted), or expired
-            if (!is_array($data) || !isset($data['expires']) || $data['expires'] < $now) {
-                if (@unlink($file)) {
+            try {
+                // Generation counters and ordinary entries are written under an
+                // exclusive lock. GC must take that same exclusive lock or it
+                // could mistake an in-progress truncate/write for corruption.
+                if (!flock($handle, LOCK_EX)) {
+                    continue;
+                }
+
+                $content = stream_get_contents($handle);
+                $delete = false;
+                if ($content === false) {
+                    $delete = true;
+                } else {
+                    // Use safe unserialize to prevent object injection attacks.
+                    $data = @unserialize($content, ['allowed_classes' => false]);
+                    $delete = !is_array($data)
+                        || !isset($data['expires'])
+                        || $data['expires'] < $now;
+                }
+
+                // Unlink while the inode is still exclusively locked. Waiting
+                // until after unlock would let a concurrent writer refresh the
+                // same path between our expiry check and unlink().
+                if ($delete && @unlink($file)) {
                     $count++;
                 }
+            } finally {
+                flock($handle, LOCK_UN);
+                fclose($handle);
             }
         }
 

--- a/php.ini.recommended
+++ b/php.ini.recommended
@@ -30,10 +30,13 @@ opcache.revalidate_freq=2
 ; pipeline guarantees that invalidation.
 opcache.validate_timestamps=1
 
-; JIT: intentionally NOT enabled here. It is off by default (opcache.jit_buffer_size=0)
-; and Pinakes is DB/IO-bound — JIT compiles CPU-bound loops, so it yields
-; ~nothing for this workload while adding memory overhead and (historically)
-; edge-case bugs.
+; JIT: intentionally DISABLED. Pinakes is DB/IO-bound — JIT compiles CPU-bound
+; loops, so it yields ~nothing for this workload while adding memory overhead
+; and (historically) edge-case bugs. Set BOTH directives explicitly: opcache.jit
+; alone is not enough because opcache.jit_buffer_size defaults to a non-zero value
+; on some builds (notably PHP 8.4+), which would still reserve JIT memory.
+opcache.jit=disable
+opcache.jit_buffer_size=0
 
 ; ===================================
 ; MEMORY & PERFORMANCE

--- a/php.ini.recommended
+++ b/php.ini.recommended
@@ -11,15 +11,29 @@
 
 opcache.enable=1
 opcache.enable_cli=0
+; 128 MB / 10000 files is enough for a stock Pinakes install. Raise to
+; 256 / 20000 ONLY if opcache_get_status() shows saturation (memory_usage
+; near full, num_cached_keys close to max_cached_keys, or oom_restarts > 0)
+; — not a priori: oversizing just wastes shared memory.
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=16
 opcache.max_accelerated_files=10000
 opcache.revalidate_freq=2
-opcache.fast_shutdown=1
+; NOTE: opcache.fast_shutdown was removed here on purpose — it has been a
+; no-op since PHP 7.2 (the fast shutdown sequence is always used).
 
-; In production, set to 0 for maximum performance
-; In development, set to 1 to see changes immediately
+; Keep validate_timestamps=1. Setting it to 0 gives a marginal stat() saving
+; but then EVERY code path that mutates PHP files (the in-app updater,
+; plugin install/upgrade, manual deploys) must explicitly invalidate OPcache
+; (opcache_reset()/opcache_invalidate() or an FPM reload) or the server keeps
+; executing the OLD code indefinitely. Do not set it to 0 unless your deploy
+; pipeline guarantees that invalidation.
 opcache.validate_timestamps=1
+
+; JIT: intentionally NOT enabled here. It is off by default (opcache.jit_buffer_size=0)
+; and Pinakes is DB/IO-bound — JIT compiles CPU-bound loops, so it yields
+; ~nothing for this workload while adding memory overhead and (historically)
+; edge-case bugs.
 
 ; ===================================
 ; MEMORY & PERFORMANCE

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -46,8 +46,12 @@ $checkCacheNamespace = static function (
         $keys !== [] && count(array_filter($keys, static fn(string $key): bool => str_starts_with($key, $namespace))) === count($keys),
         "{$label} keys use the {$namespace} namespace"
     );
+    // Either invalidation form targets the namespace: the legacy prefix scan
+    // or the O(1) generation bump (issue #387) — both make every prior entry
+    // in the namespace unservable.
     $check(
-        str_contains($invalidator, "QueryCache::clearByPrefix('{$namespace}')"),
+        str_contains($invalidator, "QueryCache::clearByPrefix('{$namespace}')")
+            || str_contains($invalidator, "QueryCache::bumpGeneration('{$namespace}')"),
         "{$label} invalidator clears the {$namespace} namespace"
     );
 };

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -178,6 +178,23 @@ foreach (array_keys($cacheKeys) as $key) {
 \App\Support\QueryCache::delete($boundedKey);
 \App\Support\QueryCache::delete('catalog_' . $runKey . '_unbounded');
 \App\Support\QueryCache::delete('i18n_languages');
+
+// Generation bumps make old entries unreachable, so delete() can only remove
+// the current generation. Reclaim every fixture from this run explicitly in
+// both possible stores without flushing unrelated application/test entries.
+if (\App\Support\QueryCache::stats()['backend'] === 'apcu' && class_exists('APCUIterator')) {
+    $runPattern = '/^pinakes_.*' . preg_quote($runKey, '/') . '/';
+    foreach (new APCUIterator($runPattern) as $entry) {
+        apcu_delete($entry['key']);
+    }
+}
+$leftovers = glob(__DIR__ . '/../storage/cache/pinakes_*' . $runKey . '*');
+if ($leftovers !== false) {
+    foreach ($leftovers as $leftover) {
+        @unlink($leftover);
+    }
+}
+
 $i18nReflection->getProperty('languagesCache')->setValue(null, null);
 $i18nReflection->getProperty('languagesLoadedFromDb')->setValue(null, false);
 

--- a/tests/querycache-apcu-backend.unit.php
+++ b/tests/querycache-apcu-backend.unit.php
@@ -177,6 +177,15 @@ try {
             @unlink($file);
         }
     }
+
+    // delete() only targets the current generation. Remove older-generation
+    // fixtures too, so a native APCu run does not leak entries until TTL.
+    if (class_exists('APCUIterator')) {
+        $iterator = new APCUIterator('/^pinakes_.*' . preg_quote($run, '/') . '/');
+        foreach ($iterator as $entry) {
+            apcu_delete($entry['key']);
+        }
+    }
 }
 
 echo "\n{$pass} checks passed\n";

--- a/tests/querycache-apcu-backend.unit.php
+++ b/tests/querycache-apcu-backend.unit.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * APCu-path contract for QueryCache.
+ *
+ * When the extension is absent (the common CI image), a small in-process APCu
+ * double exercises the same public function contract. When APCu is installed
+ * but disabled for CLI, the test re-executes itself with apc.enable_cli=1.
+ */
+
+if (function_exists('apcu_fetch') && !apcu_enabled() && getenv('QC_APCU_CHILD') !== '1') {
+    $command = escapeshellarg(PHP_BINARY)
+        . ' -d apc.enable_cli=1 '
+        . escapeshellarg(__FILE__);
+    putenv('QC_APCU_CHILD=1');
+    passthru($command, $exitCode);
+    exit($exitCode);
+}
+
+if (!function_exists('apcu_fetch')) {
+    /** @var array<string, array{value: mixed, expires: int}> */
+    $GLOBALS['querycache_apcu_stub'] = [];
+
+    function apcu_enabled(): bool
+    {
+        return true;
+    }
+
+    function apcu_fetch(string $key, ?bool &$success = null): mixed
+    {
+        $entry = $GLOBALS['querycache_apcu_stub'][$key] ?? null;
+        if (!is_array($entry) || ($entry['expires'] !== 0 && $entry['expires'] < time())) {
+            unset($GLOBALS['querycache_apcu_stub'][$key]);
+            $success = false;
+            return false;
+        }
+
+        $success = true;
+        return $entry['value'];
+    }
+
+    function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+    {
+        $GLOBALS['querycache_apcu_stub'][$key] = [
+            'value' => $value,
+            'expires' => $ttl > 0 ? time() + $ttl : 0,
+        ];
+        return true;
+    }
+
+    function apcu_add(string $key, mixed $value, int $ttl = 0): bool
+    {
+        $success = false;
+        apcu_fetch($key, $success);
+        if ($success) {
+            return false;
+        }
+
+        return apcu_store($key, $value, $ttl);
+    }
+
+    function apcu_delete(string $key): bool
+    {
+        $exists = array_key_exists($key, $GLOBALS['querycache_apcu_stub']);
+        unset($GLOBALS['querycache_apcu_stub'][$key]);
+        return $exists;
+    }
+
+    function apcu_exists(string $key): bool
+    {
+        $success = false;
+        apcu_fetch($key, $success);
+        return $success;
+    }
+
+    function apcu_cas(string $key, int $old, int $new): bool
+    {
+        $success = false;
+        $current = apcu_fetch($key, $success);
+        if (!$success || $current !== $old) {
+            return false;
+        }
+
+        return apcu_store($key, $new, 300);
+    }
+}
+
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$pass = 0;
+$check = static function (bool $ok, string $label) use (&$pass): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $pass++;
+    echo "  OK  {$label}\n";
+};
+
+$run = bin2hex(random_bytes(4));
+$cacheDir = $root . '/storage/cache';
+$createdKeys = [];
+
+try {
+    $check(QueryCache::stats()['backend'] === 'apcu', '01 APCu backend is selected');
+
+    $key = "qc_apcu_roundtrip_{$run}";
+    $createdKeys[] = $key;
+    $check(QueryCache::set($key, 'value', 60), '02 APCu set succeeds');
+    $check(QueryCache::get($key) === 'value', '03 APCu get returns the value');
+    $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($key, 0, 80));
+    $check(glob($cacheDir . '/pinakes_' . $prefix . '_*') === [], '04 APCu does not dual-write data to files');
+
+    // Invoke the APCu remember primitive with a value inserted immediately
+    // before lock acquisition: its post-acquire double-check must avoid the
+    // callback even though the outer logical lookup would previously have missed.
+    $reflection = new ReflectionClass(QueryCache::class);
+    $hashKey = $reflection->getMethod('hashKey');
+    $backendSet = $reflection->getMethod('backendSet');
+    $rememberApcu = $reflection->getMethod('rememberWithApcuLock');
+    $lateKey = "qc_apcu_late_fill_{$run}";
+    $createdKeys[] = $lateKey;
+    $hashedLateKey = $hashKey->invoke(null, $lateKey);
+    $backendSet->invoke(null, $hashedLateKey, 'filled-by-peer', 60);
+    $calls = 0;
+    $value = $rememberApcu->invoke(
+        null,
+        $lateKey,
+        $hashedLateKey,
+        static function () use (&$calls): string {
+            $calls++;
+            return 'duplicate-computation';
+        },
+        60
+    );
+    $check($value === 'filled-by-peer' && $calls === 0, '05 lock acquisition double-check avoids duplicate computation');
+
+    // Ownership-safe release: an old token must not delete a successor lock.
+    $release = $reflection->getMethod('releaseApcuLock');
+    $lockKey = 'pinakes_lock_test_' . $run;
+    apcu_store($lockKey, 222, 300);
+    $release->invoke(null, $lockKey, 111);
+    $success = false;
+    $owner = apcu_fetch($lockKey, $success);
+    $check($success && $owner === 222, '06 stale owner cannot delete successor APCu lock');
+    $release->invoke(null, $lockKey, 222);
+    $check(!apcu_exists($lockKey), '07 current owner releases its APCu lock');
+
+    // The same generation-capture invariant must hold on APCu.
+    $inFlightKey = "home_qc_apcu_inflight_{$run}";
+    $createdKeys[] = $inFlightKey;
+    QueryCache::remember($inFlightKey, static function (): string {
+        ContentCache::homeContentChanged();
+        return 'stale';
+    }, 300);
+    $check(QueryCache::get($inFlightKey) === null, '08 APCu loader cannot publish into a newer generation');
+
+    $before = QueryCache::stats();
+    $statsKey = "qc_apcu_stats_{$run}";
+    $createdKeys[] = $statsKey;
+    QueryCache::remember($statsKey, static fn(): string => 'v', 60);
+    $after = QueryCache::stats();
+    $check(($after['gets'] - $before['gets']) === 1, '09 APCu remember counts one logical lookup');
+    $check(($after['misses'] - $before['misses']) === 1, '10 APCu remember counts one logical miss');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+} finally {
+    foreach ($createdKeys as $createdKey) {
+        QueryCache::delete($createdKey);
+        $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($createdKey, 0, 80));
+        foreach (glob($cacheDir . '/pinakes_' . $prefix . '_*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+}
+
+echo "\n{$pass} checks passed\n";
+exit(0);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -1,0 +1,232 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural contract for the QueryCache single-backend + generation-key
+ * refactor (issue #387, step 1+3 of the caching plan). No DB needed.
+ *
+ * Covers:
+ *  - set/get/delete round-trip and TTL expiry on the selected backend;
+ *  - remember(): returns the callback value on miss and computes ONCE
+ *    (second call served from cache, callback not re-run);
+ *  - single selected backend: stats() reports which backend holds the
+ *    values ('apcu' when available+enabled, 'file' otherwise) and the
+ *    round-trip proves that backend serves them;
+ *  - O(1) generation-key invalidation: after ContentCache::booksChanged()
+ *    previously cached catalog_* and home_* entries are no longer served while
+ *    an unrelated (non-namespaced) entry survives — AND, on the file
+ *    backend, the stale entry's file is left on disk untouched (proof the
+ *    invalidation is a generation bump, not a scan/delete storm; gc()
+ *    reclaims it later). ContentCache::homeContentChanged() only kills the
+ *    home_ namespace, catalog_ survives;
+ *  - clearByPrefix() keeps its invalidation semantics both for a known
+ *    namespace (generation bump) and for an arbitrary prefix (legacy scan);
+ *  - security: a file-backend payload replaced with a bare serialized
+ *    object is neutralized by unserialize(..., allowed_classes=false)
+ *    (get() returns null, poisoned file removed);
+ *  - stats() hit/miss counters move correctly across a miss and a hit.
+ *
+ * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
+ * do not exist there (fatal Error), and the "stale file left on disk after
+ * booksChanged()" assertion is false under the old prefix-scan deletion.
+ *
+ * Run: php tests/querycache-backend-and-generation.unit.php
+ */
+
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$cacheDir = $root . '/storage/cache';
+
+$pass = 0;
+$check = static function (bool $ok, string $label) use (&$pass): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $pass++;
+    echo "  OK  {$label}\n";
+};
+
+$run = substr(md5((string) mt_rand()), 0, 8);
+
+// Every logical key this test creates (for cleanup).
+$createdKeys = [];
+$key = static function (string $logical) use (&$createdKeys): string {
+    $createdKeys[] = $logical;
+    return $logical;
+};
+
+// Locate the storage/cache file(s) of a logical key by its sanitized
+// human-readable prefix (the refactor keeps that prefix in the filename).
+$filesFor = static function (string $logical) use ($cacheDir): array {
+    $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($logical, 0, 80));
+    $files = glob($cacheDir . '/pinakes_' . $prefix . '_*');
+    return $files === false ? [] : $files;
+};
+
+try {
+    // ── Backend identity ────────────────────────────────────────────────
+    $stats = QueryCache::stats();
+    $backend = $stats['backend'] ?? '';
+    $check(in_array($backend, ['apcu', 'file'], true), "01 stats() reports a deterministic backend ({$backend})");
+    if ($backend !== 'file') {
+        // The generation/security file-level assertions below inspect the
+        // file store directly; they are meaningful on the file backend.
+        echo "NOTE: APCu backend active in this environment; file-level assertions run against APCu semantics where applicable.\n";
+    } else {
+        echo "NOTE: no APCu in this PHP (CLI without apcu/apc.enable_cli) — exercising the file backend, the shared-hosting default.\n";
+    }
+
+    // ── set/get/delete round-trip on the selected backend ───────────────
+    $k1 = $key("qc_test_roundtrip_{$run}");
+    $check(QueryCache::get($k1) === null, '02 unknown key misses');
+    $check(QueryCache::set($k1, ['a' => 1, 'b' => 'x'], 60) === true, '03 set() succeeds on the selected backend');
+    $check(QueryCache::get($k1) === ['a' => 1, 'b' => 'x'], '04 get() returns the stored value (selected backend holds it)');
+    QueryCache::delete($k1);
+    $check(QueryCache::get($k1) === null, '05 delete() removes the entry');
+
+    // Single-backend observability: on the file backend the value must be on
+    // disk; nothing is (or can be) dual-written to APCu here. On APCu the
+    // inverse holds: no file must appear for the key.
+    $k2 = $key("qc_test_backend_{$run}");
+    QueryCache::set($k2, 'v', 60);
+    if ($backend === 'file') {
+        $check(count($filesFor($k2)) === 1, '06 file backend physically holds the entry (single backend)');
+    } else {
+        $check(count($filesFor($k2)) === 0, '06 apcu backend does NOT dual-write to disk (single backend)');
+    }
+    QueryCache::delete($k2);
+
+    // ── TTL expiry ──────────────────────────────────────────────────────
+    $k3 = $key("qc_test_ttl_{$run}");
+    QueryCache::set($k3, 'short-lived', 1);
+    $check(QueryCache::get($k3) === 'short-lived', '07 entry readable within TTL');
+    sleep(2);
+    $check(QueryCache::get($k3) === null, '08 entry expired after TTL');
+
+    // ── remember(): miss → callback value, then computed once ───────────
+    $k4 = $key("qc_test_remember_{$run}");
+    $calls = 0;
+    $producer = static function () use (&$calls): string {
+        $calls++;
+        return 'computed-value';
+    };
+    $check(QueryCache::remember($k4, $producer, 60) === 'computed-value', '09 remember() returns callback value on miss');
+    $check($calls === 1, '10 callback executed exactly once on miss');
+    $check(QueryCache::remember($k4, $producer, 60) === 'computed-value', '11 remember() serves the cached value');
+    $check($calls === 1, '12 callback NOT re-executed on hit');
+    QueryCache::delete($k4);
+
+    // ── Generation-key invalidation via ContentCache ────────────────────
+    $catKey = $key("catalog_qc_test_{$run}");
+    $homeKey = $key("home_qc_test_{$run}");
+    $otherKey = $key("qc_test_survivor_{$run}");
+
+    QueryCache::set($catKey, 'catalog-data', 300);
+    QueryCache::set($homeKey, 'home-data', 300);
+    QueryCache::set($otherKey, 'unrelated-data', 300);
+    $check(QueryCache::get($catKey) === 'catalog-data', '13 catalog_ entry cached');
+    $check(QueryCache::get($homeKey) === 'home-data', '14 home_ entry cached');
+
+    $catFilesBefore = $filesFor($catKey);
+
+    ContentCache::booksChanged();
+
+    $check(QueryCache::get($catKey) === null, '15 catalog_ entry no longer served after booksChanged()');
+    $check(QueryCache::get($homeKey) === null, '16 home_ entry no longer served after booksChanged()');
+    $check(QueryCache::get($otherKey) === 'unrelated-data', '17 unrelated namespace survives booksChanged()');
+
+    if ($backend === 'file') {
+        // O(1) proof: the stale entry was NOT deleted (no scan) — it merely
+        // became unreachable because the namespace generation moved on.
+        $stillOnDisk = count($catFilesBefore) === 1 && file_exists($catFilesBefore[0]);
+        $check($stillOnDisk, '18 stale catalog_ file left on disk (generation bump, not a delete scan)');
+        foreach ($catFilesBefore as $f) {
+            @unlink($f);
+        }
+    } else {
+        $check(true, '18 (apcu backend: on-disk staleness proof not applicable)');
+    }
+
+    // Scoped invalidation: homeContentChanged() bumps only home_.
+    QueryCache::set($catKey, 'catalog-data-2', 300);
+    QueryCache::set($homeKey, 'home-data-2', 300);
+    ContentCache::homeContentChanged();
+    $check(QueryCache::get($homeKey) === null, '19 home_ entry invalidated by homeContentChanged()');
+    $check(QueryCache::get($catKey) === 'catalog-data-2', '20 catalog_ entry survives homeContentChanged()');
+
+    // ── clearByPrefix() keeps its semantics ─────────────────────────────
+    // Known namespace → generation bump under the hood.
+    QueryCache::clearByPrefix('catalog_');
+    $check(QueryCache::get($catKey) === null, '21 clearByPrefix(catalog_) still invalidates the namespace');
+
+    // Arbitrary (non-namespace) prefix → legacy scan fallback still works
+    // with the new storage naming.
+    $arbKey = $key("qc_arbitrary_{$run}_entry");
+    QueryCache::set($arbKey, 'arb', 300);
+    $cleared = QueryCache::clearByPrefix("qc_arbitrary_{$run}_");
+    $check(QueryCache::get($arbKey) === null, '22 clearByPrefix(arbitrary prefix) still clears matching entries');
+    if ($backend === 'file') {
+        $check($cleared >= 1, '23 arbitrary-prefix scan reports removed entries');
+    } else {
+        $check(true, '23 (apcu backend: scan count covered by assertion 22)');
+    }
+
+    // ── Security: allowed_classes=false guard on the file store ─────────
+    if ($backend === 'file') {
+        $poisonKey = $key("qc_test_poison_{$run}");
+        QueryCache::set($poisonKey, 'benign', 300);
+        $poisonFiles = $filesFor($poisonKey);
+        $check(count($poisonFiles) === 1, '24 poisoned-entry fixture in place');
+        // Simulate an attacker-controlled payload: a bare serialized object.
+        file_put_contents($poisonFiles[0], 'O:8:"stdClass":0:{}');
+        $check(QueryCache::get($poisonKey) === null, '25 serialized-object payload rejected (allowed_classes=false guard)');
+        clearstatcache();
+        $check(!file_exists($poisonFiles[0]), '26 poisoned file removed on read');
+    } else {
+        // APCu stores native values (no unserialize on read); craft the same
+        // guard check directly against the file reader is not applicable.
+        $check(true, '24 (apcu backend: no file deserialization path in use)');
+        $check(true, '25 (apcu backend: object-injection surface absent)');
+        $check(true, '26 (apcu backend: object-injection surface absent)');
+    }
+
+    // ── stats() hit/miss accounting ─────────────────────────────────────
+    $before = QueryCache::stats();
+    $missKey = $key("qc_test_stats_missing_{$run}");
+    QueryCache::get($missKey);                       // miss
+    $hitKey = $key("qc_test_stats_hit_{$run}");
+    QueryCache::set($hitKey, 1, 60);
+    QueryCache::get($hitKey);                        // hit
+    $after = QueryCache::stats();
+
+    $check(($after['gets'] - $before['gets']) === 2, '27 stats(): gets incremented per get()');
+    $check(($after['misses'] - $before['misses']) === 1, '28 stats(): miss counted');
+    $check(($after['hits'] - $before['hits']) === 1, '29 stats(): hit counted');
+    $check(
+        $after['gets'] > 0 && abs($after['hit_ratio'] - round($after['hits'] / $after['gets'], 4)) < 0.0001,
+        '30 stats(): hit_ratio consistent with counters'
+    );
+    QueryCache::delete($hitKey);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+} finally {
+    // Cleanup: remove every key this test created (current generation) and
+    // any leftover files matching this run's unique marker.
+    foreach (array_unique($createdKeys) as $logical) {
+        QueryCache::delete($logical);
+    }
+    $leftovers = glob($cacheDir . '/pinakes_*' . $run . '*');
+    if ($leftovers !== false) {
+        foreach ($leftovers as $f) {
+            @unlink($f);
+        }
+    }
+}
+
+echo "\n{$pass} checks passed\n";
+exit(0);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -28,7 +28,12 @@ declare(strict_types=1);
  *    remember() records one logical lookup despite its mutex double-check;
  *  - in-flight loaders cannot publish stale data into a newer generation;
  *  - generation bumps are atomic across concurrent processes;
- *  - time-gated GC is actually reached by normal file-cache writes.
+ *  - time-gated GC is actually reached by normal file-cache writes;
+ *  - counter writes are atomic (temp + rename): the on-disk counter is a
+ *    complete valid payload after every bump, no .tmp residue is left, and a
+ *    simulated write failure leaves the previous value intact (adamsreview
+ *    F1: an in-place ftruncate+fwrite could leave the file empty and reset
+ *    the namespace generation below an already-climbed value).
  *
  * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
  * do not exist there (fatal Error), and the "stale file left on disk after
@@ -302,6 +307,75 @@ try {
             '36 file writes schedule time-gated GC (APCu selected here)'
         );
     }
+
+    // ── Atomic counter writes: temp+rename, never empty/partial ─────────
+    // The generation counter is file-backed regardless of backend, so these
+    // assertions are meaningful everywhere. A mid-write failure must never
+    // leave the counter file empty (that would re-initialize the namespace at
+    // time(), potentially BELOW a counter that climbed past wall-clock,
+    // resurrecting invalidated TTL-live entries).
+    $atomicReflection = new ReflectionClass(QueryCache::class);
+    $storageKeyMethod = $atomicReflection->getMethod('generationStorageKey');
+    $atomicMemo = $atomicReflection->getProperty('generationCache');
+    $genPath = $cacheDir . '/' . $storageKeyMethod->invoke(null, 'schema_table_');
+
+    $readCounter = static function () use ($genPath): ?int {
+        clearstatcache();
+        $content = @file_get_contents($genPath);
+        if ($content === false || $content === '') {
+            return null;
+        }
+        $data = @unserialize($content, ['allowed_classes' => false]);
+        if (!is_array($data) || !isset($data['value']) || !is_int($data['value'])) {
+            return null;
+        }
+        return $data['value'];
+    };
+
+    $alwaysValid = true;
+    $monotonic = true;
+    $prevOnDisk = null;
+    for ($i = 0; $i < 30; $i++) {
+        QueryCache::bumpGeneration('schema_table_');
+        $onDisk = $readCounter();
+        if ($onDisk === null) {
+            $alwaysValid = false;
+            break;
+        }
+        if ($prevOnDisk !== null && $onDisk <= $prevOnDisk) {
+            $monotonic = false;
+            break;
+        }
+        $prevOnDisk = $onDisk;
+    }
+    $check($alwaysValid, '37 counter file is a complete valid payload after every bump (never empty/partial)');
+    $check($monotonic, '38 counter value strictly monotonic across rapid bumps');
+
+    $tmpResidue = glob($genPath . '.tmp.*');
+    $check($tmpResidue === false || $tmpResidue === [], '39 no .tmp residue left behind by successful bumps');
+
+    // Simulated write failure: occupy the exact temp path the next bump will
+    // use (deterministic: pid + private monotonic sequence) with a directory,
+    // so the temp-file write fails. The previous counter value must remain
+    // intact on disk — under the old ftruncate-then-write scheme an
+    // equivalent failure wiped the file.
+    $seqProp = $atomicReflection->getProperty('generationTmpSeq');
+    $blockedTmp = $genPath . '.tmp.' . getmypid() . '.' . $seqProp->getValue(null);
+    $beforeFailure = $readCounter();
+    if (!@mkdir($blockedTmp)) {
+        throw new RuntimeException('could not create blocking directory for write-failure simulation');
+    }
+    try {
+        QueryCache::bumpGeneration('schema_table_'); // write fails → legacy fallback
+    } finally {
+        @rmdir($blockedTmp);
+    }
+    $check(
+        $beforeFailure !== null && $readCounter() === $beforeFailure,
+        '40 failed counter write leaves the previous on-disk value intact (no truncation)'
+    );
+    // Drop the request-local fallback generation installed by the failed bump.
+    $atomicMemo->setValue(null, []);
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -376,6 +376,49 @@ try {
     );
     // Drop the request-local fallback generation installed by the failed bump.
     $atomicMemo->setValue(null, []);
+
+    // ── Full flush preserves synchronization and invalidation barriers ──
+    QueryCache::bumpGeneration('schema_table_');
+    clearstatcache(true, $genPath . '.lock');
+    $lockInodeBefore = @fileinode($genPath . '.lock');
+    $flushKey = $key("schema_table_flush_{$run}");
+    QueryCache::set($flushKey, 'stale', 300);
+    $check(QueryCache::flush(), '41 full flush succeeds');
+    clearstatcache(true, $genPath . '.lock');
+    $check(
+        $lockInodeBefore !== false
+            && file_exists($genPath . '.lock')
+            && @fileinode($genPath . '.lock') === $lockInodeBefore,
+        '42 full flush preserves the persistent generation-lock inode'
+    );
+    $lockMode = @fileperms($genPath . '.lock');
+    $check(
+        $lockMode !== false && ($lockMode & 0777) === 0660,
+        '43 generation writer lock has group-writable 0660 permissions'
+    );
+    $check(QueryCache::get($flushKey) === null, '44 full flush publishes a newer generation barrier');
+
+    // GC is request-time maintenance. A busy entry must be skipped rather
+    // than making an application request wait for another writer.
+    $busyPath = $cacheDir . '/pinakes_gc_busy_' . $run;
+    file_put_contents($busyPath, serialize([
+        'value' => 'expired',
+        'expires' => time() - 10,
+        'created' => time() - 20,
+    ]));
+    $busyHandle = fopen($busyPath, 'r');
+    if ($busyHandle === false || !flock($busyHandle, LOCK_EX | LOCK_NB)) {
+        throw new RuntimeException('could not lock busy GC fixture');
+    }
+    try {
+        QueryCache::gc();
+        $check(file_exists($busyPath), '45 GC skips an entry currently locked by another writer');
+    } finally {
+        flock($busyHandle, LOCK_UN);
+        fclose($busyHandle);
+    }
+    QueryCache::gc();
+    $check(!file_exists($busyPath), '46 GC reclaims the expired entry once its lock is released');
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -24,7 +24,11 @@ declare(strict_types=1);
  *  - security: a file-backend payload replaced with a bare serialized
  *    object is neutralized by unserialize(..., allowed_classes=false)
  *    (get() returns null, poisoned file removed);
- *  - stats() hit/miss counters move correctly across a miss and a hit.
+ *  - stats() hit/miss counters move correctly across a miss and a hit, and
+ *    remember() records one logical lookup despite its mutex double-check;
+ *  - in-flight loaders cannot publish stale data into a newer generation;
+ *  - generation bumps are atomic across concurrent processes;
+ *  - time-gated GC is actually reached by normal file-cache writes.
  *
  * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
  * do not exist there (fatal Error), and the "stale file left on disk after
@@ -211,6 +215,93 @@ try {
         '30 stats(): hit_ratio consistent with counters'
     );
     QueryCache::delete($hitKey);
+
+    // ── remember() must not publish across an invalidation ──────────────
+    $inFlightKey = $key("home_qc_inflight_{$run}");
+    $inFlight = QueryCache::remember($inFlightKey, static function (): string {
+        // Simulate a committed mutation/invalidation while an older loader is
+        // still computing. Its result may be returned to that caller, but must
+        // remain stored under the old generation and be unreachable afterwards.
+        ContentCache::homeContentChanged();
+        return 'pre-invalidation-value';
+    }, 300);
+    $check($inFlight === 'pre-invalidation-value', '31 in-flight loader returns its callback value');
+    $check(QueryCache::get($inFlightKey) === null, '32 in-flight loader cannot populate the newer generation');
+
+    // ── remember() instrumentation counts logical lookups only ──────────
+    $statsRememberKey = $key("qc_stats_remember_{$run}");
+    $beforeRemember = QueryCache::stats();
+    QueryCache::remember($statsRememberKey, static fn(): string => 'v', 60);
+    $afterRemember = QueryCache::stats();
+    $check(($afterRemember['gets'] - $beforeRemember['gets']) === 1, '33 cold remember() counts one logical get');
+    $check(($afterRemember['misses'] - $beforeRemember['misses']) === 1, '34 cold remember() counts one logical miss');
+
+    // ── Generation increments remain atomic across processes ───────────
+    if (function_exists('pcntl_fork') && function_exists('pcntl_waitpid')) {
+        $reflection = new ReflectionClass(QueryCache::class);
+        $generationMethod = $reflection->getMethod('currentGeneration');
+        $generationMemo = $reflection->getProperty('generationCache');
+
+        QueryCache::bumpGeneration('schema_table_');
+        $generationMemo->setValue(null, []);
+        $beforeGeneration = $generationMethod->invoke(null, 'schema_table_');
+
+        $children = [];
+        $childCount = 6;
+        $bumpsPerChild = 20;
+        for ($child = 0; $child < $childCount; $child++) {
+            $pid = pcntl_fork();
+            if ($pid === -1) {
+                throw new RuntimeException('pcntl_fork failed');
+            }
+            if ($pid === 0) {
+                for ($i = 0; $i < $bumpsPerChild; $i++) {
+                    QueryCache::bumpGeneration('schema_table_');
+                }
+                exit(0);
+            }
+            $children[] = $pid;
+        }
+        foreach ($children as $pid) {
+            pcntl_waitpid($pid, $status);
+            if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+                throw new RuntimeException('generation bump child failed');
+            }
+        }
+
+        // The parent intentionally held its request-local memo while children
+        // worked; clear it to model the next request reading the canonical file.
+        $generationMemo->setValue(null, []);
+        $afterGeneration = $generationMethod->invoke(null, 'schema_table_');
+        $check(
+            ($afterGeneration - $beforeGeneration) === $childCount * $bumpsPerChild,
+            '35 concurrent generation bumps have no lost updates or rollback'
+        );
+    } else {
+        $source = file_get_contents($root . '/app/Support/QueryCache.php');
+        $check(
+            is_string($source) && str_contains($source, 'flock($handle, LOCK_EX)'),
+            '35 generation mutation uses an exclusive lock (pcntl unavailable)'
+        );
+    }
+
+    // ── File GC is wired into writes ────────────────────────────────────
+    if ($backend === 'file') {
+        $gcMarker = $cacheDir . '/.pinakes_gc';
+        @touch($gcMarker, time() - 7200);
+        $reflection = new ReflectionClass(QueryCache::class);
+        $reflection->getProperty('gcCheckedThisRequest')->setValue(null, false);
+
+        $expiredKey = $key("qc_gc_expired_{$run}");
+        QueryCache::set($expiredKey, 'expired', -1);
+        $check($filesFor($expiredKey) === [], '36 time-gated GC reclaims expired generation leftovers');
+    } else {
+        $source = file_get_contents($root . '/app/Support/QueryCache.php');
+        $check(
+            is_string($source) && str_contains($source, 'self::maybeGc();'),
+            '36 file writes schedule time-gated GC (APCu selected here)'
+        );
+    }
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);


### PR DESCRIPTION
First measured, low-risk block of the caching overhaul tracked in #387 (steps 1-3). Redis and edge/full-page cache are deliberately deferred to later PRs pending the numbers.

## What changed
- **QueryCache — single backend** (APCu when available+enabled, else file): no more mandatory dual-write to disk; the file `.lock` is used only on the file backend, an `apcu_add()` sentinel guards stampede on the APCu hot path.
- **O(1) namespace invalidation via generation counters**: `ContentCache::booksChanged()/homeContentChanged()` bump a counter instead of scanning `APCUIterator`+`glob`. The storage key embeds the namespace generation; counters are monotonic (init to `time()`) so a lost counter can't resurrect stale entries. Unknown prefixes keep the legacy scan.
- **Instrumentation**: `QueryCache::stats()` → `{backend, gets, hits, misses, hit_ratio}` from per-request counters (zero alloc/log per call). No `index.php` wiring yet — a later PR surfaces it.
- **OPcache guidance only** (`php.ini.recommended`, no runtime change): removed `opcache.fast_shutdown` (no-op since 7.2), documented why `validate_timestamps=0` needs deploy-side invalidation, JIT left off (DB/IO-bound), 128/10000 kept with a "raise only on `opcache_get_status()` saturation" note.

## Safety / existing installs
- No migration, no new config, no new PHP extension. Non-namespaced keys hash identically to before (cache survives upgrade); namespaced keys miss once, stale files reclaimed by `gc()`/APCu TTL.
- Security invariants preserved: file cache keeps `unserialize(allowed_classes=false)` + expiry; `pinakes_` isolation kept; F008 stampede behavior preserved.
- **Known trade-off** (single backend, as designed): a server with APCu in FPM but not CLI no longer partially propagates invalidations across that boundary — already the case with the old APCu-first read, bounded by short data TTLs; availability stays live outside the cache.

## Tests
- New `tests/querycache-backend-and-generation.unit.php` (30 checks): round-trip, TTL expiry, remember-once, single-backend evidence, generation invalidation (unrelated namespace survives), object-payload rejection, stats deltas. **Fails by design** on the pre-refactor code.
- Full unit suite **137/137**, PHPStan level 5 clean, soft-delete guard clean.

Closes part of #387.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Miglioramenti**
  - Ottimizzata la gestione della cache con invalidazione più rapida e minore impatto sulle prestazioni.
  - Migliorata la coerenza dei contenuti durante gli aggiornamenti e la rigenerazione della cache.
  - Rafforzata la protezione contro richieste duplicate durante la ricostruzione dei dati.
  - Aggiunte statistiche sugli accessi riusciti e mancati alla cache.
  - Migliorata la selezione automatica del sistema di archiviazione della cache, con fallback affidabile.

- **Configurazione**
  - Aggiornata la documentazione delle impostazioni OPcache, inclusi limiti, validazione dei timestamp e JIT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->