### PR TITLE
perf(cache): hot-dataset caching — book-detail DTO, reviews, bounded catalog (availability stays live) (#387)

### DIFF
--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -294,17 +294,9 @@ class FrontendController
             LIMIT ? OFFSET ?
         ";
 
-        $stmt_books = $db->prepare($books_query);
-        $final_params = array_merge($query_params, [$limit, $offset]);
-        $final_types = $param_types . 'ii';
-        $stmt_books->bind_param($final_types, ...$final_params);
-        $stmt_books->execute();
-        $books_result = $stmt_books->get_result();
-
-        $books = [];
-        while ($book = $books_result->fetch_assoc()) {
-            $books[] = $book;
-        }
+        // Listing rows: cached only for the bounded filter states (availability
+        // fields stripped from the cached copy and merged back live per request).
+        $books = $this->loadCatalogPageRows($db, $books_query, $param_types, $query_params, $filters, $limit, $offset, $page);
 
         // Ottieni le opzioni per i filtri
         $filter_options = $this->getFilterOptions($db, $filters);
@@ -404,17 +396,9 @@ class FrontendController
             LIMIT ? OFFSET ?
         ";
 
-        $stmt_books = $db->prepare($books_query);
-        $final_params = array_merge($query_params, [$limit, $offset]);
-        $final_types = $param_types . 'ii';
-        $stmt_books->bind_param($final_types, ...$final_params);
-        $stmt_books->execute();
-        $books_result = $stmt_books->get_result();
-
-        $books = [];
-        while ($book = $books_result->fetch_assoc()) {
-            $books[] = $book;
-        }
+        // Listing rows: cached only for the bounded filter states (availability
+        // fields stripped from the cached copy and merged back live per request).
+        $books = $this->loadCatalogPageRows($db, $books_query, $param_types, $query_params, $filters, $limit, $offset, $page);
 
         // Render only the books grid
         ob_start();
@@ -509,39 +493,33 @@ class FrontendController
 
         $book_id = (int)$params['id'];
 
-        // Query per recuperare i dettagli completi del libro con gerarchia generi
-        $query = "
-            SELECT l.*,
-                   a.nome AS autore_principale,
-                   g.nome AS genere,
-                   gp.id AS genere_parent_id_resolved,
-                   gp.nome AS genere_parent,
-                   gpp.id AS genere_grandparent_id,
-                   gpp.nome AS genere_grandparent,
-                   sg.nome AS sottogenere,
-                   e.nome AS editore
-            FROM libri l
-            LEFT JOIN libri_autori la ON l.id = la.libro_id AND la.ruolo = 'principale'
-            LEFT JOIN autori a ON la.autore_id = a.id
-            LEFT JOIN generi g ON l.genere_id = g.id
-            LEFT JOIN generi gp ON g.parent_id = gp.id
-            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
-            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
-            LEFT JOIN editori e ON l.editore_id = e.id
-            WHERE l.id = ? AND l.deleted_at IS NULL
-            LIMIT 1
-        ";
+        // Static book-detail DTO (issue #387 step 4): the book row, its
+        // authors, publishers, series and related volumes are identical for
+        // every visitor and change only through admin write paths that all
+        // funnel into ContentCache::booksChanged() → 'book_detail_' generation
+        // bump. Live availability (copie_disponibili/copie_totali/stato) is
+        // deliberately EXCLUDED from the cached payload and re-read from the
+        // database on every request further below: a stale availability number
+        // is a user-facing correctness bug (double-loan), a stale title is not.
+        $locale = \App\Support\I18n::getLocale();
+        $detail = \App\Support\QueryCache::remember(
+            'book_detail_' . $locale . '_' . $book_id,
+            function () use ($db, $book_id): ?array {
+                return $this->buildBookDetailStatic($db, $book_id);
+            },
+            300
+        );
 
-        $stmt = $db->prepare($query);
-        $stmt->bind_param("i", $book_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-
-        if (!$result || $result->num_rows == 0) {
+        // A missing/soft-deleted book yields null, which remember() treats as
+        // a miss on the next request — 404s are never negatively cached.
+        if (!is_array($detail) || !isset($detail['book'])) {
             return $this->render404($response);
         }
 
-        $book = $result->fetch_assoc();
+        $book = $detail['book'];
+        $authors = $detail['authors'];
+        $seriesBooks = $detail['seriesBooks'];
+        $related_books = $detail['related_books'];
 
         // Ensure canonical URL structure (author slug + book slug + ID)
         $canonicalPath = book_url([
@@ -560,90 +538,54 @@ class FrontendController
             return $response->withHeader('Location', $canonicalPath)->withStatus(301);
         }
 
-        // Query per ottenere tutti gli autori del libro
-        $query_authors = "
-            SELECT a.*, la.ruolo
-            FROM autori a
-            JOIN libri_autori la ON a.id = la.autore_id
-            WHERE la.libro_id = ?
-            ORDER BY
-                CASE la.ruolo
-                    WHEN 'principale' THEN 1
-                    WHEN 'co-autore' THEN 2
-                    WHEN 'traduttore' THEN 3
-                    WHEN 'illustratore' THEN 4
-                    WHEN 'curatore' THEN 5
-                    WHEN 'colorista' THEN 6
-                    ELSE 7
-                END
-        ";
-
-        $stmt_authors = $db->prepare($query_authors);
-        $stmt_authors->bind_param("i", $book_id);
-        $stmt_authors->execute();
-        $result_authors = $stmt_authors->get_result();
-
-        $authors = [];
-        while ($author = $result_authors->fetch_assoc()) {
-            $authors[] = $author;
-        }
-
-        // Publishers (issue #143): full ordered list for multi-publisher books.
-        // Falls back to the single primary publisher for pre-#143 data.
-        $book['editori'] = [];
-        $stmtPub = $db->prepare(
-            'SELECT e.id, e.nome FROM libri_editori le JOIN editori e ON le.editore_id = e.id WHERE le.libro_id = ? ORDER BY le.ordine, e.nome'
+        // LIVE availability merge — NEVER served from cache. One indexed
+        // primary-key lookup refreshes copie_disponibili/copie_totali/stato
+        // for the book and its related volumes; the soft-delete-aware read is
+        // also the authority on whether the book still exists.
+        $liveAvailability = $this->fetchLiveAvailability(
+            $db,
+            array_merge([$book_id], array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $related_books))
         );
-        if ($stmtPub) {
-            $stmtPub->bind_param('i', $book_id);
-            $stmtPub->execute();
-            $resPub = $stmtPub->get_result();
-            while ($pub = $resPub->fetch_assoc()) {
-                $book['editori'][] = $pub;
+        if (!isset($liveAvailability[$book_id])) {
+            // Soft-deleted after the DTO was cached: the live read wins → 404.
+            return $this->render404($response);
+        }
+        $book = array_merge($book, $liveAvailability[$book_id]);
+        $freshRelated = [];
+        foreach ($related_books as $row) {
+            $rowId = (int) ($row['id'] ?? 0);
+            if (!isset($liveAvailability[$rowId])) {
+                continue; // soft-deleted since the DTO was cached
             }
-            $stmtPub->close();
+            $freshRelated[] = array_merge($row, $liveAvailability[$rowId]);
         }
-        if ($book['editori'] === [] && !empty($book['editore'])) {
-            $book['editori'][] = ['id' => (int) ($book['editore_id'] ?? 0), 'nome' => (string) $book['editore']];
-        }
+        $related_books = $freshRelated;
 
-        // Get approved reviews and statistics
-        $recensioniRepo = new RecensioniRepository($db);
-        $reviews = $recensioniRepo->getApprovedReviewsForBook($book_id);
-        $reviewStats = $recensioniRepo->getReviewStats($book_id);
-
-        // Other volumes in the same series (collana)
-        $seriesBooks = [];
-        $collana = trim((string) ($book['collana'] ?? ''));
-        if ($collana !== '') {
-            $stmtSeries = $db->prepare("
-                SELECT l.id, l.titolo, l.numero_serie, l.copertina_url,
-                       (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale,
-                       (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale_nome
-                FROM libri l
-                WHERE l.collana = ? AND l.id != ? AND l.deleted_at IS NULL
-                ORDER BY
-                    CASE WHEN TRIM(l.numero_serie) REGEXP '^[0-9]+$' THEN 0 ELSE 1 END,
-                    CAST(l.numero_serie AS UNSIGNED),
-                    l.titolo
-            ");
-            if ($stmtSeries) {
-                $stmtSeries->bind_param('si', $collana, $book_id);
-                $stmtSeries->execute();
-                $resSeries = $stmtSeries->get_result();
-                while ($row = $resSeries->fetch_assoc()) {
-                    $seriesBooks[] = $row;
-                }
-                $stmtSeries->close();
-            } else {
-                \App\Support\SecureLogger::warning('FrontendController: series query prepare failed', ['db_error' => $db->error]);
-            }
-        }
-
-        // Get related books (pass seriesBooks to avoid duplicate collana query)
-        $related_books = $this->getRelatedBooks($db, $book_id, $book, $authors, $seriesBooks);
+        // Approved reviews + statistics: cached per book ('book_reviews_'
+        // namespace), invalidated on moderation (approve/reject/delete →
+        // ContentCache::reviewsChanged()). New reviews are 'pendente' and
+        // never publicly visible, so submission does not need to invalidate.
+        $reviewsBlock = \App\Support\QueryCache::remember(
+            'book_reviews_' . $locale . '_' . $book_id,
+            static function () use ($db, $book_id): array {
+                $recensioniRepo = new RecensioniRepository($db);
+                return [
+                    'reviews' => $recensioniRepo->getApprovedReviewsForBook($book_id),
+                    'stats' => $recensioniRepo->getReviewStats($book_id),
+                ];
+            },
+            300
+        );
+        $reviews = is_array($reviewsBlock['reviews'] ?? null) ? $reviewsBlock['reviews'] : [];
+        $reviewStats = is_array($reviewsBlock['stats'] ?? null) ? $reviewsBlock['stats'] : [
+            'total_reviews' => 0,
+            'average_rating' => 0,
+            'one_star' => 0,
+            'two_star' => 0,
+            'three_star' => 0,
+            'four_star' => 0,
+            'five_star' => 0,
+        ];
 
         // Social sharing
         $sharingProviders = array_values(array_filter(array_map('trim', explode(',', (string) ConfigStore::get('sharing.enabled_providers', '')))));
@@ -715,6 +657,320 @@ class FrontendController
         return $response
             ->withHeader('Content-Type', 'text/html')
             ->withHeader('Link', implode(', ', $signLinks));
+    }
+
+    /**
+     * Fields whose value depends on live circulation state. They are stripped
+     * from every cached payload and re-read from the database at request time
+     * (fetchLiveAvailability), so a warm cache can never serve a stale
+     * availability number.
+     */
+    private const LIVE_AVAILABILITY_FIELDS = ['copie_disponibili', 'copie_totali', 'stato'];
+
+    /**
+     * Highest catalog page number eligible for the page-rows cache. Together
+     * with hasBoundedCatalogCacheKey() this keeps the cached key space finite
+     * (locale × 4 availability states × 6 sorts × N pages); deeper pages are
+     * request-controlled long-tail traffic and always hit the database.
+     */
+    private const CATALOG_PAGE_CACHE_MAX_PAGE = 10;
+
+    /**
+     * Build the visitor-independent portion of the book-detail page: the book
+     * row (WITHOUT the live availability fields), its authors, publishers
+     * (issue #143), same-series volumes and related volumes (also stripped of
+     * availability). Returns null when the book does not exist or is
+     * soft-deleted — callers must treat that as a 404.
+     *
+     * Cached by bookDetail() under the 'book_detail_' namespace; every book
+     * write path (create/edit/soft-delete, author/publisher/genre/series
+     * mutations, imports, availability recomputes) funnels into
+     * ContentCache::booksChanged(), which bumps that generation.
+     *
+     * @return array{book: array<string, mixed>, authors: array<int, array<string, mixed>>,
+     *               seriesBooks: array<int, array<string, mixed>>,
+     *               related_books: array<int, array<string, mixed>>}|null
+     */
+    private function buildBookDetailStatic(mysqli $db, int $book_id): ?array
+    {
+        // Query per recuperare i dettagli completi del libro con gerarchia generi
+        $query = "
+            SELECT l.*,
+                   a.nome AS autore_principale,
+                   g.nome AS genere,
+                   gp.id AS genere_parent_id_resolved,
+                   gp.nome AS genere_parent,
+                   gpp.id AS genere_grandparent_id,
+                   gpp.nome AS genere_grandparent,
+                   sg.nome AS sottogenere,
+                   e.nome AS editore
+            FROM libri l
+            LEFT JOIN libri_autori la ON l.id = la.libro_id AND la.ruolo = 'principale'
+            LEFT JOIN autori a ON la.autore_id = a.id
+            LEFT JOIN generi g ON l.genere_id = g.id
+            LEFT JOIN generi gp ON g.parent_id = gp.id
+            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
+            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
+            LEFT JOIN editori e ON l.editore_id = e.id
+            WHERE l.id = ? AND l.deleted_at IS NULL
+            LIMIT 1
+        ";
+
+        $stmt = $db->prepare($query);
+        $stmt->bind_param("i", $book_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if (!$result || $result->num_rows == 0) {
+            return null;
+        }
+
+        $book = $result->fetch_assoc();
+
+        // Query per ottenere tutti gli autori del libro
+        $query_authors = "
+            SELECT a.*, la.ruolo
+            FROM autori a
+            JOIN libri_autori la ON a.id = la.autore_id
+            WHERE la.libro_id = ?
+            ORDER BY
+                CASE la.ruolo
+                    WHEN 'principale' THEN 1
+                    WHEN 'co-autore' THEN 2
+                    WHEN 'traduttore' THEN 3
+                    WHEN 'illustratore' THEN 4
+                    WHEN 'curatore' THEN 5
+                    WHEN 'colorista' THEN 6
+                    ELSE 7
+                END
+        ";
+
+        $stmt_authors = $db->prepare($query_authors);
+        $stmt_authors->bind_param("i", $book_id);
+        $stmt_authors->execute();
+        $result_authors = $stmt_authors->get_result();
+
+        $authors = [];
+        while ($author = $result_authors->fetch_assoc()) {
+            $authors[] = $author;
+        }
+
+        // Publishers (issue #143): full ordered list for multi-publisher books.
+        // Falls back to the single primary publisher for pre-#143 data.
+        $book['editori'] = [];
+        $stmtPub = $db->prepare(
+            'SELECT e.id, e.nome FROM libri_editori le JOIN editori e ON le.editore_id = e.id WHERE le.libro_id = ? ORDER BY le.ordine, e.nome'
+        );
+        if ($stmtPub) {
+            $stmtPub->bind_param('i', $book_id);
+            $stmtPub->execute();
+            $resPub = $stmtPub->get_result();
+            while ($pub = $resPub->fetch_assoc()) {
+                $book['editori'][] = $pub;
+            }
+            $stmtPub->close();
+        }
+        if ($book['editori'] === [] && !empty($book['editore'])) {
+            $book['editori'][] = ['id' => (int) ($book['editore_id'] ?? 0), 'nome' => (string) $book['editore']];
+        }
+
+        // Other volumes in the same series (collana)
+        $seriesBooks = [];
+        $collana = trim((string) ($book['collana'] ?? ''));
+        if ($collana !== '') {
+            $stmtSeries = $db->prepare("
+                SELECT l.id, l.titolo, l.numero_serie, l.copertina_url,
+                       (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale,
+                       (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale_nome
+                FROM libri l
+                WHERE l.collana = ? AND l.id != ? AND l.deleted_at IS NULL
+                ORDER BY
+                    CASE WHEN TRIM(l.numero_serie) REGEXP '^[0-9]+$' THEN 0 ELSE 1 END,
+                    CAST(l.numero_serie AS UNSIGNED),
+                    l.titolo
+            ");
+            if ($stmtSeries) {
+                $stmtSeries->bind_param('si', $collana, $book_id);
+                $stmtSeries->execute();
+                $resSeries = $stmtSeries->get_result();
+                while ($row = $resSeries->fetch_assoc()) {
+                    $seriesBooks[] = $row;
+                }
+                $stmtSeries->close();
+            } else {
+                \App\Support\SecureLogger::warning('FrontendController: series query prepare failed', ['db_error' => $db->error]);
+            }
+        }
+
+        // Get related books (pass seriesBooks to avoid duplicate collana query)
+        $related_books = $this->getRelatedBooks($db, $book_id, $book, $authors, $seriesBooks);
+
+        return [
+            'book' => $this->stripLiveAvailability($book),
+            'authors' => $authors,
+            'seriesBooks' => $seriesBooks,
+            'related_books' => array_map(
+                fn (array $row): array => $this->stripLiveAvailability($row),
+                $related_books
+            ),
+        ];
+    }
+
+    /**
+     * Remove the live availability fields from a row destined for the cache.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function stripLiveAvailability(array $row): array
+    {
+        foreach (self::LIVE_AVAILABILITY_FIELDS as $field) {
+            unset($row[$field]);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Read the CURRENT availability of the given books straight from the
+     * database (soft-delete aware). This is the only source of the
+     * copie_disponibili/copie_totali/stato values the frontend renders — by
+     * design it runs on every request and is never cached.
+     *
+     * @param array<int, int> $ids
+     * @return array<int, array{copie_disponibili: int, copie_totali: int, stato: mixed}>
+     */
+    private function fetchLiveAvailability(mysqli $db, array $ids): array
+    {
+        $ids = array_values(array_unique(array_filter(array_map('intval', $ids), static fn (int $id): bool => $id > 0)));
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $stmt = $db->prepare(
+            "SELECT id, copie_disponibili, copie_totali, stato FROM libri WHERE id IN ({$placeholders}) AND deleted_at IS NULL"
+        );
+        if ($stmt === false) {
+            \App\Support\SecureLogger::error('FrontendController: live availability prepare failed', ['db_error' => $db->error]);
+            throw new \RuntimeException('Live availability query failed');
+        }
+
+        $types = str_repeat('i', count($ids));
+        $stmt->bind_param($types, ...$ids);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $live = [];
+        if ($result !== false) {
+            while ($row = $result->fetch_assoc()) {
+                $live[(int) $row['id']] = [
+                    'copie_disponibili' => (int) $row['copie_disponibili'],
+                    'copie_totali' => (int) $row['copie_totali'],
+                    'stato' => $row['stato'],
+                ];
+            }
+        }
+        $stmt->close();
+
+        return $live;
+    }
+
+    /**
+     * Merge fresh availability into cached listing rows, dropping rows whose
+     * book was soft-deleted after the cache entry was written (defence in
+     * depth on top of the booksChanged() generation bump).
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function mergeLiveAvailability(mysqli $db, array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        $live = $this->fetchLiveAvailability($db, array_map(static fn (array $row): int => (int) ($row['id'] ?? 0), $rows));
+
+        $fresh = [];
+        foreach ($rows as $row) {
+            $rowId = (int) ($row['id'] ?? 0);
+            if (!isset($live[$rowId])) {
+                continue;
+            }
+            $fresh[] = array_merge($row, $live[$rowId]);
+        }
+
+        return $fresh;
+    }
+
+    /**
+     * Load one page of catalog listing rows. For the finite, high-traffic
+     * bounded filter states (same bounding as the facets cache, plus a page
+     * cap and the canonicalized sort) the rows are cached WITHOUT their live
+     * availability fields, which are merged back fresh on every request.
+     * Unbounded states (free text, ids, years, deep pages) always query.
+     *
+     * @param array<int, mixed> $query_params
+     * @param array<string, mixed> $filters
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadCatalogPageRows(
+        mysqli $db,
+        string $books_query,
+        string $param_types,
+        array $query_params,
+        array $filters,
+        int $limit,
+        int $offset,
+        int $page
+    ): array {
+        $fetch = static function () use ($db, $books_query, $param_types, $query_params, $limit, $offset): array {
+            $stmt_books = $db->prepare($books_query);
+            $final_params = array_merge($query_params, [$limit, $offset]);
+            $final_types = $param_types . 'ii';
+            $stmt_books->bind_param($final_types, ...$final_params);
+            $stmt_books->execute();
+            $books_result = $stmt_books->get_result();
+
+            $books = [];
+            while ($book = $books_result->fetch_assoc()) {
+                $books[] = $book;
+            }
+            $stmt_books->close();
+
+            return $books;
+        };
+
+        if (!$this->hasBoundedCatalogCacheKey($filters) || $page < 1 || $page > self::CATALOG_PAGE_CACHE_MAX_PAGE) {
+            return $fetch();
+        }
+
+        // Key: locale + bounded filter signature + canonical sort + page. The
+        // sort goes through buildOrderBy() so arbitrary request strings
+        // collapse onto the six real orderings instead of fragmenting keys.
+        $cacheKey = 'catalog_page_' . \App\Support\I18n::getLocale() . '_' . md5(serialize([
+            $this->normalizeFiltersForCache($filters),
+            $this->buildOrderBy((string) ($filters['sort'] ?? 'newest')),
+            $page,
+        ]));
+
+        $rows = \App\Support\QueryCache::remember($cacheKey, function () use ($fetch): array {
+            // Live availability never enters the cache (hard rule): strip it
+            // here, mergeLiveAvailability() re-reads it per request.
+            return array_map(
+                fn (array $row): array => $this->stripLiveAvailability($row),
+                $fetch()
+            );
+        }, 120);
+
+        if (!is_array($rows)) {
+            return $fetch();
+        }
+
+        return $this->mergeLiveAvailability($db, $rows);
     }
 
     private function render404(Response $response): Response

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -683,9 +683,10 @@ class FrontendController
      * soft-deleted — callers must treat that as a 404.
      *
      * Cached by bookDetail() under the 'book_detail_' namespace; every book
-     * write path (create/edit/soft-delete, author/publisher/genre/series
-     * mutations, imports, availability recomputes) funnels into
-     * ContentCache::booksChanged(), which bumps that generation.
+     * metadata write path (create/edit/soft-delete, author/publisher/genre/
+     * series mutations and imports) funnels into ContentCache::booksChanged(),
+     * which bumps that generation. Availability-only recomputes use
+     * availabilityChanged() and intentionally leave this static DTO warm.
      *
      * @return array{book: array<string, mixed>, authors: array<int, array<string, mixed>>,
      *               seriesBooks: array<int, array<string, mixed>>,
@@ -722,10 +723,12 @@ class FrontendController
         $result = $stmt->get_result();
 
         if (!$result || $result->num_rows == 0) {
+            $stmt->close();
             return null;
         }
 
         $book = $result->fetch_assoc();
+        $stmt->close();
 
         // Query per ottenere tutti gli autori del libro
         $query_authors = "
@@ -754,6 +757,7 @@ class FrontendController
         while ($author = $result_authors->fetch_assoc()) {
             $authors[] = $author;
         }
+        $stmt_authors->close();
 
         // Publishers (issue #143): full ordered list for multi-publisher books.
         // Falls back to the single primary publisher for pre-#143 data.
@@ -955,6 +959,7 @@ class FrontendController
             $this->normalizeFiltersForCache($filters),
             $this->buildOrderBy((string) ($filters['sort'] ?? 'newest')),
             $page,
+            $limit,
         ]));
 
         $rows = \App\Support\QueryCache::remember($cacheKey, function () use ($fetch): array {

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2755,6 +2755,10 @@ class LibriController
         $stmt->execute();
         $stmt->close();
 
+        // The cover URL is part of the cached book-detail DTO and catalog rows
+        // (#387): invalidate so the new cover shows without waiting for the TTL.
+        \App\Support\ContentCache::booksChanged();
+
         $response->getBody()->write(json_encode(['success' => true, 'fetched' => true, 'cover_url' => $coverUrl]));
         return $response->withHeader('Content-Type', 'application/json');
     }
@@ -3843,6 +3847,11 @@ class LibriController
                             $stmt->bind_param('si', $coverData['file_url'], $book['id']);
                             $stmt->execute();
                             $stmt->close();
+
+                            // Cover is in the cached book-detail DTO / catalog rows
+                            // (#387). Defer collapses the whole bulk sync into a
+                            // single invalidation at shutdown.
+                            \App\Support\ContentCache::deferBooksChanged();
 
                             $synced++;
                             error_log("[Cover Sync] Cover downloaded for book ID {$book['id']}: {$coverData['file_url']}");

--- a/app/Controllers/ProfileController.php
+++ b/app/Controllers/ProfileController.php
@@ -248,6 +248,9 @@ class ProfileController
         }
 
         if ($updated) {
+            // The cached reviews block (#387) stores the reviewer display name as
+            // CONCAT(nome,' ',cognome), so a name change must invalidate it.
+            \App\Support\ContentCache::reviewsChanged();
             // Update session data
             $_SESSION['user']['name'] = trim($nome . ' ' . $cognome);
             // Apply locale change immediately (only when locale was in the form)

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -515,6 +515,13 @@ class UsersController
         }
         $stmt->close();
 
+        // Public review DTOs include the reviewer's display name. Invalidate
+        // only when that rendered identity actually changed.
+        if ((string) ($original['nome'] ?? '') !== $nome
+            || (string) ($original['cognome'] ?? '') !== $cognome) {
+            \App\Support\ContentCache::reviewsChanged();
+        }
+
         // Keep the current browser session coherent when an administrator edits
         // their own account; other users pick up the persisted locale at login.
         if ($currentUserId === $id) {

--- a/app/Models/SeriesRepository.php
+++ b/app/Models/SeriesRepository.php
@@ -341,6 +341,10 @@ class SeriesRepository
             $stmtUpsert->execute();
             $stmtUpsert->close();
         }
+
+        // Series data (collana / numero_serie / sibling volumes) is part of the
+        // cached book-detail DTO (#387): invalidate on every series mutation.
+        \App\Support\ContentCache::deferBooksChanged();
     }
 
     /** @return array<int, array<string, mixed>> */
@@ -668,6 +672,10 @@ class SeriesRepository
             }
         }
 
+        if ($ok) {
+            \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
+        }
+
         return $ok;
     }
 
@@ -700,6 +708,10 @@ class SeriesRepository
                 $this->promoteLegacySeries($bookId);
                 $affected++;
             }
+        }
+
+        if ($affected > 0) {
+            \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
         }
 
         return $affected;
@@ -801,6 +813,8 @@ class SeriesRepository
             }
         }
 
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
+
         return count($bookIds);
     }
 
@@ -867,6 +881,8 @@ class SeriesRepository
                 $stmtBackfill->close();
             }
         }
+
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
 
         return $affected;
     }
@@ -945,6 +961,8 @@ class SeriesRepository
                 $stmtDelete->close();
             }
         }
+
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
 
         return $affected;
     }

--- a/app/Repositories/RecensioniRepository.php
+++ b/app/Repositories/RecensioniRepository.php
@@ -201,8 +201,7 @@ class RecensioniRepository
         try {
             $stmt = $this->db->prepare("
                 SELECT r.*,
-                       CONCAT(u.nome, ' ', u.cognome) as utente_nome,
-                       u.email as utente_email
+                       CONCAT(u.nome, ' ', u.cognome) as utente_nome
                 FROM recensioni r
                 JOIN utenti u ON r.utente_id = u.id
                 WHERE r.libro_id = ?

--- a/app/Repositories/RecensioniRepository.php
+++ b/app/Repositories/RecensioniRepository.php
@@ -295,6 +295,12 @@ class RecensioniRepository
             $result = $stmt->execute();
             $stmt->close();
 
+            if ($result) {
+                // The review becomes publicly visible: drop the cached
+                // book-detail reviews block (O(1) generation bump).
+                \App\Support\ContentCache::reviewsChanged();
+            }
+
             return $result;
 
         } catch (\Throwable $e) {
@@ -321,6 +327,12 @@ class RecensioniRepository
             $result = $stmt->execute();
             $stmt->close();
 
+            if ($result) {
+                // An already-approved review can be rejected: it must leave
+                // the cached public reviews block immediately.
+                \App\Support\ContentCache::reviewsChanged();
+            }
+
             return $result;
 
         } catch (\Throwable $e) {
@@ -339,6 +351,12 @@ class RecensioniRepository
             $stmt->bind_param('i', $reviewId);
             $result = $stmt->execute();
             $stmt->close();
+
+            if ($result) {
+                // A deleted approved review must disappear from the cached
+                // public reviews block immediately.
+                \App\Support\ContentCache::reviewsChanged();
+            }
 
             return $result;
 

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -13,12 +13,13 @@ namespace App\Support;
 final class ContentCache
 {
     private static bool $booksInvalidationDeferred = false;
+    private static bool $availabilityInvalidationDeferred = false;
 
     /**
-     * A book (or its availability) changed: invalidate catalog counts/facets,
-     * every home entry (home_page_data_v1 and home_api_count_*), and the
-     * cached genre tree. O(1) generation bumps — previously cached entries in
-     * these namespaces become unreachable immediately, no scan/delete storm.
+     * Book metadata or taxonomy changed: invalidate catalog counts/facets,
+     * every home entry (home_page_data_v1 and home_api_count_*), the cached
+     * genre tree and static detail DTOs. Availability-only writes use the
+     * narrower availabilityChanged() path below.
      */
     public static function booksChanged(): void
     {
@@ -45,6 +46,37 @@ final class ContentCache
         register_shutdown_function(static function (): void {
             self::$booksInvalidationDeferred = false;
             self::booksChanged();
+        });
+    }
+
+    /**
+     * Only circulation-derived availability changed. Catalog membership,
+     * counts and the home dataset must be refreshed, while the static
+     * book-detail DTO deliberately remains valid because its availability is
+     * always merged from a live query.
+     */
+    public static function availabilityChanged(): void
+    {
+        QueryCache::bumpGeneration('catalog_');
+        QueryCache::bumpGeneration('home_');
+    }
+
+    /**
+     * Defer and coalesce availability invalidation for caller-owned
+     * transactions. A broader deferred booksChanged() subsumes this work.
+     */
+    public static function deferAvailabilityChanged(): void
+    {
+        if (self::$booksInvalidationDeferred || self::$availabilityInvalidationDeferred) {
+            return;
+        }
+
+        self::$availabilityInvalidationDeferred = true;
+        register_shutdown_function(static function (): void {
+            self::$availabilityInvalidationDeferred = false;
+            if (!self::$booksInvalidationDeferred) {
+                self::availabilityChanged();
+            }
         });
     }
 

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -25,6 +25,7 @@ final class ContentCache
         QueryCache::bumpGeneration('catalog_');
         QueryCache::bumpGeneration('home_');
         QueryCache::bumpGeneration('genre_tree_');
+        QueryCache::bumpGeneration('book_detail_');
     }
 
     /**
@@ -53,5 +54,16 @@ final class ContentCache
     public static function homeContentChanged(): void
     {
         QueryCache::bumpGeneration('home_');
+    }
+
+    /**
+     * A review was approved, rejected or deleted: the cached public reviews
+     * block ('book_reviews_' namespace, book-detail page) is stale. New
+     * reviews are created as 'pendente' (never publicly visible), so only
+     * moderation transitions need to invalidate.
+     */
+    public static function reviewsChanged(): void
+    {
+        QueryCache::bumpGeneration('book_reviews_');
     }
 }

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -151,9 +151,9 @@ class DataIntegrity {
 
             if (!$insideTransaction) {
                 $this->db->commit();
-                ContentCache::booksChanged();
+                ContentCache::availabilityChanged();
             } else {
-                ContentCache::deferBooksChanged();
+                ContentCache::deferAvailabilityChanged();
             }
 
         } catch (\Throwable $e) {
@@ -246,7 +246,7 @@ class DataIntegrity {
                 $processed++;
             }
             if ($chunkDirty) {
-                ContentCache::booksChanged();
+                ContentCache::availabilityChanged();
             }
 
             // Report progress
@@ -417,9 +417,9 @@ class DataIntegrity {
             // once per book.
             if ($result && !$skipCacheInvalidation) {
                 if ($insideTransaction) {
-                    ContentCache::deferBooksChanged();
+                    ContentCache::deferAvailabilityChanged();
                 } else {
-                    ContentCache::booksChanged();
+                    ContentCache::availabilityChanged();
                 }
             }
 

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -34,6 +34,8 @@ class QueryCache
         'genre_tree_',
         'plugins_maintenance_',
         'schema_table_',
+        'book_detail_',
+        'book_reviews_',
     ];
 
     /**

--- a/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
@@ -193,6 +193,10 @@ class ReviewsController
                 $stmt->bind_param('isii', $rating, $textOrNull, $existingId, $userId);
                 $stmt->execute();
                 $stmt->close();
+                // An approved review may just have become pending again. Keep
+                // the public web review block coherent with this plugin write
+                // path, which intentionally bypasses RecensioniRepository.
+                \App\Support\ContentCache::reviewsChanged();
                 $reviewId = $existingId;
                 $created = false;
             } else {
@@ -258,6 +262,10 @@ class ReviewsController
             if (!$removed) {
                 return ResponseEnvelope::error($response, 'not_found', __('Nessuna recensione da eliminare.'), 404);
             }
+
+            // The deleted row may have been approved and present in the public
+            // book-detail cache. This plugin write bypasses the core repository.
+            \App\Support\ContentCache::reviewsChanged();
 
             return ResponseEnvelope::success($response, null, [], 200);
         } catch (\Throwable $e) {

--- a/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
+++ b/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\ViafAuthority;
 
+use App\Support\ContentCache;
 use App\Support\HookManager;
 use App\Support\RateLimiter;
 use App\Support\SecureLogger;
@@ -576,6 +577,9 @@ class ViafAuthorityPlugin
         if ($affected === 0 && !$this->authorExists($id)) {
             return $this->json($response, ['error' => true, 'message' => __('Autore non trovato.')], 404);
         }
+        if ($affected > 0) {
+            ContentCache::booksChanged();
+        }
 
         return $this->json($response, [
             'success'  => true,
@@ -666,6 +670,9 @@ class ViafAuthorityPlugin
         }
         if ($affected === 0 && !$this->authorExists($id)) {
             return $this->json($response, ['error' => true, 'message' => __('Autore non trovato.')], 404);
+        }
+        if ($affected > 0) {
+            ContentCache::booksChanged();
         }
 
         return $this->json($response, [

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -1,0 +1,284 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural contract for issue #387 step 4 (hot public dataset caching):
+ *
+ *  A. Book-detail STATIC/LIVE split — the static DTO (book row, authors,
+ *     publishers, series, related) is cached under 'book_detail_' while
+ *     availability (copie_disponibili/copie_totali/stato) is re-read from the
+ *     database on EVERY request:
+ *       - mutate copie_disponibili+stato+titolo directly in the DB (no
+ *         invalidation) → the served page shows the NEW availability but the
+ *         OLD title (metadata came from cache, availability did not);
+ *       - ContentCache::booksChanged() → the page shows the new title.
+ *  B. Reviews block — cached under 'book_reviews_':
+ *       - a review force-approved via raw SQL (bypassing moderation) does NOT
+ *         appear while the cache is warm (proves the block is cached);
+ *       - the real moderation path (RecensioniRepository::approveReview /
+ *         deleteReview) invalidates immediately.
+ *  C. Bounded catalog page rows — cached under 'catalog_' ('catalog_page_*'):
+ *       - the default catalog listing serves cached rows (old title) while the
+ *         per-card availability badge is merged live (status flips without any
+ *         invalidation);
+ *       - booksChanged() invalidates the rows.
+ *  D. Namespace mechanics — 'book_detail_' and 'book_reviews_' are
+ *     generation-tracked; booksChanged() bumps book_detail_ but not
+ *     book_reviews_; reviewsChanged() bumps only book_reviews_.
+ *
+ * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
+ * show the NEW title in step A (assertion "old title still served" fails), and
+ * the force-approved review in step B would appear immediately.
+ *
+ * Seeds run inside a transaction that is always rolled back; every cache
+ * namespace touched is generation-bumped in the finally block so no cached
+ * uncommitted row can leak into the shared dev cache.
+ *
+ * Run: php tests/hot-dataset-cache-387.unit.php
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Controllers\FrontendController;
+use App\Repositories\RecensioniRepository;
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+    } else {
+        $failed++;
+        echo "  FAIL {$label}\n";
+    }
+};
+
+// ── DB connection: E2E_* env first, .env fallback ───────────────────────────
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $value = trim($value);
+    if (strlen($value) >= 2 && ($value[0] === '"' || $value[0] === "'") && $value[-1] === $value[0]) {
+        $value = substr($value, 1, -1);
+    }
+    $env[trim($key)] = $value;
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$dbName = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+$dbUser = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$dbPass = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+
+try {
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $dbUser, $dbPass, $dbName, 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $dbUser, $dbPass, $dbName, (int) ($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+
+$_SESSION = $_SESSION ?? [];
+
+$controller = new FrontendController();
+$requestFactory = new ServerRequestFactory();
+
+/**
+ * Invoke bookDetail for the given id starting from an arbitrary path,
+ * following canonical 301 redirects (max 3). Returns [status, body, path].
+ */
+$renderBookPage = static function (int $bookId, string $path = '/__cache387__') use ($controller, $requestFactory, $db): array {
+    for ($hop = 0; $hop < 4; $hop++) {
+        $request = $requestFactory->createServerRequest('GET', $path)->withQueryParams(['id' => $bookId]);
+        $response = $controller->bookDetail($request, new Response(), $db);
+        $status = $response->getStatusCode();
+        if ($status !== 301) {
+            return [$status, (string) $response->getBody(), $path];
+        }
+        $location = $response->getHeaderLine('Location');
+        $path = (string) (parse_url($location, PHP_URL_PATH) ?: $location);
+    }
+    return [301, '', $path];
+};
+
+$callCatalog = static function (array $params) use ($controller, $requestFactory, $db): array {
+    $request = $requestFactory->createServerRequest('GET', '/api/catalogo')->withQueryParams($params);
+    $response = $controller->catalogAPI($request, new Response(), $db);
+    $decoded = json_decode((string) $response->getBody(), true);
+    return is_array($decoded) ? $decoded : [];
+};
+
+/** The status-badge marker inside the card whose <img alt> carries $title. */
+$badgeNearTitle = static function (string $html, string $title): string {
+    $needle = 'alt="' . htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '"';
+    $pos = strpos($html, $needle);
+    if ($pos === false) {
+        return '';
+    }
+    $window = substr($html, $pos, 600);
+    if (preg_match('/book-status-badge (status-[a-z]+)/', $window, $m)) {
+        return $m[1];
+    }
+    return '';
+};
+
+$token = bin2hex(random_bytes(5));
+$titleV1 = "ZZ Cache387 Original {$token}";
+$titleV2 = "ZZ Cache387 Renamed {$token}";
+$reviewTitle = "ZZ Review387 {$token}";
+
+$db->begin_transaction();
+
+try {
+    // ── Seed: one book (2/2 available) + one user ───────────────────────────
+    $stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, 2, 2, 'disponibile')");
+    $stmt->bind_param('s', $titleV1);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+
+    $card = 'C387' . substr($token, 0, 8);
+    $email = "cache387.{$token}@example.test";
+    $stmt = $db->prepare("INSERT INTO utenti (codice_tessera, nome, cognome, email, password, privacy_accettata) VALUES (?, 'Cache', 'Tester', ?, 'x', 1)");
+    $stmt->bind_param('ss', $card, $email);
+    $stmt->execute();
+    $userId = (int) $db->insert_id;
+    $stmt->close();
+
+    // Start from clean generations so stale dev-cache entries cannot interfere.
+    ContentCache::booksChanged();
+    ContentCache::reviewsChanged();
+
+    echo "A. Book-detail static/live split:\n";
+
+    [$status1, $body1] = $renderBookPage($bookId);
+    $check($status1 === 200, "first render returns 200 (got {$status1})");
+    $check(str_contains($body1, $titleV1), 'first render shows the seeded title');
+    $check(str_contains($body1, 'availability-badge available'), 'first render shows the book as available (2/2)');
+
+    // Mutate availability AND metadata directly — deliberately WITHOUT any
+    // cache invalidation. Availability must change on the next render (live
+    // read), metadata must NOT (cached DTO reused, no re-query).
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 0, stato = 'prestato' WHERE id = ?");
+    $stmt->bind_param('si', $titleV2, $bookId);
+    $stmt->execute();
+    $stmt->close();
+
+    [$status2, $body2] = $renderBookPage($bookId);
+    $check($status2 === 200, "second render returns 200 (got {$status2})");
+    $check(str_contains($body2, 'availability-badge unavailable'), 'availability flips to unavailable WITHOUT invalidation (read live every request)');
+    $check(str_contains($body2, $titleV1), 'cached static metadata still served (old title — DTO not re-queried)');
+    $check(!str_contains($body2, $titleV2), 'new title NOT visible while the DTO cache is warm');
+
+    // booksChanged() (the bump every book write path fires) must rebuild the DTO.
+    ContentCache::booksChanged();
+    [$status3, $body3] = $renderBookPage($bookId);
+    $check($status3 === 200, "post-invalidation render returns 200 (got {$status3})");
+    $check(str_contains($body3, $titleV2), 'booksChanged() invalidates the DTO (new title now served)');
+    $check(str_contains($body3, 'availability-badge unavailable'), 'availability still correct after invalidation');
+
+    echo "\nB. Reviews block cache + moderation invalidation:\n";
+
+    $stmt = $db->prepare("INSERT INTO recensioni (libro_id, utente_id, stelle, titolo, descrizione, stato) VALUES (?, ?, 5, ?, 'body', 'pendente')");
+    $stmt->bind_param('iis', $bookId, $userId, $reviewTitle);
+    $stmt->execute();
+    $reviewId = (int) $db->insert_id;
+    $stmt->close();
+
+    [, $bodyR1] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR1, $reviewTitle), 'pending review is not publicly visible (reviews block cached empty)');
+
+    // Force-approve via raw SQL (bypassing moderation): the cached block must
+    // keep serving the old state — this is the assertion that fails when the
+    // reviews block is not cached at all (pre-change behaviour).
+    $db->query("UPDATE recensioni SET stato = 'approvata' WHERE id = {$reviewId}");
+    [, $bodyR2] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR2, $reviewTitle), 'raw-SQL approval does not appear while the reviews cache is warm (block IS cached)');
+
+    // The real moderation path must invalidate immediately.
+    $db->query("UPDATE recensioni SET stato = 'pendente' WHERE id = {$reviewId}");
+    $repo = new RecensioniRepository($db);
+    $check($repo->approveReview($reviewId, $userId), 'approveReview() succeeds');
+    [, $bodyR3] = $renderBookPage($bookId);
+    $check(str_contains($bodyR3, $reviewTitle), 'approved review visible immediately (approve bumps book_reviews_)');
+
+    $check($repo->deleteReview($reviewId), 'deleteReview() succeeds');
+    [, $bodyR4] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR4, $reviewTitle), 'deleted review disappears immediately (delete bumps book_reviews_)');
+
+    echo "\nC. Bounded catalog page rows (static rows cached, availability live):\n";
+
+    // Reset the book to a stable, available state and clear the catalog cache.
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 2, stato = 'disponibile' WHERE id = ?");
+    $stmt->bind_param('si', $titleV1, $bookId);
+    $stmt->execute();
+    $stmt->close();
+    ContentCache::booksChanged();
+
+    // Default catalog state (no filters) is bounded → page 1 rows get cached.
+    // The seeded book is the newest row, so it is on page 1 of sort=newest.
+    $cat1 = $callCatalog(['page' => '1']);
+    $html1 = (string) ($cat1['html'] ?? '');
+    $check(str_contains($html1, $titleV1), 'seeded book appears on the default catalog first page');
+    $check($badgeNearTitle($html1, $titleV1) === 'status-available', 'catalog card badge shows available (2 copies)');
+
+    // Mutate availability + title with NO invalidation: cached rows must keep
+    // the old title, the badge must flip (merged live).
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 0, stato = 'prestato' WHERE id = ?");
+    $stmt->bind_param('si', $titleV2, $bookId);
+    $stmt->execute();
+    $stmt->close();
+
+    $cat2 = $callCatalog(['page' => '1']);
+    $html2 = (string) ($cat2['html'] ?? '');
+    $check(str_contains($html2, $titleV1), 'catalog rows still served from cache (old title)');
+    $check(!str_contains($html2, $titleV2), 'new title NOT visible in the cached catalog rows');
+    $check($badgeNearTitle($html2, $titleV1) === 'status-borrowed', 'catalog card badge flips to borrowed WITHOUT invalidation (availability merged live)');
+
+    ContentCache::booksChanged();
+    $cat3 = $callCatalog(['page' => '1']);
+    $html3 = (string) ($cat3['html'] ?? '');
+    $check(str_contains($html3, $titleV2), 'booksChanged() invalidates the catalog page rows (new title served)');
+
+    echo "\nD. Namespace mechanics:\n";
+
+    $nsRun = 'ns387_' . $token;
+    QueryCache::set('book_detail_' . $nsRun, 'dto', 120);
+    QueryCache::set('book_reviews_' . $nsRun, 'reviews', 120);
+    QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
+    ContentCache::booksChanged();
+    $check(QueryCache::get('book_detail_' . $nsRun) === null, 'booksChanged bumps book_detail_');
+    $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'booksChanged bumps catalog_page_* (catalog_ namespace)');
+    $check(QueryCache::get('book_reviews_' . $nsRun) === 'reviews', 'booksChanged leaves book_reviews_ alone');
+    ContentCache::reviewsChanged();
+    $check(QueryCache::get('book_reviews_' . $nsRun) === null, 'reviewsChanged bumps book_reviews_');
+} catch (\Throwable $e) {
+    $failed++;
+    echo "FAIL  unexpected exception: {$e->getMessage()} @ {$e->getFile()}:{$e->getLine()}\n";
+} finally {
+    // Roll back every seeded row and make any cache entry built from the
+    // uncommitted rows unreachable (the dev site shares storage/cache).
+    try {
+        $db->rollback();
+    } catch (\Throwable $e) {
+        // connection already gone — nothing to roll back
+    }
+    ContentCache::booksChanged();
+    ContentCache::reviewsChanged();
+}
+
+echo "\n{$passed} passed, {$failed} failed\n";
+exit($failed === 0 ? 0 : 1);

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -24,7 +24,8 @@ declare(strict_types=1);
  *       - booksChanged() invalidates the rows.
  *  D. Namespace mechanics — 'book_detail_' and 'book_reviews_' are
  *     generation-tracked; booksChanged() bumps book_detail_ but not
- *     book_reviews_; reviewsChanged() bumps only book_reviews_.
+ *     book_reviews_; availabilityChanged() leaves book_detail_ intact;
+ *     reviewsChanged() bumps only book_reviews_.
  *
  * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
  * show the NEW title in step A (assertion "old title still served" fails), and
@@ -212,6 +213,11 @@ try {
     $db->query("UPDATE recensioni SET stato = 'pendente' WHERE id = {$reviewId}");
     $repo = new RecensioniRepository($db);
     $check($repo->approveReview($reviewId, $userId), 'approveReview() succeeds');
+    $approvedRows = $repo->getApprovedReviewsForBook($bookId);
+    $check(
+        isset($approvedRows[0]) && !array_key_exists('utente_email', $approvedRows[0]),
+        'public review DTO does not cache reviewer email'
+    );
     [, $bodyR3] = $renderBookPage($bookId);
     $check(str_contains($bodyR3, $reviewTitle), 'approved review visible immediately (approve bumps book_reviews_)');
 
@@ -259,12 +265,24 @@ try {
     QueryCache::set('book_detail_' . $nsRun, 'dto', 120);
     QueryCache::set('book_reviews_' . $nsRun, 'reviews', 120);
     QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
+    ContentCache::availabilityChanged();
+    $check(QueryCache::get('book_detail_' . $nsRun) === 'dto', 'availabilityChanged leaves static book_detail_ DTOs warm');
+    $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'availabilityChanged bumps catalog_page_* membership');
+    QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
     ContentCache::booksChanged();
     $check(QueryCache::get('book_detail_' . $nsRun) === null, 'booksChanged bumps book_detail_');
     $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'booksChanged bumps catalog_page_* (catalog_ namespace)');
     $check(QueryCache::get('book_reviews_' . $nsRun) === 'reviews', 'booksChanged leaves book_reviews_ alone');
     ContentCache::reviewsChanged();
     $check(QueryCache::get('book_reviews_' . $nsRun) === null, 'reviewsChanged bumps book_reviews_');
+
+    $mobileReviews = (string) file_get_contents(
+        $root . '/storage/plugins/mobile-api/src/Controllers/ReviewsController.php'
+    );
+    $check(
+        substr_count($mobileReviews, 'ContentCache::reviewsChanged()') >= 2,
+        'mobile review edit/delete paths invalidate the public reviews block'
+    );
 } catch (\Throwable $e) {
     $failed++;
     echo "FAIL  unexpected exception: {$e->getMessage()} @ {$e->getFile()}:{$e->getLine()}\n";

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
  *     generation-tracked; booksChanged() bumps book_detail_ but not
  *     book_reviews_; availabilityChanged() leaves book_detail_ intact;
  *     reviewsChanged() bumps only book_reviews_.
+ *  E. Indirect write paths — authority updates invalidate book DTOs and
+ *     admin edits of reviewer names invalidate rendered review DTOs.
  *
  * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
  * show the NEW title in step A (assertion "old title still served" fails), and
@@ -282,6 +284,24 @@ try {
     $check(
         substr_count($mobileReviews, 'ContentCache::reviewsChanged()') >= 2,
         'mobile review edit/delete paths invalidate the public reviews block'
+    );
+
+    echo "\nE. Indirect write-path invalidation:\n";
+
+    $authorityPlugin = (string) file_get_contents(
+        $root . '/storage/plugins/viaf-authority/ViafAuthorityPlugin.php'
+    );
+    $check(
+        substr_count($authorityPlugin, 'ContentCache::booksChanged()') >= 2,
+        'VIAF and ISNI author updates invalidate cached book-detail DTOs'
+    );
+
+    $usersController = (string) file_get_contents($root . '/app/Controllers/UsersController.php');
+    $check(
+        str_contains($usersController, "original['nome']")
+            && str_contains($usersController, "original['cognome']")
+            && str_contains($usersController, 'ContentCache::reviewsChanged()'),
+        'admin reviewer-name edits invalidate cached public review DTOs'
     );
 } catch (\Throwable $e) {
     $failed++;

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -214,10 +214,10 @@ $contentCache = $read('app/Support/ContentCache.php');
 $checkCacheNamespace($frontend, 'home_api_count_', 'home_', $contentCache, 'home API counts');
 $check(str_contains($contentCache, 'function deferBooksChanged'), 'transaction-owned writers can defer invalidation');
 $integrity = $read('app/Support/DataIntegrity.php');
-$check(str_contains($integrity, 'ContentCache::deferBooksChanged()'), 'DataIntegrity defers invalidation for outer transactions');
+$check(str_contains($integrity, 'ContentCache::deferAvailabilityChanged()'), 'DataIntegrity defers availability invalidation for outer transactions');
 $check(
-    substr_count($integrity, 'ContentCache::booksChanged()') >= 2,
-    'single and global standalone recalculations invalidate after their commits'
+    substr_count($integrity, 'ContentCache::availabilityChanged()') >= 2,
+    'single and global standalone recalculations invalidate availability after their commits'
 );
 $settingsRepository = $read('app/Models/SettingsRepository.php');
 $check(


### PR DESCRIPTION
Step 4 of #387, stacked on #388 (uses its generation-key invalidation). Availability is NEVER cached — the design separates the static DTO (cached) from live copie_disponibili/copie_totali/stato (read fresh every request).

## Cached, and how each invalidates
- Book-detail static DTO book_detail_{locale}_{id} (TTL 300): metadata + authors/publishers/series/related, availability stripped before storage; re-read LIVE every request (fetchLiveAvailability, PK IN + deleted_at IS NULL), soft-deleted book 404s. Invalidated by booksChanged().
- Reviews book_reviews_{locale}_{id}: invalidated by new ContentCache::reviewsChanged() from RecensioniRepository approve/reject/delete.
- Bounded catalog pages catalog_page_{locale}_{md5(bounded filters+sort+page)}: only the finite low-cardinality filter space (facet bounding + page<=10 + canonical sort); rows availability-stripped, merged live per request, soft-deleted dropped. Invalidated by booksChanged() (fires from every write-path + DataIntegrity availability recompute).

## Not cached (deliberate)
Autocomplete/search-preview: SearchController carries live availability, and the preview key embeds free text -> unbounded key space = disk-fill vector the codebase forbids. Left live.

## Safety / tests
No migration/new config/new extension; cold cache = identical behavior. tests/hot-dataset-cache-387.unit.php (26 checks) proves via real renders that a warm cache serves fresh availability while keeping cached metadata. Full suite 139/139, PHPStan level 5 clean, soft-delete guard clean.

Part of #387.