### PR TITLE
Release 0.7.69-rc.1 — caching overhaul (#387)

### DIFF
--- a/.github/workflows/ci-browser-security.yml
+++ b/.github/workflows/ci-browser-security.yml
@@ -60,17 +60,27 @@ jobs:
           # apt refresh so a mid-sync Google mirror cannot break the job.
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update -q
-          sudo apt-get install -y apache2 libapache2-mod-php jq rsync unzip zip
+          # php-apcu: the app's page cache must run on its production backend
+          # (APCu shared memory) under Apache/mod_php, not the file fallback.
+          sudo apt-get install -y apache2 libapache2-mod-php php-apcu jq rsync unzip zip
           sudo a2enmod rewrite headers env
           php_module=$(find /etc/apache2/mods-available -maxdepth 1 -name 'php*.load' -printf '%f\n' | sed 's/\.load$//' | sort -V | tail -n1)
           if [ -n "$php_module" ]; then sudo a2enmod "$php_module"; fi
           sudo a2dissite 000-default || true
+          # Enable APCu for every distro-PHP SAPI (Apache mod_php + distro CLI).
+          while IFS= read -r conf_dir; do
+            sudo tee "${conf_dir}/99-pinakes-apcu.ini" >/dev/null <<'EOF'
+          apc.enable=1
+          apc.enable_cli=1
+          EOF
+          done < <(find /etc/php -type d -path '*/conf.d' | sort -u)
 
       - name: Setup PHP 8.2 tooling
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
-          extensions: mysqli, pdo_mysql, mbstring, curl, intl, xml, zip, gd
+          extensions: mysqli, pdo_mysql, mbstring, curl, intl, xml, zip, gd, apcu
+          ini-values: apc.enable=1, apc.enable_cli=1
           coverage: none
 
       - name: Setup Node 22
@@ -115,6 +125,9 @@ jobs:
               DocumentRoot ${PACKAGE_ROOT}/public
               SetEnv PINAKES_E2E_BYPASS_RATE_LIMIT 1
               SetEnv PINAKES_E2E_SCRAPER_STUB 1
+              # E2E only — arms GET /_e2e/flush-cache so specs that write to the
+              # DB directly can invalidate the page cache; 404s when unset.
+              SetEnv PINAKES_E2E_CACHE_FLUSH 1
               <Directory "${PACKAGE_ROOT}/public">
                   Options -Indexes +FollowSymLinks
                   AllowOverride All

--- a/.github/workflows/ci-deep-regression.yml
+++ b/.github/workflows/ci-deep-regression.yml
@@ -71,7 +71,9 @@ jobs:
           # apt source before the first refresh so mirror syncs cannot break CI.
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update -q
-          sudo apt-get install -y apache2 libapache2-mod-php default-mysql-client msmtp-mta
+          # php-apcu: the app's page cache must run on its production backend
+          # (APCu shared memory) under Apache/mod_php, not the file fallback.
+          sudo apt-get install -y apache2 libapache2-mod-php php-apcu default-mysql-client msmtp-mta
           sudo a2enmod rewrite headers env
           php_module="$(find /etc/apache2/mods-available -maxdepth 1 -name 'php*.load' -printf '%f\n' | sed 's/\.load$//' | sort -V | tail -n1)"
           [ -z "${php_module}" ] || sudo a2enmod "${php_module}"
@@ -90,6 +92,8 @@ jobs:
           sendmail_path = "/usr/bin/msmtp -t"
           upload_max_filesize = 8M
           post_max_size = 10M
+          apc.enable=1
+          apc.enable_cli=1
           EOF
           done < <(find /etc/php -type d -path '*/conf.d' | sort -u)
 
@@ -97,7 +101,8 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
-          extensions: mysqli, mbstring, json, curl, openssl, zip, gd, intl, xml
+          extensions: mysqli, mbstring, json, curl, openssl, zip, gd, intl, xml, apcu
+          ini-values: apc.enable=1, apc.enable_cli=1
           coverage: none
 
       - name: Setup Node 22
@@ -129,6 +134,9 @@ jobs:
               DocumentRoot ${WORKSPACE}/public
               SetEnv PINAKES_E2E_BYPASS_RATE_LIMIT 1
               SetEnv PINAKES_E2E_SCRAPER_STUB 1
+              # E2E only — arms GET /_e2e/flush-cache so specs that write to the
+              # DB directly can invalidate the page cache; 404s when unset.
+              SetEnv PINAKES_E2E_CACHE_FLUSH 1
               <Directory "${WORKSPACE}/public">
                   Options -Indexes +FollowSymLinks
                   AllowOverride All

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -59,20 +59,30 @@ jobs:
           # apt source before the first refresh so mirror syncs cannot break CI.
           sudo rm -f /etc/apt/sources.list.d/google-chrome.list
           sudo apt-get update -q
-          sudo apt-get install -y apache2 libapache2-mod-php
+          # php-apcu: the app's page cache must run on its production backend
+          # (APCu shared memory) under Apache/mod_php, not the file fallback.
+          sudo apt-get install -y apache2 libapache2-mod-php php-apcu
           sudo a2enmod rewrite headers env
           php_module="$(find /etc/apache2/mods-available -maxdepth 1 -name 'php*.load' -printf '%f\n' | sed 's/\.load$//' | sort -V | tail -n1)"
           if [ -n "${php_module}" ]; then
             sudo a2enmod "${php_module}"
           fi
           sudo a2dissite 000-default || true
+          # Enable APCu for every distro-PHP SAPI (Apache mod_php + distro CLI).
+          while IFS= read -r conf_dir; do
+            sudo tee "${conf_dir}/99-pinakes-apcu.ini" >/dev/null <<'EOF'
+          apc.enable=1
+          apc.enable_cli=1
+          EOF
+          done < <(find /etc/php -type d -path '*/conf.d' | sort -u)
 
       # ── PHP 8.2 CLI for Composer and tooling ────────────────────────────────
       - name: Setup PHP 8.2
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
-          extensions: mysqli, mbstring, json, curl, openssl, zip, gd, intl, xml
+          extensions: mysqli, mbstring, json, curl, openssl, zip, gd, intl, xml, apcu
+          ini-values: apc.enable=1, apc.enable_cli=1
           coverage: none
 
       - name: Configure virtual host on port 8081
@@ -88,6 +98,9 @@ jobs:
               # E2E only — deterministic, network-free bulk-enrich scraper stub.
               # Removes external-API latency/flakiness; never set in production.
               SetEnv PINAKES_E2E_SCRAPER_STUB 1
+              # E2E only — arms GET /_e2e/flush-cache so specs that write to the
+              # DB directly can invalidate the page cache; 404s when unset.
+              SetEnv PINAKES_E2E_CACHE_FLUSH 1
               <Directory "${WORKSPACE}/public">
                   Options -Indexes +FollowSymLinks
                   AllowOverride All

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -2,6 +2,7 @@ name: Test Database Migrations
 
 on:
   push:
+    branches: [main]
     paths:
       - 'installer/database/migrations/**'
       - 'installer/database/schema.sql'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.5]
+
+Fifth release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.
+
+### Fixed
+
+- Tag pushes no longer start the migration workflow a second time on the already-verified PR commit. Prerelease verification also waits for any concurrently attached non-release check to settle before evaluating GitHub's merge state, while terminal failures and bounded-timeout checks continue to fail closed.
+
 ## [0.7.69-rc.4]
 
 Fourth release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.2]
+
+Second release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.
+
+### Fixed
+
+- File-cache stampede protection now uses a bounded pool of persistent mutex inodes. Cache flushes, prefix invalidation and garbage collection never unlink a lock that a current or rolling-deploy worker may already have open; late lock acquisition also rechecks the cache before recomputing.
+- Shared public book payloads no longer retain the large FULLTEXT `search_index` column or private LibraryThing patron/loan fields. Catalog queries also remove redundant `DISTINCT` aggregation and unused taxonomy joins.
+- Bulk author deletion invalidates cached public book-detail DTOs immediately after its transaction commits.
+- APCu flush treats a concurrent disappearance as success instead of reporting a false maintenance failure.
+
 ## [0.7.69-rc.1]
 
 Release candidate for a performance/caching overhaul (issue #387). No schema change, no new required configuration — every install upgrades with identical behaviour on a cold cache. Bundles three reviewed pieces:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.1]
+
+Release candidate for a performance/caching overhaul (issue #387). No schema change, no new required configuration — every install upgrades with identical behaviour on a cold cache. Bundles three reviewed pieces:
+
+### Performance
+
+- **Single-backend query cache with O(1) invalidation.** `QueryCache` now uses one backend per request (APCu when available, else file) instead of writing to both on every set, and invalidates the content namespaces (catalog, home, genre-tree, book-detail, reviews) through monotonic generation counters — a bump makes every prior entry unreachable without scanning or deleting. The counters are file-backed and written atomically (temp + `rename()`), so a failed write can never wipe one and re-expose invalidated data; a scheduled non-blocking GC reclaims orphaned files. Per-request hit/miss instrumentation (`QueryCache::stats()`) is available for a later diagnostics surface.
+- **Hot public datasets are cached, availability stays live.** The book-detail static DTO (metadata/authors/publishers/series/related), the reviews block and the bounded catalog listing pages are cached per locale, while `copie_disponibili`/`copie_totali`/`stato` are stripped before storage and re-read live on every request — a stale availability number can never be served. Every write-path that changes a cached column (book edit, cover download, series mutation, reviewer name, author enrichment) invalidates the right namespace.
+- **Sessionless anonymous request path + lazy CSRF.** Anonymous read-only requests with no auth cookie no longer open a PHP session or embed a per-visitor CSRF token in the HTML (the token is minted on demand via `GET /csrf-token`), clearing the two blockers to a future shared edge cache. CSRF validation is unchanged — every state-changing request still opens a session and is validated exactly as before; private-mode gating and the login/remember-me flows are untouched. Only the genuinely public `/uploads` subtrees (covers, author photos, branding) are treated as sessionless; the private ones stay behind the session.
+
+### Internal
+
+- OPcache guidance in `php.ini.recommended` corrected (JIT explicitly disabled, `fast_shutdown` removed, sizing driven by `opcache_get_status()`). Extensive new behavioural coverage for the cache backend, generation invalidation, atomicity, the availability split and the sessionless/CSRF predicate.
+
 ## [0.7.68]
 
 Circulation fixes. A request for a book that is currently out no longer fails on approval — it becomes a real waitlist reservation — and copy allocation is made consistent everywhere a copy is chosen. Also restores the "waiting for pickup" cancel action (#381), the terminal pickup email for archived books, and author photos supplied as a URL (#382).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.6]
+
+Sixth release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.
+
+### Fixed
+
+- The circular prerelease-check exception now recognizes only an actively pending or failed Verified Release run. A cancelled, skipped or neutral self-check can no longer satisfy the `BLOCKED` safeguard; regression tests cover both terminal buckets.
+
 ## [0.7.69-rc.5]
 
 Fifth release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.4]
+
+Fourth release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.
+
+### Fixed
+
+- Prerelease source verification now handles GitHub's observed circular `BLOCKED` state for the tag workflow itself. It accepts that state only when the PR remains mergeable, no review is missing or rejected, every other visible check is green, and the sole blocker is the current Verified Release check; genuine conflicts, policy failures and review blocks still fail closed.
+
 ## [0.7.69-rc.3]
 
 Third release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.69-rc.3]
+
+Third release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.
+
+### Fixed
+
+- Live availability reads now handle failures from the complete MySQLi statement lifecycle, not only `prepare()`. A database outage is distinct from a successful empty result: book detail returns a retryable, non-cacheable 503 instead of a false 404, while a cached catalog page keeps its rows instead of collapsing to an empty grid.
+
 ## [0.7.69-rc.2]
 
 Second release candidate for the issue #387 caching overhaul. No schema change and no new required configuration.

--- a/app/Controllers/AutoriApiController.php
+++ b/app/Controllers/AutoriApiController.php
@@ -314,6 +314,11 @@ class AutoriApiController
             // Commit transaction
             $db->commit();
 
+            // Public book-detail DTOs embed the linked author rows. This API
+            // bypasses AuthorRepository, so invalidate immediately after the
+            // transaction commits instead of serving deleted authors for TTL.
+            \App\Support\ContentCache::booksChanged();
+
             // Rebuild the search_index of the (now author-less) books so the
             // deleted authors' names no longer surface in catalog search.
             \App\Support\SearchIndexBuilder::rebuildMany($db, array_values($affectedBookIds));

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -502,6 +502,16 @@ class FrontendController
         // database on every request further below: a stale availability number
         // is a user-facing correctness bug (double-loan), a stale title is not.
         $locale = \App\Support\I18n::getLocale();
+
+        // Live availability is read FIRST — it is also the soft-delete-aware proof
+        // that the book exists. Reading it before remember() means an unknown id
+        // never creates a cache entry (bounded, mirrors hasBoundedCatalogCacheKey);
+        // a raw scan of nonexistent ids cannot grow storage/cache. Reused below.
+        $liveBook = $this->fetchLiveAvailability($db, [$book_id]);
+        if (!isset($liveBook[$book_id])) {
+            return $this->render404($response);
+        }
+
         $detail = \App\Support\QueryCache::remember(
             'book_detail_' . $locale . '_' . $book_id,
             function () use ($db, $book_id): ?array {
@@ -510,8 +520,9 @@ class FrontendController
             300
         );
 
-        // A missing/soft-deleted book yields null, which remember() treats as
-        // a miss on the next request — 404s are never negatively cached.
+        // Defence in depth: a soft-delete racing between the live read above and
+        // the DTO build yields null (remember() treats null as a miss — never
+        // negatively cached).
         if (!is_array($detail) || !isset($detail['book'])) {
             return $this->render404($response);
         }
@@ -538,26 +549,20 @@ class FrontendController
             return $response->withHeader('Location', $canonicalPath)->withStatus(301);
         }
 
-        // LIVE availability merge — NEVER served from cache. One indexed
-        // primary-key lookup refreshes copie_disponibili/copie_totali/stato
-        // for the book and its related volumes; the soft-delete-aware read is
-        // also the authority on whether the book still exists.
-        $liveAvailability = $this->fetchLiveAvailability(
-            $db,
-            array_merge([$book_id], array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $related_books))
-        );
-        if (!isset($liveAvailability[$book_id])) {
-            // Soft-deleted after the DTO was cached: the live read wins → 404.
-            return $this->render404($response);
-        }
-        $book = array_merge($book, $liveAvailability[$book_id]);
+        // LIVE availability merge — NEVER served from cache. The book's own
+        // availability was already read above ($liveBook); here we only refresh
+        // the related volumes (one indexed primary-key lookup), reusing $liveBook
+        // for the book itself rather than querying it twice.
+        $relatedIds = array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $related_books);
+        $liveRelated = $relatedIds !== [] ? $this->fetchLiveAvailability($db, $relatedIds) : [];
+        $book = array_merge($book, $liveBook[$book_id]);
         $freshRelated = [];
         foreach ($related_books as $row) {
             $rowId = (int) ($row['id'] ?? 0);
-            if (!isset($liveAvailability[$rowId])) {
+            if (!isset($liveRelated[$rowId])) {
                 continue; // soft-deleted since the DTO was cached
             }
-            $freshRelated[] = array_merge($row, $liveAvailability[$rowId]);
+            $freshRelated[] = array_merge($row, $liveRelated[$rowId]);
         }
         $related_books = $freshRelated;
 
@@ -858,8 +863,12 @@ class FrontendController
             "SELECT id, copie_disponibili, copie_totali, stato FROM libri WHERE id IN ({$placeholders}) AND deleted_at IS NULL"
         );
         if ($stmt === false) {
+            // Degrade gracefully instead of throwing: this runs on the most
+            // trafficked public pages. An empty map lets the caller decide —
+            // the book-detail path 404s (existence unknown), the catalog path
+            // renders rows without availability — rather than a hard 500.
             \App\Support\SecureLogger::error('FrontendController: live availability prepare failed', ['db_error' => $db->error]);
-            throw new \RuntimeException('Live availability query failed');
+            return [];
         }
 
         $types = str_repeat('i', count($ids));

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -294,17 +294,9 @@ class FrontendController
             LIMIT ? OFFSET ?
         ";
 
-        $stmt_books = $db->prepare($books_query);
-        $final_params = array_merge($query_params, [$limit, $offset]);
-        $final_types = $param_types . 'ii';
-        $stmt_books->bind_param($final_types, ...$final_params);
-        $stmt_books->execute();
-        $books_result = $stmt_books->get_result();
-
-        $books = [];
-        while ($book = $books_result->fetch_assoc()) {
-            $books[] = $book;
-        }
+        // Listing rows: cached only for the bounded filter states (availability
+        // fields stripped from the cached copy and merged back live per request).
+        $books = $this->loadCatalogPageRows($db, $books_query, $param_types, $query_params, $filters, $limit, $offset, $page);
 
         // Ottieni le opzioni per i filtri
         $filter_options = $this->getFilterOptions($db, $filters);
@@ -404,17 +396,9 @@ class FrontendController
             LIMIT ? OFFSET ?
         ";
 
-        $stmt_books = $db->prepare($books_query);
-        $final_params = array_merge($query_params, [$limit, $offset]);
-        $final_types = $param_types . 'ii';
-        $stmt_books->bind_param($final_types, ...$final_params);
-        $stmt_books->execute();
-        $books_result = $stmt_books->get_result();
-
-        $books = [];
-        while ($book = $books_result->fetch_assoc()) {
-            $books[] = $book;
-        }
+        // Listing rows: cached only for the bounded filter states (availability
+        // fields stripped from the cached copy and merged back live per request).
+        $books = $this->loadCatalogPageRows($db, $books_query, $param_types, $query_params, $filters, $limit, $offset, $page);
 
         // Render only the books grid
         ob_start();
@@ -509,39 +493,33 @@ class FrontendController
 
         $book_id = (int)$params['id'];
 
-        // Query per recuperare i dettagli completi del libro con gerarchia generi
-        $query = "
-            SELECT l.*,
-                   a.nome AS autore_principale,
-                   g.nome AS genere,
-                   gp.id AS genere_parent_id_resolved,
-                   gp.nome AS genere_parent,
-                   gpp.id AS genere_grandparent_id,
-                   gpp.nome AS genere_grandparent,
-                   sg.nome AS sottogenere,
-                   e.nome AS editore
-            FROM libri l
-            LEFT JOIN libri_autori la ON l.id = la.libro_id AND la.ruolo = 'principale'
-            LEFT JOIN autori a ON la.autore_id = a.id
-            LEFT JOIN generi g ON l.genere_id = g.id
-            LEFT JOIN generi gp ON g.parent_id = gp.id
-            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
-            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
-            LEFT JOIN editori e ON l.editore_id = e.id
-            WHERE l.id = ? AND l.deleted_at IS NULL
-            LIMIT 1
-        ";
+        // Static book-detail DTO (issue #387 step 4): the book row, its
+        // authors, publishers, series and related volumes are identical for
+        // every visitor and change only through admin write paths that all
+        // funnel into ContentCache::booksChanged() → 'book_detail_' generation
+        // bump. Live availability (copie_disponibili/copie_totali/stato) is
+        // deliberately EXCLUDED from the cached payload and re-read from the
+        // database on every request further below: a stale availability number
+        // is a user-facing correctness bug (double-loan), a stale title is not.
+        $locale = \App\Support\I18n::getLocale();
+        $detail = \App\Support\QueryCache::remember(
+            'book_detail_' . $locale . '_' . $book_id,
+            function () use ($db, $book_id): ?array {
+                return $this->buildBookDetailStatic($db, $book_id);
+            },
+            300
+        );
 
-        $stmt = $db->prepare($query);
-        $stmt->bind_param("i", $book_id);
-        $stmt->execute();
-        $result = $stmt->get_result();
-
-        if (!$result || $result->num_rows == 0) {
+        // A missing/soft-deleted book yields null, which remember() treats as
+        // a miss on the next request — 404s are never negatively cached.
+        if (!is_array($detail) || !isset($detail['book'])) {
             return $this->render404($response);
         }
 
-        $book = $result->fetch_assoc();
+        $book = $detail['book'];
+        $authors = $detail['authors'];
+        $seriesBooks = $detail['seriesBooks'];
+        $related_books = $detail['related_books'];
 
         // Ensure canonical URL structure (author slug + book slug + ID)
         $canonicalPath = book_url([
@@ -560,90 +538,54 @@ class FrontendController
             return $response->withHeader('Location', $canonicalPath)->withStatus(301);
         }
 
-        // Query per ottenere tutti gli autori del libro
-        $query_authors = "
-            SELECT a.*, la.ruolo
-            FROM autori a
-            JOIN libri_autori la ON a.id = la.autore_id
-            WHERE la.libro_id = ?
-            ORDER BY
-                CASE la.ruolo
-                    WHEN 'principale' THEN 1
-                    WHEN 'co-autore' THEN 2
-                    WHEN 'traduttore' THEN 3
-                    WHEN 'illustratore' THEN 4
-                    WHEN 'curatore' THEN 5
-                    WHEN 'colorista' THEN 6
-                    ELSE 7
-                END
-        ";
-
-        $stmt_authors = $db->prepare($query_authors);
-        $stmt_authors->bind_param("i", $book_id);
-        $stmt_authors->execute();
-        $result_authors = $stmt_authors->get_result();
-
-        $authors = [];
-        while ($author = $result_authors->fetch_assoc()) {
-            $authors[] = $author;
-        }
-
-        // Publishers (issue #143): full ordered list for multi-publisher books.
-        // Falls back to the single primary publisher for pre-#143 data.
-        $book['editori'] = [];
-        $stmtPub = $db->prepare(
-            'SELECT e.id, e.nome FROM libri_editori le JOIN editori e ON le.editore_id = e.id WHERE le.libro_id = ? ORDER BY le.ordine, e.nome'
+        // LIVE availability merge — NEVER served from cache. One indexed
+        // primary-key lookup refreshes copie_disponibili/copie_totali/stato
+        // for the book and its related volumes; the soft-delete-aware read is
+        // also the authority on whether the book still exists.
+        $liveAvailability = $this->fetchLiveAvailability(
+            $db,
+            array_merge([$book_id], array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $related_books))
         );
-        if ($stmtPub) {
-            $stmtPub->bind_param('i', $book_id);
-            $stmtPub->execute();
-            $resPub = $stmtPub->get_result();
-            while ($pub = $resPub->fetch_assoc()) {
-                $book['editori'][] = $pub;
+        if (!isset($liveAvailability[$book_id])) {
+            // Soft-deleted after the DTO was cached: the live read wins → 404.
+            return $this->render404($response);
+        }
+        $book = array_merge($book, $liveAvailability[$book_id]);
+        $freshRelated = [];
+        foreach ($related_books as $row) {
+            $rowId = (int) ($row['id'] ?? 0);
+            if (!isset($liveAvailability[$rowId])) {
+                continue; // soft-deleted since the DTO was cached
             }
-            $stmtPub->close();
+            $freshRelated[] = array_merge($row, $liveAvailability[$rowId]);
         }
-        if ($book['editori'] === [] && !empty($book['editore'])) {
-            $book['editori'][] = ['id' => (int) ($book['editore_id'] ?? 0), 'nome' => (string) $book['editore']];
-        }
+        $related_books = $freshRelated;
 
-        // Get approved reviews and statistics
-        $recensioniRepo = new RecensioniRepository($db);
-        $reviews = $recensioniRepo->getApprovedReviewsForBook($book_id);
-        $reviewStats = $recensioniRepo->getReviewStats($book_id);
-
-        // Other volumes in the same series (collana)
-        $seriesBooks = [];
-        $collana = trim((string) ($book['collana'] ?? ''));
-        if ($collana !== '') {
-            $stmtSeries = $db->prepare("
-                SELECT l.id, l.titolo, l.numero_serie, l.copertina_url,
-                       (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale,
-                       (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale_nome
-                FROM libri l
-                WHERE l.collana = ? AND l.id != ? AND l.deleted_at IS NULL
-                ORDER BY
-                    CASE WHEN TRIM(l.numero_serie) REGEXP '^[0-9]+$' THEN 0 ELSE 1 END,
-                    CAST(l.numero_serie AS UNSIGNED),
-                    l.titolo
-            ");
-            if ($stmtSeries) {
-                $stmtSeries->bind_param('si', $collana, $book_id);
-                $stmtSeries->execute();
-                $resSeries = $stmtSeries->get_result();
-                while ($row = $resSeries->fetch_assoc()) {
-                    $seriesBooks[] = $row;
-                }
-                $stmtSeries->close();
-            } else {
-                \App\Support\SecureLogger::warning('FrontendController: series query prepare failed', ['db_error' => $db->error]);
-            }
-        }
-
-        // Get related books (pass seriesBooks to avoid duplicate collana query)
-        $related_books = $this->getRelatedBooks($db, $book_id, $book, $authors, $seriesBooks);
+        // Approved reviews + statistics: cached per book ('book_reviews_'
+        // namespace), invalidated on moderation (approve/reject/delete →
+        // ContentCache::reviewsChanged()). New reviews are 'pendente' and
+        // never publicly visible, so submission does not need to invalidate.
+        $reviewsBlock = \App\Support\QueryCache::remember(
+            'book_reviews_' . $locale . '_' . $book_id,
+            static function () use ($db, $book_id): array {
+                $recensioniRepo = new RecensioniRepository($db);
+                return [
+                    'reviews' => $recensioniRepo->getApprovedReviewsForBook($book_id),
+                    'stats' => $recensioniRepo->getReviewStats($book_id),
+                ];
+            },
+            300
+        );
+        $reviews = is_array($reviewsBlock['reviews'] ?? null) ? $reviewsBlock['reviews'] : [];
+        $reviewStats = is_array($reviewsBlock['stats'] ?? null) ? $reviewsBlock['stats'] : [
+            'total_reviews' => 0,
+            'average_rating' => 0,
+            'one_star' => 0,
+            'two_star' => 0,
+            'three_star' => 0,
+            'four_star' => 0,
+            'five_star' => 0,
+        ];
 
         // Social sharing
         $sharingProviders = array_values(array_filter(array_map('trim', explode(',', (string) ConfigStore::get('sharing.enabled_providers', '')))));
@@ -715,6 +657,320 @@ class FrontendController
         return $response
             ->withHeader('Content-Type', 'text/html')
             ->withHeader('Link', implode(', ', $signLinks));
+    }
+
+    /**
+     * Fields whose value depends on live circulation state. They are stripped
+     * from every cached payload and re-read from the database at request time
+     * (fetchLiveAvailability), so a warm cache can never serve a stale
+     * availability number.
+     */
+    private const LIVE_AVAILABILITY_FIELDS = ['copie_disponibili', 'copie_totali', 'stato'];
+
+    /**
+     * Highest catalog page number eligible for the page-rows cache. Together
+     * with hasBoundedCatalogCacheKey() this keeps the cached key space finite
+     * (locale × 4 availability states × 6 sorts × N pages); deeper pages are
+     * request-controlled long-tail traffic and always hit the database.
+     */
+    private const CATALOG_PAGE_CACHE_MAX_PAGE = 10;
+
+    /**
+     * Build the visitor-independent portion of the book-detail page: the book
+     * row (WITHOUT the live availability fields), its authors, publishers
+     * (issue #143), same-series volumes and related volumes (also stripped of
+     * availability). Returns null when the book does not exist or is
+     * soft-deleted — callers must treat that as a 404.
+     *
+     * Cached by bookDetail() under the 'book_detail_' namespace; every book
+     * write path (create/edit/soft-delete, author/publisher/genre/series
+     * mutations, imports, availability recomputes) funnels into
+     * ContentCache::booksChanged(), which bumps that generation.
+     *
+     * @return array{book: array<string, mixed>, authors: array<int, array<string, mixed>>,
+     *               seriesBooks: array<int, array<string, mixed>>,
+     *               related_books: array<int, array<string, mixed>>}|null
+     */
+    private function buildBookDetailStatic(mysqli $db, int $book_id): ?array
+    {
+        // Query per recuperare i dettagli completi del libro con gerarchia generi
+        $query = "
+            SELECT l.*,
+                   a.nome AS autore_principale,
+                   g.nome AS genere,
+                   gp.id AS genere_parent_id_resolved,
+                   gp.nome AS genere_parent,
+                   gpp.id AS genere_grandparent_id,
+                   gpp.nome AS genere_grandparent,
+                   sg.nome AS sottogenere,
+                   e.nome AS editore
+            FROM libri l
+            LEFT JOIN libri_autori la ON l.id = la.libro_id AND la.ruolo = 'principale'
+            LEFT JOIN autori a ON la.autore_id = a.id
+            LEFT JOIN generi g ON l.genere_id = g.id
+            LEFT JOIN generi gp ON g.parent_id = gp.id
+            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
+            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
+            LEFT JOIN editori e ON l.editore_id = e.id
+            WHERE l.id = ? AND l.deleted_at IS NULL
+            LIMIT 1
+        ";
+
+        $stmt = $db->prepare($query);
+        $stmt->bind_param("i", $book_id);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        if (!$result || $result->num_rows == 0) {
+            return null;
+        }
+
+        $book = $result->fetch_assoc();
+
+        // Query per ottenere tutti gli autori del libro
+        $query_authors = "
+            SELECT a.*, la.ruolo
+            FROM autori a
+            JOIN libri_autori la ON a.id = la.autore_id
+            WHERE la.libro_id = ?
+            ORDER BY
+                CASE la.ruolo
+                    WHEN 'principale' THEN 1
+                    WHEN 'co-autore' THEN 2
+                    WHEN 'traduttore' THEN 3
+                    WHEN 'illustratore' THEN 4
+                    WHEN 'curatore' THEN 5
+                    WHEN 'colorista' THEN 6
+                    ELSE 7
+                END
+        ";
+
+        $stmt_authors = $db->prepare($query_authors);
+        $stmt_authors->bind_param("i", $book_id);
+        $stmt_authors->execute();
+        $result_authors = $stmt_authors->get_result();
+
+        $authors = [];
+        while ($author = $result_authors->fetch_assoc()) {
+            $authors[] = $author;
+        }
+
+        // Publishers (issue #143): full ordered list for multi-publisher books.
+        // Falls back to the single primary publisher for pre-#143 data.
+        $book['editori'] = [];
+        $stmtPub = $db->prepare(
+            'SELECT e.id, e.nome FROM libri_editori le JOIN editori e ON le.editore_id = e.id WHERE le.libro_id = ? ORDER BY le.ordine, e.nome'
+        );
+        if ($stmtPub) {
+            $stmtPub->bind_param('i', $book_id);
+            $stmtPub->execute();
+            $resPub = $stmtPub->get_result();
+            while ($pub = $resPub->fetch_assoc()) {
+                $book['editori'][] = $pub;
+            }
+            $stmtPub->close();
+        }
+        if ($book['editori'] === [] && !empty($book['editore'])) {
+            $book['editori'][] = ['id' => (int) ($book['editore_id'] ?? 0), 'nome' => (string) $book['editore']];
+        }
+
+        // Other volumes in the same series (collana)
+        $seriesBooks = [];
+        $collana = trim((string) ($book['collana'] ?? ''));
+        if ($collana !== '') {
+            $stmtSeries = $db->prepare("
+                SELECT l.id, l.titolo, l.numero_serie, l.copertina_url,
+                       (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale,
+                       (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+                        WHERE la.libro_id = l.id AND la.ruolo = 'principale' LIMIT 1) AS autore_principale_nome
+                FROM libri l
+                WHERE l.collana = ? AND l.id != ? AND l.deleted_at IS NULL
+                ORDER BY
+                    CASE WHEN TRIM(l.numero_serie) REGEXP '^[0-9]+$' THEN 0 ELSE 1 END,
+                    CAST(l.numero_serie AS UNSIGNED),
+                    l.titolo
+            ");
+            if ($stmtSeries) {
+                $stmtSeries->bind_param('si', $collana, $book_id);
+                $stmtSeries->execute();
+                $resSeries = $stmtSeries->get_result();
+                while ($row = $resSeries->fetch_assoc()) {
+                    $seriesBooks[] = $row;
+                }
+                $stmtSeries->close();
+            } else {
+                \App\Support\SecureLogger::warning('FrontendController: series query prepare failed', ['db_error' => $db->error]);
+            }
+        }
+
+        // Get related books (pass seriesBooks to avoid duplicate collana query)
+        $related_books = $this->getRelatedBooks($db, $book_id, $book, $authors, $seriesBooks);
+
+        return [
+            'book' => $this->stripLiveAvailability($book),
+            'authors' => $authors,
+            'seriesBooks' => $seriesBooks,
+            'related_books' => array_map(
+                fn (array $row): array => $this->stripLiveAvailability($row),
+                $related_books
+            ),
+        ];
+    }
+
+    /**
+     * Remove the live availability fields from a row destined for the cache.
+     *
+     * @param array<string, mixed> $row
+     * @return array<string, mixed>
+     */
+    private function stripLiveAvailability(array $row): array
+    {
+        foreach (self::LIVE_AVAILABILITY_FIELDS as $field) {
+            unset($row[$field]);
+        }
+
+        return $row;
+    }
+
+    /**
+     * Read the CURRENT availability of the given books straight from the
+     * database (soft-delete aware). This is the only source of the
+     * copie_disponibili/copie_totali/stato values the frontend renders — by
+     * design it runs on every request and is never cached.
+     *
+     * @param array<int, int> $ids
+     * @return array<int, array{copie_disponibili: int, copie_totali: int, stato: mixed}>
+     */
+    private function fetchLiveAvailability(mysqli $db, array $ids): array
+    {
+        $ids = array_values(array_unique(array_filter(array_map('intval', $ids), static fn (int $id): bool => $id > 0)));
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $stmt = $db->prepare(
+            "SELECT id, copie_disponibili, copie_totali, stato FROM libri WHERE id IN ({$placeholders}) AND deleted_at IS NULL"
+        );
+        if ($stmt === false) {
+            \App\Support\SecureLogger::error('FrontendController: live availability prepare failed', ['db_error' => $db->error]);
+            throw new \RuntimeException('Live availability query failed');
+        }
+
+        $types = str_repeat('i', count($ids));
+        $stmt->bind_param($types, ...$ids);
+        $stmt->execute();
+        $result = $stmt->get_result();
+
+        $live = [];
+        if ($result !== false) {
+            while ($row = $result->fetch_assoc()) {
+                $live[(int) $row['id']] = [
+                    'copie_disponibili' => (int) $row['copie_disponibili'],
+                    'copie_totali' => (int) $row['copie_totali'],
+                    'stato' => $row['stato'],
+                ];
+            }
+        }
+        $stmt->close();
+
+        return $live;
+    }
+
+    /**
+     * Merge fresh availability into cached listing rows, dropping rows whose
+     * book was soft-deleted after the cache entry was written (defence in
+     * depth on top of the booksChanged() generation bump).
+     *
+     * @param array<int, array<string, mixed>> $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function mergeLiveAvailability(mysqli $db, array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        $live = $this->fetchLiveAvailability($db, array_map(static fn (array $row): int => (int) ($row['id'] ?? 0), $rows));
+
+        $fresh = [];
+        foreach ($rows as $row) {
+            $rowId = (int) ($row['id'] ?? 0);
+            if (!isset($live[$rowId])) {
+                continue;
+            }
+            $fresh[] = array_merge($row, $live[$rowId]);
+        }
+
+        return $fresh;
+    }
+
+    /**
+     * Load one page of catalog listing rows. For the finite, high-traffic
+     * bounded filter states (same bounding as the facets cache, plus a page
+     * cap and the canonicalized sort) the rows are cached WITHOUT their live
+     * availability fields, which are merged back fresh on every request.
+     * Unbounded states (free text, ids, years, deep pages) always query.
+     *
+     * @param array<int, mixed> $query_params
+     * @param array<string, mixed> $filters
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadCatalogPageRows(
+        mysqli $db,
+        string $books_query,
+        string $param_types,
+        array $query_params,
+        array $filters,
+        int $limit,
+        int $offset,
+        int $page
+    ): array {
+        $fetch = static function () use ($db, $books_query, $param_types, $query_params, $limit, $offset): array {
+            $stmt_books = $db->prepare($books_query);
+            $final_params = array_merge($query_params, [$limit, $offset]);
+            $final_types = $param_types . 'ii';
+            $stmt_books->bind_param($final_types, ...$final_params);
+            $stmt_books->execute();
+            $books_result = $stmt_books->get_result();
+
+            $books = [];
+            while ($book = $books_result->fetch_assoc()) {
+                $books[] = $book;
+            }
+            $stmt_books->close();
+
+            return $books;
+        };
+
+        if (!$this->hasBoundedCatalogCacheKey($filters) || $page < 1 || $page > self::CATALOG_PAGE_CACHE_MAX_PAGE) {
+            return $fetch();
+        }
+
+        // Key: locale + bounded filter signature + canonical sort + page. The
+        // sort goes through buildOrderBy() so arbitrary request strings
+        // collapse onto the six real orderings instead of fragmenting keys.
+        $cacheKey = 'catalog_page_' . \App\Support\I18n::getLocale() . '_' . md5(serialize([
+            $this->normalizeFiltersForCache($filters),
+            $this->buildOrderBy((string) ($filters['sort'] ?? 'newest')),
+            $page,
+        ]));
+
+        $rows = \App\Support\QueryCache::remember($cacheKey, function () use ($fetch): array {
+            // Live availability never enters the cache (hard rule): strip it
+            // here, mergeLiveAvailability() re-reads it per request.
+            return array_map(
+                fn (array $row): array => $this->stripLiveAvailability($row),
+                $fetch()
+            );
+        }, 120);
+
+        if (!is_array($rows)) {
+            return $fetch();
+        }
+
+        return $this->mergeLiveAvailability($db, $rows);
     }
 
     private function render404(Response $response): Response

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -505,6 +505,9 @@ class FrontendController
         // never creates a cache entry (bounded, mirrors hasBoundedCatalogCacheKey);
         // a raw scan of nonexistent ids cannot grow storage/cache. Reused below.
         $liveBook = $this->fetchLiveAvailability($db, [$book_id]);
+        if ($liveBook === null) {
+            return $this->renderAvailabilityUnavailable($response);
+        }
         if (!isset($liveBook[$book_id])) {
             return $this->render404($response);
         }
@@ -560,13 +563,20 @@ class FrontendController
         $relatedIds = array_map(static fn(array $row): int => (int) ($row['id'] ?? 0), $related_books);
         $liveRelated = $relatedIds !== [] ? $this->fetchLiveAvailability($db, $relatedIds) : [];
         $book = array_merge($book, $liveBook[$book_id]);
-        $freshRelated = [];
-        foreach ($related_books as $row) {
-            $rowId = (int) ($row['id'] ?? 0);
-            if (!isset($liveRelated[$rowId])) {
-                continue; // soft-deleted since the DTO was cached
+        if ($liveRelated === null) {
+            // The main book's availability is known, so keep rendering the
+            // page. Preserve static related-volume metadata, but do not invent
+            // availability values for it while the second live query is down.
+            $freshRelated = $related_books;
+        } else {
+            $freshRelated = [];
+            foreach ($related_books as $row) {
+                $rowId = (int) ($row['id'] ?? 0);
+                if (!isset($liveRelated[$rowId])) {
+                    continue; // soft-deleted since the DTO was cached
+                }
+                $freshRelated[] = array_merge($row, $liveRelated[$rowId]);
             }
-            $freshRelated[] = array_merge($row, $liveRelated[$rowId]);
         }
         $related_books = $freshRelated;
 
@@ -871,9 +881,11 @@ class FrontendController
      * design it runs on every request and is never cached.
      *
      * @param array<int, int> $ids
-     * @return array<int, array{copie_disponibili: int, copie_totali: int, stato: mixed}>
+     * @return array<int, array{copie_disponibili: int, copie_totali: int, stato: mixed}>|null
+     *         null means the live query failed; an empty array is a successful
+     *         query that found no active books.
      */
-    private function fetchLiveAvailability(mysqli $db, array $ids): array
+    private function fetchLiveAvailability(mysqli $db, array $ids): ?array
     {
         $ids = array_values(array_unique(array_filter(array_map('intval', $ids), static fn (int $id): bool => $id > 0)));
         if ($ids === []) {
@@ -881,25 +893,29 @@ class FrontendController
         }
 
         $placeholders = implode(',', array_fill(0, count($ids), '?'));
-        $stmt = $db->prepare(
-            "SELECT id, copie_disponibili, copie_totali, stato FROM libri WHERE id IN ({$placeholders}) AND deleted_at IS NULL"
-        );
-        if ($stmt === false) {
-            // Degrade gracefully instead of throwing: this runs on the most
-            // trafficked public pages. An empty map lets the caller decide —
-            // the book-detail path 404s (existence unknown), the catalog path
-            // renders rows without availability — rather than a hard 500.
-            \App\Support\SecureLogger::error('FrontendController: live availability prepare failed', ['db_error' => $db->error]);
-            return [];
-        }
+        $stmt = null;
 
-        $types = str_repeat('i', count($ids));
-        $stmt->bind_param($types, ...$ids);
-        $stmt->execute();
-        $result = $stmt->get_result();
+        try {
+            $stmt = $db->prepare(
+                "SELECT id, copie_disponibili, copie_totali, stato FROM libri WHERE id IN ({$placeholders}) AND deleted_at IS NULL"
+            );
+            if ($stmt === false) {
+                throw new \RuntimeException('mysqli::prepare returned false: ' . $db->error);
+            }
 
-        $live = [];
-        if ($result !== false) {
+            $types = str_repeat('i', count($ids));
+            if (!$stmt->bind_param($types, ...$ids)) {
+                throw new \RuntimeException('mysqli_stmt::bind_param returned false: ' . $stmt->error);
+            }
+            if (!$stmt->execute()) {
+                throw new \RuntimeException('mysqli_stmt::execute returned false: ' . $stmt->error);
+            }
+            $result = $stmt->get_result();
+            if ($result === false) {
+                throw new \RuntimeException('mysqli_stmt::get_result returned false: ' . $stmt->error);
+            }
+
+            $live = [];
             while ($row = $result->fetch_assoc()) {
                 $live[(int) $row['id']] = [
                     'copie_disponibili' => (int) $row['copie_disponibili'],
@@ -907,10 +923,22 @@ class FrontendController
                     'stato' => $row['stato'],
                 ];
             }
-        }
-        $stmt->close();
 
-        return $live;
+            return $live;
+        } catch (\Throwable $e) {
+            // This query protects the correctness of every public availability
+            // indicator. Keep a DB outage distinct from a successful no-row
+            // result: detail returns a retryable 503, while catalog keeps its
+            // cached rows instead of incorrectly rendering an empty grid.
+            \App\Support\SecureLogger::error('FrontendController: live availability query failed', [
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        } finally {
+            if ($stmt instanceof \mysqli_stmt) {
+                $stmt->close();
+            }
+        }
     }
 
     /**
@@ -928,6 +956,9 @@ class FrontendController
         }
 
         $live = $this->fetchLiveAvailability($db, array_map(static fn (array $row): int => (int) ($row['id'] ?? 0), $rows));
+        if ($live === null) {
+            return $rows;
+        }
 
         $fresh = [];
         foreach ($rows as $row) {
@@ -1007,6 +1038,20 @@ class FrontendController
         }
 
         return $this->mergeLiveAvailability($db, $rows);
+    }
+
+    private function renderAvailabilityUnavailable(Response $response): Response
+    {
+        ob_start();
+        include __DIR__ . '/../Views/errors/500.php';
+        $content = ob_get_clean();
+
+        $response->getBody()->write($content);
+        return $response
+            ->withHeader('Content-Type', 'text/html')
+            ->withHeader('Cache-Control', 'no-store, private')
+            ->withHeader('Retry-After', '30')
+            ->withStatus(503);
     }
 
     private function render404(Response $response): Response

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -683,9 +683,10 @@ class FrontendController
      * soft-deleted — callers must treat that as a 404.
      *
      * Cached by bookDetail() under the 'book_detail_' namespace; every book
-     * write path (create/edit/soft-delete, author/publisher/genre/series
-     * mutations, imports, availability recomputes) funnels into
-     * ContentCache::booksChanged(), which bumps that generation.
+     * metadata write path (create/edit/soft-delete, author/publisher/genre/
+     * series mutations and imports) funnels into ContentCache::booksChanged(),
+     * which bumps that generation. Availability-only recomputes use
+     * availabilityChanged() and intentionally leave this static DTO warm.
      *
      * @return array{book: array<string, mixed>, authors: array<int, array<string, mixed>>,
      *               seriesBooks: array<int, array<string, mixed>>,
@@ -722,10 +723,12 @@ class FrontendController
         $result = $stmt->get_result();
 
         if (!$result || $result->num_rows == 0) {
+            $stmt->close();
             return null;
         }
 
         $book = $result->fetch_assoc();
+        $stmt->close();
 
         // Query per ottenere tutti gli autori del libro
         $query_authors = "
@@ -754,6 +757,7 @@ class FrontendController
         while ($author = $result_authors->fetch_assoc()) {
             $authors[] = $author;
         }
+        $stmt_authors->close();
 
         // Publishers (issue #143): full ordered list for multi-publisher books.
         // Falls back to the single primary publisher for pre-#143 data.
@@ -955,6 +959,7 @@ class FrontendController
             $this->normalizeFiltersForCache($filters),
             $this->buildOrderBy((string) ($filters['sort'] ?? 'newest')),
             $page,
+            $limit,
         ]));
 
         $rows = \App\Support\QueryCache::remember($cacheKey, function () use ($fetch): array {

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -532,6 +532,13 @@ class FrontendController
         $seriesBooks = $detail['seriesBooks'];
         $related_books = $detail['related_books'];
 
+        // Series/collection name shown by the "Nella stessa collana" heading.
+        // buildBookDetailStatic() computes an identically-named local $collana
+        // for the sibling query but does not return it, so re-derive it here in
+        // the render scope from the (cached) book row — the field survives
+        // stripLiveAvailability(), which only removes copie_*/stato.
+        $collana = trim((string) ($book['collana'] ?? ''));
+
         // Ensure canonical URL structure (author slug + book slug + ID)
         $canonicalPath = book_url([
             'id' => $book_id,

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -237,15 +237,14 @@ class FrontendController
             ? \App\Support\Hooks::apply('frontend.catalog.archive_results', [], [$searchTerm])
             : [];
 
-        // Query base senza JOIN con autori per evitare duplicati
-        // Include genre parents/grandparents to support filtering at any level
+        // Query base without the many-to-many authors join, so one book stays
+        // one row. g + gp are sufficient for filtering every supported genre
+        // level; sottogenere matches directly on l.sottogenere_id.
         $base_query = "
             FROM libri l
             LEFT JOIN editori e ON l.editore_id = e.id
             LEFT JOIN generi g ON l.genere_id = g.id
             LEFT JOIN generi gp ON g.parent_id = gp.id
-            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
-            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
             WHERE l.deleted_at IS NULL
         ";
 
@@ -253,11 +252,12 @@ class FrontendController
             $base_query .= " AND " . implode(' AND ', $where_conditions['conditions']);
         }
 
-        // Cached total: the COUNT(DISTINCT) scan is identical for every page of
-        // the same filter set. Short TTL; book mutations clear the 'catalog_'
-        // prefix so admin edits show up immediately.
+        // Cached total is identical for every page of the same filter set.
+        // Every join in base_query is many-to-one and filter-only relations use
+        // EXISTS, so one libri row can never multiply: COUNT(*) avoids the
+        // unnecessary DISTINCT aggregation. Short TTL; mutations invalidate it.
         $catalogCacheSuffix = md5(serialize($this->normalizeFiltersForCache($filters)));
-        $count_query = "SELECT COUNT(DISTINCT l.id) as total " . $base_query;
+        $count_query = "SELECT COUNT(*) as total " . $base_query;
         $countLoader = function () use ($db, $count_query, $param_types, $query_params) {
             $stmt_count = $db->prepare($count_query);
             if (!empty($query_params)) {
@@ -280,7 +280,7 @@ class FrontendController
         // re-running the correlated subquery twice per row (once for the
         // NULLs-last predicate, once for the sort value).
         $books_query = "
-            SELECT DISTINCT l.*,
+            SELECT l.*,
                    (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
                     WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore,
                    (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
@@ -339,15 +339,13 @@ class FrontendController
         // returning archive matches in the search-as-you-type JSON payload.
         // catalog() still renders archives in its empty-state block.
 
-        // Query base senza JOIN con autori per evitare duplicati
-        // Include genre parents/grandparents/subgenre to support filtering at any level
+        // Same one-row-per-book join shape as catalog(). g + gp cover the
+        // hierarchy predicates; no unused grandparent/subgenre joins here.
         $base_query = "
             FROM libri l
             LEFT JOIN editori e ON l.editore_id = e.id
             LEFT JOIN generi g ON l.genere_id = g.id
             LEFT JOIN generi gp ON g.parent_id = gp.id
-            LEFT JOIN generi gpp ON gp.parent_id = gpp.id
-            LEFT JOIN generi sg ON l.sottogenere_id = sg.id
             WHERE l.deleted_at IS NULL
         ";
 
@@ -355,11 +353,10 @@ class FrontendController
             $base_query .= " AND " . implode(' AND ', $where_conditions['conditions']);
         }
 
-        // Cached total: the COUNT(DISTINCT) scan is identical for every page of
-        // the same filter set. Short TTL; book mutations clear the 'catalog_'
-        // prefix so admin edits show up immediately.
+        // The base joins are many-to-one, so COUNT(*) is exact without a
+        // DISTINCT aggregation (same invariant as catalog()).
         $catalogCacheSuffix = md5(serialize($this->normalizeFiltersForCache($filters)));
-        $count_query = "SELECT COUNT(DISTINCT l.id) as total " . $base_query;
+        $count_query = "SELECT COUNT(*) as total " . $base_query;
         $countLoader = function () use ($db, $count_query, $param_types, $query_params) {
             $stmt_count = $db->prepare($count_query);
             if (!empty($query_params)) {
@@ -382,7 +379,7 @@ class FrontendController
         // re-running the correlated subquery twice per row (once for the
         // NULLs-last predicate, once for the sort value).
         $books_query = "
-            SELECT DISTINCT l.*,
+            SELECT l.*,
                    (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
                     WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore,
                    (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
@@ -430,7 +427,7 @@ class FrontendController
         $available_books = null;
         if (($params['with_stats'] ?? '') === '1') {
             $availabilityLoader = function () use ($db, $base_query, $param_types, $query_params) {
-                $available_stmt = $db->prepare("SELECT COUNT(DISTINCT l.id) as total " . $base_query . " AND l.copie_disponibili > 0");
+                $available_stmt = $db->prepare("SELECT COUNT(*) as total " . $base_query . " AND l.copie_disponibili > 0");
                 if ($available_stmt === false) {
                     \App\Support\SecureLogger::error('Available-books count prepare failed', ['db_error' => $db->error]);
                     return 0;
@@ -536,7 +533,7 @@ class FrontendController
         // buildBookDetailStatic() computes an identically-named local $collana
         // for the sibling query but does not return it, so re-derive it here in
         // the render scope from the (cached) book row — the field survives
-        // stripLiveAvailability(), which only removes copie_*/stato.
+        // stripSharedCacheFields(), which preserves display metadata.
         $collana = trim((string) ($book['collana'] ?? ''));
 
         // Ensure canonical URL structure (author slug + book slug + ID)
@@ -678,6 +675,21 @@ class FrontendController
      * availability number.
      */
     private const LIVE_AVAILABILITY_FIELDS = ['copie_disponibili', 'copie_totali', 'stato'];
+
+    /**
+     * Columns fetched by l.* that must never enter a shared public cache.
+     * search_index is a potentially large denormalized MEDIUMTEXT used only by
+     * SQL; the remaining LibraryThing fields are explicitly private in the
+     * frontend and may contain patron identity or loan dates.
+     */
+    private const SHARED_CACHE_EXCLUDED_FIELDS = [
+        'search_index',
+        'private_comment',
+        'lending_patron',
+        'lending_status',
+        'lending_start',
+        'lending_end',
+    ];
 
     /**
      * Highest catalog page number eligible for the page-rows cache. Together
@@ -824,11 +836,11 @@ class FrontendController
         $related_books = $this->getRelatedBooks($db, $book_id, $book, $authors, $seriesBooks);
 
         return [
-            'book' => $this->stripLiveAvailability($book),
+            'book' => $this->stripSharedCacheFields($book),
             'authors' => $authors,
             'seriesBooks' => $seriesBooks,
             'related_books' => array_map(
-                fn (array $row): array => $this->stripLiveAvailability($row),
+                fn (array $row): array => $this->stripSharedCacheFields($row),
                 $related_books
             ),
         ];
@@ -840,9 +852,12 @@ class FrontendController
      * @param array<string, mixed> $row
      * @return array<string, mixed>
      */
-    private function stripLiveAvailability(array $row): array
+    private function stripSharedCacheFields(array $row): array
     {
         foreach (self::LIVE_AVAILABILITY_FIELDS as $field) {
+            unset($row[$field]);
+        }
+        foreach (self::SHARED_CACHE_EXCLUDED_FIELDS as $field) {
             unset($row[$field]);
         }
 
@@ -982,7 +997,7 @@ class FrontendController
             // Live availability never enters the cache (hard rule): strip it
             // here, mergeLiveAvailability() re-reads it per request.
             return array_map(
-                fn (array $row): array => $this->stripLiveAvailability($row),
+                fn (array $row): array => $this->stripSharedCacheFields($row),
                 $fetch()
             );
         }, 120);

--- a/app/Controllers/LanguageController.php
+++ b/app/Controllers/LanguageController.php
@@ -58,8 +58,11 @@ class LanguageController
         $secure = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
             || $forwardedProto === 'https'
             || $forwardedSsl === 'on';
+        $basePath = rtrim(\App\Support\HtmlHelper::getBasePath(), '/');
+        $cookiePath = ($basePath === '' ? '' : $basePath) . '/';
         $cookie = 'pinakes_locale=' . rawurlencode($locale)
-            . '; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
+            . '; Path=' . $cookiePath
+            . '; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
 
         // Determine safe redirect target
         $queryParams = $request->getQueryParams();

--- a/app/Controllers/LanguageController.php
+++ b/app/Controllers/LanguageController.php
@@ -26,11 +26,14 @@ class LanguageController
         // Set locale in I18n
         I18n::setLocale($locale);
 
-        // Save in session
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
+        // Save in session — but only when one is already open (logged-in
+        // users and cookie-bearing visitors). A sessionless anonymous visitor
+        // (issue #387 step 6) must NOT be handed a session just to remember
+        // the language: the choice is persisted in the pinakes_locale cookie
+        // below, which public/index.php reads on the no-session path.
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION['locale'] = $locale;
         }
-        $_SESSION['locale'] = $locale;
 
         // Save to database if user is logged in
         if (isset($_SESSION['user']['id'])) {
@@ -44,11 +47,26 @@ class LanguageController
             }
         }
 
+        // Persist the choice in a cookie so the anonymous no-session path
+        // (issue #387 step 6) resolves the locale deterministically without a
+        // session. $locale is normalized and validated against the available
+        // locales above, so the value is always a safe xx_XX code. HTTPS
+        // detection mirrors AuthController::loginForm() (honours
+        // X-Forwarded-Proto/-Ssl behind TLS-terminating proxies).
+        $forwardedProto = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? ''));
+        $forwardedSsl = strtolower((string) ($_SERVER['HTTP_X_FORWARDED_SSL'] ?? ''));
+        $secure = (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off')
+            || $forwardedProto === 'https'
+            || $forwardedSsl === 'on';
+        $cookie = 'pinakes_locale=' . rawurlencode($locale)
+            . '; Path=/; Max-Age=31536000; SameSite=Lax; HttpOnly' . ($secure ? '; Secure' : '');
+
         // Determine safe redirect target
         $queryParams = $request->getQueryParams();
         $redirect = $this->sanitizeRedirect($queryParams['redirect'] ?? '/');
 
         return $response
+            ->withAddedHeader('Set-Cookie', $cookie)
             ->withHeader('Location', $redirect)
             ->withStatus(302);
     }

--- a/app/Controllers/LibriController.php
+++ b/app/Controllers/LibriController.php
@@ -2755,6 +2755,10 @@ class LibriController
         $stmt->execute();
         $stmt->close();
 
+        // The cover URL is part of the cached book-detail DTO and catalog rows
+        // (#387): invalidate so the new cover shows without waiting for the TTL.
+        \App\Support\ContentCache::booksChanged();
+
         $response->getBody()->write(json_encode(['success' => true, 'fetched' => true, 'cover_url' => $coverUrl]));
         return $response->withHeader('Content-Type', 'application/json');
     }
@@ -3843,6 +3847,11 @@ class LibriController
                             $stmt->bind_param('si', $coverData['file_url'], $book['id']);
                             $stmt->execute();
                             $stmt->close();
+
+                            // Cover is in the cached book-detail DTO / catalog rows
+                            // (#387). Defer collapses the whole bulk sync into a
+                            // single invalidation at shutdown.
+                            \App\Support\ContentCache::deferBooksChanged();
 
                             $synced++;
                             error_log("[Cover Sync] Cover downloaded for book ID {$book['id']}: {$coverData['file_url']}");

--- a/app/Controllers/ProfileController.php
+++ b/app/Controllers/ProfileController.php
@@ -248,6 +248,9 @@ class ProfileController
         }
 
         if ($updated) {
+            // The cached reviews block (#387) stores the reviewer display name as
+            // CONCAT(nome,' ',cognome), so a name change must invalidate it.
+            \App\Support\ContentCache::reviewsChanged();
             // Update session data
             $_SESSION['user']['name'] = trim($nome . ' ' . $cognome);
             // Apply locale change immediately (only when locale was in the form)

--- a/app/Controllers/ProfileController.php
+++ b/app/Controllers/ProfileController.php
@@ -250,7 +250,7 @@ class ProfileController
         if ($updated) {
             // The cached reviews block (#387) stores the reviewer display name as
             // CONCAT(nome,' ',cognome), so a name change must invalidate it.
-            \App\Support\ContentCache::reviewsChanged();
+            \App\Support\ContentCache::deferReviewsChanged();
             // Update session data
             $_SESSION['user']['name'] = trim($nome . ' ' . $cognome);
             // Apply locale change immediately (only when locale was in the form)

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -515,6 +515,13 @@ class UsersController
         }
         $stmt->close();
 
+        // Public review DTOs include the reviewer's display name. Invalidate
+        // only when that rendered identity actually changed.
+        if ((string) ($original['nome'] ?? '') !== $nome
+            || (string) ($original['cognome'] ?? '') !== $cognome) {
+            \App\Support\ContentCache::reviewsChanged();
+        }
+
         // Keep the current browser session coherent when an administrator edits
         // their own account; other users pick up the persisted locale at login.
         if ($currentUserId === $id) {

--- a/app/Controllers/UsersController.php
+++ b/app/Controllers/UsersController.php
@@ -519,7 +519,7 @@ class UsersController
         // only when that rendered identity actually changed.
         if ((string) ($original['nome'] ?? '') !== $nome
             || (string) ($original['cognome'] ?? '') !== $cognome) {
-            \App\Support\ContentCache::reviewsChanged();
+            \App\Support\ContentCache::deferReviewsChanged();
         }
 
         // Keep the current browser session coherent when an administrator edits

--- a/app/Middleware/PrivateModeMiddleware.php
+++ b/app/Middleware/PrivateModeMiddleware.php
@@ -49,6 +49,11 @@ class PrivateModeMiddleware implements MiddlewareInterface
         '/uploads/settings/',
         '/installer', '/language/', '/health', '/favicon', '/robots.txt',
         '/.well-known/',
+        // Test-only cache-flush endpoint (web.php): the route 404s unless the
+        // server env sets PINAKES_E2E_CACHE_FLUSH=1, so allowing the prefix
+        // exposes nothing in production. E2E specs must be able to flush the
+        // page cache even while a test has private mode enabled.
+        '/_e2e/',
         // Security scan F3 (CWE-862): /feed.xml, /sitemap(.xml) and /llms.txt
         // are content-bearing — they leak book titles, authors, descriptions and
         // enumerate every catalog URL to unauthenticated visitors. In private

--- a/app/Models/SeriesRepository.php
+++ b/app/Models/SeriesRepository.php
@@ -341,6 +341,10 @@ class SeriesRepository
             $stmtUpsert->execute();
             $stmtUpsert->close();
         }
+
+        // Series data (collana / numero_serie / sibling volumes) is part of the
+        // cached book-detail DTO (#387): invalidate on every series mutation.
+        \App\Support\ContentCache::deferBooksChanged();
     }
 
     /** @return array<int, array<string, mixed>> */
@@ -668,6 +672,10 @@ class SeriesRepository
             }
         }
 
+        if ($ok) {
+            \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
+        }
+
         return $ok;
     }
 
@@ -700,6 +708,10 @@ class SeriesRepository
                 $this->promoteLegacySeries($bookId);
                 $affected++;
             }
+        }
+
+        if ($affected > 0) {
+            \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
         }
 
         return $affected;
@@ -801,6 +813,8 @@ class SeriesRepository
             }
         }
 
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
+
         return count($bookIds);
     }
 
@@ -867,6 +881,8 @@ class SeriesRepository
                 $stmtBackfill->close();
             }
         }
+
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
 
         return $affected;
     }
@@ -945,6 +961,8 @@ class SeriesRepository
                 $stmtDelete->close();
             }
         }
+
+        \App\Support\ContentCache::deferBooksChanged(); // #387 book-detail DTO
 
         return $affected;
     }

--- a/app/Repositories/RecensioniRepository.php
+++ b/app/Repositories/RecensioniRepository.php
@@ -201,8 +201,7 @@ class RecensioniRepository
         try {
             $stmt = $this->db->prepare("
                 SELECT r.*,
-                       CONCAT(u.nome, ' ', u.cognome) as utente_nome,
-                       u.email as utente_email
+                       CONCAT(u.nome, ' ', u.cognome) as utente_nome
                 FROM recensioni r
                 JOIN utenti u ON r.utente_id = u.id
                 WHERE r.libro_id = ?

--- a/app/Repositories/RecensioniRepository.php
+++ b/app/Repositories/RecensioniRepository.php
@@ -297,7 +297,7 @@ class RecensioniRepository
             if ($result) {
                 // The review becomes publicly visible: drop the cached
                 // book-detail reviews block (O(1) generation bump).
-                \App\Support\ContentCache::reviewsChanged();
+                \App\Support\ContentCache::deferReviewsChanged();
             }
 
             return $result;
@@ -329,7 +329,7 @@ class RecensioniRepository
             if ($result) {
                 // An already-approved review can be rejected: it must leave
                 // the cached public reviews block immediately.
-                \App\Support\ContentCache::reviewsChanged();
+                \App\Support\ContentCache::deferReviewsChanged();
             }
 
             return $result;
@@ -354,7 +354,7 @@ class RecensioniRepository
             if ($result) {
                 // A deleted approved review must disappear from the cached
                 // public reviews block immediately.
-                \App\Support\ContentCache::reviewsChanged();
+                \App\Support\ContentCache::deferReviewsChanged();
             }
 
             return $result;

--- a/app/Repositories/RecensioniRepository.php
+++ b/app/Repositories/RecensioniRepository.php
@@ -295,6 +295,12 @@ class RecensioniRepository
             $result = $stmt->execute();
             $stmt->close();
 
+            if ($result) {
+                // The review becomes publicly visible: drop the cached
+                // book-detail reviews block (O(1) generation bump).
+                \App\Support\ContentCache::reviewsChanged();
+            }
+
             return $result;
 
         } catch (\Throwable $e) {
@@ -321,6 +327,12 @@ class RecensioniRepository
             $result = $stmt->execute();
             $stmt->close();
 
+            if ($result) {
+                // An already-approved review can be rejected: it must leave
+                // the cached public reviews block immediately.
+                \App\Support\ContentCache::reviewsChanged();
+            }
+
             return $result;
 
         } catch (\Throwable $e) {
@@ -339,6 +351,12 @@ class RecensioniRepository
             $stmt->bind_param('i', $reviewId);
             $result = $stmt->execute();
             $stmt->close();
+
+            if ($result) {
+                // A deleted approved review must disappear from the cached
+                // public reviews block immediately.
+                \App\Support\ContentCache::reviewsChanged();
+            }
 
             return $result;
 

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -128,6 +128,28 @@ return function (App $app): void {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    // Lazy CSRF endpoint (issue #387 step 6). Sessionless anonymous pages
+    // carry no CSRF token in their cacheable HTML; JS fetches one from here
+    // right before a state-changing request (see public/assets/js/
+    // csrf-helper.js). Starting the session on demand mints the same
+    // session-backed token CsrfMiddleware validates — protection is
+    // unchanged, only WHEN the token is minted moves. The hardened session
+    // ini parameters were already applied unconditionally in public/index.php,
+    // so this lazy session_start() uses the exact same secure cookie settings.
+    // The same-origin policy keeps the JSON unreadable cross-site (no CORS
+    // headers are emitted) and no-store keeps any cache from persisting a
+    // per-visitor token. Technical endpoint → literal path, like /health.
+    $app->get('/csrf-token', function ($request, $response) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+        $payload = json_encode(['token' => \App\Support\Csrf::ensureToken()], JSON_HEX_TAG);
+        $response->getBody()->write((string) $payload);
+        return $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Cache-Control', 'no-store, private');
+    });
+
     // Private uploaded files (digital-library content, archive documents,
     // generic storage). public/.htaccess routes ONLY these private prefixes
     // here instead of serving them directly, so the global middleware stack

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -146,8 +146,11 @@ return function (App $app): void {
         $payload = json_encode(['token' => \App\Support\Csrf::ensureToken()], JSON_HEX_TAG);
         $response->getBody()->write((string) $payload);
         return $response
-            ->withHeader('Content-Type', 'application/json')
-            ->withHeader('Cache-Control', 'no-store, private');
+            ->withHeader('Content-Type', 'application/json; charset=UTF-8')
+            ->withHeader('Cache-Control', 'no-store, private')
+            ->withHeader('Pragma', 'no-cache')
+            ->withHeader('Vary', 'Cookie')
+            ->withHeader('X-Content-Type-Options', 'nosniff');
     });
 
     // Private uploaded files (digital-library content, archive documents,

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -147,9 +147,13 @@ return function (App $app): void {
         if ($flag !== '1' && strtolower((string) $flag) !== 'true') {
             throw new \Slim\Exception\HttpNotFoundException($request);
         }
-        \App\Support\QueryCache::flush();
-        $response->getBody()->write((string) json_encode(['flushed' => true]));
+        // Honour the flush result: a false return means a real apcu_delete /
+        // unlink failure. Surface it as HTTP 500 so the E2E helper can fail the
+        // run loudly instead of proceeding to read a stale cached page.
+        $flushed = \App\Support\QueryCache::flush();
+        $response->getBody()->write((string) json_encode(['flushed' => $flushed]));
         return $response
+            ->withStatus($flushed ? 200 : 500)
             ->withHeader('Content-Type', 'application/json; charset=UTF-8')
             ->withHeader('Cache-Control', 'no-store, private');
     });

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -128,6 +128,32 @@ return function (App $app): void {
         return $response->withHeader('Content-Type', 'application/json');
     });
 
+    // TEST-ONLY page-cache flush (E2E infrastructure, NOT a production route).
+    // E2E specs that mutate the DB directly (bypassing the app code and its
+    // ContentCache generation bumps) call this endpoint before asserting on a
+    // cached frontend page, replicating the invalidation a real edit performs.
+    // Gated STRICTLY on a server-side env var that only the CI virtual host
+    // sets (`SetEnv PINAKES_E2E_CACHE_FLUSH 1`, next to the existing
+    // PINAKES_E2E_* flags): nothing client-controllable — no header, cookie or
+    // query parameter — is consulted, so a remote caller cannot enable it.
+    // When the flag is absent/empty the route throws the same
+    // HttpNotFoundException an unregistered path produces, making it inert in
+    // production. GET is deliberate: it keeps the call outside CsrfMiddleware
+    // and the only side effect is dropping cache entries (idempotent).
+    $app->get('/_e2e/flush-cache', function ($request, $response) {
+        $flag = $_ENV['PINAKES_E2E_CACHE_FLUSH']
+            ?? getenv('PINAKES_E2E_CACHE_FLUSH')
+            ?: '';
+        if ($flag !== '1' && strtolower((string) $flag) !== 'true') {
+            throw new \Slim\Exception\HttpNotFoundException($request);
+        }
+        \App\Support\QueryCache::flush();
+        $response->getBody()->write((string) json_encode(['flushed' => true]));
+        return $response
+            ->withHeader('Content-Type', 'application/json; charset=UTF-8')
+            ->withHeader('Cache-Control', 'no-store, private');
+    });
+
     // Lazy CSRF endpoint (issue #387 step 6). Sessionless anonymous pages
     // carry no CSRF token in their cacheable HTML; JS fetches one from here
     // right before a state-changing request (see public/assets/js/

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -13,12 +13,13 @@ namespace App\Support;
 final class ContentCache
 {
     private static bool $booksInvalidationDeferred = false;
+    private static bool $availabilityInvalidationDeferred = false;
 
     /**
-     * A book (or its availability) changed: invalidate catalog counts/facets,
-     * every home entry (home_page_data_v1 and home_api_count_*), and the
-     * cached genre tree. O(1) generation bumps — previously cached entries in
-     * these namespaces become unreachable immediately, no scan/delete storm.
+     * Book metadata or taxonomy changed: invalidate catalog counts/facets,
+     * every home entry (home_page_data_v1 and home_api_count_*), the cached
+     * genre tree and static detail DTOs. Availability-only writes use the
+     * narrower availabilityChanged() path below.
      */
     public static function booksChanged(): void
     {
@@ -45,6 +46,37 @@ final class ContentCache
         register_shutdown_function(static function (): void {
             self::$booksInvalidationDeferred = false;
             self::booksChanged();
+        });
+    }
+
+    /**
+     * Only circulation-derived availability changed. Catalog membership,
+     * counts and the home dataset must be refreshed, while the static
+     * book-detail DTO deliberately remains valid because its availability is
+     * always merged from a live query.
+     */
+    public static function availabilityChanged(): void
+    {
+        QueryCache::bumpGeneration('catalog_');
+        QueryCache::bumpGeneration('home_');
+    }
+
+    /**
+     * Defer and coalesce availability invalidation for caller-owned
+     * transactions. A broader deferred booksChanged() subsumes this work.
+     */
+    public static function deferAvailabilityChanged(): void
+    {
+        if (self::$booksInvalidationDeferred || self::$availabilityInvalidationDeferred) {
+            return;
+        }
+
+        self::$availabilityInvalidationDeferred = true;
+        register_shutdown_function(static function (): void {
+            self::$availabilityInvalidationDeferred = false;
+            if (!self::$booksInvalidationDeferred) {
+                self::availabilityChanged();
+            }
         });
     }
 

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -14,6 +14,7 @@ final class ContentCache
 {
     private static bool $booksInvalidationDeferred = false;
     private static bool $availabilityInvalidationDeferred = false;
+    private static bool $reviewsInvalidationDeferred = false;
 
     /**
      * Book metadata or taxonomy changed: invalidate catalog counts/facets,
@@ -97,5 +98,27 @@ final class ContentCache
     public static function reviewsChanged(): void
     {
         QueryCache::bumpGeneration('book_reviews_');
+    }
+
+    /**
+     * Defer and coalesce review-cache invalidation for caller-owned
+     * transactions (moderation runs inside a transaction). Bumping the
+     * generation immediately would let a concurrent public read populate the
+     * new generation with pre-commit rows, and no second bump happens after
+     * commit — the public page would show the stale moderation state for the
+     * TTL. Shutdown runs after the controller has committed (or rolled back);
+     * duplicate calls collapse into a single invalidation.
+     */
+    public static function deferReviewsChanged(): void
+    {
+        if (self::$reviewsInvalidationDeferred) {
+            return;
+        }
+
+        self::$reviewsInvalidationDeferred = true;
+        register_shutdown_function(static function (): void {
+            self::$reviewsInvalidationDeferred = false;
+            self::reviewsChanged();
+        });
     }
 }

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -15,15 +15,16 @@ final class ContentCache
     private static bool $booksInvalidationDeferred = false;
 
     /**
-     * A book (or its availability) changed: clear catalog counts/facets,
+     * A book (or its availability) changed: invalidate catalog counts/facets,
      * every home entry (home_page_data_v1 and home_api_count_*), and the
-     * cached genre tree.
+     * cached genre tree. O(1) generation bumps — previously cached entries in
+     * these namespaces become unreachable immediately, no scan/delete storm.
      */
     public static function booksChanged(): void
     {
-        QueryCache::clearByPrefix('catalog_');
-        QueryCache::clearByPrefix('home_');
-        QueryCache::clearByPrefix('genre_tree_');
+        QueryCache::bumpGeneration('catalog_');
+        QueryCache::bumpGeneration('home_');
+        QueryCache::bumpGeneration('genre_tree_');
     }
 
     /**
@@ -31,7 +32,7 @@ final class ContentCache
      * in an outer transaction cannot safely invalidate immediately: another
      * request could rebuild the cache from pre-commit rows. Shutdown runs after
      * the controller has committed (or rolled back), and duplicate calls from a
-     * batch collapse into a single prefix sweep.
+     * batch collapse into a single invalidation.
      */
     public static function deferBooksChanged(): void
     {
@@ -51,6 +52,6 @@ final class ContentCache
      */
     public static function homeContentChanged(): void
     {
-        QueryCache::clearByPrefix('home_');
+        QueryCache::bumpGeneration('home_');
     }
 }

--- a/app/Support/ContentCache.php
+++ b/app/Support/ContentCache.php
@@ -25,6 +25,7 @@ final class ContentCache
         QueryCache::bumpGeneration('catalog_');
         QueryCache::bumpGeneration('home_');
         QueryCache::bumpGeneration('genre_tree_');
+        QueryCache::bumpGeneration('book_detail_');
     }
 
     /**
@@ -53,5 +54,16 @@ final class ContentCache
     public static function homeContentChanged(): void
     {
         QueryCache::bumpGeneration('home_');
+    }
+
+    /**
+     * A review was approved, rejected or deleted: the cached public reviews
+     * block ('book_reviews_' namespace, book-detail page) is stale. New
+     * reviews are created as 'pendente' (never publicly visible), so only
+     * moderation transitions need to invalidate.
+     */
+    public static function reviewsChanged(): void
+    {
+        QueryCache::bumpGeneration('book_reviews_');
     }
 }

--- a/app/Support/DataIntegrity.php
+++ b/app/Support/DataIntegrity.php
@@ -151,9 +151,9 @@ class DataIntegrity {
 
             if (!$insideTransaction) {
                 $this->db->commit();
-                ContentCache::booksChanged();
+                ContentCache::availabilityChanged();
             } else {
-                ContentCache::deferBooksChanged();
+                ContentCache::deferAvailabilityChanged();
             }
 
         } catch (\Throwable $e) {
@@ -246,7 +246,7 @@ class DataIntegrity {
                 $processed++;
             }
             if ($chunkDirty) {
-                ContentCache::booksChanged();
+                ContentCache::availabilityChanged();
             }
 
             // Report progress
@@ -417,9 +417,9 @@ class DataIntegrity {
             // once per book.
             if ($result && !$skipCacheInvalidation) {
                 if ($insideTransaction) {
-                    ContentCache::deferBooksChanged();
+                    ContentCache::deferAvailabilityChanged();
                 } else {
-                    ContentCache::booksChanged();
+                    ContentCache::availabilityChanged();
                 }
             }
 

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -581,6 +581,12 @@ class QueryCache
         if (self::hasApcu()) {
             $iterator = new \APCUIterator('/^pinakes_/');
             foreach ($iterator as $item) {
+                // Never remove a live mutex: deleting it while its owner is
+                // computing would allow a second worker to acquire a new
+                // lock for the same key. The sentinel expires on its own.
+                if (str_starts_with($item['key'], 'pinakes_lock_')) {
+                    continue;
+                }
                 if (!apcu_delete($item['key'])) {
                     $successApcu = false;
                 }
@@ -594,11 +600,27 @@ class QueryCache
             $files = glob($cacheDir . '/pinakes_*');
             if ($files !== false) {
                 foreach ($files as $file) {
+                    $basename = basename($file);
+                    // Generation writer locks must keep the same inode for
+                    // their entire lifetime. Counter files are superseded by
+                    // the generation bumps below, rather than deleted while
+                    // another process may be updating them.
+                    if (str_ends_with($basename, '.lock')
+                        || str_starts_with($basename, 'pinakes_gen_')) {
+                        continue;
+                    }
                     if (!@unlink($file)) {
                         $successFiles = false;
                     }
                 }
             }
+        }
+
+        // Publish a generation newer than every value visible before the
+        // flush. An in-flight loader may still finish afterwards, but it will
+        // write under its captured old generation and remain unreachable.
+        foreach (self::NAMESPACE_PREFIXES as $namespace) {
+            self::bumpGeneration($namespace);
         }
 
         return $successApcu && $successFiles;
@@ -735,10 +757,12 @@ class QueryCache
     {
         $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
 
-        $handle = @fopen($path . '.lock', 'c');
+        $lockPath = $path . '.lock';
+        $handle = @fopen($lockPath, 'c');
         if ($handle === false) {
             return null;
         }
+        @chmod($lockPath, 0660);
 
         try {
             if (!flock($handle, LOCK_EX)) {
@@ -1034,13 +1058,15 @@ class QueryCache
                 continue;
             }
 
+            $locked = false;
             try {
                 // Ordinary entries are written in place under an exclusive
                 // lock (file_put_contents LOCK_EX); GC must take that same
                 // exclusive lock or it could mistake an in-progress write for
                 // corruption. Generation counters are replaced atomically via
                 // temp + rename, so any inode opened here is always complete.
-                if (!flock($handle, LOCK_EX)) {
+                $locked = flock($handle, LOCK_EX | LOCK_NB);
+                if (!$locked) {
                     continue;
                 }
 
@@ -1063,7 +1089,9 @@ class QueryCache
                     $count++;
                 }
             } finally {
-                flock($handle, LOCK_UN);
+                if ($locked) {
+                    flock($handle, LOCK_UN);
+                }
                 fclose($handle);
             }
         }

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -67,6 +67,15 @@ class QueryCache
     /** Avoid checking the GC marker more than once in the same request. */
     private static bool $gcCheckedThisRequest = false;
 
+    /**
+     * Monotonic per-process sequence for generation temp filenames. Combined
+     * with getmypid() it yields a collision-free name without any time- or
+     * random-based component (two live processes never share a PID; a stale
+     * leftover from a crashed same-PID process is only ever overwritten while
+     * holding the namespace writer lock, so it is safe to reuse).
+     */
+    private static int $generationTmpSeq = 0;
+
     /** @var int Instrumentation: total get() calls this request */
     private static int $statGets = 0;
 
@@ -703,12 +712,30 @@ class QueryCache
     /**
      * Initialize or atomically increment a namespace generation.
      *
+     * Crash/IO safety: the counter file itself is NEVER truncated or written
+     * in place. The new payload goes to a temp file in the same directory
+     * (flushed + fsynced) and is then rename()d over the counter path —
+     * atomic on POSIX — so a failed write leaves the previous counter intact
+     * and a reader can never observe an empty/partial file. An in-place
+     * ftruncate+fwrite scheme could leave the file empty on a mid-write
+     * failure, making the next initializer fall back to time() — potentially
+     * LOWER than a counter that had climbed past wall-clock, which would make
+     * invalidated-but-TTL-live entries reachable again.
+     *
+     * Writer serialization: because rename() swaps the inode, an flock held
+     * on the counter file itself would not serialize concurrent writers (the
+     * second writer would lock the OLD inode). Writers therefore serialize on
+     * a dedicated sibling lock file (<counter>.lock) that is never unlinked
+     * (gc() skips it), held across the whole read-current → write-temp →
+     * rename sequence, so concurrent bumps cannot lose an increment.
+     *
      * @param bool $increment true for invalidation, false for initialize-if-missing
      */
     private static function mutateGenerationFile(string $ns, bool $increment): ?int
     {
         $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
-        $handle = @fopen($path, 'c+');
+
+        $handle = @fopen($path . '.lock', 'c');
         if ($handle === false) {
             return null;
         }
@@ -718,7 +745,7 @@ class QueryCache
                 return null;
             }
 
-            $current = self::generationFromHandle($handle);
+            $current = self::readGenerationFile($ns);
             if ($current !== null && !$increment) {
                 return $current;
             }
@@ -730,22 +757,53 @@ class QueryCache
                 'created' => time(),
             ]);
 
-            rewind($handle);
-            if (!ftruncate($handle, 0)) {
+            if (!self::replaceGenerationFile($path, $payload)) {
                 return null;
             }
-
-            $written = fwrite($handle, $payload);
-            if ($written === false || $written !== strlen($payload) || !fflush($handle)) {
-                return null;
-            }
-            @chmod($path, 0660);
 
             return $next;
         } finally {
             flock($handle, LOCK_UN);
             fclose($handle);
         }
+    }
+
+    /**
+     * Atomically replace the counter file with $payload via temp + rename.
+     * Must be called while holding the namespace writer lock. Returns false
+     * (leaving the previous counter untouched) on any failure.
+     */
+    private static function replaceGenerationFile(string $path, string $payload): bool
+    {
+        $tmpPath = $path . '.tmp.' . getmypid() . '.' . self::$generationTmpSeq++;
+
+        $tmp = @fopen($tmpPath, 'w');
+        if ($tmp === false) {
+            return false;
+        }
+
+        $written = fwrite($tmp, $payload);
+        $flushed = $written === strlen($payload) && fflush($tmp);
+        // Persist the payload before publishing the name: a rename made
+        // durable before its data could surface an empty file after a crash.
+        if ($flushed && function_exists('fsync')) {
+            $flushed = fsync($tmp);
+        }
+        fclose($tmp);
+
+        if (!$flushed) {
+            @unlink($tmpPath);
+            return false;
+        }
+
+        @chmod($tmpPath, 0660);
+
+        if (!@rename($tmpPath, $path)) {
+            @unlink($tmpPath);
+            return false;
+        }
+
+        return true;
     }
 
     /** Parse a generation payload from an already locked file handle. */
@@ -954,6 +1012,20 @@ class QueryCache
                 continue;
             }
 
+            // Generation temp files (counter payloads awaiting their atomic
+            // rename) are not cache entries: never parse them, and only
+            // remove residue left behind by a crashed writer once it is
+            // unambiguously stale.
+            if (str_contains(basename($file), '.tmp.')) {
+                $tmpMtime = @filemtime($file);
+                if ($tmpMtime !== false
+                    && $tmpMtime < $now - self::LOCK_STALE_SECONDS
+                    && @unlink($file)) {
+                    $count++;
+                }
+                continue;
+            }
+
             $handle = @fopen($file, 'r');
             if ($handle === false) {
                 if (@unlink($file)) {
@@ -963,9 +1035,11 @@ class QueryCache
             }
 
             try {
-                // Generation counters and ordinary entries are written under an
-                // exclusive lock. GC must take that same exclusive lock or it
-                // could mistake an in-progress truncate/write for corruption.
+                // Ordinary entries are written in place under an exclusive
+                // lock (file_put_contents LOCK_EX); GC must take that same
+                // exclusive lock or it could mistake an in-progress write for
+                // corruption. Generation counters are replaced atomically via
+                // temp + rename, so any inode opened here is always complete.
                 if (!flock($handle, LOCK_EX)) {
                     continue;
                 }
@@ -998,6 +1072,14 @@ class QueryCache
         if ($lockFiles !== false) {
             $staleTime = $now - self::LOCK_STALE_SECONDS;
             foreach ($lockFiles as $lockFile) {
+                // Generation writer locks are deliberately persistent: writers
+                // flock() the same never-recreated file to serialize bumps.
+                // Unlinking one here would let a new writer create a second
+                // lock inode at the same path and race the current holder.
+                if (str_starts_with(basename($lockFile), 'pinakes_gen_')) {
+                    continue;
+                }
+
                 $lockMtime = @filemtime($lockFile);
                 if ($lockMtime !== false && $lockMtime < $staleTime) {
                     if (@unlink($lockFile)) {

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -34,6 +34,8 @@ class QueryCache
         'genre_tree_',
         'plugins_maintenance_',
         'schema_table_',
+        'book_detail_',
+        'book_reviews_',
     ];
 
     /**

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -6,19 +6,61 @@ namespace App\Support;
 /**
  * QueryCache - Simple caching layer for expensive database queries
  *
- * Uses APCu for in-memory caching when available, falls back to file-based
- * caching in storage/cache directory. Designed for caching dashboard stats,
- * aggregations, and other expensive queries that don't need real-time data.
+ * Uses a SINGLE backend per request: APCu when available and enabled,
+ * otherwise file-based caching in storage/cache. Designed for caching
+ * dashboard stats, aggregations, and other expensive queries that don't
+ * need real-time data.
+ *
+ * Invalidation of the known content namespaces (catalog_, home_, ...) is
+ * O(1) via generation counters (namespace versioning): the effective storage
+ * key embeds the namespace's current generation, so bumping the generation
+ * makes every prior entry unreachable without scanning or deleting anything.
+ * Unreachable entries are reclaimed lazily by gc() / APCu TTL expiry.
  *
  * @package App\Support
  */
 class QueryCache
 {
+    /**
+     * Namespace prefixes eligible for O(1) generation-based invalidation.
+     * A logical key starting with one of these prefixes has its storage key
+     * derived from (key, current generation of the namespace).
+     *
+     * Keep in sync with ContentCache and the clearByPrefix() callers.
+     */
+    private const NAMESPACE_PREFIXES = [
+        'catalog_',
+        'home_',
+        'genre_tree_',
+        'plugins_maintenance_',
+        'schema_table_',
+    ];
+
+    /**
+     * TTL for generation counter entries (~1 year). Must outlive any data TTL:
+     * if a generation counter is ever lost, it is re-initialized to time(),
+     * which is monotonic w.r.t. every previously issued generation, so stale
+     * entries can never be resurrected.
+     */
+    private const GENERATION_TTL = 31536000;
+
+    /** Stale threshold (seconds) shared by the file lock and the APCu lock sentinel */
+    private const LOCK_STALE_SECONDS = 300;
+
     /** @var string Base directory for file cache */
     private static string $cacheDir = '';
 
-    /** @var bool|null Whether APCu is available (cached check) */
+    /** @var bool|null Whether APCu is available (cached check = deterministic backend per request) */
     private static ?bool $apcuAvailable = null;
+
+    /** @var int Instrumentation: total get() calls this request */
+    private static int $statGets = 0;
+
+    /** @var int Instrumentation: get() calls served from cache this request */
+    private static int $statHits = 0;
+
+    /** @var int Instrumentation: get() calls that missed this request */
+    private static int $statMisses = 0;
 
     /**
      * Get the cache directory path
@@ -38,7 +80,9 @@ class QueryCache
     }
 
     /**
-     * Check if APCu is available and enabled
+     * Check if APCu is available and enabled.
+     *
+     * Memoized: the backend choice is deterministic for the whole request.
      */
     private static function hasApcu(): bool
     {
@@ -50,10 +94,30 @@ class QueryCache
     }
 
     /**
+     * Per-request cache statistics (lightweight instrumentation, no persistence).
+     *
+     * @return array{backend: string, gets: int, hits: int, misses: int, hit_ratio: float}
+     */
+    public static function stats(): array
+    {
+        $gets = self::$statGets;
+
+        return [
+            'backend' => self::hasApcu() ? 'apcu' : 'file',
+            'gets' => $gets,
+            'hits' => self::$statHits,
+            'misses' => self::$statMisses,
+            'hit_ratio' => $gets > 0 ? round(self::$statHits / $gets, 4) : 0.0,
+        ];
+    }
+
+    /**
      * Get a value from cache or execute callback to generate it
      *
      * Uses mutex locking to prevent cache stampede (thundering herd problem).
-     * Only one process computes the value while others wait.
+     * Only one process computes the value while others wait. The mutex lives
+     * in the selected backend: an apcu_add() sentinel when APCu holds the
+     * values (no filesystem I/O on the APCu hot path), a .lock file otherwise.
      *
      * @param string $key Unique cache key
      * @param callable $callback Function to generate value if not cached
@@ -68,6 +132,101 @@ class QueryCache
             return $cached;
         }
 
+        if (self::hasApcu()) {
+            return self::rememberWithApcuLock($key, $callback, $ttl);
+        }
+
+        return self::rememberWithFileLock($key, $callback, $ttl);
+    }
+
+    /**
+     * remember() body for the APCu backend: stampede protection via an
+     * apcu_add() sentinel instead of a filesystem lock. Mirrors the file-lock
+     * timeout/stale/graceful-degradation semantics:
+     *  - the sentinel's own TTL replaces the stale-mtime check;
+     *  - same 8s bounded wait, then the FIX F008 final-attempt pass and
+     *    SecureLogger warning before proceeding unprotected.
+     */
+    private static function rememberWithApcuLock(string $key, callable $callback, int $ttl): mixed
+    {
+        // Lock identity is the logical key (not the generation-resolved storage
+        // key) so concurrent callers agree on the mutex even across a bump.
+        $lockKey = 'pinakes_lock_' . md5($key);
+
+        $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+        $timedOut = false;
+
+        try {
+            if (!$lockAcquired) {
+                $start = microtime(true);
+                $maxWaitSeconds = 8.0;
+                $sleepMicros = 200000;
+
+                while (true) {
+                    usleep($sleepMicros);
+
+                    $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+                    if ($lockAcquired) {
+                        break;
+                    }
+
+                    if ((microtime(true) - $start) >= $maxWaitSeconds) {
+                        $timedOut = true;
+                        break;
+                    }
+                }
+
+                $cached = self::get($key);
+                if ($cached !== null) {
+                    return $cached;
+                }
+
+                // FIX F008 (mirrored from the file-lock path): after a timeout,
+                // attempt a short bounded retry so at most one caller proceeds
+                // unprotected; surface the bypass via SecureLogger either way.
+                // ($timedOut === true implies the lock was never acquired.)
+                if ($timedOut) {
+                    $finalAttempts = 5;
+                    for ($i = 0; $i < $finalAttempts; $i++) {
+                        if (apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS)) {
+                            $lockAcquired = true;
+                            break;
+                        }
+                        usleep(100000); // 100ms between attempts → up to ~500ms extra wait
+                    }
+
+                    if (!$lockAcquired) {
+                        SecureLogger::warning(
+                            'QueryCache: proceeding without mutex after lock timeout (stampede protection bypassed)',
+                            [
+                                'key_prefix' => substr($key, 0, 80),
+                                'wait_seconds' => round(microtime(true) - $start, 3),
+                            ]
+                        );
+                    }
+                }
+            }
+
+            // Execute callback to get fresh value
+            $value = $callback();
+
+            // Store in cache
+            self::set($key, $value, $ttl);
+
+            return $value;
+        } finally {
+            if ($lockAcquired) {
+                apcu_delete($lockKey);
+            }
+        }
+    }
+
+    /**
+     * remember() body for the file backend: the original flock()-based
+     * stampede protection, unchanged.
+     */
+    private static function rememberWithFileLock(string $key, callable $callback, int $ttl): mixed
+    {
         // Acquire mutex lock to prevent stampede
         $lockKey = self::hashKey($key) . '.lock';
         $lockFile = self::getCacheDir() . '/' . $lockKey;
@@ -89,7 +248,7 @@ class QueryCache
             $timedOut = false;
             $start = microtime(true);
             $maxWaitSeconds = 8.0;
-            $staleThreshold = 300;
+            $staleThreshold = self::LOCK_STALE_SECONDS;
             $sleepMicros = 200000;
 
             // Check if lock file was already stale before we opened it
@@ -184,24 +343,21 @@ class QueryCache
      */
     public static function get(string $key): mixed
     {
-        $hashedKey = self::hashKey($key);
+        self::$statGets++;
 
-        // Try APCu first
-        if (self::hasApcu()) {
-            $success = false;
-            $value = apcu_fetch($hashedKey, $success);
-            if ($success) {
-                return $value;
-            }
-            // APCu miss - fall through to file cache
+        $value = self::backendGet(self::hashKey($key));
+
+        if ($value !== null) {
+            self::$statHits++;
+        } else {
+            self::$statMisses++;
         }
 
-        // Fallback to file cache
-        return self::getFromFile($hashedKey);
+        return $value;
     }
 
     /**
-     * Set a value in cache
+     * Set a value in cache (in the selected backend only — no dual-write)
      *
      * @param string $key Cache key
      * @param mixed $value Value to cache
@@ -210,14 +366,7 @@ class QueryCache
      */
     public static function set(string $key, mixed $value, int $ttl = 300): bool
     {
-        $hashedKey = self::hashKey($key);
-
-        // Also write to APCu if available
-        $apcuOk = !self::hasApcu() || apcu_store($hashedKey, $value, $ttl);
-
-        $success = self::setToFile($hashedKey, $value, $ttl) && $apcuOk;
-
-        return $success;
+        return self::backendSet(self::hashKey($key), $value, $ttl);
     }
 
     /**
@@ -229,23 +378,67 @@ class QueryCache
     public static function delete(string $key): bool
     {
         $hashedKey = self::hashKey($key);
-        $success = self::deleteFromFile($hashedKey);
 
-        // Also delete from APCu if available
         if (self::hasApcu()) {
-            $success = apcu_delete($hashedKey) && $success;
+            return apcu_delete($hashedKey);
         }
 
-        return $success;
+        return self::deleteFromFile($hashedKey);
+    }
+
+    /**
+     * Bump the generation counter of a known namespace: O(1) invalidation of
+     * every entry whose key starts with that prefix (they become unreachable,
+     * no scan, no delete storm). Unknown prefixes fall back to the legacy scan
+     * so semantics stay correct for arbitrary callers.
+     *
+     * @param string $namespace Namespace prefix, with or without trailing '_'
+     *                          (e.g. 'catalog' or 'catalog_')
+     */
+    public static function bumpGeneration(string $namespace): void
+    {
+        $ns = str_ends_with($namespace, '_') ? $namespace : $namespace . '_';
+
+        if (!in_array($ns, self::NAMESPACE_PREFIXES, true)) {
+            // Not generation-tracked: only a scan can invalidate it correctly.
+            self::legacyClearByPrefix($ns);
+            return;
+        }
+
+        $genKey = self::generationStorageKey($ns);
+        $current = self::backendGet($genKey);
+        // max(current+1, time()): monotonic even if the counter was ever lost
+        // and re-initialized (init value is time(), see currentGeneration()).
+        $next = is_int($current) ? max($current + 1, time()) : time();
+        self::backendSet($genKey, $next, self::GENERATION_TTL);
     }
 
     /**
      * Clear all cache entries with a given prefix
      *
+     * For the known content namespaces this is an O(1) generation bump (the
+     * return value is 0 because nothing is enumerated — no caller consumes
+     * the count). Arbitrary prefixes keep the original scan behavior.
+     *
      * @param string $prefix Key prefix to match (e.g., 'dashboard_')
-     * @return int Number of entries cleared
+     * @return int Number of entries physically removed (0 for generation bumps)
      */
     public static function clearByPrefix(string $prefix): int
+    {
+        if (in_array($prefix, self::NAMESPACE_PREFIXES, true)) {
+            self::bumpGeneration($prefix);
+            return 0;
+        }
+
+        return self::legacyClearByPrefix($prefix);
+    }
+
+    /**
+     * Original O(n) prefix scan (APCUIterator + glob). Kept as fallback for
+     * prefixes outside the generation-tracked namespaces; scans BOTH stores so
+     * pre-upgrade leftovers from the old dual-write scheme are reclaimed too.
+     */
+    private static function legacyClearByPrefix(string $prefix): int
     {
         $hashedPrefix = 'pinakes_' . $prefix;
         $count = 0;
@@ -286,6 +479,8 @@ class QueryCache
      *
      * Only clears entries with the 'pinakes_' prefix to avoid clearing
      * other applications' cache entries that may share the same APCu instance.
+     * Intentionally clears BOTH stores (maintenance operation): prevents
+     * resurrection of pre-upgrade dual-written entries if the backend flips.
      *
      * @return bool Success status
      */
@@ -322,13 +517,96 @@ class QueryCache
     }
 
     /**
+     * Read a raw hashed key from the selected backend (no stats, no
+     * generation resolution — internal primitive).
+     */
+    private static function backendGet(string $hashedKey): mixed
+    {
+        if (self::hasApcu()) {
+            $success = false;
+            $value = apcu_fetch($hashedKey, $success);
+
+            return $success ? $value : null;
+        }
+
+        return self::getFromFile($hashedKey);
+    }
+
+    /**
+     * Write a raw hashed key to the selected backend (internal primitive).
+     */
+    private static function backendSet(string $hashedKey, mixed $value, int $ttl): bool
+    {
+        if (self::hasApcu()) {
+            return apcu_store($hashedKey, $value, $ttl);
+        }
+
+        return self::setToFile($hashedKey, $value, $ttl);
+    }
+
+    /**
+     * Namespace prefix of a logical key, or null if not generation-tracked.
+     */
+    private static function namespaceFor(string $key): ?string
+    {
+        foreach (self::NAMESPACE_PREFIXES as $prefix) {
+            if (str_starts_with($key, $prefix)) {
+                return $prefix;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Storage key of a namespace's generation counter. Deliberately outside
+     * every namespace prefix so it never resolves through itself.
+     */
+    private static function generationStorageKey(string $ns): string
+    {
+        $safe = preg_replace('/[^A-Za-z0-9_\-]/', '_', $ns);
+
+        return 'pinakes_gen_' . $safe . md5('__gen__' . $ns);
+    }
+
+    /**
+     * Current generation of a namespace. Missing counters are initialized to
+     * time(): monotonic w.r.t. every generation ever issued before, so a lost
+     * counter can never make previously invalidated entries reachable again.
+     */
+    private static function currentGeneration(string $ns): int
+    {
+        $genKey = self::generationStorageKey($ns);
+        $value = self::backendGet($genKey);
+        if (is_int($value)) {
+            return $value;
+        }
+
+        $gen = time();
+        self::backendSet($genKey, $gen, self::GENERATION_TTL);
+
+        return $gen;
+    }
+
+    /**
      * Hash a cache key for storage
+     *
+     * The human-readable sanitized prefix is preserved (filesystem safety +
+     * the legacy prefix scan keeps matching); the hash suffix embeds the
+     * namespace generation for generation-tracked keys.
      */
     private static function hashKey(string $key): string
     {
         // Sanitize prefix for filesystem safety + append hash for uniqueness
         $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($key, 0, 80));
-        return 'pinakes_' . $prefix . '_' . md5($key);
+
+        $hashInput = $key;
+        $ns = self::namespaceFor($key);
+        if ($ns !== null) {
+            $hashInput .= '|gen:' . self::currentGeneration($ns);
+        }
+
+        return 'pinakes_' . $prefix . '_' . md5($hashInput);
     }
 
     /**
@@ -466,7 +744,7 @@ class QueryCache
 
         $lockFiles = glob($cacheDir . '/*.lock');
         if ($lockFiles !== false) {
-            $staleTime = $now - 300;
+            $staleTime = $now - self::LOCK_STALE_SECONDS;
             foreach ($lockFiles as $lockFile) {
                 $lockMtime = @filemtime($lockFile);
                 if ($lockMtime !== false && $lockMtime < $staleTime) {

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -45,8 +45,15 @@ class QueryCache
      */
     private const GENERATION_TTL = 31536000;
 
-    /** Stale threshold (seconds) shared by the file lock and the APCu lock sentinel */
+    /** Stale threshold (seconds) for APCu sentinels and abandoned temp files. */
     private const LOCK_STALE_SECONDS = 300;
+
+    /**
+     * Number of persistent file-mutex stripes (three hexadecimal digits).
+     * A bounded pool avoids one never-removed lock file per cache key while
+     * preserving a stable inode for flock() across every waiter.
+     */
+    private const FILE_MUTEX_HEX_LENGTH = 3;
 
     /** Run file-cache garbage collection at most once per hour. */
     private const GC_INTERVAL_SECONDS = 3600;
@@ -294,10 +301,7 @@ class QueryCache
         }
     }
 
-    /**
-     * remember() body for the file backend: the original flock()-based
-     * stampede protection, unchanged.
-     */
+    /** remember() body for the file backend with flock()-based protection. */
     private static function rememberWithFileLock(
         string $key,
         string $hashedKey,
@@ -305,14 +309,12 @@ class QueryCache
         int $ttl
     ): mixed
     {
-        // Acquire mutex lock to prevent stampede
-        $lockKey = $hashedKey . '.lock';
-        $lockFile = self::getCacheDir() . '/' . $lockKey;
-
-        // Check lock file mtime BEFORE fopen (fopen 'c' mode can update mtime)
-        clearstatcache(true, $lockFile);
-        $initialLockMtime = @filemtime($lockFile);
-
+        // Lock files are deliberately persistent and striped. Unlinking a
+        // flock() path is unsafe: a waiter can still hold the old inode while
+        // a new worker creates and locks a second inode at the same pathname,
+        // allowing duplicate callbacks for the same key. A fixed 4096-file
+        // pool gives all workers a stable inode without unbounded lock files.
+        $lockFile = self::fileMutexPath($hashedKey);
         $lockHandle = @fopen($lockFile, 'c');
 
         if ($lockHandle === false) {
@@ -320,36 +322,21 @@ class QueryCache
             return $callback();
         }
 
+        @chmod($lockFile, 0660);
+
         try {
             $lockAcquired = false;
-            $staleLock = false;
-            $timedOut = false;
             $start = microtime(true);
             $maxWaitSeconds = 8.0;
-            $staleThreshold = self::LOCK_STALE_SECONDS;
             $sleepMicros = 200000;
 
-            // Check if lock file was already stale before we opened it
-            if ($initialLockMtime !== false && (time() - $initialLockMtime) > $staleThreshold) {
-                $staleLock = true;
-            }
-
-            while (!$staleLock) {
+            while (true) {
                 $lockAcquired = flock($lockHandle, LOCK_EX | LOCK_NB);
                 if ($lockAcquired) {
                     break;
                 }
 
-                // Re-check mtime periodically (using clearstatcache for fresh stat)
-                clearstatcache(true, $lockFile);
-                $lockMtime = @filemtime($lockFile);
-                if ($lockMtime !== false && (time() - $lockMtime) > $staleThreshold) {
-                    $staleLock = true;
-                    continue; // re-evaluate while(!$staleLock) → exits loop
-                }
-
                 if ((microtime(true) - $start) >= $maxWaitSeconds) {
-                    $timedOut = true;
                     break;
                 }
 
@@ -361,13 +348,13 @@ class QueryCache
                 return $cached;
             }
 
-            // FIX F008: When the wait loop timed out without acquiring the lock and
-            // without detecting a stale lock, we previously fell through to $callback()
+            // When the wait loop times out without acquiring the lock, do not
+            // immediately fall through to $callback()
             // + self::set() WITHOUT holding any lock. That defeats the stampede
             // protection: every concurrent caller that timed out would run the
             // (expensive) callback in parallel. Attempt one final LOCK_EX acquisition
             // (with a short bounded retry) so at most one caller proceeds unprotected.
-            if ($timedOut && !$lockAcquired && !$staleLock) {
+            if (!$lockAcquired) {
                 // FIX F008: short blocking-ish retry — try a few non-blocking attempts
                 // separated by usleep so we don't risk holding the request indefinitely.
                 $finalAttempts = 5;
@@ -377,6 +364,16 @@ class QueryCache
                         break;
                     }
                     usleep(100000); // 100ms between attempts → up to ~500ms extra wait
+                }
+
+                // The previous owner may have populated the key between the
+                // pre-retry read and this late acquisition. Recheck while
+                // holding the mutex before invoking the expensive callback.
+                if ($lockAcquired) {
+                    $cached = self::backendGet($hashedKey);
+                    if ($cached !== null) {
+                        return $cached;
+                    }
                 }
 
                 // FIX F008: observability — if we still couldn't acquire the lock we
@@ -406,11 +403,15 @@ class QueryCache
                 flock($lockHandle, LOCK_UN);
             }
             fclose($lockHandle);
-            // Clean up lock file (best effort) - also clean up on timeout to prevent accumulation
-            if ($lockAcquired || $staleLock || $timedOut) {
-                @unlink($lockFile);
-            }
         }
+    }
+
+    /** Stable path in the bounded persistent file-mutex pool. */
+    private static function fileMutexPath(string $hashedKey): string
+    {
+        $stripe = substr(md5($hashedKey), 0, self::FILE_MUTEX_HEX_LENGTH);
+
+        return self::getCacheDir() . '/pinakes_mutex_' . $stripe . '.lock';
     }
 
     /**
@@ -537,6 +538,10 @@ class QueryCache
         if (self::hasApcu()) {
             $iterator = new \APCUIterator('/^' . preg_quote($hashedPrefix, '/') . '/');
             foreach ($iterator as $item) {
+                // Never remove a mutex sentinel while a loader may own it.
+                if (str_starts_with($item['key'], 'pinakes_lock_')) {
+                    continue;
+                }
                 if (apcu_delete($item['key'])) {
                     $count++;
                 }
@@ -556,6 +561,12 @@ class QueryCache
         }
 
         foreach ($files as $file) {
+            // Lock paths keep a stable inode across current workers and across
+            // rolling deployments that may still have an older worker waiting
+            // on a legacy per-key lock file.
+            if (str_ends_with($file, '.lock')) {
+                continue;
+            }
             if (@unlink($file)) {
                 $count++;
             }
@@ -589,7 +600,7 @@ class QueryCache
                 if (str_starts_with($item['key'], 'pinakes_lock_')) {
                     continue;
                 }
-                if (!apcu_delete($item['key'])) {
+                if (!apcu_delete($item['key']) && apcu_exists($item['key'])) {
                     $successApcu = false;
                 }
             }
@@ -1095,27 +1106,6 @@ class QueryCache
                     flock($handle, LOCK_UN);
                 }
                 fclose($handle);
-            }
-        }
-
-        $lockFiles = glob($cacheDir . '/*.lock');
-        if ($lockFiles !== false) {
-            $staleTime = $now - self::LOCK_STALE_SECONDS;
-            foreach ($lockFiles as $lockFile) {
-                // Generation writer locks are deliberately persistent: writers
-                // flock() the same never-recreated file to serialize bumps.
-                // Unlinking one here would let a new writer create a second
-                // lock inode at the same path and race the current holder.
-                if (str_starts_with(basename($lockFile), 'pinakes_gen_')) {
-                    continue;
-                }
-
-                $lockMtime = @filemtime($lockFile);
-                if ($lockMtime !== false && $lockMtime < $staleTime) {
-                    if (@unlink($lockFile)) {
-                        $count++;
-                    }
-                }
             }
         }
 

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -37,21 +37,35 @@ class QueryCache
     ];
 
     /**
-     * TTL for generation counter entries (~1 year). Must outlive any data TTL:
-     * if a generation counter is ever lost, it is re-initialized to time(),
-     * which is monotonic w.r.t. every previously issued generation, so stale
-     * entries can never be resurrected.
+     * TTL for generation counter entries (~1 year). It intentionally outlives
+     * every data TTL, so all entries that referenced an expired counter are
+     * already expired before the counter can be initialized again.
      */
     private const GENERATION_TTL = 31536000;
 
     /** Stale threshold (seconds) shared by the file lock and the APCu lock sentinel */
     private const LOCK_STALE_SECONDS = 300;
 
+    /** Run file-cache garbage collection at most once per hour. */
+    private const GC_INTERVAL_SECONDS = 3600;
+
     /** @var string Base directory for file cache */
     private static string $cacheDir = '';
 
     /** @var bool|null Whether APCu is available (cached check = deterministic backend per request) */
     private static ?bool $apcuAvailable = null;
+
+    /**
+     * Request-local namespace generations. The canonical counters live on
+     * disk so FPM/APCu and CLI/file users observe the same invalidations; the
+     * memo avoids an extra filesystem read for every cache operation.
+     *
+     * @var array<string, int>
+     */
+    private static array $generationCache = [];
+
+    /** Avoid checking the GC marker more than once in the same request. */
+    private static bool $gcCheckedThisRequest = false;
 
     /** @var int Instrumentation: total get() calls this request */
     private static int $statGets = 0;
@@ -117,7 +131,9 @@ class QueryCache
      * Uses mutex locking to prevent cache stampede (thundering herd problem).
      * Only one process computes the value while others wait. The mutex lives
      * in the selected backend: an apcu_add() sentinel when APCu holds the
-     * values (no filesystem I/O on the APCu hot path), a .lock file otherwise.
+     * values, a .lock file otherwise. Generation-tracked keys read their small
+     * canonical generation file once per namespace/request so CLI and FPM stay
+     * coherent even when APCu is disabled for CLI.
      *
      * @param string $key Unique cache key
      * @param callable $callback Function to generate value if not cached
@@ -126,17 +142,26 @@ class QueryCache
      */
     public static function remember(string $key, callable $callback, int $ttl = 300): mixed
     {
-        // Try to get from cache first
-        $cached = self::get($key);
+        // Resolve the generation exactly once. If an invalidation happens while
+        // the callback is running, the result is written under this old storage
+        // key and therefore stays unreachable from the new generation.
+        $hashedKey = self::hashKey($key);
+
+        // This is the one logical lookup represented in stats(). Mutex
+        // double-checks below deliberately use backendGet() without counters.
+        self::$statGets++;
+        $cached = self::backendGet($hashedKey);
         if ($cached !== null) {
+            self::$statHits++;
             return $cached;
         }
+        self::$statMisses++;
 
         if (self::hasApcu()) {
-            return self::rememberWithApcuLock($key, $callback, $ttl);
+            return self::rememberWithApcuLock($key, $hashedKey, $callback, $ttl);
         }
 
-        return self::rememberWithFileLock($key, $callback, $ttl);
+        return self::rememberWithFileLock($key, $hashedKey, $callback, $ttl);
     }
 
     /**
@@ -147,25 +172,31 @@ class QueryCache
      *  - same 8s bounded wait, then the FIX F008 final-attempt pass and
      *    SecureLogger warning before proceeding unprotected.
      */
-    private static function rememberWithApcuLock(string $key, callable $callback, int $ttl): mixed
+    private static function rememberWithApcuLock(
+        string $key,
+        string $hashedKey,
+        callable $callback,
+        int $ttl
+    ): mixed
     {
-        // Lock identity is the logical key (not the generation-resolved storage
-        // key) so concurrent callers agree on the mutex even across a bump.
-        $lockKey = 'pinakes_lock_' . md5($key);
+        // The lock follows the resolved generation. A request for a new
+        // generation must not wait for (or consume) an old-generation loader.
+        $lockKey = 'pinakes_lock_' . md5($hashedKey);
+        $lockToken = random_int(1, PHP_INT_MAX);
 
-        $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+        $lockAcquired = apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS);
         $timedOut = false;
+        $start = microtime(true);
 
         try {
             if (!$lockAcquired) {
-                $start = microtime(true);
                 $maxWaitSeconds = 8.0;
                 $sleepMicros = 200000;
 
                 while (true) {
                     usleep($sleepMicros);
 
-                    $lockAcquired = apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS);
+                    $lockAcquired = apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS);
                     if ($lockAcquired) {
                         break;
                     }
@@ -176,7 +207,7 @@ class QueryCache
                     }
                 }
 
-                $cached = self::get($key);
+                $cached = self::backendGet($hashedKey);
                 if ($cached !== null) {
                     return $cached;
                 }
@@ -188,7 +219,7 @@ class QueryCache
                 if ($timedOut) {
                     $finalAttempts = 5;
                     for ($i = 0; $i < $finalAttempts; $i++) {
-                        if (apcu_add($lockKey, 1, self::LOCK_STALE_SECONDS)) {
+                        if (apcu_add($lockKey, $lockToken, self::LOCK_STALE_SECONDS)) {
                             $lockAcquired = true;
                             break;
                         }
@@ -207,17 +238,48 @@ class QueryCache
                 }
             }
 
+            // Always double-check after acquiring the sentinel. Another worker
+            // may have populated the value between our first miss and apcu_add(),
+            // or immediately before a final retry acquired the released lock.
+            if ($lockAcquired) {
+                $cached = self::backendGet($hashedKey);
+                if ($cached !== null) {
+                    return $cached;
+                }
+            }
+
             // Execute callback to get fresh value
             $value = $callback();
 
-            // Store in cache
-            self::set($key, $value, $ttl);
+            // Store under the generation resolved before the callback.
+            self::backendSet($hashedKey, $value, $ttl);
 
             return $value;
         } finally {
             if ($lockAcquired) {
+                self::releaseApcuLock($lockKey, $lockToken);
+            }
+        }
+    }
+
+    /** Release an APCu sentinel only when it is still owned by this caller. */
+    private static function releaseApcuLock(string $lockKey, int $lockToken): void
+    {
+        if (function_exists('apcu_cas')) {
+            // CAS keeps an expired/reacquired successor lock from being deleted
+            // by the previous owner. The temporary zero remains locked until
+            // this caller deletes it immediately below.
+            if (apcu_cas($lockKey, $lockToken, 0)) {
                 apcu_delete($lockKey);
             }
+            return;
+        }
+
+        // Compatibility fallback for unusual APCu builds without apcu_cas().
+        $success = false;
+        $current = apcu_fetch($lockKey, $success);
+        if ($success && $current === $lockToken) {
+            apcu_delete($lockKey);
         }
     }
 
@@ -225,10 +287,15 @@ class QueryCache
      * remember() body for the file backend: the original flock()-based
      * stampede protection, unchanged.
      */
-    private static function rememberWithFileLock(string $key, callable $callback, int $ttl): mixed
+    private static function rememberWithFileLock(
+        string $key,
+        string $hashedKey,
+        callable $callback,
+        int $ttl
+    ): mixed
     {
         // Acquire mutex lock to prevent stampede
-        $lockKey = self::hashKey($key) . '.lock';
+        $lockKey = $hashedKey . '.lock';
         $lockFile = self::getCacheDir() . '/' . $lockKey;
 
         // Check lock file mtime BEFORE fopen (fopen 'c' mode can update mtime)
@@ -278,7 +345,7 @@ class QueryCache
                 usleep($sleepMicros);
             }
 
-            $cached = self::get($key);
+            $cached = self::backendGet($hashedKey);
             if ($cached !== null) {
                 return $cached;
             }
@@ -319,8 +386,8 @@ class QueryCache
             // Execute callback to get fresh value
             $value = $callback();
 
-            // Store in cache
-            self::set($key, $value, $ttl);
+            // Store under the generation resolved before the callback.
+            self::backendSet($hashedKey, $value, $ttl);
 
             return $value;
         } finally {
@@ -378,12 +445,17 @@ class QueryCache
     public static function delete(string $key): bool
     {
         $hashedKey = self::hashKey($key);
+        $successFiles = self::deleteFromFile($hashedKey);
+        $successApcu = true;
 
+        // Invalidation intentionally reaches both stores when this SAPI can
+        // access APCu. This preserves web/FPM -> CLI/file coherence while data
+        // writes themselves remain single-backend.
         if (self::hasApcu()) {
-            return apcu_delete($hashedKey);
+            $successApcu = apcu_delete($hashedKey) || !apcu_exists($hashedKey);
         }
 
-        return self::deleteFromFile($hashedKey);
+        return $successFiles && $successApcu;
     }
 
     /**
@@ -405,12 +477,19 @@ class QueryCache
             return;
         }
 
-        $genKey = self::generationStorageKey($ns);
-        $current = self::backendGet($genKey);
-        // max(current+1, time()): monotonic even if the counter was ever lost
-        // and re-initialized (init value is time(), see currentGeneration()).
-        $next = is_int($current) ? max($current + 1, time()) : time();
-        self::backendSet($genKey, $next, self::GENERATION_TTL);
+        $next = self::mutateGenerationFile($ns, true);
+        if ($next === null) {
+            // If the canonical counter cannot be persisted, fall back to the
+            // physical invalidation used before namespace generations. Keep a
+            // request-local unique generation as an additional safety net so
+            // this process cannot reuse the old key after the invalidation.
+            self::legacyClearByPrefix($ns);
+            self::$generationCache[$ns] = -random_int(1, PHP_INT_MAX);
+            return;
+        }
+
+        self::$generationCache[$ns] = $next;
+        self::maybeGc();
     }
 
     /**
@@ -558,10 +637,7 @@ class QueryCache
         return null;
     }
 
-    /**
-     * Storage key of a namespace's generation counter. Deliberately outside
-     * every namespace prefix so it never resolves through itself.
-     */
+    /** Storage filename of a namespace's canonical generation counter. */
     private static function generationStorageKey(string $ns): string
     {
         $safe = preg_replace('/[^A-Za-z0-9_\-]/', '_', $ns);
@@ -570,22 +646,126 @@ class QueryCache
     }
 
     /**
-     * Current generation of a namespace. Missing counters are initialized to
-     * time(): monotonic w.r.t. every generation ever issued before, so a lost
-     * counter can never make previously invalidated entries reachable again.
+     * Current generation of a namespace.
+     *
+     * The canonical counter is deliberately file-backed even when APCu is the
+     * selected data backend. PHP-FPM and CLI commonly disagree on APCu
+     * availability (apc.enable_cli is normally off); one shared file keeps
+     * invalidation coherent across those SAPIs. The value is memoized for the
+     * remainder of this request, so each namespace costs at most one file read.
      */
     private static function currentGeneration(string $ns): int
     {
-        $genKey = self::generationStorageKey($ns);
-        $value = self::backendGet($genKey);
-        if (is_int($value)) {
-            return $value;
+        if (isset(self::$generationCache[$ns])) {
+            return self::$generationCache[$ns];
         }
 
-        $gen = time();
-        self::backendSet($genKey, $gen, self::GENERATION_TTL);
+        $gen = self::readGenerationFile($ns);
+        if ($gen === null) {
+            // Initialize under an exclusive lock. A concurrent initializer may
+            // win; mutateGenerationFile(false) then returns its value unchanged.
+            $gen = self::mutateGenerationFile($ns, false);
+        }
+
+        if ($gen === null) {
+            // Graceful degradation when the cache directory is unavailable:
+            // a process-unique negative generation prevents stale cross-request
+            // reuse while still allowing repeat lookups within this request.
+            $gen = -random_int(1, PHP_INT_MAX);
+        }
+
+        self::$generationCache[$ns] = $gen;
 
         return $gen;
+    }
+
+    /** Read a valid generation file under a shared lock. */
+    private static function readGenerationFile(string $ns): ?int
+    {
+        $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
+        $handle = @fopen($path, 'r');
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            if (!flock($handle, LOCK_SH)) {
+                return null;
+            }
+
+            return self::generationFromHandle($handle);
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /**
+     * Initialize or atomically increment a namespace generation.
+     *
+     * @param bool $increment true for invalidation, false for initialize-if-missing
+     */
+    private static function mutateGenerationFile(string $ns, bool $increment): ?int
+    {
+        $path = self::getCacheDir() . '/' . self::generationStorageKey($ns);
+        $handle = @fopen($path, 'c+');
+        if ($handle === false) {
+            return null;
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                return null;
+            }
+
+            $current = self::generationFromHandle($handle);
+            if ($current !== null && !$increment) {
+                return $current;
+            }
+
+            $next = $current !== null ? max($current + 1, time()) : time();
+            $payload = serialize([
+                'value' => $next,
+                'expires' => time() + self::GENERATION_TTL,
+                'created' => time(),
+            ]);
+
+            rewind($handle);
+            if (!ftruncate($handle, 0)) {
+                return null;
+            }
+
+            $written = fwrite($handle, $payload);
+            if ($written === false || $written !== strlen($payload) || !fflush($handle)) {
+                return null;
+            }
+            @chmod($path, 0660);
+
+            return $next;
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    /** Parse a generation payload from an already locked file handle. */
+    private static function generationFromHandle($handle): ?int
+    {
+        rewind($handle);
+        $content = stream_get_contents($handle);
+        if ($content === false || $content === '') {
+            return null;
+        }
+
+        $data = @unserialize($content, ['allowed_classes' => false]);
+        if (!is_array($data)
+            || !isset($data['expires'], $data['value'])
+            || (int) $data['expires'] < time()
+            || !is_int($data['value'])) {
+            return null;
+        }
+
+        return $data['value'];
     }
 
     /**
@@ -678,9 +858,59 @@ class QueryCache
         $result = @file_put_contents($path, serialize($data), LOCK_EX);
         if ($result !== false) {
             @chmod($path, 0660);
+            self::maybeGc();
         }
 
         return $result !== false;
+    }
+
+    /**
+     * Run file-cache GC at most once per configured interval and never make a
+     * request wait behind another collector. Generation invalidation leaves
+     * old filenames unreachable, so TTL alone is insufficient: without this
+     * scheduled sweep those files would remain on disk forever.
+     */
+    private static function maybeGc(): void
+    {
+        if (self::$gcCheckedThisRequest) {
+            return;
+        }
+        self::$gcCheckedThisRequest = true;
+
+        $cacheDir = self::getCacheDir();
+        $marker = $cacheDir . '/.pinakes_gc';
+        clearstatcache(true, $marker);
+        $lastRun = @filemtime($marker);
+        if ($lastRun !== false && $lastRun >= time() - self::GC_INTERVAL_SECONDS) {
+            return;
+        }
+
+        $lockPath = $cacheDir . '/.pinakes_gc.lock';
+        $lock = @fopen($lockPath, 'c');
+        if ($lock === false) {
+            return;
+        }
+
+        try {
+            if (!flock($lock, LOCK_EX | LOCK_NB)) {
+                return;
+            }
+
+            // Recheck after acquiring the lock: another process may have run
+            // GC between the optimistic marker check and flock().
+            clearstatcache(true, $marker);
+            $lastRun = @filemtime($marker);
+            if ($lastRun !== false && $lastRun >= time() - self::GC_INTERVAL_SECONDS) {
+                return;
+            }
+
+            // Mark before scanning so a fatal error cannot trigger a GC storm.
+            @touch($marker);
+            self::gc();
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
     }
 
     /**
@@ -724,21 +954,43 @@ class QueryCache
                 continue;
             }
 
-            $content = @file_get_contents($file);
-            if ($content === false) {
+            $handle = @fopen($file, 'r');
+            if ($handle === false) {
                 if (@unlink($file)) {
                     $count++;
                 }
                 continue;
             }
 
-            // Use safe unserialize to prevent object injection attacks
-            $data = @unserialize($content, ['allowed_classes' => false]);
-            // Delete if: not an array, missing 'expires' key (corrupted), or expired
-            if (!is_array($data) || !isset($data['expires']) || $data['expires'] < $now) {
-                if (@unlink($file)) {
+            try {
+                // Generation counters and ordinary entries are written under an
+                // exclusive lock. GC must take that same exclusive lock or it
+                // could mistake an in-progress truncate/write for corruption.
+                if (!flock($handle, LOCK_EX)) {
+                    continue;
+                }
+
+                $content = stream_get_contents($handle);
+                $delete = false;
+                if ($content === false) {
+                    $delete = true;
+                } else {
+                    // Use safe unserialize to prevent object injection attacks.
+                    $data = @unserialize($content, ['allowed_classes' => false]);
+                    $delete = !is_array($data)
+                        || !isset($data['expires'])
+                        || $data['expires'] < $now;
+                }
+
+                // Unlink while the inode is still exclusively locked. Waiting
+                // until after unlock would let a concurrent writer refresh the
+                // same path between our expiry check and unlink().
+                if ($delete && @unlink($file)) {
                     $count++;
                 }
+            } finally {
+                flock($handle, LOCK_UN);
+                fclose($handle);
             }
         }
 

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -1,0 +1,178 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Decides whether the current HTTP request needs a PHP session.
+ *
+ * Step 6 of the caching overhaul (issue #387): the anonymous public request
+ * path must be sessionless so a later PR can put anonymous pages behind a
+ * shared full-page/edge cache. A request is served WITHOUT a session only
+ * when ALL of the following hold:
+ *
+ *   1. The method is read-only (GET/HEAD). Every state-changing method
+ *      (POST/PUT/PATCH/DELETE/…) keeps the session so CSRF validation always
+ *      has its session-backed token store — this also covers login and every
+ *      other auth POST by construction.
+ *   2. The request carries NO auth-related cookie: no session cookie
+ *      (session_name()), no remember_token (persistent login) and no
+ *      csrf_login (login form double-submit cookie). Any hint of an
+ *      authenticated — or authenticating — browser keeps the exact current
+ *      session behavior.
+ *   3. The path is not an auth/contact route (in any registered locale).
+ *      Those pages mint session-backed CSRF tokens into their HTML forms
+ *      (login, register, forgot/reset password, contact) and must keep
+ *      opening the session so the subsequent POST validates.
+ *
+ * Fail-safe direction: anything unknown (CLI, missing method, malformed
+ * path) requires a session — correctness over cacheability.
+ */
+final class SessionPolicy
+{
+    /**
+     * Route keys whose GET pages need a session (they render session-backed
+     * CSRF form tokens, or belong to the authentication flow). Mirrors
+     * PrivateModeMiddleware::AUTH_ROUTE_KEYS plus the contact form.
+     *
+     * @var string[]
+     */
+    private const SESSION_ROUTE_KEYS = [
+        'login', 'logout', 'register', 'register_success',
+        'verify_email', 'forgot_password', 'reset_password',
+        'contact', 'contact_submit',
+    ];
+
+    /**
+     * Legacy English aliases always registered in web.php regardless of the
+     * install locale (see the login allow-list in PrivateModeMiddleware).
+     *
+     * @var string[]
+     */
+    private const LEGACY_SESSION_PATHS = ['/login', '/login.php', '/logout'];
+
+    /** @var string[]|null Cached localized session-route prefixes. */
+    private static ?array $sessionRoutesCache = null;
+
+    /**
+     * True when the request must be served with a PHP session (the default,
+     * conservative outcome); false only for the anonymous no-cookie
+     * read-only path described in the class docblock.
+     *
+     * @param string               $method   HTTP method ('' outside HTTP, e.g. CLI)
+     * @param array<string, mixed> $cookies  Request cookies ($_COOKIE)
+     * @param string               $path     Request URI path (no query string)
+     * @param string|null          $basePath Base path override (null = autodetect)
+     */
+    public static function requiresSession(
+        string $method,
+        array $cookies,
+        string $path,
+        ?string $basePath = null
+    ): bool {
+        // 1. Only read-only methods can be sessionless. CLI/unknown ('') and
+        //    every state-changing method keep the session.
+        if (!in_array(strtoupper($method), ['GET', 'HEAD'], true)) {
+            return true;
+        }
+
+        // 2. Any auth-related cookie keeps the exact current behavior.
+        if (isset($cookies[session_name()])) {
+            return true;
+        }
+        if (isset($cookies['remember_token'])) {
+            return true;
+        }
+        if (isset($cookies['csrf_login'])) {
+            return true;
+        }
+
+        // 3. Auth/contact routes mint session-backed CSRF form tokens.
+        return self::isSessionRoute($path, $basePath);
+    }
+
+    /**
+     * True when the path matches an auth/contact route in any registered
+     * locale (or a legacy English alias), after stripping the base path of
+     * sub-folder installs.
+     */
+    private static function isSessionRoute(string $path, ?string $basePath = null): bool
+    {
+        $basePath = $basePath ?? HtmlHelper::getBasePath();
+        $basePath = rtrim($basePath, '/');
+        if ($basePath !== '' && str_starts_with($path, $basePath)) {
+            $path = substr($path, strlen($basePath));
+        }
+        $path = '/' . ltrim($path, '/');
+        if ($path !== '/') {
+            $path = rtrim($path, '/');
+        }
+
+        foreach (self::sessionRoutes() as $route) {
+            if ($path === $route || str_starts_with($path, $route . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * All localized variants of the session-requiring routes, computed from
+     * the locale route files on disk (file-based, safe before the DB/container
+     * are available) plus the static English fallbacks and legacy aliases.
+     *
+     * @return string[]
+     */
+    private static function sessionRoutes(): array
+    {
+        if (self::$sessionRoutesCache !== null) {
+            return self::$sessionRoutesCache;
+        }
+
+        $routes = [];
+        foreach (self::registeredLocales() as $locale) {
+            foreach (self::SESSION_ROUTE_KEYS as $key) {
+                $route = RouteTranslator::getRouteForLocale($key, $locale);
+                if ($route !== '' && $route !== '/') {
+                    $routes[rtrim($route, '/')] = true;
+                }
+            }
+        }
+        foreach (self::LEGACY_SESSION_PATHS as $legacy) {
+            $routes[$legacy] = true;
+        }
+
+        self::$sessionRoutesCache = array_keys($routes);
+        return self::$sessionRoutesCache;
+    }
+
+    /**
+     * Locales that have a route-translation file on disk. Falls back to the
+     * locales whose route variants web.php always registers.
+     *
+     * @return string[]
+     */
+    private static function registeredLocales(): array
+    {
+        $locales = [];
+        $files = glob(__DIR__ . '/../../locale/routes_*.json');
+        foreach (($files === false ? [] : $files) as $file) {
+            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $m) === 1) {
+                $locales[] = $m[1];
+            }
+        }
+        if ($locales === []) {
+            $locales = ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
+        }
+        return $locales;
+    }
+
+    /**
+     * Test hook: clear the computed route cache.
+     */
+    public static function clearCache(): void
+    {
+        self::$sessionRoutesCache = null;
+    }
+}

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -6,58 +6,55 @@ namespace App\Support;
 /**
  * Decides whether the current HTTP request needs a PHP session.
  *
- * Step 6 of the caching overhaul (issue #387): the anonymous public request
- * path must be sessionless so a later PR can put anonymous pages behind a
- * shared full-page/edge cache. A request is served WITHOUT a session only
- * when ALL of the following hold:
- *
- *   1. The method is read-only (GET/HEAD). Every state-changing method
- *      (POST/PUT/PATCH/DELETE/…) keeps the session so CSRF validation always
- *      has its session-backed token store — this also covers login and every
- *      other auth POST by construction.
- *   2. The request carries NO auth-related cookie: no session cookie
- *      (session_name()), no remember_token (persistent login) and no
- *      csrf_login (login form double-submit cookie). Any hint of an
- *      authenticated — or authenticating — browser keeps the exact current
- *      session behavior.
- *   3. The path is not an auth/contact route (in any registered locale).
- *      Those pages mint session-backed CSRF tokens into their HTML forms
- *      (login, register, forgot/reset password, contact) and must keep
- *      opening the session so the subsequent POST validates.
- *
- * Fail-safe direction: anything unknown (CLI, missing method, malformed
- * path) requires a session — correctness over cacheability.
+ * Only explicitly known, read-only public routes may skip session_start().
+ * Keeping this as an allow-list is intentional: plugin routes and future
+ * pages may render session-backed forms or consume flash/auth state, so an
+ * unknown route must remain sessionful until it is audited.
  */
 final class SessionPolicy
 {
     /**
-     * Route keys whose GET pages need a session (they render session-backed
-     * CSRF form tokens, or belong to the authentication flow). Mirrors
-     * PrivateModeMiddleware::AUTH_ROUTE_KEYS plus the contact form.
+     * Audited public route families that do not require server-side session
+     * state for an anonymous GET/HEAD. A translated route also matches its
+     * descendants (for example /book/42 or /events/summer-reading).
      *
      * @var string[]
      */
-    private const SESSION_ROUTE_KEYS = [
-        'login', 'logout', 'register', 'register_success',
-        'verify_email', 'forgot_password', 'reset_password',
-        'contact', 'contact_submit',
+    private const SESSIONLESS_ROUTE_KEYS = [
+        'catalog', 'catalog_legacy',
+        'book', 'book_legacy',
+        'author', 'publisher', 'genre',
+        'events',
+        'about', 'privacy', 'cookies',
+        'api_catalog', 'api_book', 'api_home',
     ];
 
     /**
-     * Legacy English aliases always registered in web.php regardless of the
-     * install locale (see the login allow-list in PrivateModeMiddleware).
+     * Non-translated public endpoints audited for sessionless access.
+     * Descendant matching is enabled only for entries ending in a slash.
      *
      * @var string[]
      */
-    private const LEGACY_SESSION_PATHS = ['/login', '/login.php', '/logout'];
+    private const SESSIONLESS_PATHS = [
+        '/',
+        '/home.php',
+        '/health',
+        '/csrf-token',
+        '/robots.txt',
+        '/sitemap.xml',
+        '/feed.xml',
+        '/llms.txt',
+        '/language/',
+        '/uploads/',
+        '/proxy/cover',
+    ];
 
-    /** @var string[]|null Cached localized session-route prefixes. */
-    private static ?array $sessionRoutesCache = null;
+    /** @var string[]|null Cached localized public-route prefixes. */
+    private static ?array $sessionlessRoutesCache = null;
 
     /**
      * True when the request must be served with a PHP session (the default,
-     * conservative outcome); false only for the anonymous no-cookie
-     * read-only path described in the class docblock.
+     * conservative outcome); false only for an audited anonymous public path.
      *
      * @param string               $method   HTTP method ('' outside HTTP, e.g. CLI)
      * @param array<string, mixed> $cookies  Request cookies ($_COOKIE)
@@ -70,45 +67,61 @@ final class SessionPolicy
         string $path,
         ?string $basePath = null
     ): bool {
-        // 1. Only read-only methods can be sessionless. CLI/unknown ('') and
-        //    every state-changing method keep the session.
         if (!in_array(strtoupper($method), ['GET', 'HEAD'], true)) {
             return true;
         }
 
-        // 2. Any auth-related cookie keeps the exact current behavior.
-        if (isset($cookies[session_name()])) {
-            return true;
-        }
-        if (isset($cookies['remember_token'])) {
-            return true;
-        }
-        if (isset($cookies['csrf_login'])) {
+        // Any authentication-flow state makes the response visitor-specific.
+        if (
+            isset($cookies[session_name()])
+            || isset($cookies['remember_token'])
+            || isset($cookies['csrf_login'])
+        ) {
             return true;
         }
 
-        // 3. Auth/contact routes mint session-backed CSRF form tokens.
-        return self::isSessionRoute($path, $basePath);
+        return !self::isSessionlessRoute($path, $basePath);
     }
 
     /**
-     * True when the path matches an auth/contact route in any registered
-     * locale (or a legacy English alias), after stripping the base path of
-     * sub-folder installs.
+     * Match only audited public routes after safely removing a subfolder base
+     * path. The boundary check prevents /pinakes-other from being mistaken for
+     * an installation mounted at /pinakes.
      */
-    private static function isSessionRoute(string $path, ?string $basePath = null): bool
+    private static function isSessionlessRoute(string $path, ?string $basePath = null): bool
     {
-        $basePath = $basePath ?? HtmlHelper::getBasePath();
-        $basePath = rtrim($basePath, '/');
-        if ($basePath !== '' && str_starts_with($path, $basePath)) {
-            $path = substr($path, strlen($basePath));
+        $basePath = rtrim($basePath ?? HtmlHelper::getBasePath(), '/');
+        if ($basePath !== '') {
+            if ($path === $basePath) {
+                $path = '/';
+            } elseif (str_starts_with($path, $basePath . '/')) {
+                $path = substr($path, strlen($basePath));
+            } else {
+                return false;
+            }
         }
+
         $path = '/' . ltrim($path, '/');
         if ($path !== '/') {
             $path = rtrim($path, '/');
         }
 
-        foreach (self::sessionRoutes() as $route) {
+        foreach (self::SESSIONLESS_PATHS as $publicPath) {
+            if ($publicPath === '/') {
+                if ($path === '/') {
+                    return true;
+                }
+            } elseif (str_ends_with($publicPath, '/')) {
+                $prefix = rtrim($publicPath, '/');
+                if ($path === $prefix || str_starts_with($path, $prefix . '/')) {
+                    return true;
+                }
+            } elseif ($path === $publicPath) {
+                return true;
+            }
+        }
+
+        foreach (self::sessionlessRoutes() as $route) {
             if ($path === $route || str_starts_with($path, $route . '/')) {
                 return true;
             }
@@ -118,61 +131,48 @@ final class SessionPolicy
     }
 
     /**
-     * All localized variants of the session-requiring routes, computed from
-     * the locale route files on disk (file-based, safe before the DB/container
-     * are available) plus the static English fallbacks and legacy aliases.
+     * Build every localized variant directly from route files, before the
+     * application container/database is available.
      *
      * @return string[]
      */
-    private static function sessionRoutes(): array
+    private static function sessionlessRoutes(): array
     {
-        if (self::$sessionRoutesCache !== null) {
-            return self::$sessionRoutesCache;
+        if (self::$sessionlessRoutesCache !== null) {
+            return self::$sessionlessRoutesCache;
         }
 
         $routes = [];
         foreach (self::registeredLocales() as $locale) {
-            foreach (self::SESSION_ROUTE_KEYS as $key) {
+            foreach (self::SESSIONLESS_ROUTE_KEYS as $key) {
                 $route = RouteTranslator::getRouteForLocale($key, $locale);
                 if ($route !== '' && $route !== '/') {
                     $routes[rtrim($route, '/')] = true;
                 }
             }
         }
-        foreach (self::LEGACY_SESSION_PATHS as $legacy) {
-            $routes[$legacy] = true;
-        }
 
-        self::$sessionRoutesCache = array_keys($routes);
-        return self::$sessionRoutesCache;
+        self::$sessionlessRoutesCache = array_keys($routes);
+        return self::$sessionlessRoutesCache;
     }
 
-    /**
-     * Locales that have a route-translation file on disk. Falls back to the
-     * locales whose route variants web.php always registers.
-     *
-     * @return string[]
-     */
+    /** @return string[] */
     private static function registeredLocales(): array
     {
         $locales = [];
         $files = glob(__DIR__ . '/../../locale/routes_*.json');
         foreach (($files === false ? [] : $files) as $file) {
-            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $m) === 1) {
-                $locales[] = $m[1];
+            if (preg_match('/routes_([A-Za-z]{2}_[A-Za-z]{2})\.json$/', $file, $matches) === 1) {
+                $locales[] = $matches[1];
             }
         }
-        if ($locales === []) {
-            $locales = ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
-        }
-        return $locales;
+
+        return $locales !== [] ? $locales : ['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'];
     }
 
-    /**
-     * Test hook: clear the computed route cache.
-     */
+    /** Test hook: clear the computed route cache. */
     public static function clearCache(): void
     {
-        self::$sessionRoutesCache = null;
+        self::$sessionlessRoutesCache = null;
     }
 }

--- a/app/Support/SessionPolicy.php
+++ b/app/Support/SessionPolicy.php
@@ -45,7 +45,16 @@ final class SessionPolicy
         '/feed.xml',
         '/llms.txt',
         '/language/',
-        '/uploads/',
+        // Only the genuinely public /uploads subtrees are sessionless. The
+        // private ones — /uploads/digital/, /uploads/archives/documents/,
+        // /uploads/storage/ — are deliberately NOT listed: PrivateModeMiddleware
+        // keeps them behind the login wall, and a blanket '/uploads/' would stamp
+        // them session-free / cache-eligible, which the later shared edge cache
+        // would turn into unauthenticated content disclosure. Mirrors
+        // PrivateModeMiddleware::ALLOWED_PREFIXES (which exposes only settings).
+        '/uploads/copertine/', // public book covers (catalog + book page)
+        '/uploads/autori/',    // public author photos
+        '/uploads/settings/',  // admin-uploaded branding/logo
         '/proxy/cover',
     ];
 

--- a/app/Views/frontend/event-detail.php
+++ b/app/Views/frontend/event-detail.php
@@ -18,7 +18,10 @@ $baseUrl = ConfigStore::get('app.canonical_url');
 
 $contentHtml = ContentSanitizer::normalizeExternalAssets($event['content'] ?? '');
 
-$locale = $_SESSION['locale'] ?? 'it_IT';
+// Session locale wins (unchanged); on the sessionless anonymous path
+// (issue #387 step 6) fall back to the request locale resolved by
+// public/index.php from the pinakes_locale cookie / install default.
+$locale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
 if (class_exists('IntlDateFormatter')) {
     $dateFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE);
     $timeFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);

--- a/app/Views/frontend/events.php
+++ b/app/Views/frontend/events.php
@@ -28,7 +28,10 @@ $twitterTitle = $seoTitle;
 $twitterDescription = $seoDescription;
 $twitterImage = $ogImage;
 
-$locale = $_SESSION['locale'] ?? 'it_IT';
+// Session locale wins (unchanged); on the sessionless anonymous path
+// (issue #387 step 6) fall back to the request locale resolved by
+// public/index.php from the pinakes_locale cookie / install default.
+$locale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
 if (class_exists('IntlDateFormatter')) {
     $dateFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE);
     $timeFormatter = new \IntlDateFormatter($locale, \IntlDateFormatter::NONE, \IntlDateFormatter::SHORT);

--- a/app/Views/frontend/home-sections/events.php
+++ b/app/Views/frontend/home-sections/events.php
@@ -9,7 +9,7 @@ $homeEvents = $homeEvents ?? [];
 $homeEventsEnabled = $homeEventsEnabled ?? false;
 
 if ($homeEventsEnabled && !empty($homeEvents)):
-    $homeEventsLocale = $_SESSION['locale'] ?? 'it_IT';
+    $homeEventsLocale = $_SESSION['locale'] ?? (\App\Support\I18n::getLocale() ?: 'it_IT');
     $homeEventsDateFormatter = class_exists('IntlDateFormatter')
         ? new \IntlDateFormatter($homeEventsLocale, \IntlDateFormatter::LONG, \IntlDateFormatter::NONE)
         : null;

--- a/app/Views/frontend/layout.php
+++ b/app/Views/frontend/layout.php
@@ -238,8 +238,18 @@ $htmlLang = substr($currentLocale, 0, 2);
                 </script>
     <?php endif; ?>
 
+    <?php
+    // Lazy CSRF (issue #387 step 6): a sessionless anonymous render must not
+    // mint a CSRF token — it would not be backed by any session, could never
+    // validate, and would make the HTML per-visitor (uncacheable). The meta
+    // stays empty on the no-session path; JS that needs a token for a
+    // state-changing call fetches one from GET /csrf-token, which lazily
+    // opens the session (see public/assets/js/csrf-helper.js). With an
+    // active session the token is emitted exactly as before.
+    $csrfMetaToken = session_status() === PHP_SESSION_ACTIVE ? App\Support\Csrf::ensureToken() : '';
+    ?>
     <meta name="csrf-token"
-        content="<?php echo htmlspecialchars(App\Support\Csrf::ensureToken(), ENT_QUOTES, 'UTF-8'); ?>" />
+        content="<?php echo htmlspecialchars($csrfMetaToken, ENT_QUOTES, 'UTF-8'); ?>" />
     <link rel="icon" type="image/x-icon" href="<?= htmlspecialchars(url('/favicon.ico'), ENT_QUOTES, 'UTF-8') ?>">
     <script>window.BASE_PATH = <?= json_encode(\App\Support\HtmlHelper::getBasePath(), JSON_HEX_TAG | JSON_HEX_AMP) ?>;</script>
 

--- a/php.ini.recommended
+++ b/php.ini.recommended
@@ -30,10 +30,13 @@ opcache.revalidate_freq=2
 ; pipeline guarantees that invalidation.
 opcache.validate_timestamps=1
 
-; JIT: intentionally NOT enabled here. It is off by default (opcache.jit_buffer_size=0)
-; and Pinakes is DB/IO-bound — JIT compiles CPU-bound loops, so it yields
-; ~nothing for this workload while adding memory overhead and (historically)
-; edge-case bugs.
+; JIT: intentionally DISABLED. Pinakes is DB/IO-bound — JIT compiles CPU-bound
+; loops, so it yields ~nothing for this workload while adding memory overhead
+; and (historically) edge-case bugs. Set BOTH directives explicitly: opcache.jit
+; alone is not enough because opcache.jit_buffer_size defaults to a non-zero value
+; on some builds (notably PHP 8.4+), which would still reserve JIT memory.
+opcache.jit=disable
+opcache.jit_buffer_size=0
 
 ; ===================================
 ; MEMORY & PERFORMANCE

--- a/php.ini.recommended
+++ b/php.ini.recommended
@@ -11,15 +11,29 @@
 
 opcache.enable=1
 opcache.enable_cli=0
+; 128 MB / 10000 files is enough for a stock Pinakes install. Raise to
+; 256 / 20000 ONLY if opcache_get_status() shows saturation (memory_usage
+; near full, num_cached_keys close to max_cached_keys, or oom_restarts > 0)
+; — not a priori: oversizing just wastes shared memory.
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=16
 opcache.max_accelerated_files=10000
 opcache.revalidate_freq=2
-opcache.fast_shutdown=1
+; NOTE: opcache.fast_shutdown was removed here on purpose — it has been a
+; no-op since PHP 7.2 (the fast shutdown sequence is always used).
 
-; In production, set to 0 for maximum performance
-; In development, set to 1 to see changes immediately
+; Keep validate_timestamps=1. Setting it to 0 gives a marginal stat() saving
+; but then EVERY code path that mutates PHP files (the in-app updater,
+; plugin install/upgrade, manual deploys) must explicitly invalidate OPcache
+; (opcache_reset()/opcache_invalidate() or an FPM reload) or the server keeps
+; executing the OLD code indefinitely. Do not set it to 0 unless your deploy
+; pipeline guarantees that invalidation.
 opcache.validate_timestamps=1
+
+; JIT: intentionally NOT enabled here. It is off by default (opcache.jit_buffer_size=0)
+; and Pinakes is DB/IO-bound — JIT compiles CPU-bound loops, so it yields
+; ~nothing for this workload while adding memory overhead and (historically)
+; edge-case bugs.
 
 ; ===================================
 ; MEMORY & PERFORMANCE

--- a/public/assets/js/csrf-helper.js
+++ b/public/assets/js/csrf-helper.js
@@ -51,9 +51,15 @@
       headers.set('X-CSRF-Token', token);
     }
 
-    // Add Content-Type for JSON requests if not already set
+    // Only default the Content-Type to JSON for string bodies that actually
+    // look like JSON (object/array). The Fetch spec assigns text/plain to a bare
+    // string; forcing application/json on e.g. 'a=1' would make the server
+    // misparse a form/plain payload. An explicit caller Content-Type is kept.
     if (options.body && typeof options.body === 'string' && !headers.has('Content-Type')) {
-      headers.set('Content-Type', 'application/json');
+      const trimmed = options.body.trimStart();
+      if (trimmed.charAt(0) === '{' || trimmed.charAt(0) === '[') {
+        headers.set('Content-Type', 'application/json');
+      }
     }
 
     // Create merged options with headers

--- a/public/assets/js/csrf-helper.js
+++ b/public/assets/js/csrf-helper.js
@@ -4,52 +4,94 @@
  * This helper function automatically adds the CSRF token to all fetch requests.
  * It reads the token from the <meta name="csrf-token"> tag in the page.
  *
+ * Lazy CSRF (issue #387 step 6): sessionless anonymous pages are rendered
+ * with an EMPTY csrf-token meta (no session, cacheable HTML). When a
+ * state-changing request is made from such a page, the helper first fetches
+ * a token from the same-origin GET /csrf-token endpoint — which lazily opens
+ * the session — and only then performs the request. Pages rendered with an
+ * active session keep the exact previous behavior (token read from the meta).
+ *
  * Usage:
  *   csrfFetch('/api/endpoint', { method: 'POST', body: JSON.stringify(data) })
  *
- * This is a drop-in replacement for fetch() that automatically includes CSRF protection.
+ * This is a drop-in replacement for fetch() that automatically includes CSRF
+ * protection and always returns a Promise<Response>.
  */
 
-/**
- * Fetch wrapper that automatically includes CSRF token
- * @param {string} url - The URL to fetch
- * @param {object} options - Fetch options (method, body, headers, etc.)
- * @returns {Promise<Response>} - The fetch response
- */
-window.csrfFetch = function(url, options = {}) {
-  // Get CSRF token from meta tag
-  const csrfToken = document.querySelector('meta[name="csrf-token"]');
-  const token = csrfToken ? csrfToken.getAttribute('content') : null;
+(function() {
+  'use strict';
 
-  // If no token found, log warning but proceed with request
-  if (!token) {
-    console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
+  function metaEl() {
+    return document.querySelector('meta[name="csrf-token"]');
   }
 
-  // Merge default headers with user-provided headers
-  const headers = {
-    ...options.headers,
+  function doFetch(url, options, token) {
+    // If no token found, log warning but proceed with request
+    if (!token) {
+      console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
+    }
+
+    // Merge default headers with user-provided headers
+    const headers = {
+      ...options.headers,
+    };
+
+    // Add CSRF token header if token exists
+    if (token) {
+      headers['X-CSRF-Token'] = token;
+    }
+
+    // Add Content-Type for JSON requests if not already set
+    if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    // Create merged options with headers
+    const mergedOptions = {
+      ...options,
+      headers,
+    };
+
+    // Make the fetch request
+    return fetch(url, mergedOptions);
+  }
+
+  /**
+   * Fetch wrapper that automatically includes CSRF token
+   * @param {string} url - The URL to fetch
+   * @param {object} options - Fetch options (method, body, headers, etc.)
+   * @returns {Promise<Response>} - The fetch response
+   */
+  window.csrfFetch = function(url, options = {}) {
+    const meta = metaEl();
+    const token = meta ? meta.getAttribute('content') : null;
+
+    const method = String(options.method || 'GET').toUpperCase();
+    const isStateChanging = ['GET', 'HEAD', 'OPTIONS'].indexOf(method) === -1;
+
+    // Lazy mint: no token in the markup and the request needs one.
+    if (!token && isStateChanging) {
+      const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH : '';
+      return fetch(base + '/csrf-token', { credentials: 'same-origin', cache: 'no-store' })
+        .then(function(res) { return res.ok ? res.json() : null; })
+        .then(function(data) {
+          const fresh = (data && typeof data.token === 'string' && data.token !== '') ? data.token : null;
+          if (fresh && meta) {
+            // Cache for subsequent calls on this page.
+            meta.setAttribute('content', fresh);
+          }
+          return doFetch(url, options, fresh);
+        })
+        .catch(function() {
+          // Endpoint unreachable: proceed without a token — the server-side
+          // CSRF validation stays authoritative and will reject if required.
+          return doFetch(url, options, null);
+        });
+    }
+
+    return doFetch(url, options, token);
   };
-
-  // Add CSRF token header if token exists
-  if (token) {
-    headers['X-CSRF-Token'] = token;
-  }
-
-  // Add Content-Type for JSON requests if not already set
-  if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  // Create merged options with headers
-  const mergedOptions = {
-    ...options,
-    headers,
-  };
-
-  // Make the fetch request
-  return fetch(url, mergedOptions);
-};
+})();
 
 // CSRF Helper loaded (silent - log removed for production)
 // Uncomment for debugging:

--- a/public/assets/js/csrf-helper.js
+++ b/public/assets/js/csrf-helper.js
@@ -21,29 +21,39 @@
 (function() {
   'use strict';
 
+  let lazyTokenPromise = null;
+  let memoryToken = null;
+
   function metaEl() {
     return document.querySelector('meta[name="csrf-token"]');
   }
 
-  function doFetch(url, options, token) {
+  function isSameOrigin(url) {
+    try {
+      return new URL(url, window.location.href).origin === window.location.origin;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function doFetch(url, options, token, warnIfMissing = true) {
     // If no token found, log warning but proceed with request
-    if (!token) {
+    if (!token && warnIfMissing) {
       console.warn('CSRF token not found in page. Request may fail if CSRF protection is enabled.');
     }
 
-    // Merge default headers with user-provided headers
-    const headers = {
-      ...options.headers,
-    };
+    // Headers accepts objects, arrays and existing Headers instances without
+    // silently discarding values from the latter.
+    const headers = new Headers(options.headers || {});
 
     // Add CSRF token header if token exists
     if (token) {
-      headers['X-CSRF-Token'] = token;
+      headers.set('X-CSRF-Token', token);
     }
 
     // Add Content-Type for JSON requests if not already set
-    if (options.body && typeof options.body === 'string' && !headers['Content-Type']) {
-      headers['Content-Type'] = 'application/json';
+    if (options.body && typeof options.body === 'string' && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
     }
 
     // Create merged options with headers
@@ -56,6 +66,43 @@
     return fetch(url, mergedOptions);
   }
 
+  function lazyToken() {
+    if (lazyTokenPromise) {
+      return lazyTokenPromise;
+    }
+
+    const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH.replace(/\/$/, '') : '';
+    lazyTokenPromise = fetch(base + '/csrf-token', {
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    })
+      .then(function(res) {
+        if (!res.ok) {
+          throw new Error('Unable to mint CSRF token (HTTP ' + res.status + ')');
+        }
+        return res.json();
+      })
+      .then(function(data) {
+        if (!data || typeof data.token !== 'string' || data.token === '') {
+          throw new Error('Invalid CSRF token response');
+        }
+        memoryToken = data.token;
+        const meta = metaEl();
+        if (meta) {
+          meta.setAttribute('content', memoryToken);
+        }
+        return memoryToken;
+      })
+      .finally(function() {
+        // Share only the in-flight operation. The token itself lives in the
+        // meta element/memory cache; failures may be retried by a later action.
+        lazyTokenPromise = null;
+      });
+
+    return lazyTokenPromise;
+  }
+
   /**
    * Fetch wrapper that automatically includes CSRF token
    * @param {string} url - The URL to fetch
@@ -64,24 +111,22 @@
    */
   window.csrfFetch = function(url, options = {}) {
     const meta = metaEl();
-    const token = meta ? meta.getAttribute('content') : null;
+    const token = (meta ? meta.getAttribute('content') : null) || memoryToken;
 
     const method = String(options.method || 'GET').toUpperCase();
     const isStateChanging = ['GET', 'HEAD', 'OPTIONS'].indexOf(method) === -1;
+    const sameOrigin = isSameOrigin(url);
+
+    // Never disclose the application's CSRF token to another origin. Callers
+    // may still use csrfFetch as a normal fetch wrapper for such URLs.
+    if (!sameOrigin) {
+      return doFetch(url, options, null, false);
+    }
 
     // Lazy mint: no token in the markup and the request needs one.
     if (!token && isStateChanging) {
-      const base = (typeof window.BASE_PATH === 'string') ? window.BASE_PATH : '';
-      return fetch(base + '/csrf-token', { credentials: 'same-origin', cache: 'no-store' })
-        .then(function(res) { return res.ok ? res.json() : null; })
-        .then(function(data) {
-          const fresh = (data && typeof data.token === 'string' && data.token !== '') ? data.token : null;
-          if (fresh && meta) {
-            // Cache for subsequent calls on this page.
-            meta.setAttribute('content', fresh);
-          }
-          return doFetch(url, options, fresh);
-        })
+      return lazyToken()
+        .then(function(fresh) { return doFetch(url, options, fresh); })
         .catch(function() {
           // Endpoint unreachable: proceed without a token — the server-side
           // CSRF validation stays authoritative and will reject if required.

--- a/public/index.php
+++ b/public/index.php
@@ -284,7 +284,11 @@ $httpsDetected = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
     || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https')
     || (isset($_SERVER['HTTP_X_FORWARDED_SSL']) && strtolower((string)$_SERVER['HTTP_X_FORWARDED_SSL']) === 'on');
 
-// Secure session configuration
+// Secure session configuration. The ini parameters below are ALWAYS applied
+// (even when no session is started for this request) so that any session
+// started later in the request — e.g. the lazy GET /csrf-token endpoint or
+// the /language/{locale} switch — inherits the exact same hardened cookie
+// settings instead of PHP's defaults.
 if (session_status() !== PHP_SESSION_ACTIVE) {
     // Use application-local session storage to avoid /tmp cleanup issues.
     // Create the directory if missing: otherwise PHP silently falls back to the
@@ -323,23 +327,41 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     ini_set('session.gc_probability', '1');
     ini_set('session.gc_divisor', '100');
 
-    session_start();
+    // Step 6 of the caching overhaul (issue #387): an anonymous request that
+    // carries no auth-related cookie and targets no auth/contact route is
+    // served WITHOUT a session, so a later PR can put anonymous pages behind
+    // a shared full-page cache. Not starting the session also means the
+    // response emits no Set-Cookie. Any request with a session cookie, a
+    // remember_token, a csrf_login cookie, any non-GET/HEAD method (login and
+    // every other state-changing request) or an auth/contact path keeps the
+    // exact pre-existing session behavior. The predicate fails safe: when in
+    // doubt (CLI, malformed URI) the session is started.
+    $sessionUriPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
+    $needsSession = !is_string($sessionUriPath) || \App\Support\SessionPolicy::requiresSession(
+        (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
+        $_COOKIE,
+        $sessionUriPath
+    );
 
-    // Regenera session ID periodicamente per prevenire session hijacking.
-    // delete_old_session = FALSE on purpose: with TRUE the previous session
-    // file is destroyed immediately, so concurrent in-flight AJAX requests
-    // (common on DataTable-heavy admin pages) that still carry the old ID are
-    // rejected by use_strict_mode and the user is bounced to login. Keeping the
-    // old session briefly (it is GC'd at gc_maxlifetime) lets those concurrent
-    // requests finish on the old ID while the browser switches to the new
-    // cookie. The security-critical regeneration still happens with TRUE at
-    // login (AuthController), which is what defends against fixation. Interval
-    // raised 5min -> 30min to keep the number of lingering rotated sessions low.
-    if (!isset($_SESSION['last_regeneration'])) {
-        $_SESSION['last_regeneration'] = time();
-    } elseif (time() - $_SESSION['last_regeneration'] > 1800) { // Ogni 30 minuti
-        session_regenerate_id(false);
-        $_SESSION['last_regeneration'] = time();
+    if ($needsSession) {
+        session_start();
+
+        // Regenera session ID periodicamente per prevenire session hijacking.
+        // delete_old_session = FALSE on purpose: with TRUE the previous session
+        // file is destroyed immediately, so concurrent in-flight AJAX requests
+        // (common on DataTable-heavy admin pages) that still carry the old ID are
+        // rejected by use_strict_mode and the user is bounced to login. Keeping the
+        // old session briefly (it is GC'd at gc_maxlifetime) lets those concurrent
+        // requests finish on the old ID while the browser switches to the new
+        // cookie. The security-critical regeneration still happens with TRUE at
+        // login (AuthController), which is what defends against fixation. Interval
+        // raised 5min -> 30min to keep the number of lingering rotated sessions low.
+        if (!isset($_SESSION['last_regeneration'])) {
+            $_SESSION['last_regeneration'] = time();
+        } elseif (time() - $_SESSION['last_regeneration'] > 1800) { // Ogni 30 minuti
+            session_regenerate_id(false);
+            $_SESSION['last_regeneration'] = time();
+        }
     }
 }
 
@@ -485,6 +507,17 @@ if (!$isCli) {
         $sessionLocale = (string)$_SESSION['locale'];
         if (!\App\Support\I18n::setLocale($sessionLocale)) {
             unset($_SESSION['locale']);
+        }
+    } elseif (session_status() !== PHP_SESSION_ACTIVE) {
+        // Sessionless anonymous request (issue #387 step 6): the language
+        // choice is persisted in the pinakes_locale cookie written by
+        // /language/{locale}, so the anonymous locale is deterministic
+        // per-request (cookie/URL, not session) and a cached page can be
+        // correct per-locale. setLocale() validates against the available
+        // locales, so an unknown/tampered cookie value is simply ignored.
+        $cookieLocale = $_COOKIE['pinakes_locale'] ?? '';
+        if (is_string($cookieLocale) && $cookieLocale !== '') {
+            \App\Support\I18n::setLocale(\App\Support\I18n::normalizeLocaleCode($cookieLocale));
         }
     }
 }

--- a/public/index.php
+++ b/public/index.php
@@ -327,15 +327,11 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
     ini_set('session.gc_probability', '1');
     ini_set('session.gc_divisor', '100');
 
-    // Step 6 of the caching overhaul (issue #387): an anonymous request that
-    // carries no auth-related cookie and targets no auth/contact route is
-    // served WITHOUT a session, so a later PR can put anonymous pages behind
-    // a shared full-page cache. Not starting the session also means the
-    // response emits no Set-Cookie. Any request with a session cookie, a
-    // remember_token, a csrf_login cookie, any non-GET/HEAD method (login and
-    // every other state-changing request) or an auth/contact path keeps the
-    // exact pre-existing session behavior. The predicate fails safe: when in
-    // doubt (CLI, malformed URI) the session is started.
+    // Step 6 of the caching overhaul (issue #387): audited public GET/HEAD
+    // routes can be served without a session when no auth-flow cookie exists,
+    // allowing a later shared full-page cache to reuse the response. Unknown,
+    // plugin and state-changing routes fail safe by retaining the pre-existing
+    // session behavior. See SessionPolicy for the deliberately narrow list.
     $sessionUriPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH);
     $needsSession = !is_string($sessionUriPath) || \App\Support\SessionPolicy::requiresSession(
         (string) ($_SERVER['REQUEST_METHOD'] ?? ''),
@@ -503,18 +499,20 @@ if (!$isCli) {
         error_log("Failed to load languages from database: " . $e->getMessage());
     }
 
+    $localeRestoredFromSession = false;
     if (!empty($_SESSION['locale'])) {
         $sessionLocale = (string)$_SESSION['locale'];
-        if (!\App\Support\I18n::setLocale($sessionLocale)) {
+        $localeRestoredFromSession = \App\Support\I18n::setLocale($sessionLocale);
+        if (!$localeRestoredFromSession) {
             unset($_SESSION['locale']);
         }
-    } elseif (session_status() !== PHP_SESSION_ACTIVE) {
-        // Sessionless anonymous request (issue #387 step 6): the language
-        // choice is persisted in the pinakes_locale cookie written by
-        // /language/{locale}, so the anonymous locale is deterministic
-        // per-request (cookie/URL, not session) and a cached page can be
-        // correct per-locale. setLocale() validates against the available
-        // locales, so an unknown/tampered cookie value is simply ignored.
+    }
+
+    if (!$localeRestoredFromSession) {
+        // The cookie also covers a newly opened session (for example one
+        // created because remember_token/csrf_login is present) that does not
+        // yet contain a locale. A valid session locale always wins. setLocale
+        // validates the normalized cookie against the available locales.
         $cookieLocale = $_COOKIE['pinakes_locale'] ?? '';
         if (is_string($cookieLocale) && $cookieLocale !== '') {
             \App\Support\I18n::setLocale(\App\Support\I18n::normalizeLocaleCode($cookieLocale));

--- a/scripts/ci-verify-release-source.sh
+++ b/scripts/ci-verify-release-source.sh
@@ -52,30 +52,59 @@ elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
   pr_number="$(jq -r '.[0].number' <<<"$matching_pulls")"
   pr_branch="$(jq -r '.[0].head.ref' <<<"$matching_pulls")"
   pr_state="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
-    --json headRefOid,mergeStateStatus)"
+    --json headRefOid,mergeStateStatus,mergeable,reviewDecision)"
   pr_head="$(jq -r '.headRefOid' <<<"$pr_state")"
   merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_state")"
+  mergeable="$(jq -r '.mergeable' <<<"$pr_state")"
+  review_decision="$(jq -r '.reviewDecision // ""' <<<"$pr_state")"
   if [[ "$pr_head" != "$GITHUB_SHA" ]]; then
     echo "Prerelease PR #${pr_number} moved from tagged commit ${GITHUB_SHA} to ${pr_head}" >&2
     exit 1
   fi
-  # Why UNSTABLE is accepted alongside CLEAN: this very script runs inside the
-  # tag-triggered "Verified Release" workflow, whose check run attaches to the
-  # tagged commit — which IS the PR head. While this job is in progress GitHub
-  # reports the PR as UNSTABLE ("mergeable, but a non-required status is
-  # pending/failing"), so demanding CLEAN here is circular: the check that must
-  # pass keeps the PR from ever being CLEAN. UNSTABLE by definition still means
-  # the PR is mergeable (no conflicts, branch protection satisfied); the only
-  # thing it relaxes versus CLEAN is non-required statuses — and the loop below
-  # closes exactly that gap by independently requiring every branch-protection
-  # REQUIRED check to be green, excluding only this release workflow's own
-  # check run (tag-triggered, so by construction never a PR-required check).
-  # BLOCKED, DIRTY, BEHIND and UNKNOWN remain fatal: merge conflicts, missing
-  # approvals or unmet branch protection still veto the prerelease.
-  if [[ "$merge_state" != "CLEAN" && "$merge_state" != "UNSTABLE" ]]; then
-    echo "Prerelease PR #${pr_number} is not merge-ready (mergeStateStatus=${merge_state})" >&2
+
+  # Audit every visible check, not only required checks, before interpreting
+  # mergeStateStatus. The tag-triggered Verified Release check is attached to
+  # the same commit as the PR head. GitHub may report that circular in-progress
+  # check as either UNSTABLE or BLOCKED; the latter was observed in production
+  # even though the PR was CLEAN immediately before the tag was pushed.
+  all_checks_json="$(gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" \
+    --json name,state,bucket,workflow || true)"
+  if ! jq -e 'type == "array" and length > 0' >/dev/null <<<"$all_checks_json"; then
+    echo "Prerelease PR #${pr_number} has no readable check result" >&2
     exit 1
   fi
+  non_self_failing="$(jq -r --arg self_workflow "Verified Release" \
+    '.[] | select(.workflow != $self_workflow) | select(.bucket != "pass") | "\(.workflow // "external") / \(.name): \(.state)"' \
+    <<<"$all_checks_json")"
+  self_is_pending_or_failed="$(jq -r --arg self_workflow "Verified Release" \
+    'any(.[]; .workflow == $self_workflow and .bucket != "pass")' <<<"$all_checks_json")"
+
+  case "$merge_state" in
+    CLEAN|UNSTABLE)
+      ;;
+    BLOCKED)
+      # Accept BLOCKED only when it is demonstrably the release workflow's own
+      # circular check: GitHub still considers the PR mergeable, no review is
+      # missing/rejected, every other visible check passed, and this workflow
+      # has a pending/failed check attached to the head. A genuinely blocked PR
+      # (conflict, required review, policy or any other check) remains fatal.
+      if [[ "$mergeable" != "MERGEABLE" \
+        || "$review_decision" == "REVIEW_REQUIRED" \
+        || "$review_decision" == "CHANGES_REQUESTED" \
+        || "$self_is_pending_or_failed" != "true" \
+        || -n "$non_self_failing" ]]; then
+        echo "Prerelease PR #${pr_number} is genuinely blocked (mergeable=${mergeable}, reviewDecision=${review_decision:-none})" >&2
+        if [[ -n "$non_self_failing" ]]; then
+          printf '%s\n' "$non_self_failing" >&2
+        fi
+        exit 1
+      fi
+      ;;
+    *)
+      echo "Prerelease PR #${pr_number} is not merge-ready (mergeStateStatus=${merge_state})" >&2
+      exit 1
+      ;;
+  esac
 
   checks_json="$(gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" \
     --required --json name,state,bucket,workflow || true)"

--- a/scripts/ci-verify-release-source.sh
+++ b/scripts/ci-verify-release-source.sh
@@ -124,7 +124,8 @@ elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
     '.[] | select(.workflow != $self_workflow) | select(.bucket != "pass") | "\(.workflow // "external") / \(.name): \(.state)"' \
     <<<"$all_checks_json")"
   self_is_pending_or_failed="$(jq -r --arg self_workflow "Verified Release" \
-    'any(.[]; .workflow == $self_workflow and .bucket != "pass")' <<<"$all_checks_json")"
+    'any(.[]; .workflow == $self_workflow and (.bucket == "pending" or .bucket == "fail"))' \
+    <<<"$all_checks_json")"
 
   case "$merge_state" in
     CLEAN|UNSTABLE)

--- a/scripts/ci-verify-release-source.sh
+++ b/scripts/ci-verify-release-source.sh
@@ -54,9 +54,6 @@ elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
   pr_state="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
     --json headRefOid,mergeStateStatus,mergeable,reviewDecision)"
   pr_head="$(jq -r '.headRefOid' <<<"$pr_state")"
-  merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_state")"
-  mergeable="$(jq -r '.mergeable' <<<"$pr_state")"
-  review_decision="$(jq -r '.reviewDecision // ""' <<<"$pr_state")"
   if [[ "$pr_head" != "$GITHUB_SHA" ]]; then
     echo "Prerelease PR #${pr_number} moved from tagged commit ${GITHUB_SHA} to ${pr_head}" >&2
     exit 1
@@ -67,10 +64,60 @@ elif [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
   # the same commit as the PR head. GitHub may report that circular in-progress
   # check as either UNSTABLE or BLOCKED; the latter was observed in production
   # even though the PR was CLEAN immediately before the tag was pushed.
-  all_checks_json="$(gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" \
-    --json name,state,bucket,workflow || true)"
-  if ! jq -e 'type == "array" and length > 0' >/dev/null <<<"$all_checks_json"; then
-    echo "Prerelease PR #${pr_number} has no readable check result" >&2
+  check_attempts="${RELEASE_CHECK_MAX_ATTEMPTS:-90}"
+  check_interval="${RELEASE_CHECK_POLL_INTERVAL_SECONDS:-10}"
+  if ! [[ "$check_attempts" =~ ^[1-9][0-9]*$ && "$check_interval" =~ ^[0-9]+$ ]]; then
+    echo "Invalid release-check polling configuration" >&2
+    exit 1
+  fi
+
+  # A tag push can temporarily attach fresh checks to the same commit as the
+  # already-green PR. Wait for those checks instead of racing them. Terminal
+  # failures still fail immediately, and the bounded wait preserves fail-closed
+  # behaviour when a check remains queued or in progress indefinitely.
+  for ((attempt = 1; attempt <= check_attempts; attempt++)); do
+    all_checks_json="$(gh pr checks "$pr_number" --repo "$GITHUB_REPOSITORY" \
+      --json name,state,bucket,workflow || true)"
+    if ! jq -e 'type == "array" and length > 0' >/dev/null <<<"$all_checks_json"; then
+      echo "Prerelease PR #${pr_number} has no readable check result" >&2
+      exit 1
+    fi
+
+    terminal_non_self="$(jq -r --arg self_workflow "Verified Release" \
+      '.[] | select(.workflow != $self_workflow) | select(.bucket != "pass" and .bucket != "pending") | "\(.workflow // "external") / \(.name): \(.state)"' \
+      <<<"$all_checks_json")"
+    if [[ -n "$terminal_non_self" ]]; then
+      echo "Prerelease PR #${pr_number} has non-passing checks:" >&2
+      printf '%s\n' "$terminal_non_self" >&2
+      exit 1
+    fi
+
+    pending_non_self="$(jq -r --arg self_workflow "Verified Release" \
+      '.[] | select(.workflow != $self_workflow and .bucket == "pending") | "\(.workflow // "external") / \(.name): \(.state)"' \
+      <<<"$all_checks_json")"
+    if [[ -z "$pending_non_self" ]]; then
+      break
+    fi
+    if ((attempt == check_attempts)); then
+      echo "Prerelease PR #${pr_number} still has pending checks after ${check_attempts} attempts:" >&2
+      printf '%s\n' "$pending_non_self" >&2
+      exit 1
+    fi
+    echo "Waiting for tag-triggered checks on prerelease PR #${pr_number} (${attempt}/${check_attempts}):" >&2
+    printf '%s\n' "$pending_non_self" >&2
+    sleep "$check_interval"
+  done
+
+  # Refresh mergeability after the bounded wait. The head must remain pinned to
+  # the tagged SHA throughout the policy decision.
+  pr_state="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" \
+    --json headRefOid,mergeStateStatus,mergeable,reviewDecision)"
+  pr_head="$(jq -r '.headRefOid' <<<"$pr_state")"
+  merge_state="$(jq -r '.mergeStateStatus' <<<"$pr_state")"
+  mergeable="$(jq -r '.mergeable' <<<"$pr_state")"
+  review_decision="$(jq -r '.reviewDecision // ""' <<<"$pr_state")"
+  if [[ "$pr_head" != "$GITHUB_SHA" ]]; then
+    echo "Prerelease PR #${pr_number} moved while tag-triggered checks were settling" >&2
     exit 1
   fi
   non_self_failing="$(jq -r --arg self_workflow "Verified Release" \

--- a/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
+++ b/storage/plugins/mobile-api/src/Controllers/ReviewsController.php
@@ -193,6 +193,10 @@ class ReviewsController
                 $stmt->bind_param('isii', $rating, $textOrNull, $existingId, $userId);
                 $stmt->execute();
                 $stmt->close();
+                // An approved review may just have become pending again. Keep
+                // the public web review block coherent with this plugin write
+                // path, which intentionally bypasses RecensioniRepository.
+                \App\Support\ContentCache::reviewsChanged();
                 $reviewId = $existingId;
                 $created = false;
             } else {
@@ -258,6 +262,10 @@ class ReviewsController
             if (!$removed) {
                 return ResponseEnvelope::error($response, 'not_found', __('Nessuna recensione da eliminare.'), 404);
             }
+
+            // The deleted row may have been approved and present in the public
+            // book-detail cache. This plugin write bypasses the core repository.
+            \App\Support\ContentCache::reviewsChanged();
 
             return ResponseEnvelope::success($response, null, [], 200);
         } catch (\Throwable $e) {

--- a/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
+++ b/storage/plugins/viaf-authority/ViafAuthorityPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Plugins\ViafAuthority;
 
+use App\Support\ContentCache;
 use App\Support\HookManager;
 use App\Support\RateLimiter;
 use App\Support\SecureLogger;
@@ -576,6 +577,9 @@ class ViafAuthorityPlugin
         if ($affected === 0 && !$this->authorExists($id)) {
             return $this->json($response, ['error' => true, 'message' => __('Autore non trovato.')], 404);
         }
+        if ($affected > 0) {
+            ContentCache::booksChanged();
+        }
 
         return $this->json($response, [
             'success'  => true,
@@ -666,6 +670,9 @@ class ViafAuthorityPlugin
         }
         if ($affected === 0 && !$this->authorExists($id)) {
             return $this->json($response, ['error' => true, 'message' => __('Autore non trovato.')], 404);
+        }
+        if ($affected > 0) {
+            ContentCache::booksChanged();
         }
 
         return $this->json($response, [

--- a/tests/catalog-subtitle-align-298.spec.js
+++ b/tests/catalog-subtitle-align-298.spec.js
@@ -13,6 +13,7 @@
 // Run: /tmp/run-e2e.sh tests/catalog-subtitle-align-298.spec.js --config=tests/playwright.config.js --workers=1
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const { flushCache } = require('./helpers/flush-cache');
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 const DB_USER = process.env.E2E_DB_USER || '';
@@ -57,15 +58,19 @@ const SEED = [
   { t: `${TAG} Foxtrot`, s: 'Another subtitle, second one' },
 ];
 
-test.beforeAll(() => {
+test.beforeAll(async () => {
   db(`DELETE FROM libri WHERE titolo LIKE ${sqlq(TAG + '%')}`);
   for (const b of SEED) {
     const sub = b.s === null ? 'NULL' : sqlq(b.s);
     db(`INSERT INTO libri (titolo, sottotitolo, stato) VALUES (${sqlq(b.t)}, ${sub}, 'disponibile')`);
   }
+  // Direct SQL seeding bypasses ContentCache — the bare /catalogo page 1 these
+  // tests pin their fixture to may be cached from an earlier spec in the run.
+  await flushCache();
 });
-test.afterAll(() => {
+test.afterAll(async () => {
   db(`DELETE FROM libri WHERE titolo LIKE ${sqlq(TAG + '%')}`);
+  await flushCache();
 });
 
 test('#298: subtitle space is reserved per row so cards stay aligned', async ({ page }) => {

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const { flushCache } = require('./helpers/flush-cache');
 const fs = require('fs');
 const path = require('path');
 
@@ -2994,6 +2995,9 @@ test.describe.serial('Phase 18: Issue Regressions', () => {
     // Directly set genere_id = root, sottogenere_id = child via DB
     // This mirrors what the controller normalization does
     dbQuery(`UPDATE libri SET genere_id=${rootId}, sottogenere_id=${childId} WHERE id=${bookId}`);
+    // Direct DB write bypasses ContentCache invalidation — flush the page
+    // cache or the (already visited) public detail page is served stale.
+    await flushCache();
 
     // 1) Admin book detail page
     await page.goto(`${BASE}/admin/books/${bookId}`);

--- a/tests/helpers/flush-cache.js
+++ b/tests/helpers/flush-cache.js
@@ -1,0 +1,54 @@
+// @ts-check
+/**
+ * E2E page-cache flush helper (follow-up to the PR #389 page cache).
+ *
+ * The app caches the public home page, the bounded (filter-less) catalog
+ * listing and the book-detail DTO/reviews (QueryCache namespaces home_/
+ * catalog_/book_detail_/book_reviews_), invalidated through ContentCache
+ * generation bumps on every APP write path. Specs that mutate the DB
+ * DIRECTLY (dbQuery/dbExec with INSERT/UPDATE/DELETE) bypass the app code,
+ * so nothing bumps the generations and a subsequent frontend assertion can
+ * read a stale cached page. Call `await flushCache()` AFTER such a direct
+ * write and BEFORE the frontend navigation/assertion — it replicates the
+ * invalidation a real edit performs.
+ *
+ * Server side: GET /_e2e/flush-cache (app/Routes/web.php) calls
+ * QueryCache::flush() inside the app process — required because with the
+ * APCu backend the cache lives in the web server's shared memory, which no
+ * CLI/Node process can reach. The route only exists when the app
+ * environment sets PINAKES_E2E_CACHE_FLUSH=1 (Apache `SetEnv`, next to the
+ * other PINAKES_E2E_* flags); otherwise it 404s and is inert in production.
+ *
+ * Mutations performed through the app UI/API invalidate themselves — do NOT
+ * add flush calls for those. Catalog pages with any search/genre/publisher/
+ * author filter are never cached, so assertions behind such filters do not
+ * need a flush either.
+ */
+const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
+
+let warned = false;
+
+/** Flush the app's page cache from inside the app process. */
+async function flushCache() {
+  try {
+    const res = await fetch(`${BASE}/_e2e/flush-cache`, { redirect: 'manual' });
+    if (!res.ok && !warned) {
+      warned = true;
+      // Non-fatal: without the flush the run behaves exactly like before this
+      // helper existed (assertion may hit a stale cached page). The warning
+      // turns that mystery into an actionable config hint.
+      console.warn(
+        `[flush-cache] GET /_e2e/flush-cache returned ${res.status} — ` +
+        'set "SetEnv PINAKES_E2E_CACHE_FLUSH 1" in the E2E Apache vhost so ' +
+        'direct-DB test writes can invalidate the page cache.'
+      );
+    }
+  } catch (err) {
+    if (!warned) {
+      warned = true;
+      console.warn(`[flush-cache] request failed: ${err && err.message}`);
+    }
+  }
+}
+
+module.exports = { flushCache };

--- a/tests/helpers/flush-cache.js
+++ b/tests/helpers/flush-cache.js
@@ -26,27 +26,46 @@
  */
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 
+// GitHub Actions (and most CI) set CI=true. In CI a flush that never happened
+// silently corrupts every subsequent assertion after a direct-DB write, so it
+// must FAIL the run loudly. Locally the endpoint may legitimately be absent
+// (no PINAKES_E2E_CACHE_FLUSH / no APCu): keep the tolerant one-shot warning so
+// a dev without the flag configured still gets a usable run plus a hint.
+const IS_CI = !!process.env.CI;
+
 let warned = false;
 
 /** Flush the app's page cache from inside the app process. */
 async function flushCache() {
+  let res;
   try {
-    const res = await fetch(`${BASE}/_e2e/flush-cache`, { redirect: 'manual' });
-    if (!res.ok && !warned) {
-      warned = true;
-      // Non-fatal: without the flush the run behaves exactly like before this
-      // helper existed (assertion may hit a stale cached page). The warning
-      // turns that mystery into an actionable config hint.
-      console.warn(
-        `[flush-cache] GET /_e2e/flush-cache returned ${res.status} — ` +
-        'set "SetEnv PINAKES_E2E_CACHE_FLUSH 1" in the E2E Apache vhost so ' +
-        'direct-DB test writes can invalidate the page cache.'
-      );
-    }
+    res = await fetch(`${BASE}/_e2e/flush-cache`, { redirect: 'manual' });
   } catch (err) {
+    const msg = `[flush-cache] request to ${BASE}/_e2e/flush-cache failed: ${err && err.message}`;
+    if (IS_CI) {
+      throw new Error(msg);
+    }
     if (!warned) {
       warned = true;
-      console.warn(`[flush-cache] request failed: ${err && err.message}`);
+      console.warn(msg);
+    }
+    return;
+  }
+
+  if (!res.ok) {
+    // The route returns 404 when PINAKES_E2E_CACHE_FLUSH is unset and 500 when
+    // QueryCache::flush() reported a real delete failure — both mean the page
+    // cache was NOT reliably cleared and a stale read is possible.
+    const msg =
+      `[flush-cache] GET /_e2e/flush-cache returned ${res.status} — ` +
+      'ensure "SetEnv PINAKES_E2E_CACHE_FLUSH 1" is set in the E2E Apache ' +
+      'vhost so direct-DB test writes can invalidate the page cache.';
+    if (IS_CI) {
+      throw new Error(msg);
+    }
+    if (!warned) {
+      warned = true;
+      console.warn(msg);
     }
   }
 }

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -1,0 +1,284 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural contract for issue #387 step 4 (hot public dataset caching):
+ *
+ *  A. Book-detail STATIC/LIVE split — the static DTO (book row, authors,
+ *     publishers, series, related) is cached under 'book_detail_' while
+ *     availability (copie_disponibili/copie_totali/stato) is re-read from the
+ *     database on EVERY request:
+ *       - mutate copie_disponibili+stato+titolo directly in the DB (no
+ *         invalidation) → the served page shows the NEW availability but the
+ *         OLD title (metadata came from cache, availability did not);
+ *       - ContentCache::booksChanged() → the page shows the new title.
+ *  B. Reviews block — cached under 'book_reviews_':
+ *       - a review force-approved via raw SQL (bypassing moderation) does NOT
+ *         appear while the cache is warm (proves the block is cached);
+ *       - the real moderation path (RecensioniRepository::approveReview /
+ *         deleteReview) invalidates immediately.
+ *  C. Bounded catalog page rows — cached under 'catalog_' ('catalog_page_*'):
+ *       - the default catalog listing serves cached rows (old title) while the
+ *         per-card availability badge is merged live (status flips without any
+ *         invalidation);
+ *       - booksChanged() invalidates the rows.
+ *  D. Namespace mechanics — 'book_detail_' and 'book_reviews_' are
+ *     generation-tracked; booksChanged() bumps book_detail_ but not
+ *     book_reviews_; reviewsChanged() bumps only book_reviews_.
+ *
+ * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
+ * show the NEW title in step A (assertion "old title still served" fails), and
+ * the force-approved review in step B would appear immediately.
+ *
+ * Seeds run inside a transaction that is always rolled back; every cache
+ * namespace touched is generation-bumped in the finally block so no cached
+ * uncommitted row can leak into the shared dev cache.
+ *
+ * Run: php tests/hot-dataset-cache-387.unit.php
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Controllers\FrontendController;
+use App\Repositories\RecensioniRepository;
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response;
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $condition, string $label) use (&$passed, &$failed): void {
+    if ($condition) {
+        $passed++;
+        echo "  OK  {$label}\n";
+    } else {
+        $failed++;
+        echo "  FAIL {$label}\n";
+    }
+};
+
+// ── DB connection: E2E_* env first, .env fallback ───────────────────────────
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || $line[0] === '#' || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $value = trim($value);
+    if (strlen($value) >= 2 && ($value[0] === '"' || $value[0] === "'") && $value[-1] === $value[0]) {
+        $value = substr($value, 1, -1);
+    }
+    $env[trim($key)] = $value;
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '/opt/homebrew/var/mysql/mysql.sock');
+$dbName = getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? '');
+$dbUser = getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? '');
+$dbPass = getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? ''));
+
+try {
+    $db = is_string($socket) && $socket !== '' && file_exists($socket)
+        ? new mysqli(null, $dbUser, $dbPass, $dbName, 0, $socket)
+        : new mysqli($env['DB_HOST'] ?? '127.0.0.1', $dbUser, $dbPass, $dbName, (int) ($env['DB_PORT'] ?? 3306));
+    $db->set_charset('utf8mb4');
+} catch (\Throwable $e) {
+    echo "SKIP: database not reachable (" . $e->getMessage() . ")\n";
+    exit(0);
+}
+
+$_SESSION = $_SESSION ?? [];
+
+$controller = new FrontendController();
+$requestFactory = new ServerRequestFactory();
+
+/**
+ * Invoke bookDetail for the given id starting from an arbitrary path,
+ * following canonical 301 redirects (max 3). Returns [status, body, path].
+ */
+$renderBookPage = static function (int $bookId, string $path = '/__cache387__') use ($controller, $requestFactory, $db): array {
+    for ($hop = 0; $hop < 4; $hop++) {
+        $request = $requestFactory->createServerRequest('GET', $path)->withQueryParams(['id' => $bookId]);
+        $response = $controller->bookDetail($request, new Response(), $db);
+        $status = $response->getStatusCode();
+        if ($status !== 301) {
+            return [$status, (string) $response->getBody(), $path];
+        }
+        $location = $response->getHeaderLine('Location');
+        $path = (string) (parse_url($location, PHP_URL_PATH) ?: $location);
+    }
+    return [301, '', $path];
+};
+
+$callCatalog = static function (array $params) use ($controller, $requestFactory, $db): array {
+    $request = $requestFactory->createServerRequest('GET', '/api/catalogo')->withQueryParams($params);
+    $response = $controller->catalogAPI($request, new Response(), $db);
+    $decoded = json_decode((string) $response->getBody(), true);
+    return is_array($decoded) ? $decoded : [];
+};
+
+/** The status-badge marker inside the card whose <img alt> carries $title. */
+$badgeNearTitle = static function (string $html, string $title): string {
+    $needle = 'alt="' . htmlspecialchars($title, ENT_QUOTES, 'UTF-8') . '"';
+    $pos = strpos($html, $needle);
+    if ($pos === false) {
+        return '';
+    }
+    $window = substr($html, $pos, 600);
+    if (preg_match('/book-status-badge (status-[a-z]+)/', $window, $m)) {
+        return $m[1];
+    }
+    return '';
+};
+
+$token = bin2hex(random_bytes(5));
+$titleV1 = "ZZ Cache387 Original {$token}";
+$titleV2 = "ZZ Cache387 Renamed {$token}";
+$reviewTitle = "ZZ Review387 {$token}";
+
+$db->begin_transaction();
+
+try {
+    // ── Seed: one book (2/2 available) + one user ───────────────────────────
+    $stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, 2, 2, 'disponibile')");
+    $stmt->bind_param('s', $titleV1);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+
+    $card = 'C387' . substr($token, 0, 8);
+    $email = "cache387.{$token}@example.test";
+    $stmt = $db->prepare("INSERT INTO utenti (codice_tessera, nome, cognome, email, password, privacy_accettata) VALUES (?, 'Cache', 'Tester', ?, 'x', 1)");
+    $stmt->bind_param('ss', $card, $email);
+    $stmt->execute();
+    $userId = (int) $db->insert_id;
+    $stmt->close();
+
+    // Start from clean generations so stale dev-cache entries cannot interfere.
+    ContentCache::booksChanged();
+    ContentCache::reviewsChanged();
+
+    echo "A. Book-detail static/live split:\n";
+
+    [$status1, $body1] = $renderBookPage($bookId);
+    $check($status1 === 200, "first render returns 200 (got {$status1})");
+    $check(str_contains($body1, $titleV1), 'first render shows the seeded title');
+    $check(str_contains($body1, 'availability-badge available'), 'first render shows the book as available (2/2)');
+
+    // Mutate availability AND metadata directly — deliberately WITHOUT any
+    // cache invalidation. Availability must change on the next render (live
+    // read), metadata must NOT (cached DTO reused, no re-query).
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 0, stato = 'prestato' WHERE id = ?");
+    $stmt->bind_param('si', $titleV2, $bookId);
+    $stmt->execute();
+    $stmt->close();
+
+    [$status2, $body2] = $renderBookPage($bookId);
+    $check($status2 === 200, "second render returns 200 (got {$status2})");
+    $check(str_contains($body2, 'availability-badge unavailable'), 'availability flips to unavailable WITHOUT invalidation (read live every request)');
+    $check(str_contains($body2, $titleV1), 'cached static metadata still served (old title — DTO not re-queried)');
+    $check(!str_contains($body2, $titleV2), 'new title NOT visible while the DTO cache is warm');
+
+    // booksChanged() (the bump every book write path fires) must rebuild the DTO.
+    ContentCache::booksChanged();
+    [$status3, $body3] = $renderBookPage($bookId);
+    $check($status3 === 200, "post-invalidation render returns 200 (got {$status3})");
+    $check(str_contains($body3, $titleV2), 'booksChanged() invalidates the DTO (new title now served)');
+    $check(str_contains($body3, 'availability-badge unavailable'), 'availability still correct after invalidation');
+
+    echo "\nB. Reviews block cache + moderation invalidation:\n";
+
+    $stmt = $db->prepare("INSERT INTO recensioni (libro_id, utente_id, stelle, titolo, descrizione, stato) VALUES (?, ?, 5, ?, 'body', 'pendente')");
+    $stmt->bind_param('iis', $bookId, $userId, $reviewTitle);
+    $stmt->execute();
+    $reviewId = (int) $db->insert_id;
+    $stmt->close();
+
+    [, $bodyR1] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR1, $reviewTitle), 'pending review is not publicly visible (reviews block cached empty)');
+
+    // Force-approve via raw SQL (bypassing moderation): the cached block must
+    // keep serving the old state — this is the assertion that fails when the
+    // reviews block is not cached at all (pre-change behaviour).
+    $db->query("UPDATE recensioni SET stato = 'approvata' WHERE id = {$reviewId}");
+    [, $bodyR2] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR2, $reviewTitle), 'raw-SQL approval does not appear while the reviews cache is warm (block IS cached)');
+
+    // The real moderation path must invalidate immediately.
+    $db->query("UPDATE recensioni SET stato = 'pendente' WHERE id = {$reviewId}");
+    $repo = new RecensioniRepository($db);
+    $check($repo->approveReview($reviewId, $userId), 'approveReview() succeeds');
+    [, $bodyR3] = $renderBookPage($bookId);
+    $check(str_contains($bodyR3, $reviewTitle), 'approved review visible immediately (approve bumps book_reviews_)');
+
+    $check($repo->deleteReview($reviewId), 'deleteReview() succeeds');
+    [, $bodyR4] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR4, $reviewTitle), 'deleted review disappears immediately (delete bumps book_reviews_)');
+
+    echo "\nC. Bounded catalog page rows (static rows cached, availability live):\n";
+
+    // Reset the book to a stable, available state and clear the catalog cache.
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 2, stato = 'disponibile' WHERE id = ?");
+    $stmt->bind_param('si', $titleV1, $bookId);
+    $stmt->execute();
+    $stmt->close();
+    ContentCache::booksChanged();
+
+    // Default catalog state (no filters) is bounded → page 1 rows get cached.
+    // The seeded book is the newest row, so it is on page 1 of sort=newest.
+    $cat1 = $callCatalog(['page' => '1']);
+    $html1 = (string) ($cat1['html'] ?? '');
+    $check(str_contains($html1, $titleV1), 'seeded book appears on the default catalog first page');
+    $check($badgeNearTitle($html1, $titleV1) === 'status-available', 'catalog card badge shows available (2 copies)');
+
+    // Mutate availability + title with NO invalidation: cached rows must keep
+    // the old title, the badge must flip (merged live).
+    $stmt = $db->prepare("UPDATE libri SET titolo = ?, copie_disponibili = 0, stato = 'prestato' WHERE id = ?");
+    $stmt->bind_param('si', $titleV2, $bookId);
+    $stmt->execute();
+    $stmt->close();
+
+    $cat2 = $callCatalog(['page' => '1']);
+    $html2 = (string) ($cat2['html'] ?? '');
+    $check(str_contains($html2, $titleV1), 'catalog rows still served from cache (old title)');
+    $check(!str_contains($html2, $titleV2), 'new title NOT visible in the cached catalog rows');
+    $check($badgeNearTitle($html2, $titleV1) === 'status-borrowed', 'catalog card badge flips to borrowed WITHOUT invalidation (availability merged live)');
+
+    ContentCache::booksChanged();
+    $cat3 = $callCatalog(['page' => '1']);
+    $html3 = (string) ($cat3['html'] ?? '');
+    $check(str_contains($html3, $titleV2), 'booksChanged() invalidates the catalog page rows (new title served)');
+
+    echo "\nD. Namespace mechanics:\n";
+
+    $nsRun = 'ns387_' . $token;
+    QueryCache::set('book_detail_' . $nsRun, 'dto', 120);
+    QueryCache::set('book_reviews_' . $nsRun, 'reviews', 120);
+    QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
+    ContentCache::booksChanged();
+    $check(QueryCache::get('book_detail_' . $nsRun) === null, 'booksChanged bumps book_detail_');
+    $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'booksChanged bumps catalog_page_* (catalog_ namespace)');
+    $check(QueryCache::get('book_reviews_' . $nsRun) === 'reviews', 'booksChanged leaves book_reviews_ alone');
+    ContentCache::reviewsChanged();
+    $check(QueryCache::get('book_reviews_' . $nsRun) === null, 'reviewsChanged bumps book_reviews_');
+} catch (\Throwable $e) {
+    $failed++;
+    echo "FAIL  unexpected exception: {$e->getMessage()} @ {$e->getFile()}:{$e->getLine()}\n";
+} finally {
+    // Roll back every seeded row and make any cache entry built from the
+    // uncommitted rows unreachable (the dev site shares storage/cache).
+    try {
+        $db->rollback();
+    } catch (\Throwable $e) {
+        // connection already gone — nothing to roll back
+    }
+    ContentCache::booksChanged();
+    ContentCache::reviewsChanged();
+}
+
+echo "\n{$passed} passed, {$failed} failed\n";
+exit($failed === 0 ? 0 : 1);

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -211,7 +211,11 @@ try {
     [, $bodyR2] = $renderBookPage($bookId);
     $check(!str_contains($bodyR2, $reviewTitle), 'raw-SQL approval does not appear while the reviews cache is warm (block IS cached)');
 
-    // The real moderation path must invalidate immediately.
+    // The real moderation path DEFERS invalidation to request shutdown, so a
+    // concurrent public read during the caller's open transaction cannot
+    // populate the new generation with pre-commit rows. Within this single
+    // process the shutdown hook has not fired yet, so the cached block is still
+    // the old one; a manual reviewsChanged() stands in for the shutdown.
     $db->query("UPDATE recensioni SET stato = 'pendente' WHERE id = {$reviewId}");
     $repo = new RecensioniRepository($db);
     $check($repo->approveReview($reviewId, $userId), 'approveReview() succeeds');
@@ -220,12 +224,16 @@ try {
         isset($approvedRows[0]) && !array_key_exists('utente_email', $approvedRows[0]),
         'public review DTO does not cache reviewer email'
     );
+    [, $bodyR3a] = $renderBookPage($bookId);
+    $check(!str_contains($bodyR3a, $reviewTitle), 'approval is NOT applied mid-transaction (invalidation deferred to shutdown)');
+    ContentCache::reviewsChanged(); // simulate the request-shutdown deferred flush
     [, $bodyR3] = $renderBookPage($bookId);
-    $check(str_contains($bodyR3, $reviewTitle), 'approved review visible immediately (approve bumps book_reviews_)');
+    $check(str_contains($bodyR3, $reviewTitle), 'approved review visible after the deferred invalidation fires');
 
     $check($repo->deleteReview($reviewId), 'deleteReview() succeeds');
+    ContentCache::reviewsChanged(); // deferred → simulate shutdown flush
     [, $bodyR4] = $renderBookPage($bookId);
-    $check(!str_contains($bodyR4, $reviewTitle), 'deleted review disappears immediately (delete bumps book_reviews_)');
+    $check(!str_contains($bodyR4, $reviewTitle), 'deleted review disappears after the deferred invalidation fires');
 
     echo "\nC. Bounded catalog page rows (static rows cached, availability live):\n";
 
@@ -300,8 +308,8 @@ try {
     $check(
         str_contains($usersController, "original['nome']")
             && str_contains($usersController, "original['cognome']")
-            && str_contains($usersController, 'ContentCache::reviewsChanged()'),
-        'admin reviewer-name edits invalidate cached public review DTOs'
+            && str_contains($usersController, 'ContentCache::deferReviewsChanged()'),
+        'admin reviewer-name edits invalidate cached public review DTOs (deferred to shutdown)'
     );
 } catch (\Throwable $e) {
     $failed++;

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -24,7 +24,8 @@ declare(strict_types=1);
  *       - booksChanged() invalidates the rows.
  *  D. Namespace mechanics — 'book_detail_' and 'book_reviews_' are
  *     generation-tracked; booksChanged() bumps book_detail_ but not
- *     book_reviews_; reviewsChanged() bumps only book_reviews_.
+ *     book_reviews_; availabilityChanged() leaves book_detail_ intact;
+ *     reviewsChanged() bumps only book_reviews_.
  *
  * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
  * show the NEW title in step A (assertion "old title still served" fails), and
@@ -212,6 +213,11 @@ try {
     $db->query("UPDATE recensioni SET stato = 'pendente' WHERE id = {$reviewId}");
     $repo = new RecensioniRepository($db);
     $check($repo->approveReview($reviewId, $userId), 'approveReview() succeeds');
+    $approvedRows = $repo->getApprovedReviewsForBook($bookId);
+    $check(
+        isset($approvedRows[0]) && !array_key_exists('utente_email', $approvedRows[0]),
+        'public review DTO does not cache reviewer email'
+    );
     [, $bodyR3] = $renderBookPage($bookId);
     $check(str_contains($bodyR3, $reviewTitle), 'approved review visible immediately (approve bumps book_reviews_)');
 
@@ -259,12 +265,24 @@ try {
     QueryCache::set('book_detail_' . $nsRun, 'dto', 120);
     QueryCache::set('book_reviews_' . $nsRun, 'reviews', 120);
     QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
+    ContentCache::availabilityChanged();
+    $check(QueryCache::get('book_detail_' . $nsRun) === 'dto', 'availabilityChanged leaves static book_detail_ DTOs warm');
+    $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'availabilityChanged bumps catalog_page_* membership');
+    QueryCache::set('catalog_page_' . $nsRun, 'rows', 120);
     ContentCache::booksChanged();
     $check(QueryCache::get('book_detail_' . $nsRun) === null, 'booksChanged bumps book_detail_');
     $check(QueryCache::get('catalog_page_' . $nsRun) === null, 'booksChanged bumps catalog_page_* (catalog_ namespace)');
     $check(QueryCache::get('book_reviews_' . $nsRun) === 'reviews', 'booksChanged leaves book_reviews_ alone');
     ContentCache::reviewsChanged();
     $check(QueryCache::get('book_reviews_' . $nsRun) === null, 'reviewsChanged bumps book_reviews_');
+
+    $mobileReviews = (string) file_get_contents(
+        $root . '/storage/plugins/mobile-api/src/Controllers/ReviewsController.php'
+    );
+    $check(
+        substr_count($mobileReviews, 'ContentCache::reviewsChanged()') >= 2,
+        'mobile review edit/delete paths invalidate the public reviews block'
+    );
 } catch (\Throwable $e) {
     $failed++;
     echo "FAIL  unexpected exception: {$e->getMessage()} @ {$e->getFile()}:{$e->getLine()}\n";

--- a/tests/hot-dataset-cache-387.unit.php
+++ b/tests/hot-dataset-cache-387.unit.php
@@ -26,6 +26,8 @@ declare(strict_types=1);
  *     generation-tracked; booksChanged() bumps book_detail_ but not
  *     book_reviews_; availabilityChanged() leaves book_detail_ intact;
  *     reviewsChanged() bumps only book_reviews_.
+ *  E. Indirect write paths — authority updates invalidate book DTOs and
+ *     admin edits of reviewer names invalidate rendered review DTOs.
  *
  * FAILS BY DESIGN on pre-change code: without the DTO cache the page would
  * show the NEW title in step A (assertion "old title still served" fails), and
@@ -282,6 +284,24 @@ try {
     $check(
         substr_count($mobileReviews, 'ContentCache::reviewsChanged()') >= 2,
         'mobile review edit/delete paths invalidate the public reviews block'
+    );
+
+    echo "\nE. Indirect write-path invalidation:\n";
+
+    $authorityPlugin = (string) file_get_contents(
+        $root . '/storage/plugins/viaf-authority/ViafAuthorityPlugin.php'
+    );
+    $check(
+        substr_count($authorityPlugin, 'ContentCache::booksChanged()') >= 2,
+        'VIAF and ISNI author updates invalidate cached book-detail DTOs'
+    );
+
+    $usersController = (string) file_get_contents($root . '/app/Controllers/UsersController.php');
+    $check(
+        str_contains($usersController, "original['nome']")
+            && str_contains($usersController, "original['cognome']")
+            && str_contains($usersController, 'ContentCache::reviewsChanged()'),
+        'admin reviewer-name edits invalidate cached public review DTOs'
     );
 } catch (\Throwable $e) {
     $failed++;

--- a/tests/issue-75-issn-series-volumes.spec.js
+++ b/tests/issue-75-issn-series-volumes.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const { flushCache } = require('./helpers/flush-cache');
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
@@ -85,6 +86,12 @@ test.describe.serial('Issue #75: ISSN, Series & Multi-Volume', () => {
       dbExec(`INSERT INTO volumi (opera_id, volume_id, numero_volume, titolo_volume)
               VALUES (${parentWorkId}, ${vid}, ${i}, 'Part ${i}')`);
     }
+
+    // The books/series above are seeded via direct SQL, which bypasses the app
+    // and thus never invalidates the page cache (#387). A book-detail or bare
+    // /catalogo entry primed by an earlier spec in this shard would otherwise be
+    // served stale, hiding the freshly-seeded ISSN / sibling volumes.
+    await flushCache();
   });
 
   test.afterAll(async () => {

--- a/tests/issue-81-audio-player.spec.js
+++ b/tests/issue-81-audio-player.spec.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const { flushCache } = require('./helpers/flush-cache');
 
 const BASE = process.env.E2E_BASE_URL || 'http://localhost:8081';
 const ADMIN_EMAIL = process.env.E2E_ADMIN_EMAIL || '';
@@ -76,6 +77,9 @@ test.describe.serial('Issue #81: Audiobook MP3 Player', () => {
     }
     if (testBookId) {
       dbQuery(`UPDATE libri SET audio_url='${FAKE_AUDIO_URL}' WHERE id=${testBookId}`);
+      // Direct DB write bypasses ContentCache — this pre-existing book's
+      // public detail page may already be cached without audio_url.
+      await flushCache();
     }
   });
 
@@ -86,6 +90,8 @@ test.describe.serial('Issue #81: Audiobook MP3 Player', () => {
         ? 'NULL'
         : `'${String(originalAudioUrl).replace(/'/g, "''")}'`;
       dbQuery(`UPDATE libri SET audio_url=${restored} WHERE id=${testBookId}`);
+      // Don't leave the fake audio_url cached for later specs.
+      await flushCache();
     }
     await context?.close();
   });

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -123,6 +123,22 @@ $check(
     str_contains($availabilityBody, 'return 0;') && str_contains($availabilityBody, '$available_books = 0;'),
     'available-book DB failures return a cacheable zero instead of repeated null misses'
 );
+$check(
+    str_contains($frontend, 'private function fetchLiveAvailability(mysqli $db, array $ids): ?array')
+        && str_contains($frontend, 'catch (\\Throwable $e)')
+        && str_contains($frontend, 'if ($live === null)')
+        && str_contains($frontend, 'return $rows;'),
+    'live-availability failures are distinguished from empty results and preserve cached catalog rows'
+);
+
+$fetchLiveAvailability = $reflection->getMethod('fetchLiveAvailability');
+$mergeLiveAvailability = $reflection->getMethod('mergeLiveAvailability');
+$unavailableDb = new mysqli();
+$failedLiveRead = $fetchLiveAvailability->invoke($controller, $unavailableDb, [42]);
+$cachedCatalogRows = [['id' => 42, 'titolo' => 'Cached title']];
+$preservedRows = $mergeLiveAvailability->invoke($controller, $unavailableDb, $cachedCatalogRows);
+$check($failedLiveRead === null, 'live-availability query exceptions return an explicit failure result');
+$check($preservedRows === $cachedCatalogRows, 'catalog rows survive a live-availability database outage');
 
 echo "\nBehavioural cache contracts:\n";
 $runKey = 'pr323_' . bin2hex(random_bytes(6));

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -46,8 +46,12 @@ $checkCacheNamespace = static function (
         $keys !== [] && count(array_filter($keys, static fn(string $key): bool => str_starts_with($key, $namespace))) === count($keys),
         "{$label} keys use the {$namespace} namespace"
     );
+    // Either invalidation form targets the namespace: the legacy prefix scan
+    // or the O(1) generation bump (issue #387) — both make every prior entry
+    // in the namespace unservable.
     $check(
-        str_contains($invalidator, "QueryCache::clearByPrefix('{$namespace}')"),
+        str_contains($invalidator, "QueryCache::clearByPrefix('{$namespace}')")
+            || str_contains($invalidator, "QueryCache::bumpGeneration('{$namespace}')"),
         "{$label} invalidator clears the {$namespace} namespace"
     );
 };

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -178,6 +178,23 @@ foreach (array_keys($cacheKeys) as $key) {
 \App\Support\QueryCache::delete($boundedKey);
 \App\Support\QueryCache::delete('catalog_' . $runKey . '_unbounded');
 \App\Support\QueryCache::delete('i18n_languages');
+
+// Generation bumps make old entries unreachable, so delete() can only remove
+// the current generation. Reclaim every fixture from this run explicitly in
+// both possible stores without flushing unrelated application/test entries.
+if (\App\Support\QueryCache::stats()['backend'] === 'apcu' && class_exists('APCUIterator')) {
+    $runPattern = '/^pinakes_.*' . preg_quote($runKey, '/') . '/';
+    foreach (new APCUIterator($runPattern) as $entry) {
+        apcu_delete($entry['key']);
+    }
+}
+$leftovers = glob(__DIR__ . '/../storage/cache/pinakes_*' . $runKey . '*');
+if ($leftovers !== false) {
+    foreach ($leftovers as $leftover) {
+        @unlink($leftover);
+    }
+}
+
 $i18nReflection->getProperty('languagesCache')->setValue(null, null);
 $i18nReflection->getProperty('languagesLoadedFromDb')->setValue(null, false);
 

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -60,6 +60,18 @@ echo "Catalogue cache cardinality:\n";
 $controller = new \App\Controllers\FrontendController();
 $reflection = new ReflectionClass($controller);
 $bounded = $reflection->getMethod('hasBoundedCatalogCacheKey');
+$stripShared = $reflection->getMethod('stripSharedCacheFields');
+$stripped = $stripShared->invoke($controller, [
+    'titolo' => 'Visible',
+    'copie_disponibili' => 1,
+    'search_index' => str_repeat('large-index ', 100),
+    'private_comment' => 'secret',
+    'lending_patron' => 'Patron Name',
+]);
+$check(
+    $stripped === ['titolo' => 'Visible'],
+    'shared public cache excludes live, search-only and privacy-sensitive book columns'
+);
 $base = [
     'search' => '',
     'genere_id' => 0,
@@ -89,6 +101,19 @@ foreach ([
 }
 $frontend = $read('app/Controllers/FrontendController.php');
 $check(!str_contains($frontend, 'QueryCache::remember($cacheKeyGeneri'), 'genre query has no second unbounded per-filter cache');
+$catalogStart = strpos($frontend, 'public function catalog(');
+$catalogApiStart = strpos($frontend, 'public function catalogAPI(');
+$catalogApiEnd = strpos($frontend, 'public function bookDetail(', $catalogApiStart ?: 0);
+$catalogQueries = $catalogStart !== false && $catalogApiStart !== false && $catalogApiEnd !== false
+    ? substr($frontend, $catalogStart, $catalogApiEnd - $catalogStart)
+    : '';
+$check(
+    substr_count($catalogQueries, '$count_query = "SELECT COUNT(*) as total " . $base_query;') === 2
+        && !str_contains($catalogQueries, 'SELECT DISTINCT l.*,')
+        && !str_contains($catalogQueries, 'LEFT JOIN generi gpp')
+        && !str_contains($catalogQueries, 'LEFT JOIN generi sg'),
+    'catalog queries avoid redundant DISTINCT and unused taxonomy joins'
+);
 $availabilityStart = strpos($frontend, '$availabilityLoader = function');
 $availabilityEnd = strpos($frontend, '$available_books = $this->rememberCatalogValue', $availabilityStart ?: 0);
 $availabilityBody = $availabilityStart !== false && $availabilityEnd !== false
@@ -235,6 +260,7 @@ foreach ([
     'app/Models/PublisherRepository.php',
     'app/Models/GenereRepository.php',
     'app/Services/BulkEnrichmentService.php',
+    'app/Controllers/AutoriApiController.php',
     'app/Controllers/LibriApiController.php',
     'app/Controllers/CsvImportController.php',
     'app/Controllers/LibraryThingImportController.php',

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -214,10 +214,10 @@ $contentCache = $read('app/Support/ContentCache.php');
 $checkCacheNamespace($frontend, 'home_api_count_', 'home_', $contentCache, 'home API counts');
 $check(str_contains($contentCache, 'function deferBooksChanged'), 'transaction-owned writers can defer invalidation');
 $integrity = $read('app/Support/DataIntegrity.php');
-$check(str_contains($integrity, 'ContentCache::deferBooksChanged()'), 'DataIntegrity defers invalidation for outer transactions');
+$check(str_contains($integrity, 'ContentCache::deferAvailabilityChanged()'), 'DataIntegrity defers availability invalidation for outer transactions');
 $check(
-    substr_count($integrity, 'ContentCache::booksChanged()') >= 2,
-    'single and global standalone recalculations invalidate after their commits'
+    substr_count($integrity, 'ContentCache::availabilityChanged()') >= 2,
+    'single and global standalone recalculations invalidate availability after their commits'
 );
 $settingsRepository = $read('app/Models/SettingsRepository.php');
 $check(

--- a/tests/pr132-fix-regressions.spec.js
+++ b/tests/pr132-fix-regressions.spec.js
@@ -24,6 +24,7 @@
 
 const { test, expect } = require('@playwright/test');
 const { execFileSync } = require('child_process');
+const { flushCache } = require('./helpers/flush-cache');
 
 // ─── Environment ──────────────────────────────────────────────────────────────
 
@@ -566,6 +567,9 @@ test.describe('F048 — book-detail.php author ruolo is HTML-escaped', () => {
         dbExec(
             `UPDATE libri_autori SET ruolo='traduttore' WHERE libro_id=${bookId} AND autore_id=${authorId}`
         );
+        // The author list (with ruolo) is part of the cached book-detail DTO,
+        // already populated by F048-1 — a direct DB write must flush it.
+        await flushCache();
         await page.goto(`${BASE}/libro/${bookId}`);
         const content = await page.content();
         // "Traduttore" (ucfirst'd) should appear as plain text.

--- a/tests/querycache-apcu-backend.unit.php
+++ b/tests/querycache-apcu-backend.unit.php
@@ -177,6 +177,15 @@ try {
             @unlink($file);
         }
     }
+
+    // delete() only targets the current generation. Remove older-generation
+    // fixtures too, so a native APCu run does not leak entries until TTL.
+    if (class_exists('APCUIterator')) {
+        $iterator = new APCUIterator('/^pinakes_.*' . preg_quote($run, '/') . '/');
+        foreach ($iterator as $entry) {
+            apcu_delete($entry['key']);
+        }
+    }
 }
 
 echo "\n{$pass} checks passed\n";

--- a/tests/querycache-apcu-backend.unit.php
+++ b/tests/querycache-apcu-backend.unit.php
@@ -1,0 +1,183 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * APCu-path contract for QueryCache.
+ *
+ * When the extension is absent (the common CI image), a small in-process APCu
+ * double exercises the same public function contract. When APCu is installed
+ * but disabled for CLI, the test re-executes itself with apc.enable_cli=1.
+ */
+
+if (function_exists('apcu_fetch') && !apcu_enabled() && getenv('QC_APCU_CHILD') !== '1') {
+    $command = escapeshellarg(PHP_BINARY)
+        . ' -d apc.enable_cli=1 '
+        . escapeshellarg(__FILE__);
+    putenv('QC_APCU_CHILD=1');
+    passthru($command, $exitCode);
+    exit($exitCode);
+}
+
+if (!function_exists('apcu_fetch')) {
+    /** @var array<string, array{value: mixed, expires: int}> */
+    $GLOBALS['querycache_apcu_stub'] = [];
+
+    function apcu_enabled(): bool
+    {
+        return true;
+    }
+
+    function apcu_fetch(string $key, ?bool &$success = null): mixed
+    {
+        $entry = $GLOBALS['querycache_apcu_stub'][$key] ?? null;
+        if (!is_array($entry) || ($entry['expires'] !== 0 && $entry['expires'] < time())) {
+            unset($GLOBALS['querycache_apcu_stub'][$key]);
+            $success = false;
+            return false;
+        }
+
+        $success = true;
+        return $entry['value'];
+    }
+
+    function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+    {
+        $GLOBALS['querycache_apcu_stub'][$key] = [
+            'value' => $value,
+            'expires' => $ttl > 0 ? time() + $ttl : 0,
+        ];
+        return true;
+    }
+
+    function apcu_add(string $key, mixed $value, int $ttl = 0): bool
+    {
+        $success = false;
+        apcu_fetch($key, $success);
+        if ($success) {
+            return false;
+        }
+
+        return apcu_store($key, $value, $ttl);
+    }
+
+    function apcu_delete(string $key): bool
+    {
+        $exists = array_key_exists($key, $GLOBALS['querycache_apcu_stub']);
+        unset($GLOBALS['querycache_apcu_stub'][$key]);
+        return $exists;
+    }
+
+    function apcu_exists(string $key): bool
+    {
+        $success = false;
+        apcu_fetch($key, $success);
+        return $success;
+    }
+
+    function apcu_cas(string $key, int $old, int $new): bool
+    {
+        $success = false;
+        $current = apcu_fetch($key, $success);
+        if (!$success || $current !== $old) {
+            return false;
+        }
+
+        return apcu_store($key, $new, 300);
+    }
+}
+
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$pass = 0;
+$check = static function (bool $ok, string $label) use (&$pass): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $pass++;
+    echo "  OK  {$label}\n";
+};
+
+$run = bin2hex(random_bytes(4));
+$cacheDir = $root . '/storage/cache';
+$createdKeys = [];
+
+try {
+    $check(QueryCache::stats()['backend'] === 'apcu', '01 APCu backend is selected');
+
+    $key = "qc_apcu_roundtrip_{$run}";
+    $createdKeys[] = $key;
+    $check(QueryCache::set($key, 'value', 60), '02 APCu set succeeds');
+    $check(QueryCache::get($key) === 'value', '03 APCu get returns the value');
+    $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($key, 0, 80));
+    $check(glob($cacheDir . '/pinakes_' . $prefix . '_*') === [], '04 APCu does not dual-write data to files');
+
+    // Invoke the APCu remember primitive with a value inserted immediately
+    // before lock acquisition: its post-acquire double-check must avoid the
+    // callback even though the outer logical lookup would previously have missed.
+    $reflection = new ReflectionClass(QueryCache::class);
+    $hashKey = $reflection->getMethod('hashKey');
+    $backendSet = $reflection->getMethod('backendSet');
+    $rememberApcu = $reflection->getMethod('rememberWithApcuLock');
+    $lateKey = "qc_apcu_late_fill_{$run}";
+    $createdKeys[] = $lateKey;
+    $hashedLateKey = $hashKey->invoke(null, $lateKey);
+    $backendSet->invoke(null, $hashedLateKey, 'filled-by-peer', 60);
+    $calls = 0;
+    $value = $rememberApcu->invoke(
+        null,
+        $lateKey,
+        $hashedLateKey,
+        static function () use (&$calls): string {
+            $calls++;
+            return 'duplicate-computation';
+        },
+        60
+    );
+    $check($value === 'filled-by-peer' && $calls === 0, '05 lock acquisition double-check avoids duplicate computation');
+
+    // Ownership-safe release: an old token must not delete a successor lock.
+    $release = $reflection->getMethod('releaseApcuLock');
+    $lockKey = 'pinakes_lock_test_' . $run;
+    apcu_store($lockKey, 222, 300);
+    $release->invoke(null, $lockKey, 111);
+    $success = false;
+    $owner = apcu_fetch($lockKey, $success);
+    $check($success && $owner === 222, '06 stale owner cannot delete successor APCu lock');
+    $release->invoke(null, $lockKey, 222);
+    $check(!apcu_exists($lockKey), '07 current owner releases its APCu lock');
+
+    // The same generation-capture invariant must hold on APCu.
+    $inFlightKey = "home_qc_apcu_inflight_{$run}";
+    $createdKeys[] = $inFlightKey;
+    QueryCache::remember($inFlightKey, static function (): string {
+        ContentCache::homeContentChanged();
+        return 'stale';
+    }, 300);
+    $check(QueryCache::get($inFlightKey) === null, '08 APCu loader cannot publish into a newer generation');
+
+    $before = QueryCache::stats();
+    $statsKey = "qc_apcu_stats_{$run}";
+    $createdKeys[] = $statsKey;
+    QueryCache::remember($statsKey, static fn(): string => 'v', 60);
+    $after = QueryCache::stats();
+    $check(($after['gets'] - $before['gets']) === 1, '09 APCu remember counts one logical lookup');
+    $check(($after['misses'] - $before['misses']) === 1, '10 APCu remember counts one logical miss');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+} finally {
+    foreach ($createdKeys as $createdKey) {
+        QueryCache::delete($createdKey);
+        $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($createdKey, 0, 80));
+        foreach (glob($cacheDir . '/pinakes_' . $prefix . '_*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+}
+
+echo "\n{$pass} checks passed\n";
+exit(0);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -1,0 +1,232 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural contract for the QueryCache single-backend + generation-key
+ * refactor (issue #387, step 1+3 of the caching plan). No DB needed.
+ *
+ * Covers:
+ *  - set/get/delete round-trip and TTL expiry on the selected backend;
+ *  - remember(): returns the callback value on miss and computes ONCE
+ *    (second call served from cache, callback not re-run);
+ *  - single selected backend: stats() reports which backend holds the
+ *    values ('apcu' when available+enabled, 'file' otherwise) and the
+ *    round-trip proves that backend serves them;
+ *  - O(1) generation-key invalidation: after ContentCache::booksChanged()
+ *    previously cached catalog_* and home_* entries are no longer served while
+ *    an unrelated (non-namespaced) entry survives — AND, on the file
+ *    backend, the stale entry's file is left on disk untouched (proof the
+ *    invalidation is a generation bump, not a scan/delete storm; gc()
+ *    reclaims it later). ContentCache::homeContentChanged() only kills the
+ *    home_ namespace, catalog_ survives;
+ *  - clearByPrefix() keeps its invalidation semantics both for a known
+ *    namespace (generation bump) and for an arbitrary prefix (legacy scan);
+ *  - security: a file-backend payload replaced with a bare serialized
+ *    object is neutralized by unserialize(..., allowed_classes=false)
+ *    (get() returns null, poisoned file removed);
+ *  - stats() hit/miss counters move correctly across a miss and a hit.
+ *
+ * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
+ * do not exist there (fatal Error), and the "stale file left on disk after
+ * booksChanged()" assertion is false under the old prefix-scan deletion.
+ *
+ * Run: php tests/querycache-backend-and-generation.unit.php
+ */
+
+use App\Support\ContentCache;
+use App\Support\QueryCache;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$cacheDir = $root . '/storage/cache';
+
+$pass = 0;
+$check = static function (bool $ok, string $label) use (&$pass): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $pass++;
+    echo "  OK  {$label}\n";
+};
+
+$run = substr(md5((string) mt_rand()), 0, 8);
+
+// Every logical key this test creates (for cleanup).
+$createdKeys = [];
+$key = static function (string $logical) use (&$createdKeys): string {
+    $createdKeys[] = $logical;
+    return $logical;
+};
+
+// Locate the storage/cache file(s) of a logical key by its sanitized
+// human-readable prefix (the refactor keeps that prefix in the filename).
+$filesFor = static function (string $logical) use ($cacheDir): array {
+    $prefix = preg_replace('/[^A-Za-z0-9_\-]/', '_', substr($logical, 0, 80));
+    $files = glob($cacheDir . '/pinakes_' . $prefix . '_*');
+    return $files === false ? [] : $files;
+};
+
+try {
+    // ── Backend identity ────────────────────────────────────────────────
+    $stats = QueryCache::stats();
+    $backend = $stats['backend'] ?? '';
+    $check(in_array($backend, ['apcu', 'file'], true), "01 stats() reports a deterministic backend ({$backend})");
+    if ($backend !== 'file') {
+        // The generation/security file-level assertions below inspect the
+        // file store directly; they are meaningful on the file backend.
+        echo "NOTE: APCu backend active in this environment; file-level assertions run against APCu semantics where applicable.\n";
+    } else {
+        echo "NOTE: no APCu in this PHP (CLI without apcu/apc.enable_cli) — exercising the file backend, the shared-hosting default.\n";
+    }
+
+    // ── set/get/delete round-trip on the selected backend ───────────────
+    $k1 = $key("qc_test_roundtrip_{$run}");
+    $check(QueryCache::get($k1) === null, '02 unknown key misses');
+    $check(QueryCache::set($k1, ['a' => 1, 'b' => 'x'], 60) === true, '03 set() succeeds on the selected backend');
+    $check(QueryCache::get($k1) === ['a' => 1, 'b' => 'x'], '04 get() returns the stored value (selected backend holds it)');
+    QueryCache::delete($k1);
+    $check(QueryCache::get($k1) === null, '05 delete() removes the entry');
+
+    // Single-backend observability: on the file backend the value must be on
+    // disk; nothing is (or can be) dual-written to APCu here. On APCu the
+    // inverse holds: no file must appear for the key.
+    $k2 = $key("qc_test_backend_{$run}");
+    QueryCache::set($k2, 'v', 60);
+    if ($backend === 'file') {
+        $check(count($filesFor($k2)) === 1, '06 file backend physically holds the entry (single backend)');
+    } else {
+        $check(count($filesFor($k2)) === 0, '06 apcu backend does NOT dual-write to disk (single backend)');
+    }
+    QueryCache::delete($k2);
+
+    // ── TTL expiry ──────────────────────────────────────────────────────
+    $k3 = $key("qc_test_ttl_{$run}");
+    QueryCache::set($k3, 'short-lived', 1);
+    $check(QueryCache::get($k3) === 'short-lived', '07 entry readable within TTL');
+    sleep(2);
+    $check(QueryCache::get($k3) === null, '08 entry expired after TTL');
+
+    // ── remember(): miss → callback value, then computed once ───────────
+    $k4 = $key("qc_test_remember_{$run}");
+    $calls = 0;
+    $producer = static function () use (&$calls): string {
+        $calls++;
+        return 'computed-value';
+    };
+    $check(QueryCache::remember($k4, $producer, 60) === 'computed-value', '09 remember() returns callback value on miss');
+    $check($calls === 1, '10 callback executed exactly once on miss');
+    $check(QueryCache::remember($k4, $producer, 60) === 'computed-value', '11 remember() serves the cached value');
+    $check($calls === 1, '12 callback NOT re-executed on hit');
+    QueryCache::delete($k4);
+
+    // ── Generation-key invalidation via ContentCache ────────────────────
+    $catKey = $key("catalog_qc_test_{$run}");
+    $homeKey = $key("home_qc_test_{$run}");
+    $otherKey = $key("qc_test_survivor_{$run}");
+
+    QueryCache::set($catKey, 'catalog-data', 300);
+    QueryCache::set($homeKey, 'home-data', 300);
+    QueryCache::set($otherKey, 'unrelated-data', 300);
+    $check(QueryCache::get($catKey) === 'catalog-data', '13 catalog_ entry cached');
+    $check(QueryCache::get($homeKey) === 'home-data', '14 home_ entry cached');
+
+    $catFilesBefore = $filesFor($catKey);
+
+    ContentCache::booksChanged();
+
+    $check(QueryCache::get($catKey) === null, '15 catalog_ entry no longer served after booksChanged()');
+    $check(QueryCache::get($homeKey) === null, '16 home_ entry no longer served after booksChanged()');
+    $check(QueryCache::get($otherKey) === 'unrelated-data', '17 unrelated namespace survives booksChanged()');
+
+    if ($backend === 'file') {
+        // O(1) proof: the stale entry was NOT deleted (no scan) — it merely
+        // became unreachable because the namespace generation moved on.
+        $stillOnDisk = count($catFilesBefore) === 1 && file_exists($catFilesBefore[0]);
+        $check($stillOnDisk, '18 stale catalog_ file left on disk (generation bump, not a delete scan)');
+        foreach ($catFilesBefore as $f) {
+            @unlink($f);
+        }
+    } else {
+        $check(true, '18 (apcu backend: on-disk staleness proof not applicable)');
+    }
+
+    // Scoped invalidation: homeContentChanged() bumps only home_.
+    QueryCache::set($catKey, 'catalog-data-2', 300);
+    QueryCache::set($homeKey, 'home-data-2', 300);
+    ContentCache::homeContentChanged();
+    $check(QueryCache::get($homeKey) === null, '19 home_ entry invalidated by homeContentChanged()');
+    $check(QueryCache::get($catKey) === 'catalog-data-2', '20 catalog_ entry survives homeContentChanged()');
+
+    // ── clearByPrefix() keeps its semantics ─────────────────────────────
+    // Known namespace → generation bump under the hood.
+    QueryCache::clearByPrefix('catalog_');
+    $check(QueryCache::get($catKey) === null, '21 clearByPrefix(catalog_) still invalidates the namespace');
+
+    // Arbitrary (non-namespace) prefix → legacy scan fallback still works
+    // with the new storage naming.
+    $arbKey = $key("qc_arbitrary_{$run}_entry");
+    QueryCache::set($arbKey, 'arb', 300);
+    $cleared = QueryCache::clearByPrefix("qc_arbitrary_{$run}_");
+    $check(QueryCache::get($arbKey) === null, '22 clearByPrefix(arbitrary prefix) still clears matching entries');
+    if ($backend === 'file') {
+        $check($cleared >= 1, '23 arbitrary-prefix scan reports removed entries');
+    } else {
+        $check(true, '23 (apcu backend: scan count covered by assertion 22)');
+    }
+
+    // ── Security: allowed_classes=false guard on the file store ─────────
+    if ($backend === 'file') {
+        $poisonKey = $key("qc_test_poison_{$run}");
+        QueryCache::set($poisonKey, 'benign', 300);
+        $poisonFiles = $filesFor($poisonKey);
+        $check(count($poisonFiles) === 1, '24 poisoned-entry fixture in place');
+        // Simulate an attacker-controlled payload: a bare serialized object.
+        file_put_contents($poisonFiles[0], 'O:8:"stdClass":0:{}');
+        $check(QueryCache::get($poisonKey) === null, '25 serialized-object payload rejected (allowed_classes=false guard)');
+        clearstatcache();
+        $check(!file_exists($poisonFiles[0]), '26 poisoned file removed on read');
+    } else {
+        // APCu stores native values (no unserialize on read); craft the same
+        // guard check directly against the file reader is not applicable.
+        $check(true, '24 (apcu backend: no file deserialization path in use)');
+        $check(true, '25 (apcu backend: object-injection surface absent)');
+        $check(true, '26 (apcu backend: object-injection surface absent)');
+    }
+
+    // ── stats() hit/miss accounting ─────────────────────────────────────
+    $before = QueryCache::stats();
+    $missKey = $key("qc_test_stats_missing_{$run}");
+    QueryCache::get($missKey);                       // miss
+    $hitKey = $key("qc_test_stats_hit_{$run}");
+    QueryCache::set($hitKey, 1, 60);
+    QueryCache::get($hitKey);                        // hit
+    $after = QueryCache::stats();
+
+    $check(($after['gets'] - $before['gets']) === 2, '27 stats(): gets incremented per get()');
+    $check(($after['misses'] - $before['misses']) === 1, '28 stats(): miss counted');
+    $check(($after['hits'] - $before['hits']) === 1, '29 stats(): hit counted');
+    $check(
+        $after['gets'] > 0 && abs($after['hit_ratio'] - round($after['hits'] / $after['gets'], 4)) < 0.0001,
+        '30 stats(): hit_ratio consistent with counters'
+    );
+    QueryCache::delete($hitKey);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+} finally {
+    // Cleanup: remove every key this test created (current generation) and
+    // any leftover files matching this run's unique marker.
+    foreach (array_unique($createdKeys) as $logical) {
+        QueryCache::delete($logical);
+    }
+    $leftovers = glob($cacheDir . '/pinakes_*' . $run . '*');
+    if ($leftovers !== false) {
+        foreach ($leftovers as $f) {
+            @unlink($f);
+        }
+    }
+}
+
+echo "\n{$pass} checks passed\n";
+exit(0);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -28,7 +28,12 @@ declare(strict_types=1);
  *    remember() records one logical lookup despite its mutex double-check;
  *  - in-flight loaders cannot publish stale data into a newer generation;
  *  - generation bumps are atomic across concurrent processes;
- *  - time-gated GC is actually reached by normal file-cache writes.
+ *  - time-gated GC is actually reached by normal file-cache writes;
+ *  - counter writes are atomic (temp + rename): the on-disk counter is a
+ *    complete valid payload after every bump, no .tmp residue is left, and a
+ *    simulated write failure leaves the previous value intact (adamsreview
+ *    F1: an in-place ftruncate+fwrite could leave the file empty and reset
+ *    the namespace generation below an already-climbed value).
  *
  * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
  * do not exist there (fatal Error), and the "stale file left on disk after
@@ -302,6 +307,75 @@ try {
             '36 file writes schedule time-gated GC (APCu selected here)'
         );
     }
+
+    // ── Atomic counter writes: temp+rename, never empty/partial ─────────
+    // The generation counter is file-backed regardless of backend, so these
+    // assertions are meaningful everywhere. A mid-write failure must never
+    // leave the counter file empty (that would re-initialize the namespace at
+    // time(), potentially BELOW a counter that climbed past wall-clock,
+    // resurrecting invalidated TTL-live entries).
+    $atomicReflection = new ReflectionClass(QueryCache::class);
+    $storageKeyMethod = $atomicReflection->getMethod('generationStorageKey');
+    $atomicMemo = $atomicReflection->getProperty('generationCache');
+    $genPath = $cacheDir . '/' . $storageKeyMethod->invoke(null, 'schema_table_');
+
+    $readCounter = static function () use ($genPath): ?int {
+        clearstatcache();
+        $content = @file_get_contents($genPath);
+        if ($content === false || $content === '') {
+            return null;
+        }
+        $data = @unserialize($content, ['allowed_classes' => false]);
+        if (!is_array($data) || !isset($data['value']) || !is_int($data['value'])) {
+            return null;
+        }
+        return $data['value'];
+    };
+
+    $alwaysValid = true;
+    $monotonic = true;
+    $prevOnDisk = null;
+    for ($i = 0; $i < 30; $i++) {
+        QueryCache::bumpGeneration('schema_table_');
+        $onDisk = $readCounter();
+        if ($onDisk === null) {
+            $alwaysValid = false;
+            break;
+        }
+        if ($prevOnDisk !== null && $onDisk <= $prevOnDisk) {
+            $monotonic = false;
+            break;
+        }
+        $prevOnDisk = $onDisk;
+    }
+    $check($alwaysValid, '37 counter file is a complete valid payload after every bump (never empty/partial)');
+    $check($monotonic, '38 counter value strictly monotonic across rapid bumps');
+
+    $tmpResidue = glob($genPath . '.tmp.*');
+    $check($tmpResidue === false || $tmpResidue === [], '39 no .tmp residue left behind by successful bumps');
+
+    // Simulated write failure: occupy the exact temp path the next bump will
+    // use (deterministic: pid + private monotonic sequence) with a directory,
+    // so the temp-file write fails. The previous counter value must remain
+    // intact on disk — under the old ftruncate-then-write scheme an
+    // equivalent failure wiped the file.
+    $seqProp = $atomicReflection->getProperty('generationTmpSeq');
+    $blockedTmp = $genPath . '.tmp.' . getmypid() . '.' . $seqProp->getValue(null);
+    $beforeFailure = $readCounter();
+    if (!@mkdir($blockedTmp)) {
+        throw new RuntimeException('could not create blocking directory for write-failure simulation');
+    }
+    try {
+        QueryCache::bumpGeneration('schema_table_'); // write fails → legacy fallback
+    } finally {
+        @rmdir($blockedTmp);
+    }
+    $check(
+        $beforeFailure !== null && $readCounter() === $beforeFailure,
+        '40 failed counter write leaves the previous on-disk value intact (no truncation)'
+    );
+    // Drop the request-local fallback generation installed by the failed bump.
+    $atomicMemo->setValue(null, []);
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -419,6 +419,53 @@ try {
     }
     QueryCache::gc();
     $check(!file_exists($busyPath), '46 GC reclaims the expired entry once its lock is released');
+
+    // File mutexes must keep one stable inode. Removing the pathname after an
+    // unlock lets an already-open waiter lock the old inode while a newcomer
+    // creates and locks a second inode, defeating stampede protection.
+    if ($backend === 'file') {
+        $mutexReflection = new ReflectionClass(QueryCache::class);
+        $hashMethod = $mutexReflection->getMethod('hashKey');
+        $mutexPathMethod = $mutexReflection->getMethod('fileMutexPath');
+        $mutexKey = $key("qc_mutex_inode_{$run}");
+        $mutexPath = $mutexPathMethod->invoke(null, $hashMethod->invoke(null, $mutexKey));
+
+        QueryCache::remember($mutexKey, static fn(): string => 'first', 60);
+        clearstatcache(true, $mutexPath);
+        $mutexInode = @fileinode($mutexPath);
+        $check($mutexInode !== false, '47 file remember() leaves its striped mutex inode persistent');
+
+        QueryCache::delete($mutexKey);
+        QueryCache::remember($mutexKey, static fn(): string => 'second', 60);
+        clearstatcache(true, $mutexPath);
+        $check(
+            @fileinode($mutexPath) === $mutexInode,
+            '48 repeated file remember() operations reuse the same mutex inode'
+        );
+
+        @touch($mutexPath, time() - 7200);
+        QueryCache::gc();
+        clearstatcache(true, $mutexPath);
+        $check(file_exists($mutexPath), '49 GC preserves persistent striped mutexes');
+    } else {
+        $source = file_get_contents($root . '/app/Support/QueryCache.php');
+        $persistentMutex = is_string($source)
+            && str_contains($source, "'/pinakes_mutex_'")
+            && !str_contains($source, '@unlink($lockFile);');
+        $check($persistentMutex, '47 file backend uses a persistent striped mutex pool');
+        $check($persistentMutex, '48 file mutex paths are never unlinked after remember()');
+        $check(
+            is_string($source) && str_contains($source, "if (str_ends_with(\$file, '.lock'))"),
+            '49 GC preserves persistent striped mutexes'
+        );
+    }
+
+    $legacyLock = $cacheDir . "/pinakes_qc_legacy_lock_{$run}_waiter.lock";
+    file_put_contents($legacyLock, '');
+    QueryCache::clearByPrefix("qc_legacy_lock_{$run}_");
+    clearstatcache(true, $legacyLock);
+    $check(file_exists($legacyLock), '50 prefix invalidation preserves legacy lock inodes during rolling deploys');
+    @unlink($legacyLock);
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -376,6 +376,49 @@ try {
     );
     // Drop the request-local fallback generation installed by the failed bump.
     $atomicMemo->setValue(null, []);
+
+    // ── Full flush preserves synchronization and invalidation barriers ──
+    QueryCache::bumpGeneration('schema_table_');
+    clearstatcache(true, $genPath . '.lock');
+    $lockInodeBefore = @fileinode($genPath . '.lock');
+    $flushKey = $key("schema_table_flush_{$run}");
+    QueryCache::set($flushKey, 'stale', 300);
+    $check(QueryCache::flush(), '41 full flush succeeds');
+    clearstatcache(true, $genPath . '.lock');
+    $check(
+        $lockInodeBefore !== false
+            && file_exists($genPath . '.lock')
+            && @fileinode($genPath . '.lock') === $lockInodeBefore,
+        '42 full flush preserves the persistent generation-lock inode'
+    );
+    $lockMode = @fileperms($genPath . '.lock');
+    $check(
+        $lockMode !== false && ($lockMode & 0777) === 0660,
+        '43 generation writer lock has group-writable 0660 permissions'
+    );
+    $check(QueryCache::get($flushKey) === null, '44 full flush publishes a newer generation barrier');
+
+    // GC is request-time maintenance. A busy entry must be skipped rather
+    // than making an application request wait for another writer.
+    $busyPath = $cacheDir . '/pinakes_gc_busy_' . $run;
+    file_put_contents($busyPath, serialize([
+        'value' => 'expired',
+        'expires' => time() - 10,
+        'created' => time() - 20,
+    ]));
+    $busyHandle = fopen($busyPath, 'r');
+    if ($busyHandle === false || !flock($busyHandle, LOCK_EX | LOCK_NB)) {
+        throw new RuntimeException('could not lock busy GC fixture');
+    }
+    try {
+        QueryCache::gc();
+        $check(file_exists($busyPath), '45 GC skips an entry currently locked by another writer');
+    } finally {
+        flock($busyHandle, LOCK_UN);
+        fclose($busyHandle);
+    }
+    QueryCache::gc();
+    $check(!file_exists($busyPath), '46 GC reclaims the expired entry once its lock is released');
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/querycache-backend-and-generation.unit.php
+++ b/tests/querycache-backend-and-generation.unit.php
@@ -24,7 +24,11 @@ declare(strict_types=1);
  *  - security: a file-backend payload replaced with a bare serialized
  *    object is neutralized by unserialize(..., allowed_classes=false)
  *    (get() returns null, poisoned file removed);
- *  - stats() hit/miss counters move correctly across a miss and a hit.
+ *  - stats() hit/miss counters move correctly across a miss and a hit, and
+ *    remember() records one logical lookup despite its mutex double-check;
+ *  - in-flight loaders cannot publish stale data into a newer generation;
+ *  - generation bumps are atomic across concurrent processes;
+ *  - time-gated GC is actually reached by normal file-cache writes.
  *
  * FAILS BY DESIGN on the pre-refactor QueryCache: stats()/bumpGeneration()
  * do not exist there (fatal Error), and the "stale file left on disk after
@@ -211,6 +215,93 @@ try {
         '30 stats(): hit_ratio consistent with counters'
     );
     QueryCache::delete($hitKey);
+
+    // ── remember() must not publish across an invalidation ──────────────
+    $inFlightKey = $key("home_qc_inflight_{$run}");
+    $inFlight = QueryCache::remember($inFlightKey, static function (): string {
+        // Simulate a committed mutation/invalidation while an older loader is
+        // still computing. Its result may be returned to that caller, but must
+        // remain stored under the old generation and be unreachable afterwards.
+        ContentCache::homeContentChanged();
+        return 'pre-invalidation-value';
+    }, 300);
+    $check($inFlight === 'pre-invalidation-value', '31 in-flight loader returns its callback value');
+    $check(QueryCache::get($inFlightKey) === null, '32 in-flight loader cannot populate the newer generation');
+
+    // ── remember() instrumentation counts logical lookups only ──────────
+    $statsRememberKey = $key("qc_stats_remember_{$run}");
+    $beforeRemember = QueryCache::stats();
+    QueryCache::remember($statsRememberKey, static fn(): string => 'v', 60);
+    $afterRemember = QueryCache::stats();
+    $check(($afterRemember['gets'] - $beforeRemember['gets']) === 1, '33 cold remember() counts one logical get');
+    $check(($afterRemember['misses'] - $beforeRemember['misses']) === 1, '34 cold remember() counts one logical miss');
+
+    // ── Generation increments remain atomic across processes ───────────
+    if (function_exists('pcntl_fork') && function_exists('pcntl_waitpid')) {
+        $reflection = new ReflectionClass(QueryCache::class);
+        $generationMethod = $reflection->getMethod('currentGeneration');
+        $generationMemo = $reflection->getProperty('generationCache');
+
+        QueryCache::bumpGeneration('schema_table_');
+        $generationMemo->setValue(null, []);
+        $beforeGeneration = $generationMethod->invoke(null, 'schema_table_');
+
+        $children = [];
+        $childCount = 6;
+        $bumpsPerChild = 20;
+        for ($child = 0; $child < $childCount; $child++) {
+            $pid = pcntl_fork();
+            if ($pid === -1) {
+                throw new RuntimeException('pcntl_fork failed');
+            }
+            if ($pid === 0) {
+                for ($i = 0; $i < $bumpsPerChild; $i++) {
+                    QueryCache::bumpGeneration('schema_table_');
+                }
+                exit(0);
+            }
+            $children[] = $pid;
+        }
+        foreach ($children as $pid) {
+            pcntl_waitpid($pid, $status);
+            if (!pcntl_wifexited($status) || pcntl_wexitstatus($status) !== 0) {
+                throw new RuntimeException('generation bump child failed');
+            }
+        }
+
+        // The parent intentionally held its request-local memo while children
+        // worked; clear it to model the next request reading the canonical file.
+        $generationMemo->setValue(null, []);
+        $afterGeneration = $generationMethod->invoke(null, 'schema_table_');
+        $check(
+            ($afterGeneration - $beforeGeneration) === $childCount * $bumpsPerChild,
+            '35 concurrent generation bumps have no lost updates or rollback'
+        );
+    } else {
+        $source = file_get_contents($root . '/app/Support/QueryCache.php');
+        $check(
+            is_string($source) && str_contains($source, 'flock($handle, LOCK_EX)'),
+            '35 generation mutation uses an exclusive lock (pcntl unavailable)'
+        );
+    }
+
+    // ── File GC is wired into writes ────────────────────────────────────
+    if ($backend === 'file') {
+        $gcMarker = $cacheDir . '/.pinakes_gc';
+        @touch($gcMarker, time() - 7200);
+        $reflection = new ReflectionClass(QueryCache::class);
+        $reflection->getProperty('gcCheckedThisRequest')->setValue(null, false);
+
+        $expiredKey = $key("qc_gc_expired_{$run}");
+        QueryCache::set($expiredKey, 'expired', -1);
+        $check($filesFor($expiredKey) === [], '36 time-gated GC reclaims expired generation leftovers');
+    } else {
+        $source = file_get_contents($root . '/app/Support/QueryCache.php');
+        $check(
+            is_string($source) && str_contains($source, 'self::maybeGc();'),
+            '36 file writes schedule time-gated GC (APCu selected here)'
+        );
+    }
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
     exit(1);

--- a/tests/release-source-policy.test.sh
+++ b/tests/release-source-policy.test.sh
@@ -32,21 +32,23 @@ if [[ "${1:-}" == api ]]; then
     *) printf '[[{"number":341,"draft":false,"base":{"ref":"main"},"head":{"sha":"sha-rc","ref":"release/0.7.59-rc.1","repo":{"full_name":"fabiodalez-dev/Pinakes"}}}]]\n' ;;
   esac
 elif [[ "${1:-} ${2:-}" == "pr view" ]]; then
-  if [[ "$*" == *"headRefOid,mergeStateStatus"* ]]; then
-    printf '{"headRefOid":"%s","mergeStateStatus":"%s"}\n' \
-      "${FAKE_PR_HEAD:-sha-rc}" "${FAKE_MERGE_STATE:-CLEAN}"
+  if [[ "$*" == *"headRefOid,mergeStateStatus,mergeable,reviewDecision"* ]]; then
+    printf '{"headRefOid":"%s","mergeStateStatus":"%s","mergeable":"%s","reviewDecision":"%s"}\n' \
+      "${FAKE_PR_HEAD:-sha-rc}" "${FAKE_MERGE_STATE:-CLEAN}" \
+      "${FAKE_MERGEABLE:-MERGEABLE}" "${FAKE_REVIEW_DECISION:-}"
   else
     printf '%s\n' "${FAKE_FINAL_PR_HEAD:-${FAKE_PR_HEAD:-sha-rc}}"
   fi
 elif [[ "${1:-} ${2:-}" == "pr checks" ]]; then
   case "${FAKE_CHECKS:-pass}" in
     pending)
-      printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass"},{"name":"Full E2E","state":"IN_PROGRESS","bucket":"pending"}]\n'
+      printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"IN_PROGRESS","bucket":"pending","workflow":"E2E"}]\n'
       exit 8
       ;;
-    missing_coderabbit) printf '[{"name":"Full E2E","state":"SUCCESS","bucket":"pass"}]\n' ;;
+    self_blocked) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"},{"name":"Verify and build release (read-only)","state":"IN_PROGRESS","bucket":"pending","workflow":"Verified Release"}]\n'; exit 8 ;;
+    missing_coderabbit) printf '[{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n' ;;
     empty) printf '[]\n' ;;
-    *) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass"},{"name":"Full E2E","state":"SUCCESS","bucket":"pass"}]\n' ;;
+    *) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n' ;;
   esac
 else
   echo "unexpected gh invocation: $*" >&2
@@ -97,6 +99,9 @@ run_case "RC from draft PR" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=draft
 run_case "RC from fork" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=external
 run_case "RC from non-release branch" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=wrong_branch
 run_case "RC from blocked PR" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED
+run_case "RC accepts BLOCKED caused only by its own tag check" pass "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked
+run_case "RC rejects self-blocked state when GitHub reports a conflict" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_MERGEABLE=CONFLICTING
+run_case "RC rejects self-blocked state when a review is required" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_REVIEW_DECISION=REVIEW_REQUIRED
 run_case "RC with pending required check" fail "0.7.59-rc.3" "sha-rc" FAKE_CHECKS=pending
 run_case "RC without required CodeRabbit" fail "0.7.59-rc.3" "sha-rc" FAKE_CHECKS=missing_coderabbit
 run_case "RC without required checks" fail "0.7.59-rc.3" "sha-rc" FAKE_CHECKS=empty

--- a/tests/release-source-policy.test.sh
+++ b/tests/release-source-policy.test.sh
@@ -46,6 +46,22 @@ elif [[ "${1:-} ${2:-}" == "pr checks" ]]; then
       exit 8
       ;;
     self_blocked) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"},{"name":"Verify and build release (read-only)","state":"IN_PROGRESS","bucket":"pending","workflow":"Verified Release"}]\n'; exit 8 ;;
+    pending_then_pass)
+      if [[ "$*" == *"--required"* ]]; then
+        printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n'
+      else
+        count=0
+        [[ -f "$FAKE_CHECK_COUNTER_FILE" ]] && read -r count <"$FAKE_CHECK_COUNTER_FILE"
+        count=$((count + 1))
+        printf '%s\n' "$count" >"$FAKE_CHECK_COUNTER_FILE"
+        if ((count == 1)); then
+          printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Tag migration check","state":"IN_PROGRESS","bucket":"pending","workflow":"Test Database Migrations"},{"name":"Verify and build release (read-only)","state":"IN_PROGRESS","bucket":"pending","workflow":"Verified Release"}]\n'
+          exit 8
+        fi
+        printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Tag migration check","state":"SUCCESS","bucket":"pass","workflow":"Test Database Migrations"},{"name":"Verify and build release (read-only)","state":"IN_PROGRESS","bucket":"pending","workflow":"Verified Release"}]\n'
+        exit 8
+      fi
+      ;;
     missing_coderabbit) printf '[{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n' ;;
     empty) printf '[]\n' ;;
     *) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n' ;;
@@ -63,6 +79,7 @@ failed=0
 run_case() {
   local name="$1" expected="$2" version="$3" sha="$4"
   shift 4
+  rm -f -- "$test_root/check-counter"
   printf '{"version":"%s"}\n' "$version" >"$test_root/repo/version.json"
   if (cd "$test_root/repo" && env \
       PATH="$test_root/bin:$PATH" \
@@ -70,6 +87,9 @@ run_case() {
       GITHUB_SHA="$sha" \
       GITHUB_REPOSITORY="fabiodalez-dev/Pinakes" \
       GH_TOKEN="test-token" \
+      RELEASE_CHECK_MAX_ATTEMPTS=2 \
+      RELEASE_CHECK_POLL_INTERVAL_SECONDS=0 \
+      FAKE_CHECK_COUNTER_FILE="$test_root/check-counter" \
       "$@" \
       bash scripts/ci-verify-release-source.sh >/dev/null 2>&1); then
     actual=pass
@@ -100,6 +120,7 @@ run_case "RC from fork" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=external
 run_case "RC from non-release branch" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=wrong_branch
 run_case "RC from blocked PR" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED
 run_case "RC accepts BLOCKED caused only by its own tag check" pass "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked
+run_case "RC waits for a tag-triggered check before accepting its own block" pass "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=pending_then_pass
 run_case "RC rejects self-blocked state when GitHub reports a conflict" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_MERGEABLE=CONFLICTING
 run_case "RC rejects self-blocked state when a review is required" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_REVIEW_DECISION=REVIEW_REQUIRED
 run_case "RC with pending required check" fail "0.7.59-rc.3" "sha-rc" FAKE_CHECKS=pending

--- a/tests/release-source-policy.test.sh
+++ b/tests/release-source-policy.test.sh
@@ -46,6 +46,8 @@ elif [[ "${1:-} ${2:-}" == "pr checks" ]]; then
       exit 8
       ;;
     self_blocked) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"},{"name":"Verify and build release (read-only)","state":"IN_PROGRESS","bucket":"pending","workflow":"Verified Release"}]\n'; exit 8 ;;
+    self_cancelled) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"},{"name":"Verify and build release (read-only)","state":"CANCELLED","bucket":"cancel","workflow":"Verified Release"}]\n'; exit 1 ;;
+    self_skipped) printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"},{"name":"Verify and build release (read-only)","state":"SKIPPED","bucket":"skipping","workflow":"Verified Release"}]\n' ;;
     pending_then_pass)
       if [[ "$*" == *"--required"* ]]; then
         printf '[{"name":"CodeRabbit","state":"SUCCESS","bucket":"pass","workflow":""},{"name":"Full E2E","state":"SUCCESS","bucket":"pass","workflow":"E2E"}]\n'
@@ -121,6 +123,8 @@ run_case "RC from non-release branch" fail "0.7.59-rc.3" "sha-rc" FAKE_PR_KIND=w
 run_case "RC from blocked PR" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED
 run_case "RC accepts BLOCKED caused only by its own tag check" pass "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked
 run_case "RC waits for a tag-triggered check before accepting its own block" pass "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=pending_then_pass
+run_case "RC rejects BLOCKED with only a cancelled self check" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_cancelled
+run_case "RC rejects BLOCKED with only a skipped self check" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_skipped
 run_case "RC rejects self-blocked state when GitHub reports a conflict" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_MERGEABLE=CONFLICTING
 run_case "RC rejects self-blocked state when a review is required" fail "0.7.59-rc.3" "sha-rc" FAKE_MERGE_STATE=BLOCKED FAKE_CHECKS=self_blocked FAKE_REVIEW_DECISION=REVIEW_REQUIRED
 run_case "RC with pending required check" fail "0.7.59-rc.3" "sha-rc" FAKE_CHECKS=pending

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
  * Step 6 of the caching overhaul (issue #387): sessionless anonymous request
  * path with lazy CSRF. Security invariants:
  *
- *   1. SessionPolicy: only a read-only, cookie-less, non-auth-route request
- *      is sessionless; everything else keeps the session (fail-safe).
+ *   1. SessionPolicy: only audited, read-only, cookie-less public routes are
+ *      sessionless; unknown and plugin routes keep the session (fail-safe).
  *   2. Csrf stays fail-closed with no session data: missing/invalid tokens
  *      are rejected; a lazily minted token (GET /csrf-token flow) validates.
  *   3. CsrfMiddleware still rejects missing/invalid tokens on POST and still
@@ -48,7 +48,12 @@ $check(!SessionPolicy::requiresSession('GET', [], '/catalog', ''), 'GET /catalog
 $check(!SessionPolicy::requiresSession('GET', [], '/catalogo', ''), 'GET /catalogo (it) with no cookies is sessionless');
 $check(!SessionPolicy::requiresSession('HEAD', [], '/book/42', ''), 'HEAD /book/42 with no cookies is sessionless');
 $check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /language/{locale} is sessionless (cookie-based)');
+$check(!SessionPolicy::requiresSession('GET', [], '/csrf-token', ''), 'lazy token endpoint reaches its own session_start');
 $check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
+
+// Unknown/plugin/canonical catch-all routes stay sessionful until audited.
+$check(SessionPolicy::requiresSession('GET', [], '/club/summer', ''), 'unknown plugin route keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/author-slug/book-slug/42', ''), 'unclassified canonical route keeps the session');
 
 // Session kept: any state-changing / unknown method.
 $check(SessionPolicy::requiresSession('POST', [], '/anything', ''), 'POST always keeps the session');
@@ -87,6 +92,7 @@ $check(SessionPolicy::requiresSession('GET', [], '/reset-password/sometoken', ''
 // Base path handling (sub-folder installs).
 $check(SessionPolicy::requiresSession('GET', [], '/pinakes/login', '/pinakes'), 'base-path auth route keeps the session');
 $check(!SessionPolicy::requiresSession('GET', [], '/pinakes/catalog', '/pinakes'), 'base-path public route is sessionless');
+$check(SessionPolicy::requiresSession('GET', [], '/pinakes-other/catalog', '/pinakes'), 'base-path stripping requires a path boundary');
 
 // ---------------------------------------------------------------------------
 // 2. Csrf fail-closed without a session + lazy mint flow
@@ -104,6 +110,23 @@ $_SESSION = [];
 $minted = Csrf::ensureToken();
 $check($minted !== '' && Csrf::validate($minted), 'lazily minted token validates');
 $check(!Csrf::validate($minted . 'x'), 'tampered minted token is rejected');
+
+// Browser helper invariants. The behavioral counterpart is exercised by the
+// browser suite; these guards keep the security-critical implementation from
+// silently regressing during a refactor.
+$csrfHelper = file_get_contents(dirname(__DIR__) . '/public/assets/js/csrf-helper.js');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'let lazyTokenPromise = null'), 'lazy CSRF mint is single-flight');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, '.finally(function()'), 'single-flight promise is cleared after completion');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'window.location.origin'), 'CSRF header is limited to same-origin requests');
+$check(is_string($csrfHelper) && str_contains($csrfHelper, 'new Headers(options.headers || {})'), 'Headers instances are preserved');
+
+$frontController = file_get_contents(dirname(__DIR__) . '/public/index.php');
+$check(
+    is_string($frontController)
+        && str_contains($frontController, '$localeRestoredFromSession')
+        && str_contains($frontController, 'if (!$localeRestoredFromSession)'),
+    'locale cookie falls back when an active session has no valid locale'
+);
 
 // ---------------------------------------------------------------------------
 // 3. CsrfMiddleware behavior (direct invocation)

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -139,6 +139,15 @@ $check(
     'locale cookie falls back when an active session has no valid locale'
 );
 
+$homeEventsView = file_get_contents(
+    dirname(__DIR__) . '/app/Views/frontend/home-sections/events.php'
+);
+$check(
+    is_string($homeEventsView)
+        && str_contains($homeEventsView, '\\App\\Support\\I18n::getLocale()'),
+    'sessionless home events use the locale resolved before rendering'
+);
+
 // ---------------------------------------------------------------------------
 // 3. CsrfMiddleware behavior (direct invocation)
 // ---------------------------------------------------------------------------

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -1,0 +1,221 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Step 6 of the caching overhaul (issue #387): sessionless anonymous request
+ * path with lazy CSRF. Security invariants:
+ *
+ *   1. SessionPolicy: only a read-only, cookie-less, non-auth-route request
+ *      is sessionless; everything else keeps the session (fail-safe).
+ *   2. Csrf stays fail-closed with no session data: missing/invalid tokens
+ *      are rejected; a lazily minted token (GET /csrf-token flow) validates.
+ *   3. CsrfMiddleware still rejects missing/invalid tokens on POST and still
+ *      accepts a valid session-backed token (body and header variants), and
+ *      the login double-submit cookie fallback still works.
+ *   4. PrivateModeMiddleware still gates anonymous access with no session.
+ */
+
+use App\Middleware\CsrfMiddleware;
+use App\Middleware\PrivateModeMiddleware;
+use App\Support\Csrf;
+use App\Support\RouteTranslator;
+use App\Support\SessionPolicy;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Factory\ServerRequestFactory;
+use Slim\Psr7\Response as SlimResponse;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+// ---------------------------------------------------------------------------
+// 1. SessionPolicy predicate
+// ---------------------------------------------------------------------------
+echo "-- SessionPolicy --\n";
+SessionPolicy::clearCache();
+$sessionCookieName = session_name();
+
+// Sessionless: anonymous read-only, no cookies, public content paths.
+$check(!SessionPolicy::requiresSession('GET', [], '/', ''), 'GET / with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/catalog', ''), 'GET /catalog with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/catalogo', ''), 'GET /catalogo (it) with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('HEAD', [], '/book/42', ''), 'HEAD /book/42 with no cookies is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /language/{locale} is sessionless (cookie-based)');
+$check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
+
+// Session kept: any state-changing / unknown method.
+$check(SessionPolicy::requiresSession('POST', [], '/anything', ''), 'POST always keeps the session');
+$check(SessionPolicy::requiresSession('PUT', [], '/anything', ''), 'PUT always keeps the session');
+$check(SessionPolicy::requiresSession('DELETE', [], '/anything', ''), 'DELETE always keeps the session');
+$check(SessionPolicy::requiresSession('PATCH', [], '/anything', ''), 'PATCH always keeps the session');
+$check(SessionPolicy::requiresSession('', [], '/', ''), 'missing method (CLI) keeps the session');
+
+// Session kept: any auth-related cookie.
+$check(SessionPolicy::requiresSession('GET', [$sessionCookieName => 'abc'], '/catalog', ''), 'session cookie keeps the session');
+$check(SessionPolicy::requiresSession('GET', ['remember_token' => 'abc'], '/catalog', ''), 'remember_token cookie keeps the session');
+$check(SessionPolicy::requiresSession('GET', ['csrf_login' => 'abc'], '/catalog', ''), 'csrf_login cookie keeps the session');
+
+// Session kept: auth/contact routes in every registered locale + legacy aliases.
+$authChecks = [];
+foreach (['it_IT', 'en_US', 'de_DE', 'fr_FR', 'da_DK'] as $locale) {
+    foreach (['login', 'register', 'forgot_password', 'reset_password', 'verify_email', 'contact'] as $key) {
+        $route = RouteTranslator::getRouteForLocale($key, $locale);
+        if ($route !== '' && $route !== '/') {
+            $authChecks[$route] = $key . ' (' . $locale . ')';
+        }
+    }
+}
+$allAuthKeepSession = true;
+foreach ($authChecks as $route => $label) {
+    if (!SessionPolicy::requiresSession('GET', [], $route, '')) {
+        $allAuthKeepSession = false;
+        echo "       route without session: {$route} [{$label}]\n";
+    }
+}
+$check($allAuthKeepSession, 'every localized auth/contact route keeps the session (' . count($authChecks) . ' routes)');
+$check(SessionPolicy::requiresSession('GET', [], '/login', ''), 'legacy /login keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/login.php', ''), 'legacy /login.php keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/reset-password/sometoken', ''), 'auth route sub-path keeps the session');
+
+// Base path handling (sub-folder installs).
+$check(SessionPolicy::requiresSession('GET', [], '/pinakes/login', '/pinakes'), 'base-path auth route keeps the session');
+$check(!SessionPolicy::requiresSession('GET', [], '/pinakes/catalog', '/pinakes'), 'base-path public route is sessionless');
+
+// ---------------------------------------------------------------------------
+// 2. Csrf fail-closed without a session + lazy mint flow
+// ---------------------------------------------------------------------------
+echo "-- Csrf fail-closed / lazy mint --\n";
+$_SESSION = [];
+$check(!Csrf::validate(null), 'no token + no session token is rejected');
+$check(!Csrf::validate('forged-token'), 'forged token with no session token is rejected');
+$check(Csrf::validateWithReason(null)['reason'] === 'missing_token', 'missing token reported as missing_token');
+$check(Csrf::validateWithReason('forged')['reason'] === 'session_expired', 'token without session store reported as session_expired');
+
+// Lazy mint: GET /csrf-token calls ensureToken() on a fresh session; the
+// returned token must validate exactly like a page-rendered one.
+$_SESSION = [];
+$minted = Csrf::ensureToken();
+$check($minted !== '' && Csrf::validate($minted), 'lazily minted token validates');
+$check(!Csrf::validate($minted . 'x'), 'tampered minted token is rejected');
+
+// ---------------------------------------------------------------------------
+// 3. CsrfMiddleware behavior (direct invocation)
+// ---------------------------------------------------------------------------
+echo "-- CsrfMiddleware --\n";
+
+$handler = new class implements RequestHandlerInterface {
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = new SlimResponse(200);
+        $response->getBody()->write('handled');
+        return $response;
+    }
+};
+
+$makePost = static function (string $path, array $body = [], array $headers = [], array $cookies = []): ServerRequestInterface {
+    $request = (new ServerRequestFactory())->createServerRequest('POST', $path);
+    foreach ($headers as $name => $value) {
+        $request = $request->withHeader($name, $value);
+    }
+    if ($body !== []) {
+        $request = $request->withParsedBody($body);
+    }
+    if ($cookies !== []) {
+        $request = $request->withCookieParams($cookies);
+    }
+    return $request;
+};
+
+$middleware = new CsrfMiddleware();
+
+// Authenticated-style session with a valid token.
+$_SESSION = [];
+$valid = Csrf::ensureToken();
+
+$res = $middleware->process($makePost('/admin/libri', ['csrf_token' => $valid], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 200 && (string) $res->getBody() === 'handled', 'valid body token on POST passes');
+
+$res = $middleware->process($makePost('/admin/libri', [], ['Accept' => 'application/json', 'X-CSRF-Token' => $valid]), $handler);
+$check($res->getStatusCode() === 200, 'valid X-CSRF-Token header on POST passes');
+
+$res = $middleware->process($makePost('/admin/libri', ['csrf_token' => $valid . 'x'], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'invalid token on POST is rejected (403)');
+
+$res = $middleware->process($makePost('/admin/libri', [], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'missing token on POST is rejected (403)');
+$decoded = json_decode((string) $res->getBody(), true);
+$check(is_array($decoded) && ($decoded['code'] ?? '') !== '', 'rejection is a structured JSON error');
+
+// Sessionless page → POST that opened a FRESH session (no csrf_token yet):
+// still rejected for non-login routes (fail closed).
+$_SESSION = [];
+$res = $middleware->process($makePost('/contact/submit', ['csrf_token' => 'anything'], ['Accept' => 'application/json']), $handler);
+$check($res->getStatusCode() === 403, 'fresh empty session + token on non-login POST stays rejected');
+
+// Login double-submit cookie fallback (unchanged behavior, now the only path
+// for a login POSTed after a sessionless login-page render would be a session
+// minted on the login GET — but the cookie fallback must still work).
+$_SESSION = [];
+$loginRoute = RouteTranslator::route('login');
+$cookieToken = implode('-', str_split(bin2hex(random_bytes(32)), 8));
+$res = $middleware->process(
+    $makePost($loginRoute, ['csrf_token' => $cookieToken], ['Accept' => 'application/json'], ['csrf_login' => $cookieToken]),
+    $handler
+);
+$check($res->getStatusCode() === 200, 'login POST with matching csrf_login double-submit cookie passes');
+
+$_SESSION = [];
+$res = $middleware->process(
+    $makePost($loginRoute, ['csrf_token' => $cookieToken], ['Accept' => 'application/json'], ['csrf_login' => 'different-value']),
+    $handler
+);
+$check($res->getStatusCode() === 403, 'login POST with mismatched csrf_login cookie is rejected');
+
+// ---------------------------------------------------------------------------
+// 4. Private mode still gates anonymous access (no session data at all)
+// ---------------------------------------------------------------------------
+echo "-- PrivateModeMiddleware --\n";
+
+// Force advanced.private_mode=1 through ConfigStore's runtime cache (no DB).
+$configRef = new ReflectionClass(\App\Support\ConfigStore::class);
+$runtimeCacheProp = $configRef->getProperty('runtimeCache');
+$runtimeCacheProp->setAccessible(true);
+$previousRuntimeCache = $runtimeCacheProp->getValue();
+$runtimeCacheProp->setValue(null, ['advanced' => ['private_mode' => '1']]);
+
+try {
+    $_SESSION = [];
+    $pm = new PrivateModeMiddleware();
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/catalog');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 302, 'private mode: anonymous catalog GET redirected');
+    $check(str_contains($res->getHeaderLine('Location'), 'private_mode'), 'private mode: redirect targets login with private_mode flag');
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/api/internal/whatever');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 401, 'private mode: anonymous API GET gets 401');
+
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/login');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 200, 'private mode: login page stays reachable');
+
+    // Authenticated user passes.
+    $_SESSION = ['user' => ['id' => 1, 'tipo_utente' => 'standard']];
+    $req = (new ServerRequestFactory())->createServerRequest('GET', '/catalog');
+    $res = $pm->process($req, $handler);
+    $check($res->getStatusCode() === 200, 'private mode: authenticated user passes');
+} finally {
+    $runtimeCacheProp->setValue(null, $previousRuntimeCache);
+    $_SESSION = [];
+}
+
+echo "\n{$passed} PASS, {$failed} FAIL\n";
+exit($failed === 0 ? 0 : 1);

--- a/tests/sessionless-anonymous-387.unit.php
+++ b/tests/sessionless-anonymous-387.unit.php
@@ -51,6 +51,17 @@ $check(!SessionPolicy::requiresSession('GET', [], '/language/en_US', ''), 'GET /
 $check(!SessionPolicy::requiresSession('GET', [], '/csrf-token', ''), 'lazy token endpoint reaches its own session_start');
 $check(!SessionPolicy::requiresSession('GET', ['pinakes_locale' => 'de_DE'], '/catalog', ''), 'locale cookie alone does not force a session');
 
+// adamsreview F1 (#390): only the PUBLIC /uploads subtrees are sessionless.
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/copertine/12.jpg', ''), 'public book cover is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/autori/3.png', ''), 'public author photo is sessionless');
+$check(!SessionPolicy::requiresSession('GET', [], '/uploads/settings/logo.png', ''), 'public branding is sessionless');
+// The PRIVATE subtrees must NOT be sessionless (else the future edge cache would
+// make them cache-eligible → unauthenticated disclosure). PrivateModeMiddleware
+// gates them; SessionPolicy must not stamp them session-free.
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/digital/secret.pdf', ''), 'private digital-library file keeps the session (not cache-eligible)');
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/archives/documents/x.pdf', ''), 'private archive document keeps the session');
+$check(SessionPolicy::requiresSession('GET', [], '/uploads/storage/x.bin', ''), 'private storage file keeps the session');
+
 // Unknown/plugin/canonical catch-all routes stay sessionful until audited.
 $check(SessionPolicy::requiresSession('GET', [], '/club/summer', ''), 'unknown plugin route keeps the session');
 $check(SessionPolicy::requiresSession('GET', [], '/author-slug/book-slug/42', ''), 'unclassified canonical route keeps the session');

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.69-rc.3",
+  "version": "0.7.69-rc.4",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.69-rc.1",
+  "version": "0.7.69-rc.2",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.69-rc.4",
+  "version": "0.7.69-rc.5",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.69-rc.5",
+  "version": "0.7.69-rc.6",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.69-rc.2",
+  "version": "0.7.69-rc.3",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.68",
+  "version": "0.7.69-rc.1",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Release candidate integrating the reviewed caching overhaul (#387). No schema change, no new required config; every install upgrades with identical behaviour on a cold cache.

## Integrates
- **#388** — single-backend QueryCache + O(1) generation invalidation + atomic file-backed counters + non-blocking GC.
- **#389** — hot-dataset caching (book-detail DTO, reviews, bounded catalog) with availability always read live.
- **#390** — sessionless anonymous request path + lazy CSRF (edge-cache prerequisite); CSRF validation unchanged.

## Review status
All three PRs were reviewed (adamsreview --full + CodeRabbit) and their findings fixed: atomic generation-counter write, non-blocking GC, cover/series/profile/user/VIAF invalidation, `/uploads` sessionless narrowed to public subtrees, CSRF single-flight, locale-on-sessionless-home. 0 open CodeRabbit threads across the three.

## Verified on the integrated branch
PHPStan level 5 clean, soft-delete guard clean, full unit suite 140/140, migration guard (all migrate_*.sql ≤ 0.7.69-rc.1; no new migration).

This is the merge-ready head for `./scripts/create-release.sh 0.7.69-rc.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuove funzionalità**
  * La lingua scelta viene mantenuta anche per i visitatori anonimi.
  * Le azioni protette recuperano automaticamente il token CSRF quando necessario.
  * Cataloghi, dettagli libro e recensioni utilizzano dati aggiornati sulla disponibilità.

* **Correzioni**
  * Le modifiche a libri, serie, profili, utenti e recensioni aggiornano correttamente i contenuti visualizzati.
  * Migliorata la coerenza della lingua nelle pagine pubbliche.
  * Le letture live distinguono correttamente tra errori e risultati vuoti.

* **Prestazioni**
  * Ottimizzate cache e invalidazioni per ridurre i tempi di aggiornamento dei contenuti.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->