### PR TITLE
perf(cache): sessionless anonymous path + lazy CSRF — edge-cache prerequisite (#387)

### DIFF
--- a/app/Controllers/LanguageController.php
+++ b/app/Controllers/LanguageController.php
@@ -58,8 +58,11 @@ class LanguageController
         $secure = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
             || $forwardedProto === 'https'
             || $forwardedSsl === 'on';
+        $basePath = rtrim(\App\Support\HtmlHelper::getBasePath(), '/');
+        $cookiePath = ($basePath === '' ? '' : $basePath) . '/';
         $cookie = 'pinakes_locale=' . rawurlencode($locale)
-            . '; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
+            . '; Path=' . $cookiePath
+            . '; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
 
         // Determine safe redirect target
         $queryParams = $request->getQueryParams();

--- a/app/Controllers/LanguageController.php
+++ b/app/Controllers/LanguageController.php
@@ -26,11 +26,14 @@ class LanguageController
         // Set locale in I18n
         I18n::setLocale($locale);
 
-        // Save in session
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
+        // Save in session — but only when one is already open (logged-in
+        // users and cookie-bearing visitors). A sessionless anonymous visitor
+        // (issue #387 step 6) must NOT be handed a session just to remember
+        // the language: the choice is persisted in the pinakes_locale cookie
+        // below, which public/index.php reads on the no-session path.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION['locale'] = $locale;
         }
-        $_SESSION['locale'] = $locale;
 
         // Save to database if user is logged in
         if (isset($_SESSION['user']['id'])) {
@@ -44,11 +47,26 @@ class LanguageController
             }
         }
 
+        // Persist the choice in a cookie so the anonymous no-session path
+        // (issue #387 step 6) resolves the locale deterministically without a
+        // session. $locale is normalized and validated against the available
+        // locales above, so the value is always a safe xx_XX code. HTTPS
+        // detection mirrors AuthController::loginForm() (honours
+        // X-Forwarded-Proto/-Ssl behind TLS-terminating proxies).
+        $forwardedProto = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? ''));
+        $forwardedSsl = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_SSL'] ?? ''));
+        $secure = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
+            || $forwardedProto === 'https'
+            || $forwardedSsl === 'on';
+        $cookie = 'pinakes_locale=' . rawurlencode($locale)
+            . '; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
+
         // Determine safe redirect target
         $queryParams = $request->getQueryParams();
         $redirect = $this->sanitizeRedirect($queryParams['redirect'] ?? '/');
 
         return $response
+            ->withAddedHeader('Set-Cookie', $cookie)
             ->withHeader('Location', $redirect)
             ->withStatus(302);
     }

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -128,6 +128,28 @@ return function (App $app): void {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    // Lazy CSRF endpoint (issue #387 step 6). Sessionless anonymous pages
+    // carry no CSRF token in their cacheable HTML; JS fetches one from here
+    // right before a state-changing request (see public/assets/js/
+    // csrf-helper.js). Starting the session on demand mints the same
+    // session-backed token CsrfMiddleware validates — protection is
+    // unchanged, only WHEN the token is minted moves. The hardened session
+    // ini parameters were already applied unconditionally in public/index.php,
+    // so this lazy session_start() uses the exact same secure cookie settings.
+    // The same-origin policy keeps the JSON unreadable cross-site (no CORS
+    // headers are emitted) and no-store keeps any cache from persisting a
+    // per-visitor token. Technical endpoint → literal path, like /health.
+    $app->get('/csrf-token', function ($request, $response) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $payload = json_encode(['token' => \App\Support\Csrf::ensureToken()], JSON_HEX_TAG);
+        $response->getBody()->write((string) $payload);
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'no-store, private');
+    });
+
     // Private uploaded files (digital-library content, archive documents,
     // generic storage). public/.htaccess routes ONLY these private prefixes
     // here instead of serving them directly, so the global middleware stack

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -146,8 +146,11 @@ return function (App $app): void {
         $payload = json_encode(['token' => \App\Support\Csrf::ensureToken()], JSON_HEX_TAG);
         $response->getBody()->write((string) $payload);
         return $response
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('Cache-Control', 'no-store, private');
+            ->withHeader('Content-Type', 'application/json; charset=UTF-8')
+            ->withHeader('Cache-Control', 'no-store, private')
+            ->withHeader('Pragma', 'no-cache')
+            ->withHeader('Vary', 'Cookie')
+            ->withHeader('X-Content-Type-Options', 'nosniff');
     });
 
     // Private uploaded files (digital-library content, archive documents,

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Decides whether the current HTTP request needs a PHP session.
+ *
+ * Step 6 of the caching overhaul (issue #387): the anonymous public request
+ * path must be sessionless so a later PR can put anonymous pages behind a
+ * shared full-page/edge cache. A request is served WITHOUT a session only
+ * when ALL of the following hold:
+ *
+ *   1. The method is read-only (GET/HEAD). Every state-changing method
+ *      (POST/PUT/PATCH/DELETE/…) keeps the session so CSRF validation always
+ *      has its session-backed token store — this also covers login and every
+ *      other auth POST by construction.
+ *   2. The request carries NO auth-related cookie: no session cookie
+ *      (session_name()), no remember_token (persistent login) and no
+ *      csrf_login (login form double-submit cookie). Any hint of an
+ *      authenticated — or authenticating — browser keeps the exact current
+ *      session behavior.
+ *   3. The path is not an auth/contact route (in any registered locale).
+ *      Those pages mint session-backed CSRF tokens into their HTML forms
+ *      (login, register, forgot/reset password, contact) and must keep
+ *      opening the session so the subsequent POST validates.
+ *
+ * Fail-safe direction: anything unknown (CLI, missing method, malformed
+ * path) requires a session — correctness over cacheability.
+ */
+final class SessionPolicy
+{
+    /**
+     * Route keys whose GET pages need a session (they render session-backed
+     * CSRF form tokens, or belong to the authentication flow). Mirrors
+     * PrivateModeMiddleware::AUTH_ROUTE_KEYS plus the contact form.
+     *
+     * @var string[]
+     */
+    private const SESSION_ROUTE_KEYS = [
+        'login', 'logout', 'register', 'register_success',
+        'verify_email', 'forgot_password', 'reset_password',
+        'contact', 'contact_submit',
+    ];
+
+    /**
+     * Legacy English aliases always registered in web.php regardless of the
+     * install locale (see the login allow-list in PrivateModeMiddleware).
+     *
+     * @var string[]
+     */
+    private const LEGACY_SESSION_PATHS = ['/login', '/login.php', '/logout'];
+
+    /** @var string[]|null Cached localized session-route prefixes. */
+    private static ?array $sessionRoutesCache = null;
+
+    /**
+     * True when the request must be served with a PHP session (the default,
+     * conservative outcome); false only for the anonymous no-cookie
+     * read-only path described in the class docblock.
+     *
+     * @param string               $method   HTTP method ('' outside HTTP, e.g. CLI)
+     * @param array<string, mixed> $cookies  Request cookies ($_COOKIE)
+     * @param string               $path     Request URI path (no query string)
+     * @param string|null          $basePath Base path override (null = autodetect)
+     */
+    public static function requiresSession(
+        string $method,
+        array $cookies,
+        string $path,
+        ?string $basePath = null
+    ): bool {
+        // 1. Only read-only methods can be sessionless. CLI/unknown ('') and
+        //    every state-changing method keep the session.
+        if (!in_array(strtoupper($method), ['GET', 'HEAD'], true)) {
+            return true;
+        }
+
+        // 2. Any auth-related cookie keeps the exact current behavior.
+        if (isset($cookies[session_name()])) {
+            return true;
+        }
+        if (isset($cookies['remember_token'])) {
+            return true;
+        }
+        if (isset($cookies['csrf_login'])) {
+            return true;
+        }
+
+        // 3. Auth/contact routes mint session-backed CSRF form tokens.
+        return self::isSessionRoute($path, $basePath);
+    }
+
+    /**
+     * True when the path matches an auth/contact route in any registered
+     * locale (or a legacy English alias), after stripping the base path of
+     * sub-folder installs.
+     */
+    private static function isSessionRoute(string $path, ?string $basePath = null): bool
+    {
+        $basePath = $basePath ?? HtmlHelper::getBasePath();
+        $basePath = rtrim($basePath, '/');
+        if ($basePath !== '' && str_starts_with($path, $basePath)) {
+            $path = substr($path, strlen($basePath));
+        }
+        $path = '/' . ltrim($path, '/');
+        if ($path !== '/') {
+            $path = rtrim($path, '/');
+        }
+
+        foreach (self::sessionRoutes() as $route) {
+            if ($path === $route || str_starts_with($path, $route . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * All localized variants of the session-requiring routes, computed from
+     * the locale route files on disk (file-based, safe before the DB/container
+     * are available) plus the static English fallbacks and legacy aliases.
+     *
+     * @return string[]
+     */
+    private static function sessionRoutes(): array
+    {
+        if (self::$sessionRoutesCache !== null) {
+            return self::$sessionRoutesCache;
+        }
+
+        $routes = [];
+        foreach (self::registeredLocales() as $locale) {
+            foreach (self::SESSION_ROUTE_KEYS as $key) {
+                $route = RouteTranslator::getRouteForLocale($key, $locale);
+                if ($route !== '' && $route !== '/') {
+                    $routes[rtrim($route, '/')] = true;
+                }
+            }
+        }
+        foreach (self::LEGACY_SESSION_PATHS as $legacy) {
+            $routes[$legacy] = true;
+        }
+
+        self::$sessionRoutesCache = array_keys($routes);
+        return self::$sessionRoutesCache;
+    }
+
+    /**
+     * Locales that have a route-translation file on disk. Falls back to the
+     * locales whose route variants web.php always registers.
+     *
+     * @return string[]
+     */
+    private static function registeredLocales(): array
+    {
+        $locales = [];
+        $files = glob(__DIR__ . '/../../locale/routes_*.json');
+        foreach (($files === false ? [] : $files) as $file) {
+            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $m) === 1) {
+                $locales[] = $m[1];
+            }
+        }
+        if ($locales === []) {
+            $locales = ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
+        }
+        return $locales;
+    }
+
+    /**
+     * Test hook: clear the computed route cache.
+     */
+    public static function clearCache(): void
+    {
+        self::$sessionRoutesCache = null;
+    }
+}

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -6,58 +6,55 @@ namespace App\Support;
 /**
  * Decides whether the current HTTP request needs a PHP session.
  *
- * Step 6 of the caching overhaul (issue #387): the anonymous public request
- * path must be sessionless so a later PR can put anonymous pages behind a
- * shared full-page/edge cache. A request is served WITHOUT a session only
- * when ALL of the following hold:
- *
- *   1. The method is read-only (GET/HEAD). Every state-changing method
- *      (POST/PUT/PATCH/DELETE/…) keeps the session so CSRF validation always
- *      has its session-backed token store — this also covers login and every
- *      other auth POST by construction.
- *   2. The request carries NO auth-related cookie: no session cookie
- *      (session_name()), no remember_token (persistent login) and no
- *      csrf_login (login form double-submit cookie). Any hint of an
- *      authenticated — or authenticating — browser keeps the exact current
- *      session behavior.
- *   3. The path is not an auth/contact route (in any registered locale).
- *      Those pages mint session-backed CSRF tokens into their HTML forms
- *      (login, register, forgot/reset password, contact) and must keep
- *      opening the session so the subsequent POST validates.
- *
- * Fail-safe direction: anything unknown (CLI, missing method, malformed
- * path) requires a session — correctness over cacheability.
+ * Only explicitly known, read-only public routes may skip session_start().
+ * Keeping this as an allow-list is intentional: plugin routes and future
+ * pages may render session-backed forms or consume flash/auth state, so an
+ * unknown route must remain sessionful until it is audited.
  */
 final class SessionPolicy
 {
     /**
-     * Route keys whose GET pages need a session (they render session-backed
-     * CSRF form tokens, or belong to the authentication flow). Mirrors
-     * PrivateModeMiddleware::AUTH_ROUTE_KEYS plus the contact form.
+     * Audited public route families that do not require server-side session
+     * state for an anonymous GET/HEAD. A translated route also matches its
+     * descendants (for example /book/42 or /events/summer-reading).
      *
      * @var string[]
      */
-    private const SESSION_ROUTE_KEYS = [
-        'login', 'logout', 'register', 'register_success',
-        'verify_email', 'forgot_password', 'reset_password',
-        'contact', 'contact_submit',
+    private const SESSIONLESS_ROUTE_KEYS = [
+        'catalog', 'catalog_legacy',
+        'book', 'book_legacy',
+        'author', 'publisher', 'genre',
+        'events',
+        'about', 'privacy', 'cookies',
+        'api_catalog', 'api_book', 'api_home',
     ];
 
     /**
-     * Legacy English aliases always registered in web.php regardless of the
-     * install locale (see the login allow-list in PrivateModeMiddleware).
+     * Non-translated public endpoints audited for sessionless access.
+     * Descendant matching is enabled only for entries ending in a slash.
      *
      * @var string[]
      */
-    private const LEGACY_SESSION_PATHS = ['/login', '/login.php', '/logout'];
+    private const SESSIONLESS_PATHS = [
+        '/',
+        '/home.php',
+        '/health',
+        '/csrf-token',
+        '/robots.txt',
+        '/sitemap.xml',
+        '/feed.xml',
+        '/llms.txt',
+        '/language/',
+        '/uploads/',
+        '/proxy/cover',
+    ];
 
-    /** @var string[]|null Cached localized session-route prefixes. */
-    private static ?array $sessionRoutesCache = null;
+    /** @var string[]|null Cached localized public-route prefixes. */
+    private static ?array $sessionlessRoutesCache = null;
 
     /**
      * True when the request must be served with a PHP session (the default,
-     * conservative outcome); false only for the anonymous no-cookie
-     * read-only path described in the class docblock.
+     * conservative outcome); false only for an audited anonymous public path.
      *
      * @param string               $method   HTTP method ('' outside HTTP, e.g. CLI)
      * @param array<string, mixed> $cookies  Request cookies ($_COOKIE)
@@ -70,45 +67,61 @@ final class SessionPolicy
         string $path,
         ?string $basePath = null
     ): bool {
-        // 1. Only read-only methods can be sessionless. CLI/unknown ('') and
-        //    every state-changing method keep the session.
         if (!in_array(strtoupper($method), ['GET', 'HEAD'], true)) {
             return true;
         }
 
-        // 2. Any auth-related cookie keeps the exact current behavior.
-        if (isset($cookies[session_name()])) {
-            return true;
-        }
-        if (isset($cookies['remember_token'])) {
-            return true;
-        }
-        if (isset($cookies['csrf_login'])) {
+        // Any authentication-flow state makes the response visitor-specific.
+        if (
+            isset($cookies[session_name()])
+            || isset($cookies['remember_token'])
+            || isset($cookies['csrf_login'])
+        ) {
             return true;
         }
 
-        // 3. Auth/contact routes mint session-backed CSRF form tokens.
-        return self::isSessionRoute($path, $basePath);
+        return !self::isSessionlessRoute($path, $basePath);
     }
 
     /**
-     * True when the path matches an auth/contact route in any registered
-     * locale (or a legacy English alias), after stripping the base path of
-     * sub-folder installs.
+     * Match only audited public routes after safely removing a subfolder base
+     * path. The boundary check prevents /pinakes-other from being mistaken for
+     * an installation mounted at /pinakes.
      */
-    private static function isSessionRoute(string $path, ?string $basePath = null): bool
+    private static function isSessionlessRoute(string $path, ?string $basePath = null): bool
     {
-        $basePath = $basePath ?? HtmlHelper::getBasePath();
-        $basePath = rtrim($basePath, '/');
-        if ($basePath !== '' && str_starts_with($path, $basePath)) {
-            $path = substr($path, strlen($basePath));
+        $basePath = rtrim($basePath ?? HtmlHelper::getBasePath(), '/');
+        if ($basePath !== '') {
+            if ($path === $basePath) {
+                $path = '/';
+            } elseif (str_starts_with($path, $basePath . '/')) {
+                $path = substr($path, strlen($basePath));
+            } else {
+                return false;
+            }
         }
+
         $path = '/' . ltrim($path, '/');
         if ($path !== '/') {
             $path = rtrim($path, '/');
         }
 
-        foreach (self::sessionRoutes() as $route) {
+        foreach (self::SESSIONLESS_PATHS as $publicPath) {
+            if ($publicPath === '/') {
+                if ($path === '/') {
+                    return true;
+                }
+            } elseif (str_ends_with($publicPath, '/')) {
+                $prefix = rtrim($publicPath, '/');
+                if ($path === $prefix || str_starts_with($path, $prefix . '/')) {
+                    return true;
+                }
+            } elseif ($path === $publicPath) {
+                return true;
+            }
+        }
+
+        foreach (self::sessionlessRoutes() as $route) {
             if ($path === $route || str_starts_with($path, $route . '/')) {
                 return true;
             }
@@ -118,61 +131,48 @@ final class SessionPolicy
     }
 
     /**
-     * All localized variants of the session-requiring routes, computed from
-     * the locale route files on disk (file-based, safe before the DB/container
-     * are available) plus the static English fallbacks and legacy aliases.
+     * Build every localized variant directly from route files, before the
+     * application container/database is available.
      *
      * @return string[]
      */
-    private static function sessionRoutes(): array
+    private static function sessionlessRoutes(): array
     {
-        if (self::$sessionRoutesCache !== null) {
-            return self::$sessionRoutesCache;
+        if (self::$sessionlessRoutesCache !== null) {
+            return self::$sessionlessRoutesCache;
         }
 
         $routes = [];
         foreach (self::registeredLocales() as $locale) {
-            foreach (self::SESSION_ROUTE_KEYS as $key) {
+            foreach (self::SESSIONLESS_ROUTE_KEYS as $key) {
                 $route = RouteTranslator::getRouteForLocale($key, $locale);
                 if ($route !== '' && $route !== '/') {
                     $routes[rtrim($route, '/')] = true;
                 }
             }
         }
-        foreach (self::LEGACY_SESSION_PATHS as $legacy) {
-            $routes[$legacy] = true;
-        }
 
-        self::$sessionRoutesCache = array_keys($routes);
-        return self::$sessionRoutesCache;
+        self::$sessionlessRoutesCache = array_keys($routes);
+        return self::$sessionlessRoutesCache;
     }
 
-    /**
-     * Locales that have a route-translation file on disk. Falls back to the
-     * locales whose route variants web.php always registers.
-     *
-     * @return string[]
-     */
+    /** @return string[] */
     private static function registeredLocales(): array
     {
         $locales = [];
         $files = glob(__DIR__ . '/../../locale/routes_*.json');
         foreach (($files === false ? [] : $files) as $file) {
-            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $m) === 1) {
-                $locales[] = $m[1];
+            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $matches) === 1) {
+                $locales[] = $matches[1];
             }
         }
-        if ($locales === []) {
-            $locales = ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
-        }
-        return $locales;
+
+        return $locales !== [] ? $locales : ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
     }
 
-    /**
-     * Test hook: clear the computed route cache.
-     */
+    /** Test hook: clear the computed route cache. */
     public static function clearCache(): void
     {
-        self::$sessionRoutesCache = null;
+        self::$sessionlessRoutesCache = null;
     }
 }

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -45,7 +45,16 @@ final class SessionPolicy
         '/feed.xml',
         '/llms.txt',
         '/language/',
-        '/uploads/',
+        // Only the genuinely public /uploads subtrees are sessionless. The
+        // private ones — /uploads/digital/, /uploads/archives/documents/,
+        // /uploads/storage/ — are deliberately NOT listed: PrivateModeMiddleware
+        // keeps them behind the login wall, and a blanket '/uploads/' would stamp
+        // them session-free / cache-eligible, which the later shared edge cache
+        // would turn into unauthenticated content disclosure. Mirrors
+        // PrivateModeMiddleware::ALLOWED_PREFIXES (which exposes only settings).
+        '/uploads/copertine/', // public book covers (catalog + book page)
+        '/uploads/autori/',    // public author photos
+        '/uploads/settings/',  // admin-uploaded branding/logo
         '/proxy/cover',
     ];
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -18,7 +18,10 @@ $baseUrl = ConfigStore::get('app.canonical_url');
 
 $contentHtml = ContentSanitizer::normalizeExternalAssets($event['content'] ?? '');
 
-$locale = $_SESSION['locale'] ?? 'it_IT';
+// Session locale wins (unchanged); on the sessionless anonymous path
+// (issue #387 step 6) fall back to the request locale resolved by
+// public/index.php from the pinakes_locale cookie / install default.
+$locale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
 if (class_exists('IntlDateFormatter')) {
     $dateFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE);
     $timeFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);

--- a/app/Views/frontend/events.php
+++ b/app/Views/frontend/events.php
@@ -28,7 +28,10 @@ $twitterTitle = $seoTitle;
 $twitterDescription = $seoDescription;
 $twitterImage = $ogImage;
 
-$locale = $_SESSION['locale'] ?? 'it_IT';
+// Session locale wins (unchanged); on the sessionless anonymous path
+// (issue #387 step 6) fall back to the request locale resolved by
+// public/index.php from the pinakes_locale cookie / install default.
+$locale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
 if (class_exists('IntlDateFormatter')) {
     $dateFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE);
     $timeFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);

--- a/app/Views/frontend/home-sections/events.php
+++ b/app/Views/frontend/home-sections/events.php
@@ -9,7 +9,7 @@ $homeEvents = $homeEvents ?? [];
 $homeEventsEnabled = $homeEventsEnabled ?? false;
 
 if ($homeEventsEnabled && !empty($homeEvents)):
-    $homeEventsLocale = $_SESSION['locale'] ?? 'it_IT';
+    $homeEventsLocale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
     $homeEventsDateFormatter = class_exists('IntlDateFormatter')
         ? new \IntlDateFormatter($homeEventsLocale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE)
         : null;

--- a/app/Views/frontend/layout.php
+++ b/app/Views/frontend/layout.php
@@ -238,8 +238,18 @@ $htmlLang = substr($currentLocale, 0, 2);
                 </script>
     <?php endif; ?>
 
+    <?php
+    // Lazy CSRF (issue #387 step 6): a sessionless anonymous render must not
+    // mint a CSRF token — it would not be backed by any session, could never
+    // validate, and would make the HTML per-visitor (uncacheable). The meta
+    // stays empty on the no-session path; JS that needs a token for a
+    // state-changing call fetches one from GET /csrf-token, which lazily
+    // opens the session (see public/assets/js/csrf-helper.js). With an
+    // active session the token is emitted exactly as before.
+    $csrfMetaToken = session_status() === PHP_SESSION_ACTIVE ? App\Support\Csrf::ensureToken() : '';
+    ?>
     <meta name="csrf-token"
-        content="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>" />
+        content="<?php echo htmlspecialchars($csrfMetaToken, ENT_QUOTES, 'UTF-8'); ?>" />
     <link rel="icon" type="image/x-icon" href="<?= htmlspecialchars(url('/favicon.ico'), ENT_QUOTES, 'UTF-8') ?>">
     <script>window.BASE_PATH = <?= json_encode(\App\Support\HtmlHelper::getBasePath(), JSON_HEX_TAG | JSON_HEX_AMP) ?>;</script>
 

--- a/public/assets/js/csrf-helper.js
+++ b/public/assets/js/csrf-helper.js
@@ -4,52 +4,94 @@
  * This helper function automatically adds the CSRF token to all fetch requests.
  * It reads the token from the <meta name="csrf-token"> tag in the page.
  *
+ * Lazy CSRF (issue #387 step 6): sessionless anonymous pages are rendered
+ * with an EMPTY csrf-token meta (no session, cacheable HTML). When a
+ * state-changing request is made from such a page, the helper first fetches
+ * a token from the same-origin GET /csrf-token endpoint — which lazily opens
+ * the session — and only then performs the request. Pages rendered with an
+ * active session keep the exact previous behavior (token read from the meta).
+ *
  * Usage:
  *   csrfFetch('/api/endpoint', { method: 'POST', body: JSON.stringify(data) })
  *
- * This is a drop-in replacement for fetch() that automatically includes CSRF protection.
+ * This is a drop-in replacement for fetch() that automatically includes CSRF
+ * protection and always returns a Promise<Response>.
  */
 
-/**
- * Fetch wrapper that automatically includes CSRF token
- * @param {string} url - The URL to fetch
- * @param {object} options - Fetch options (method, body, headers, etc.)
- * @returns {Promise<Response>} - The fetch response
- */
-window.csrfFetch = function(url, options = {}) {
-  // Get CSRF token from meta tag
-  const csrfToken = document.querySelector('meta[name="csrf-token"]');
-  const token = csrfToken ? csrfToken.getAttribute('content') : null;
+(function() {
+  'use strict';
 
-  // If no token found, log warning but proceed with request
-  if (!token) {
-    console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
+  function metaEl() {
+    return document.querySelector('meta[name="csrf-token"]');
   }
 
-  // Merge default headers with user-provided headers
-  const headers = {
-    ...options.headers,
+  function doFetch(url, options, token) {
+    // If no token found, log warning but proceed with request
+    if (!token) {
+      console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
+    }
+
+    // Merge default headers with user-provided headers
+    const headers = {
+      ...options.headers,
+    };
+
+    // Add CSRF token header if token exists
+    if (token) {
+      headers['X-CSRF-Token'] = token;
+    }
+
+    // Add Content-Type for JSON requests if not already set
+    if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    // Create merged options with headers
+    const mergedOptions = {
+      ...options,
+      headers,
+    };
+
+    // Make the fetch request
+    return fetch(url, mergedOptions);
+  }
+
+  /**
+   * Fetch wrapper that automatically includes CSRF token
+   * @param {string} url - The URL to fetch
+   * @param {object} options - Fetch options (method, body, headers, etc.)
+   * @returns {Promise<Response>} - The fetch response
+   */
+  window.csrfFetch = function(url, options = {}) {
+    const meta = metaEl();
+    const token = meta ? meta.getAttribute('content') : null;
+
+    const method = String(options.method || 'GET').toUpperCase();
+    const isStateChanging = ['GET', 'HEAD', 'OPTIONS'].indexOf(method) === -1;
+
+    // Lazy mint: no token in the markup and the request needs one.
+    if (!token && isStateChanging) {
+      const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH : '';
+      return fetch(base + '/csrf-token', { credentials: 'same-origin', cache: 'no-store' })
+        .then(function(res) { return res.ok ? res.json() : null; })
+        .then(function(data) {
+          const fresh = (data && typeof data.token === 'string' && data.token !== '') ? data.token : null;
+          if (fresh && meta) {
+            // Cache for subsequent calls on this page.
+            meta.setAttribute('content', fresh);
+          }
+          return doFetch(url, options, fresh);
+        })
+        .catch(function() {
+          // Endpoint unreachable: proceed without a token — the server-side
+          // CSRF validation stays authoritative and will reject if required.
+          return doFetch(url, options, null);
+        });
+    }
+
+    return doFetch(url, options, token);
   };
-
-  // Add CSRF token header if token exists
-  if (token) {
-    headers['X-CSRF-Token'] = token;
-  }
-
-  // Add Content-Type for JSON requests if not already set
-  if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  // Create merged options with headers
-  const mergedOptions = {
-    ...options,
-    headers,
-  };
-
-  // Make the fetch request
-  return fetch(url, mergedOptions);
-};
+})();
 
 // CSRF Helper loaded (silent - log removed for production)
 // Uncomment for debugging:

--- a/public/assets/js/csrf-helper.js
+++ b/public/assets/js/csrf-helper.js
@@ -21,29 +21,39 @@
 (function() {
   'use strict';
 
+  let lazyTokenPromise = null;
+  let memoryToken = null;
+
   function metaEl() {
     return document.querySelector('meta[name="csrf-token"]');
   }
 
-  function doFetch(url, options, token) {
+  function isSameOrigin(url) {
+    try {
+      return new URL(url, window.location.href).origin === window.location.origin;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function doFetch(url, options, token, warnIfMissing = true) {
     // If no token found, log warning but proceed with request
-    if (!token) {
+    if (!token && warnIfMissing) {
       console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
     }
 
-    // Merge default headers with user-provided headers
-    const headers = {
-      ...options.headers,
-    };
+    // Headers accepts objects, arrays and existing Headers instances without
+    // silently discarding values from the latter.
+    const headers = new Headers(options.headers || {});
 
     // Add CSRF token header if token exists
     if (token) {
-      headers['X-CSRF-Token'] = token;
+      headers.set('X-CSRF-Token', token);
     }
 
     // Add Content-Type for JSON requests if not already set
-    if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
+    if (options.body && typeof options.body === 'string' && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
     }
 
     // Create merged options with headers
@@ -56,6 +66,43 @@
     return fetch(url, mergedOptions);
   }
 
+  function lazyToken() {
+    if (lazyTokenPromise) {
+      return lazyTokenPromise;
+    }
+
+    const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH.replace(/\/$/, '') : '';
+    lazyTokenPromise = fetch(base + '/csrf-token', {
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
+      .then(function(res) {
+        if (!res.ok) {
+          throw new Error('Unable to mint CSRF token (HTTP ' + res.status + ')');
+        }
+        return res.json();
+      })
+      .then(function(data) {
+        if (!data || typeof data.token !== 'string' || data.token === '') {
+          throw new Error('Invalid CSRF token response');
+        }
+        memoryToken = data.token;
+        const meta = metaEl();
+        if (meta) {
+          meta.setAttribute('content', memoryToken);
+        }
+        return memoryToken;
+      })
+      .finally(function() {
+        // Share only the in-flight operation. The token itself lives in the
+        // meta element/memory cache; failures may be retried by a later action.
+        lazyTokenPromise = null;
+      });
+
+    return lazyTokenPromise;
+  }
+
   /**
    * Fetch wrapper that automatically includes CSRF token
    * @param {string} url - The URL to fetch
@@ -64,24 +111,22 @@
    */
   window.csrfFetch = function(url, options = {}) {
     const meta = metaEl();
-    const token = meta ? meta.getAttribute('content') : null;
+    const token = (meta ? meta.getAttribute('content') : null) || memoryToken;
 
     const method = String(options.method || 'GET').toUpperCase();
     const isStateChanging = ['GET', 'HEAD', 'OPTIONS'].indexOf(method) === -1;
+    const sameOrigin = isSameOrigin(url);
+
+    // Never disclose the application's CSRF token to another origin. Callers
+    // may still use csrfFetch as a normal fetch wrapper for such URLs.
+    if (!sameOrigin) {
+      return doFetch(url, options, null, false);
+    }
 
     // Lazy mint: no token in the markup and the request needs one.
     if (!token && isStateChanging) {
-      const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH : '';
-      return fetch(base + '/csrf-token', { credentials: 'same-origin', cache: 'no-store' })
-        .then(function(res) { return res.ok ? res.json() : null; })
-        .then(function(data) {
-          const fresh = (data && typeof data.token === 'string' && data.token !== '') ? data.token : null;
-          if (fresh && meta) {
-            // Cache for subsequent calls on this page.
-            meta.setAttribute('content', fresh);
-          }
-          return doFetch(url, options, fresh);
-        })
+      return lazyToken()
+        .then(function(fresh) { return doFetch(url, options, fresh); })
         .catch(function() {
           // Endpoint unreachable: proceed without a token — the server-side
           // CSRF validation stays authoritative and will reject if required.

--- a/public/index.php
+++ b/public/index.php
@@ -284,7 +284,11 @@ $httpsDetected = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
     || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
     || (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_SSL']) === 'on');
 
-// Secure session configuration
+// Secure session configuration. The ini parameters below are ALWAYS applied
+// (even when no session is started for this request) so that any session
+// started later in the request — e.g. the lazy GET /csrf-token endpoint or
+// the /language/{locale} switch — inherits the exact same hardened cookie
+// settings instead of PHP's defaults.
 if (session_status() !== PHP_SESSION_ACTIVE) {
     // Use application-local session storage to avoid /tmp cleanup issues.
     // Create the directory if missing: otherwise PHP silently falls back to the
@@ -323,23 +327,41 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     ini_set('session.gc_probability', '1');
     ini_set('session.gc_divisor', '100');
 
-    session_start();
+    // Step 6 of the caching overhaul (issue #387): an anonymous request that
+    // carries no auth-related cookie and targets no auth/contact route is
+    // served WITHOUT a session, so a later PR can put anonymous pages behind
+    // a shared full-page cache. Not starting the session also means the
+    // response emits no Set-Cookie. Any request with a session cookie, a
+    // remember_token, a csrf_login cookie, any non-GET/HEAD method (login and
+    // every other state-changing request) or an auth/contact path keeps the
+    // exact pre-existing session behavior. The predicate fails safe: when in
+    // doubt (CLI, malformed URI) the session is started.
+    $sessionUriPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+    $needsSession = !is_string($sessionUriPath) || \App\Support\SessionPolicy::requiresSession(
+        (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
+        $_COOKIE,
+        $sessionUriPath
+    );
 
-    // Regenera session ID periodicamente per prevenire session hijacking.
-    // delete_old_session = FALSE on purpose: with TRUE the previous session
-    // file is destroyed immediately, so concurrent in-flight AJAX requests
-    // (common on DataTable-heavy admin pages) that still carry the old ID are
-    // rejected by use_strict_mode and the user is bounced to login. Keeping the
-    // old session briefly (it is GC'd at gc_maxlifetime) lets those concurrent
-    // requests finish on the old ID while the browser switches to the new
-    // cookie. The security-critical regeneration still happens with TRUE at
-    // login (AuthController), which is what defends against fixation. Interval
-    // raised 5min -> 30min to keep the number of lingering rotated sessions low.
-    if (!isset($_SESSION['last_regeneration'])) {
-        $_SESSION['last_regeneration'] = time();
-    } elseif (time() - $_SESSION['last_regeneration'] > 1800) { // Ogni 30 minuti
-        session_regenerate_id(false);
-        $_SESSION['last_regeneration'] = time();
+    if ($needsSession) {
+        session_start();
+
+        // Regenera session ID periodicamente per prevenire session hijacking.
+        // delete_old_session = FALSE on purpose: with TRUE the previous session
+        // file is destroyed immediately, so concurrent in-flight AJAX requests
+        // (common on DataTable-heavy admin pages) that still carry the old ID are
+        // rejected by use_strict_mode and the user is bounced to login. Keeping the
+        // old session briefly (it is GC'd at gc_maxlifetime) lets those concurrent
+        // requests finish on the old ID while the browser switches to the new
+        // cookie. The security-critical regeneration still happens with TRUE at
+        // login (AuthController), which is what defends against fixation. Interval
+        // raised 5min -> 30min to keep the number of lingering rotated sessions low.
+        if (!isset($_SESSION['last_regeneration'])) {
+            $_SESSION['last_regeneration'] = time();
+        } elseif (time() - $_SESSION['last_regeneration'] > 1800) { // Ogni 30 minuti
+            session_regenerate_id(false);
+            $_SESSION['last_regeneration'] = time();
+        }
     }
 }
 
@@ -485,6 +507,17 @@ if (!$isCli) {
         $sessionLocale = (string)$_SESSION['locale'];
         if (!\App\Support\I18n::setLocale($sessionLocale)) {
             unset($_SESSION['locale']);
+        }
+    } elseif (session_status() !== PHP_SESSION_ACTIVE) {
+        // Sessionless anonymous request (issue #387 step 6): the language
+        // choice is persisted in the pinakes_locale cookie written by
+        // /language/{locale}, so the anonymous locale is deterministic
+        // per-request (cookie/URL, not session) and a cached page can be
+        // correct per-locale. setLocale() validates against the available
+        // locales, so an unknown/tampered cookie value is simply ignored.
+        $cookieLocale = $_COOKIE['pinakes_locale'] ?? '';
+        if (is_string($cookieLocale) && $cookieLocale !== '') {
+            \App\Support\I18n::setLocale(\App\Support\I18n::normalizeLocaleCode($cookieLocale));
         }
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -327,15 +327,11 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     ini_set('session.gc_probability', '1');
     ini_set('session.gc_divisor', '100');
 
-    // Step 6 of the caching overhaul (issue #387): an anonymous request that
-    // carries no auth-related cookie and targets no auth/contact route is
-    // served WITHOUT a session, so a later PR can put anonymous pages behind
-    // a shared full-page cache. Not starting the session also means the
-    // response emits no Set-Cookie. Any request with a session cookie, a
-    // remember_token, a csrf_login cookie, any non-GET/HEAD method (login and
-    // every other state-changing request) or an auth/contact path keeps the
-    // exact pre-existing session behavior. The predicate fails safe: when in
-    // doubt (CLI, malformed URI) the session is started.
+    // Step 6 of the caching overhaul (issue #387): audited public GET/HEAD
+    // routes can be served without a session when no auth-flow cookie exists,
+    // allowing a later shared full-page cache to reuse the response. Unknown,
+    // plugin and state-changing routes fail safe by retaining the pre-existing
+    // session behavior. See SessionPolicy for the deliberately narrow list.
     $sessionUriPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
     $needsSession = !is_string($sessionUriPath) || \App\Support\SessionPolicy::requiresSession(
         (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
@@ -503,18 +499,20 @@ if (!$isCli) {
         error_log("Failed to load languages from database: " . $e->getMessage());
     }
 
+    $localeRestoredFromSession = false;
     if (!empty($_SESSION['locale'])) {
         $sessionLocale = (string)$_SESSION['locale'];
-        if (!\App\Support\I18n::setLocale($sessionLocale)) {
+        $localeRestoredFromSession = \App\Support\I18n::setLocale($sessionLocale);
+        if (!$localeRestoredFromSession) {
             unset($_SESSION['locale']);
         }
-    } elseif (session_status() !== PHP_SESSION_ACTIVE) {
-        // Sessionless anonymous request (issue #387 step 6): the language
-        // choice is persisted in the pinakes_locale cookie written by
-        // /language/{locale}, so the anonymous locale is deterministic
-        // per-request (cookie/URL, not session) and a cached page can be
-        // correct per-locale. setLocale() validates against the available
-        // locales, so an unknown/tampered cookie value is simply ignored.
+    }
+
+    if (!$localeRestoredFromSession) {
+        // The cookie also covers a newly opened session (for example one
+        // created because remember_token/csrf_login is present) that does not
+        // yet contain a locale. A valid session locale always wins. setLocale
+        // validates the normalized cookie against the available locales.
         $cookieLocale = $_COOKIE['pinakes_locale'] ?? '';
         if (is_string($cookieLocale) && $cookieLocale !== '') {
             \App\Support\I18n::setLocale(\App\Support\I18n::normalizeLocaleCode($cookieLocale));

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
  * Step 6 of the caching overhaul (issue #387): sessionless anonymous request
  * path with lazy CSRF. Security invariants:
  *
- *   1. SessionPolicy: only a read-only, cookie-less, non-auth-route request
- *      is sessionless; everything else keeps the session (fail-safe).
+ *   1. SessionPolicy: only audited, read-only, cookie-less public routes are
+ *      sessionless; unknown and plugin routes keep the session (fail-safe).
  *   2. Csrf stays fail-closed with no session data: missing/invalid tokens
  *      are rejected; a lazily minted token (GET /csrf-token flow) validates.
  *   3. CsrfMiddleware still rejects missing/invalid tokens on POST and still
@@ -48,7 +48,12 @@ $check(!SessionPolicy::requiresSession('GET', [], '/catalog', ''), 'GET /catalog
 $check(!SessionPolicy::requiresSession('GET', [], '/catalogo', ''), 'GET /catalogo (it) with no cookies is sessionless');
 $check(!SessionPolicy::requiresSession('HEAD', [], '/book/42', ''), 'HEAD /book/42 with no cookies is sessionless');
 $check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /language/{locale} is sessionless (cookie-based)');
+$check(!SessionPolicy::requiresSession('GET', [], '/csrf-token', ''), 'lazy token endpoint reaches its own session_start');
 $check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
+
+// Unknown/plugin/canonical catch-all routes stay sessionful until audited.
+$check(SessionPolicy::requiresSession('GET', [], '/club/summer', ''), 'unknown plugin route keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/author-slug/book-slug/42', ''), 'unclassified canonical route keeps the session');
 
 // Session kept: any state-changing / unknown method.
 $check(SessionPolicy::requiresSession('POST', [], '/anything', ''), 'POST always keeps the session');
@@ -87,6 +92,7 @@ $check(SessionPolicy::requiresSession('GET', [], '/reset-password/sometoken', ''
 // Base path handling (sub-folder installs).
 $check(SessionPolicy::requiresSession('GET', [], '/pinakes/login', '/pinakes'), 'base-path auth route keeps the session');
 $check(!SessionPolicy::requiresSession('GET', [], '/pinakes/catalog', '/pinakes'), 'base-path public route is sessionless');
+$check(SessionPolicy::requiresSession('GET', [], '/pinakes-other/catalog', '/pinakes'), 'base-path stripping requires a path boundary');
 
 // ---------------------------------------------------------------------------
 // 2. Csrf fail-closed without a session + lazy mint flow
@@ -104,6 +110,23 @@ $_SESSION = [];
 $minted = Csrf::ensureToken();
 $check($minted !== '' && Csrf::validate($minted), 'lazily minted token validates');
 $check(!Csrf::validate($minted . 'x'), 'tampered minted token is rejected');
+
+// Browser helper invariants. The behavioral counterpart is exercised by the
+// browser suite; these guards keep the security-critical implementation from
+// silently regressing during a refactor.
+$csrfHelper = file_get_contents(dirname(__DIR__) . '/public/assets/js/csrf-helper.js');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'let lazyTokenPromise = null'), 'lazy CSRF mint is single-flight');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, '.finally(function()'), 'single-flight promise is cleared after completion');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'window.location.origin'), 'CSRF header is limited to same-origin requests');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'new Headers(options.headers || {})'), 'Headers instances are preserved');
+
+$frontController = file_get_contents(dirname(__DIR__) . '/public/index.php');
+$check(
+    is_string($frontController)
+        && str_contains($frontController, '$localeRestoredFromSession')
+        && str_contains($frontController, 'if (!$localeRestoredFromSession)'),
+    'locale cookie falls back when an active session has no valid locale'
+);
 
 // ---------------------------------------------------------------------------
 // 3. CsrfMiddleware behavior (direct invocation)

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -139,6 +139,15 @@ $check(
     'locale cookie falls back when an active session has no valid locale'
 );
 
+$homeEventsView = file_get_contents(
+    dirname(__DIR__) . '/app/Views/frontend/home-sections/events.php'
+);
+$check(
+    is_string($homeEventsView)
+        && str_contains($homeEventsView, '\\App\\Support\\I18n::getLocale()'),
+    'sessionless home events use the locale resolved before rendering'
+);
+
 // ---------------------------------------------------------------------------
 // 3. CsrfMiddleware behavior (direct invocation)
 // ---------------------------------------------------------------------------

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -1,0 +1,221 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Step 6 of the caching overhaul (issue #387): sessionless anonymous request
+ * path with lazy CSRF. Security invariants:
+ *
+ *   1. SessionPolicy: only a read-only, cookie-less, non-auth-route request
+ *      is sessionless; everything else keeps the session (fail-safe).
+ *   2. Csrf stays fail-closed with no session data: missing/invalid tokens
+ *      are rejected; a lazily minted token (GET /csrf-token flow) validates.
+ *   3. CsrfMiddleware still rejects missing/invalid tokens on POST and still
+ *      accepts a valid session-backed token (body and header variants), and
+ *      the login double-submit cookie fallback still works.
+ *   4. PrivateModeMiddleware still gates anonymous access with no session.
+ */
+
+use App\Middleware\CsrfMiddleware;
+use App\Middleware\PrivateModeMiddleware;
+use App\Support\Csrf;
+use App\Support\RouteTranslator;
+use App\Support\SessionPolicy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response as SlimResponse;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+// ---------------------------------------------------------------------------
+// 1. SessionPolicy predicate
+// ---------------------------------------------------------------------------
+echo "-- SessionPolicy --\n";
+SessionPolicy::clearCache();
+$sessionCookieName = session_name();
+
+// Sessionless: anonymous read-only, no cookies, public content paths.
+$check(!SessionPolicy::requiresSession('GET', [], '/', ''), 'GET / with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/catalog', ''), 'GET /catalog with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/catalogo', ''), 'GET /catalogo (it) with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('HEAD', [], '/book/42', ''), 'HEAD /book/42 with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /language/{locale} is sessionless (cookie-based)');
+$check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
+
+// Session kept: any state-changing / unknown method.
+$check(SessionPolicy::requiresSession('POST', [], '/anything', ''), 'POST always keeps the session');
+$check(SessionPolicy::requiresSession('PUT', [], '/anything', ''), 'PUT always keeps the session');
+$check(SessionPolicy::requiresSession('DELETE', [], '/anything', ''), 'DELETE always keeps the session');
+$check(SessionPolicy::requiresSession('PATCH', [], '/anything', ''), 'PATCH always keeps the session');
+$check(SessionPolicy::requiresSession('', [], '/', ''), 'missing method (CLI) keeps the session');
+
+// Session kept: any auth-related cookie.
+$check(SessionPolicy::requiresSession('GET', [$sessionCookieName => 'abc'], '/catalog', ''), 'session cookie keeps the session');
+$check(SessionPolicy::requiresSession('GET', ['remember_token' => 'abc'], '/catalog', ''), 'remember_token cookie keeps the session');
+$check(SessionPolicy::requiresSession('GET', ['csrf_login' => 'abc'], '/catalog', ''), 'csrf_login cookie keeps the session');
+
+// Session kept: auth/contact routes in every registered locale + legacy aliases.
+$authChecks = [];
+foreach (['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'] as $locale) {
+    foreach (['login', 'register', 'forgot_password', 'reset_password', 'verify_email', 'contact'] as $key) {
+        $route = RouteTranslator::getRouteForLocale($key, $locale);
+        if ($route !== '' && $route !== '/') {
+            $authChecks[$route] = $key . ' (' . $locale . ')';
+        }
+    }
+}
+$allAuthKeepSession = true;
+foreach ($authChecks as $route => $label) {
+    if (!SessionPolicy::requiresSession('GET', [], $route, '')) {
+        $allAuthKeepSession = false;
+        echo "       route without session: {$route} [{$label}]\n";
+    }
+}
+$check($allAuthKeepSession, 'every localized auth/contact route keeps the session (' . count($authChecks) . ' routes)');
+$check(SessionPolicy::requiresSession('GET', [], '/login', ''), 'legacy /login keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/login.php', ''), 'legacy /login.php keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/reset-password/sometoken', ''), 'auth route sub-path keeps the session');
+
+// Base path handling (sub-folder installs).
+$check(SessionPolicy::requiresSession('GET', [], '/pinakes/login', '/pinakes'), 'base-path auth route keeps the session');
+$check(!SessionPolicy::requiresSession('GET', [], '/pinakes/catalog', '/pinakes'), 'base-path public route is sessionless');
+
+// ---------------------------------------------------------------------------
+// 2. Csrf fail-closed without a session + lazy mint flow
+// ---------------------------------------------------------------------------
+echo "-- Csrf fail-closed / lazy mint --\n";
+$_SESSION = [];
+$check(!Csrf::validate(null), 'no token + no session token is rejected');
+$check(!Csrf::validate('forged-token'), 'forged token with no session token is rejected');
+$check(Csrf::validateWithReason(null)['reason'] === 'missing_token', 'missing token reported as missing_token');
+$check(Csrf::validateWithReason('forged')['reason'] === 'session_expired', 'token without session store reported as session_expired');
+
+// Lazy mint: GET /csrf-token calls ensureToken() on a fresh session; the
+// returned token must validate exactly like a page-rendered one.
+$_SESSION = [];
+$minted = Csrf::ensureToken();
+$check($minted !== '' && Csrf::validate($minted), 'lazily minted token validates');
+$check(!Csrf::validate($minted . 'x'), 'tampered minted token is rejected');
+
+// ---------------------------------------------------------------------------
+// 3. CsrfMiddleware behavior (direct invocation)
+// ---------------------------------------------------------------------------
+echo "-- CsrfMiddleware --\n";
+
+$handler = new class implements RequestHandlerInterface {
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = new SlimResponse(200);
+        $response->getBody()->write('handled');
+        return $response;
+    }
+};
+
+$makePost = static function (string $path, array $body = [], array $headers = [], array $cookies = []): ServerRequestInterface {
+    $request = (new ServerRequestFactory())->createServerRequest('POST', $path);
+    foreach ($headers as $name => $value) {
+        $request = $request->withHeader($name, $value);
+    }
+    if ($body !== []) {
+        $request = $request->withParsedBody($body);
+    }
+    if ($cookies !== []) {
+        $request = $request->withCookieParams($cookies);
+    }
+    return $request;
+};
+
+$middleware = new CsrfMiddleware();
+
+// Authenticated-style session with a valid token.
+$_SESSION = [];
+$valid = Csrf::ensureToken();
+
+$res = $middleware->process($makePost('/admin/libri', ['csrf_token' => $valid], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 200 && (string) $res->getBody() === 'handled', 'valid body token on POST passes');
+
+$res = $middleware->process($makePost('/admin/libri', [], ['Accept' => 'application/json', 'X-CSRF-Token' => $valid]), $handler);
+$check($res->getStatusCode() === 200, 'valid X-CSRF-Token header on POST passes');
+
+$res = $middleware->process($makePost('/admin/libri', ['csrf_token' => $valid . 'x'], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'invalid token on POST is rejected (403)');
+
+$res = $middleware->process($makePost('/admin/libri', [], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'missing token on POST is rejected (403)');
+$decoded = json_decode((string) $res->getBody(), true);
+$check(is_array($decoded) && ($decoded['code'] ?? '') !== '', 'rejection is a structured JSON error');
+
+// Sessionless page → POST that opened a FRESH session (no csrf_token yet):
+// still rejected for non-login routes (fail closed).
+$_SESSION = [];
+$res = $middleware->process($makePost('/contact/submit', ['csrf_token' => 'anything'], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'fresh empty session + token on non-login POST stays rejected');
+
+// Login double-submit cookie fallback (unchanged behavior, now the only path
+// for a login POSTed after a sessionless login-page render would be a session
+// minted on the login GET — but the cookie fallback must still work).
+$_SESSION = [];
+$loginRoute = RouteTranslator::route('login');
+$cookieToken = implode('-', str_split(bin2hex(random_bytes(32)), 8));
+$res = $middleware->process(
+    $makePost($loginRoute, ['csrf_token' => $cookieToken], ['Accept' => 'application/json'], ['csrf_login' => $cookieToken]),
+    $handler
+);
+$check($res->getStatusCode() === 200, 'login POST with matching csrf_login double-submit cookie passes');
+
+$_SESSION = [];
+$res = $middleware->process(
+    $makePost($loginRoute, ['csrf_token' => $cookieToken], ['Accept' => 'application/json'], ['csrf_login' => 'different-value']),
+    $handler
+);
+$check($res->getStatusCode() === 403, 'login POST with mismatched csrf_login cookie is rejected');
+
+// ---------------------------------------------------------------------------
+// 4. Private mode still gates anonymous access (no session data at all)
+// ---------------------------------------------------------------------------
+echo "-- PrivateModeMiddleware --\n";
+
+// Force advanced.private_mode=1 through ConfigStore's runtime cache (no DB).
+$configRef = new ReflectionClass(\App\Support\ConfigStore::class);
+$runtimeCacheProp = $configRef->getProperty('runtimeCache');
+$runtimeCacheProp->setAccessible(true);
+$previousRuntimeCache = $runtimeCacheProp->getValue();
+$runtimeCacheProp->setValue(null, ['advanced' => ['private_mode' => '1']]);
+
+try {
+    $_SESSION = [];
+    $pm = new PrivateModeMiddleware();
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/catalog');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 302, 'private mode: anonymous catalog GET redirected');
+    $check(str_contains($res->getHeaderLine('Location'), 'private_mode'), 'private mode: redirect targets login with private_mode flag');
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/api/internal/whatever');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 401, 'private mode: anonymous API GET gets 401');
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/login');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 200, 'private mode: login page stays reachable');
+
+    // Authenticated user passes.
+    $_SESSION = ['user' => ['id' => 1, 'tipo_utente' => 'standard']];
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/catalog');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 200, 'private mode: authenticated user passes');
+} finally {
+    $runtimeCacheProp->setValue(null, $previousRuntimeCache);
+    $_SESSION = [];
+}
+
+echo "\n{$passed} PASS, {$failed} FAIL\n";
+exit($failed === 0 ? 0 : 1);

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -51,6 +51,17 @@ $check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /
 $check(!SessionPolicy::requiresSession('GET', [], '/csrf-token', ''), 'lazy token endpoint reaches its own session_start');
 $check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
 
+// adamsreview F1 (#390): only the PUBLIC /uploads subtrees are sessionless.
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/copertine/12.jpg', ''), 'public book cover is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/autori/3.png', ''), 'public author photo is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/settings/logo.png', ''), 'public branding is sessionless');
+// The PRIVATE subtrees must NOT be sessionless (else the future edge cache would
+// make them cache-eligible → unauthenticated disclosure). PrivateModeMiddleware
+// gates them; SessionPolicy must not stamp them session-free.
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/digital/secret.pdf', ''), 'private digital-library file keeps the session (not cache-eligible)');
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/archives/documents/x.pdf', ''), 'private archive document keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/storage/x.bin', ''), 'private storage file keeps the session');
+
 // Unknown/plugin/canonical catch-all routes stay sessionful until audited.
 $check(SessionPolicy::requiresSession('GET', [], '/club/summer', ''), 'unknown plugin route keeps the session');
 $check(SessionPolicy::requiresSession('GET', [], '/author-slug/book-slug/42', ''), 'unclassified canonical route keeps the session');


### PR DESCRIPTION
Step 6 of #387 (based on main; independent of #388/#389). Removes the two blockers to a shared edge cache for anonymous pages — the unconditional session and the per-session CSRF token in anonymous HTML. **Security-critical**: CSRF validation is unchanged; only when/how the token is minted for anonymous loads changes.

## The fail-safe predicate (App\Support\SessionPolicy)
A request is sessionless ONLY when ALL hold: method GET/HEAD, no auth cookie (PHPSESSID / remember_token / csrf_login), path not an auth/contact route in any locale. Everything else (POST, any auth cookie, CLI, malformed) keeps the current session behavior. Default = session (correctness over cacheability).

## CSRF stays protected
CsrfMiddleware/Csrf untouched — missing/invalid tokens still 403 on state-changing methods. Anonymous HTML carries an empty csrf meta; JS calls GET /csrf-token (session_start + Csrf::ensureToken, Cache-Control: no-store, private) right before a state-changing request. Auth pages + contact keep rendering session-backed form tokens exactly as before.

## Other
- Session ini hardening applied unconditionally (lazily started sessions inherit secure params).
- Anonymous locale from validated pinakes_locale cookie on the no-session path only (session locale still wins for logged-in users — byte-identical).
- No Set-Cookie on an anonymous no-cookie GET.

## Safety / tests
No cache headers except no-store on the token endpoint (never public — step 7). No migration/new config; logged-in/admin/login/remember-me/private-mode identical. tests/sessionless-anonymous-387.unit.php (39 checks): predicate incl. localized auth routes + sub-folder base paths, Csrf fail-closed, CsrfMiddleware accept/reject, private-mode gating. Full suite 137/137, PHPStan level 5 clean, soft-delete guard clean.

## Residuals for step 7 (edge cache)
Cache only responses to sessionless-predicate requests (no cookies); vary the key on pinakes_locale; exclude auth/contact/csrf-token/language/uploads and everything under private mode.

Part of #387.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * La preferenza della lingua viene mantenuta per un anno tramite cookie, anche senza sessione attiva.
  * Aggiunto il recupero automatico del token CSRF quando è necessario per inviare modifiche.
  * Le pagine pubbliche possono essere visitate senza avviare una sessione.

* **Correzioni**
  * La lingua selezionata viene applicata correttamente alle pagine degli eventi.
  * Migliorata la gestione dei cookie di sessione e sicurezza.
  * Le richieste protette continuano a richiedere una sessione e una verifica CSRF valida.

* **Test**
  * Aggiunti controlli per accessi anonimi, autenticazione, CSRF e modalità privata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->