### PR TITLE
feat(performance): materialize catalog aggregates and authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.71-rc.1]
+
+First release candidate for catalog denormalization. Existing installs receive an idempotent migration; Redis remains deliberately deferred.
+
+### Performance
+
+- Bounded catalog counts and facet payloads are materialized in MySQL with the same generation token and short safety TTL used by `QueryCache`. APCu remains the fastest same-host layer, while separate nodes, SAPIs and file-cache processes reuse one shared aggregate instead of repeating six catalog scans.
+- Public catalog rows read a write-maintained principal-author projection instead of executing three correlated `libri_autori` subqueries per book. Principal/co-author priority, explicit credit order, pseudonym display and author sorting remain deterministic.
+
+### Compatibility and consistency
+
+- Book, author, import and enrichment write paths rebuild the author projection through the existing `SearchIndexBuilder` maintenance funnel. During a rolling upgrade, catalog queries retain the legacy subquery fallback until all projection columns exist.
+- Materialized aggregates fail open to live SQL if the table, generation counter or MySQL named lock is unavailable. Content and availability invalidation still use `ContentCache`; no second availability source is introduced.
+
 ## [0.7.70-rc.1]
 
 First release candidate for LiteSpeed full-page caching. No schema change and no required server dependency: the feature is disabled by default and configured by administrators from Settings → Advanced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ First release candidate for catalog denormalization. Existing installs receive a
 
 ### Performance
 
-- Bounded catalog counts and facet payloads are materialized in MySQL with the same generation token and short safety TTL used by `QueryCache`. APCu remains the fastest same-host layer, while separate nodes, SAPIs and file-cache processes reuse one shared aggregate instead of repeating six catalog scans.
+- Bounded catalog counts and facet payloads are materialized in MySQL with the same generation token and short safety TTL used by `QueryCache`. APCu remains the fastest same-host layer, while CLI/file-cache SAPIs that share the installation generation reuse the aggregate instead of repeating six catalog scans. Cross-server coherence remains deferred to the Redis phase.
 - Public catalog rows read a write-maintained principal-author projection instead of executing three correlated `libri_autori` subqueries per book. Principal/co-author priority, explicit credit order, pseudonym display and author sorting remain deterministic.
 
 ### Compatibility and consistency

--- a/app/Controllers/AutoriApiController.php
+++ b/app/Controllers/AutoriApiController.php
@@ -314,14 +314,15 @@ class AutoriApiController
             // Commit transaction
             $db->commit();
 
-            // Public book-detail DTOs embed the linked author rows. This API
-            // bypasses AuthorRepository, so invalidate immediately after the
-            // transaction commits instead of serving deleted authors for TTL.
-            \App\Support\ContentCache::booksChanged();
-
-            // Rebuild the search_index of the (now author-less) books so the
-            // deleted authors' names no longer surface in catalog search.
+            // Rebuild every derived author field before publishing the cache
+            // generation bump. Otherwise a concurrent catalog miss could fill
+            // the new generation from the old projection during this window.
             \App\Support\SearchIndexBuilder::rebuildMany($db, array_values($affectedBookIds));
+
+            // Public book-detail DTOs embed the linked author rows. This API
+            // bypasses AuthorRepository, so invalidate after the derived data
+            // is coherent and the transaction has committed.
+            \App\Support\ContentCache::booksChanged();
         } catch (\Throwable $e) {
             $db->rollback();
             AppLog::error('autori.bulk_delete.transaction_failed', ['error' => $e->getMessage()]);

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -1310,15 +1310,20 @@ class FrontendController
     }
 
     /**
-     * Catalog author columns with an upgrade-window fallback.
+     * Catalog author columns with a completeness-gated fallback.
      *
-     * New installs read the write-maintained projection directly. During a
-     * rolling deployment before the migration is applied, preserve the legacy
-     * correlated queries so public catalog pages remain available.
+     * The write-maintained projection is read only when
+     * CatalogAuthorProjection::isReadable() proves it is complete — the columns
+     * exist AND no book is missing its backfilled sort key. That covers three
+     * cases where the materialized values would otherwise be wrong: a fresh
+     * install before the migration, the migration's ADD COLUMN → backfill
+     * window (columns present but still NULL), and a failed runtime rebuild
+     * (affected rows nulled). In all of them the legacy correlated subqueries
+     * keep the public catalog correct until the projection is repaired.
      */
     private function catalogAuthorSelect(mysqli $db): string
     {
-        if (\App\Support\CatalogAuthorProjection::columnsExist($db)) {
+        if (\App\Support\CatalogAuthorProjection::isReadable($db)) {
             return 'l.catalog_author_display AS autore, '
                 . 'l.catalog_author_name AS autore_principale_nome, '
                 . 'l.catalog_author_sort AS autore_cognome';

--- a/app/Controllers/FrontendController.php
+++ b/app/Controllers/FrontendController.php
@@ -272,6 +272,7 @@ class FrontendController
             return (int) ($total_row['total'] ?? 0);
         };
         $total_books = $this->rememberCatalogValue(
+            $db,
             'catalog_count_' . $catalogCacheSuffix,
             $filters,
             $countLoader
@@ -284,12 +285,7 @@ class FrontendController
         // NULLs-last predicate, once for the sort value).
         $books_query = "
             SELECT l.*,
-                   (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore,
-                   (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore_principale_nome,
-                   (SELECT SUBSTRING_INDEX(" . \App\Support\AuthorName::preferredSql('a') . ", ' ', -1) FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore_cognome,
+                   " . $this->catalogAuthorSelect($db) . ",
                    e.nome AS editore,
                    g.nome AS genere
             " . $base_query . "
@@ -373,6 +369,7 @@ class FrontendController
             return (int) ($total_row['total'] ?? 0);
         };
         $total_books = $this->rememberCatalogValue(
+            $db,
             'catalog_count_' . $catalogCacheSuffix,
             $filters,
             $countLoader
@@ -385,12 +382,7 @@ class FrontendController
         // NULLs-last predicate, once for the sort value).
         $books_query = "
             SELECT l.*,
-                   (SELECT " . \App\Support\AuthorName::displaySql('a') . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore,
-                   (SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore_principale_nome,
-                   (SELECT SUBSTRING_INDEX(" . \App\Support\AuthorName::preferredSql('a') . ", ' ', -1) FROM libri_autori la JOIN autori a ON la.autore_id = a.id
-                    WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore') ORDER BY la.ruolo = 'principale' DESC LIMIT 1) AS autore_cognome,
+                   " . $this->catalogAuthorSelect($db) . ",
                    e.nome AS editore,
                    g.nome AS genere
             " . $base_query . "
@@ -456,6 +448,7 @@ class FrontendController
                 return $available_books;
             };
             $available_books = $this->rememberCatalogValue(
+                $db,
                 'catalog_avail_' . $catalogCacheSuffix,
                 $filters,
                 $availabilityLoader
@@ -1316,6 +1309,37 @@ class FrontendController
         return $columnCache[$column];
     }
 
+    /**
+     * Catalog author columns with an upgrade-window fallback.
+     *
+     * New installs read the write-maintained projection directly. During a
+     * rolling deployment before the migration is applied, preserve the legacy
+     * correlated queries so public catalog pages remain available.
+     */
+    private function catalogAuthorSelect(mysqli $db): string
+    {
+        if (\App\Support\CatalogAuthorProjection::columnsExist($db)) {
+            return 'l.catalog_author_display AS autore, '
+                . 'l.catalog_author_name AS autore_principale_nome, '
+                . 'l.catalog_author_sort AS autore_cognome';
+        }
+
+        return '(SELECT ' . \App\Support\AuthorName::displaySql('a')
+            . " FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+               WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore')
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id LIMIT 1) AS autore, "
+            . "(SELECT a.nome FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+               WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore')
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id LIMIT 1) AS autore_principale_nome, "
+            . '(SELECT SUBSTRING_INDEX(' . \App\Support\AuthorName::preferredSql('a') . ", ' ', -1)
+               FROM libri_autori la JOIN autori a ON la.autore_id = a.id
+               WHERE la.libro_id = l.id AND la.ruolo IN ('principale','co-autore')
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id LIMIT 1) AS autore_cognome";
+    }
+
     private function buildOrderBy(string $sort): string
     {
         switch ($sort) {
@@ -1353,7 +1377,7 @@ private function getFilterOptions(mysqli $db, array $filters = []): array
         return $this->computeFilterOptions($db, $filters);
     };
 
-    return $this->rememberCatalogValue($cacheKey, $filters, $loader);
+    return $this->rememberCatalogValue($db, $cacheKey, $filters, $loader);
 }
 
 /**
@@ -1375,13 +1399,26 @@ private function normalizeFiltersForCache(array $filters): array
  *
  * @param callable(): mixed $loader
  */
-private function rememberCatalogValue(string $key, array $filters, callable $loader): mixed
+private function rememberCatalogValue(mysqli $db, string $key, array $filters, callable $loader): mixed
 {
     if (!$this->hasBoundedCatalogCacheKey($filters)) {
         return $loader();
     }
 
-    return \App\Support\QueryCache::remember($key, $loader, 120);
+    return \App\Support\QueryCache::remember(
+        $key,
+        static fn (): mixed => \App\Support\CatalogSnapshot::remember(
+            $db,
+            $key,
+            // QueryCache::remember() has already resolved and memoized this
+            // namespace generation for its own effective key, so the DB row
+            // and the APCu/file entry are guaranteed to use the same token.
+            \App\Support\QueryCache::namespaceGeneration('catalog_'),
+            $loader,
+            120
+        ),
+        120
+    );
 }
 
 private function hasBoundedCatalogCacheKey(array $filters): bool

--- a/app/Support/CatalogAuthorProjection.php
+++ b/app/Support/CatalogAuthorProjection.php
@@ -15,8 +15,11 @@ final class CatalogAuthorProjection
 {
     private const REBUILD_CHUNK = 500;
 
-    /** @var \WeakMap<\mysqli, true>|null */
+    /** @var \WeakMap<\mysqli, true>|null Positive cache: the three columns exist. */
     private static ?\WeakMap $columnsKnownPresent = null;
+
+    /** @var \WeakMap<\mysqli, true>|null Positive cache: the projection is complete and safe to read. */
+    private static ?\WeakMap $readableKnown = null;
 
     private function __construct()
     {
@@ -83,9 +86,50 @@ final class CatalogAuthorProjection
                 $stmt->close();
             }
         } catch (\Throwable $e) {
-            // Derived display data must never abort a book/author save. The
-            // legacy SELECT remains available until the projection is repaired.
+            // Derived display data must never abort a book/author save.
             SecureLogger::warning('CatalogAuthorProjection rebuild failed', [
+                'count' => count($ids),
+                'error' => $e->getMessage(),
+            ]);
+            // A failed rebuild leaves STALE display values on these rows, which
+            // the next cache generation would republish as fresh. Null them so
+            // isReadable() detects the gap and the whole catalog falls back to
+            // the always-correct live author subqueries until a later rebuild
+            // (a subsequent contributor edit, or a full reindex) repairs them.
+            // Best effort: if this write also fails there is nothing safe left
+            // to do beyond the warning already logged above.
+            self::invalidateRows($db, $ids);
+        }
+    }
+
+    /**
+     * Null the materialized author columns for the given books so the read
+     * path stops trusting them. Used as the failure fallback for rebuildMany().
+     *
+     * @param int[] $ids already-normalized, non-empty positive ids
+     */
+    private static function invalidateRows(\mysqli $db, array $ids): void
+    {
+        try {
+            $placeholders = implode(',', array_fill(0, count($ids), '?'));
+            $stmt = $db->prepare(
+                "UPDATE libri SET catalog_author_display = NULL,
+                    catalog_author_name = NULL, catalog_author_sort = NULL
+                 WHERE id IN ({$placeholders})"
+            );
+            if ($stmt === false) {
+                return;
+            }
+            $stmt->bind_param(str_repeat('i', count($ids)), ...$ids);
+            $stmt->execute();
+            $stmt->close();
+            // Drop any positive readability cache for this connection so a
+            // later read on it re-probes and sees the gap.
+            if (self::$readableKnown !== null) {
+                unset(self::$readableKnown[$db]);
+            }
+        } catch (\Throwable $e) {
+            SecureLogger::warning('CatalogAuthorProjection invalidation failed', [
                 'count' => count($ids),
                 'error' => $e->getMessage(),
             ]);
@@ -113,5 +157,64 @@ final class CatalogAuthorProjection
         }
 
         return isset(self::$columnsKnownPresent[$db]);
+    }
+
+    /**
+     * Whether the catalog read path may trust the materialized author columns.
+     *
+     * `columnsExist()` only proves the schema is present, which is NOT enough
+     * for reads: during the migration's ADD COLUMN → backfill window the
+     * columns exist but are still NULL (wrong sort / empty author), and a
+     * failed runtime rebuild nulls the affected rows via invalidateRows(). In
+     * both cases the projection is incomplete and the reader must fall back to
+     * the live author subqueries. A book is "incomplete" when it has a
+     * principal/co-author with a non-empty name (so the backfill would have
+     * produced a sort key) yet its catalog_author_sort is NULL — the exact
+     * condition that leaves ordering and display wrong.
+     *
+     * Probed once per connection (positive result cached, matching
+     * columnsExist) so the hot catalog path pays a single indexed lookup.
+     */
+    public static function isReadable(\mysqli $db): bool
+    {
+        if (!self::columnsExist($db)) {
+            return false;
+        }
+
+        self::$readableKnown ??= new \WeakMap();
+        if (isset(self::$readableKnown[$db])) {
+            return true;
+        }
+
+        try {
+            $result = $db->query(
+                "SELECT EXISTS(
+                    SELECT 1 FROM libri l
+                    WHERE l.deleted_at IS NULL
+                      AND l.catalog_author_sort IS NULL
+                      AND EXISTS(
+                          SELECT 1 FROM libri_autori la
+                          JOIN autori a ON a.id = la.autore_id
+                          WHERE la.libro_id = l.id
+                            AND la.ruolo IN ('principale', 'co-autore')
+                            AND (TRIM(COALESCE(a.nome, '')) <> ''
+                                 OR TRIM(COALESCE(a.pseudonimo, '')) <> '')
+                      )
+                ) AS incomplete"
+            );
+            $row = $result instanceof \mysqli_result ? $result->fetch_assoc() : null;
+            if ($row !== null && (int) $row['incomplete'] === 0) {
+                self::$readableKnown[$db] = true;
+                return true;
+            }
+        } catch (\Throwable $e) {
+            // A failed probe must not upgrade to the materialized path: the
+            // live subqueries are always correct, only slower.
+            SecureLogger::warning('CatalogAuthorProjection readability probe failed', [
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return false;
     }
 }

--- a/app/Support/CatalogAuthorProjection.php
+++ b/app/Support/CatalogAuthorProjection.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Maintains the denormalized principal-author fields used by catalog lists.
+ *
+ * The public catalog previously executed three correlated author subqueries
+ * per returned book. These fields are rebuilt alongside search_index by the
+ * already-centralized contributor write paths, reducing each listing query to
+ * direct column reads while preserving a pre-migration fallback.
+ */
+final class CatalogAuthorProjection
+{
+    private const REBUILD_CHUNK = 500;
+
+    /** @var \WeakMap<\mysqli, true>|null */
+    private static ?\WeakMap $columnsKnownPresent = null;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param int[] $bookIds
+     */
+    public static function rebuildMany(\mysqli $db, array $bookIds): void
+    {
+        $ids = [];
+        foreach ($bookIds as $bookId) {
+            $bookId = (int) $bookId;
+            if ($bookId > 0) {
+                $ids[$bookId] = $bookId;
+            }
+        }
+        $ids = array_values($ids);
+        if ($ids === [] || !self::columnsExist($db)) {
+            return;
+        }
+
+        try {
+            $display = AuthorName::displaySql('a');
+            $preferred = AuthorName::preferredSql('a');
+            foreach (array_chunk($ids, self::REBUILD_CHUNK) as $chunk) {
+                $placeholders = implode(',', array_fill(0, count($chunk), '?'));
+                $sql = "UPDATE libri l
+                    LEFT JOIN (
+                        SELECT la.libro_id,
+                               SUBSTRING_INDEX(GROUP_CONCAT({$display}
+                                   ORDER BY (la.ruolo = 'principale') DESC,
+                                            COALESCE(la.ordine_credito, 2147483647),
+                                            la.autore_id
+                                   SEPARATOR 0x1F), 0x1F, 1) AS author_display,
+                               SUBSTRING_INDEX(GROUP_CONCAT(TRIM(COALESCE(a.nome, ''))
+                                   ORDER BY (la.ruolo = 'principale') DESC,
+                                            COALESCE(la.ordine_credito, 2147483647),
+                                            la.autore_id
+                                   SEPARATOR 0x1F), 0x1F, 1) AS author_name,
+                               SUBSTRING_INDEX(GROUP_CONCAT(SUBSTRING_INDEX({$preferred}, ' ', -1)
+                                   ORDER BY (la.ruolo = 'principale') DESC,
+                                            COALESCE(la.ordine_credito, 2147483647),
+                                            la.autore_id
+                                   SEPARATOR 0x1F), 0x1F, 1) AS author_sort
+                        FROM libri_autori la
+                        JOIN autori a ON a.id = la.autore_id
+                        WHERE la.libro_id IN ({$placeholders})
+                          AND la.ruolo IN ('principale', 'co-autore')
+                        GROUP BY la.libro_id
+                    ) projection ON projection.libro_id = l.id
+                    SET l.catalog_author_display = NULLIF(LEFT(projection.author_display, 512), ''),
+                        l.catalog_author_name = NULLIF(LEFT(projection.author_name, 255), ''),
+                        l.catalog_author_sort = NULLIF(LEFT(projection.author_sort, 160), '')
+                    WHERE l.id IN ({$placeholders})";
+
+                $bind = array_merge($chunk, $chunk);
+                $stmt = $db->prepare($sql);
+                if ($stmt === false) {
+                    throw new \RuntimeException('unable to prepare catalog author projection: ' . $db->error);
+                }
+                $stmt->bind_param(str_repeat('i', count($bind)), ...$bind);
+                $stmt->execute();
+                $stmt->close();
+            }
+        } catch (\Throwable $e) {
+            // Derived display data must never abort a book/author save. The
+            // legacy SELECT remains available until the projection is repaired.
+            SecureLogger::warning('CatalogAuthorProjection rebuild failed', [
+                'count' => count($ids),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public static function columnsExist(\mysqli $db): bool
+    {
+        self::$columnsKnownPresent ??= new \WeakMap();
+        if (isset(self::$columnsKnownPresent[$db])) {
+            return true;
+        }
+
+        try {
+            $result = $db->query(
+                "SELECT COUNT(*) AS cnt FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'libri'
+                   AND COLUMN_NAME IN ('catalog_author_display', 'catalog_author_name', 'catalog_author_sort')"
+            );
+            $row = $result instanceof \mysqli_result ? $result->fetch_assoc() : null;
+            if ((int) ($row['cnt'] ?? 0) === 3) {
+                self::$columnsKnownPresent[$db] = true;
+            }
+        } catch (\Throwable $e) {
+        }
+
+        return isset(self::$columnsKnownPresent[$db]);
+    }
+}

--- a/app/Support/CatalogSnapshot.php
+++ b/app/Support/CatalogSnapshot.php
@@ -1,0 +1,217 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Shared materialization for bounded catalog aggregates.
+ *
+ * QueryCache remains the fast per-worker layer. This table-backed projection
+ * lets separate application nodes, SAPIs and file-cache processes reuse the
+ * same expensive count/facet payload. Rows carry the canonical catalog
+ * generation, so ContentCache invalidation remains O(1) and an older in-flight
+ * request can never overwrite a newer projection.
+ */
+final class CatalogSnapshot
+{
+    private const TABLE = 'catalog_materialized_snapshots';
+    private const LOCK_TIMEOUT_SECONDS = 2;
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param callable(): mixed $loader
+     */
+    public static function remember(
+        \mysqli $db,
+        string $logicalKey,
+        int $generation,
+        callable $loader,
+        int $ttl = 120
+    ): mixed
+    {
+        // A negative generation means QueryCache could not persist its
+        // canonical counter. Persisting a DB snapshot in that degraded state
+        // would make invalidation unverifiable, so fail safely to a live load.
+        if ($generation <= 0) {
+            return $loader();
+        }
+
+        try {
+            if (!SchemaInfo::hasTable($db, self::TABLE)) {
+                return $loader();
+            }
+        } catch (\Throwable $e) {
+            // Schema introspection is part of the optional materialization
+            // path as well. A closed/transiently unavailable connection must
+            // not turn this optimization into a fatal error.
+            SecureLogger::warning('CatalogSnapshot schema probe failed; using live aggregate', [
+                'error' => $e->getMessage(),
+            ]);
+            return $loader();
+        }
+
+        $ttl = max(1, $ttl);
+        $snapshotKey = hash('sha256', $logicalKey);
+        $cached = self::fetch($db, $snapshotKey, $generation, $ttl);
+        if ($cached['hit']) {
+            return $cached['value'];
+        }
+
+        $lockName = self::lockName($db, $snapshotKey);
+        if (!self::acquireLock($db, $lockName)) {
+            // Never make a public request wait indefinitely for an aggregate.
+            // The result stays correct; only this request misses materialization.
+            return $loader();
+        }
+
+        try {
+            // Another worker may have published while this one waited.
+            $cached = self::fetch($db, $snapshotKey, $generation, $ttl);
+            if ($cached['hit']) {
+                return $cached['value'];
+            }
+
+            // A newer generation already won. This request belongs to an old
+            // QueryCache generation, so compute for itself but never overwrite
+            // the newer shared row.
+            if ($cached['stored_generation'] > $generation) {
+                return $loader();
+            }
+
+            $value = $loader();
+            try {
+                self::storeIfNewer($db, $snapshotKey, $generation, $value);
+            } catch (\Throwable $e) {
+                // Materialization is an optimization. A successful live query
+                // must remain successful even if the projection write fails.
+                SecureLogger::warning('CatalogSnapshot write failed; returning live aggregate', [
+                    'key' => substr($logicalKey, 0, 120),
+                    'generation' => $generation,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+            return $value;
+        } finally {
+            self::releaseLock($db, $lockName);
+        }
+    }
+
+    /**
+     * @return array{hit: bool, value: mixed, stored_generation: int}
+     */
+    private static function fetch(\mysqli $db, string $snapshotKey, int $generation, int $ttl): array
+    {
+        try {
+            $stmt = $db->prepare(
+                'SELECT generation, payload, '
+                . 'TIMESTAMPDIFF(SECOND, updated_at, CURRENT_TIMESTAMP) AS age_seconds '
+                . 'FROM ' . self::TABLE . ' WHERE cache_key = ? LIMIT 1'
+            );
+            if ($stmt === false) {
+                return ['hit' => false, 'value' => null, 'stored_generation' => 0];
+            }
+            $stmt->bind_param('s', $snapshotKey);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_assoc();
+            $stmt->close();
+            if ($row === null) {
+                return ['hit' => false, 'value' => null, 'stored_generation' => 0];
+            }
+
+            $storedGeneration = (int) ($row['generation'] ?? 0);
+            if ($storedGeneration !== $generation) {
+                return ['hit' => false, 'value' => null, 'stored_generation' => $storedGeneration];
+            }
+            // Explicit invalidation is primary, but retain QueryCache's TTL as
+            // a safety net for a missed/third-party write path. Without this,
+            // a same-generation DB snapshot could remain stale indefinitely.
+            if (max(0, (int) ($row['age_seconds'] ?? PHP_INT_MAX)) >= $ttl) {
+                return ['hit' => false, 'value' => null, 'stored_generation' => $storedGeneration];
+            }
+
+            try {
+                $value = json_decode((string) $row['payload'], true, 512, JSON_THROW_ON_ERROR);
+            } catch (\JsonException $e) {
+                SecureLogger::warning('CatalogSnapshot ignored malformed payload', [
+                    'cache_key' => $snapshotKey,
+                    'generation' => $generation,
+                    'error' => $e->getMessage(),
+                ]);
+                return ['hit' => false, 'value' => null, 'stored_generation' => $storedGeneration];
+            }
+
+            return ['hit' => true, 'value' => $value, 'stored_generation' => $storedGeneration];
+        } catch (\Throwable $e) {
+            SecureLogger::warning('CatalogSnapshot read failed', ['error' => $e->getMessage()]);
+            return ['hit' => false, 'value' => null, 'stored_generation' => 0];
+        }
+    }
+
+    private static function storeIfNewer(\mysqli $db, string $snapshotKey, int $generation, mixed $value): void
+    {
+        $payload = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $stmt = $db->prepare(
+            'INSERT INTO ' . self::TABLE . ' (cache_key, generation, payload, updated_at) '
+            . 'VALUES (?, ?, ?, CURRENT_TIMESTAMP) '
+            . 'ON DUPLICATE KEY UPDATE '
+            . 'payload = IF(VALUES(generation) >= generation, VALUES(payload), payload), '
+            . 'updated_at = IF(VALUES(generation) >= generation, CURRENT_TIMESTAMP, updated_at), '
+            . 'generation = GREATEST(generation, VALUES(generation))'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('unable to prepare catalog snapshot write: ' . $db->error);
+        }
+        $stmt->bind_param('sis', $snapshotKey, $generation, $payload);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    private static function lockName(\mysqli $db, string $snapshotKey): string
+    {
+        $database = '';
+        try {
+            $result = $db->query('SELECT DATABASE()');
+            $database = $result instanceof \mysqli_result ? (string) ($result->fetch_row()[0] ?? '') : '';
+        } catch (\Throwable $ignored) {
+        }
+
+        // MySQL lock names are limited to 64 characters on supported versions.
+        return 'pinakes:cat:' . substr(hash('sha256', $database . ':' . $snapshotKey), 0, 48);
+    }
+
+    private static function acquireLock(\mysqli $db, string $lockName): bool
+    {
+        try {
+            $stmt = $db->prepare('SELECT GET_LOCK(?, ?)');
+            if ($stmt === false) {
+                return false;
+            }
+            $timeout = self::LOCK_TIMEOUT_SECONDS;
+            $stmt->bind_param('si', $lockName, $timeout);
+            $stmt->execute();
+            $row = $stmt->get_result()->fetch_row();
+            $stmt->close();
+            return isset($row[0]) && (int) $row[0] === 1;
+        } catch (\Throwable $e) {
+            SecureLogger::warning('CatalogSnapshot lock acquisition failed', ['error' => $e->getMessage()]);
+            return false;
+        }
+    }
+
+    private static function releaseLock(\mysqli $db, string $lockName): void
+    {
+        try {
+            $stmt = $db->prepare('SELECT RELEASE_LOCK(?)');
+            if ($stmt !== false) {
+                $stmt->bind_param('s', $lockName);
+                $stmt->execute();
+                $stmt->close();
+            }
+        } catch (\Throwable $e) {
+            SecureLogger::warning('CatalogSnapshot lock release failed', ['error' => $e->getMessage()]);
+        }
+    }
+}

--- a/app/Support/CatalogSnapshot.php
+++ b/app/Support/CatalogSnapshot.php
@@ -7,10 +7,11 @@ namespace App\Support;
  * Shared materialization for bounded catalog aggregates.
  *
  * QueryCache remains the fast per-worker layer. This table-backed projection
- * lets separate application nodes, SAPIs and file-cache processes reuse the
- * same expensive count/facet payload. Rows carry the canonical catalog
+ * lets APCu and file-backed SAPIs sharing one installation generation reuse
+ * the same expensive count/facet payload. Rows carry the canonical catalog
  * generation, so ContentCache invalidation remains O(1) and an older in-flight
- * request can never overwrite a newer projection.
+ * request can never overwrite a newer projection. Cross-server coherence is
+ * intentionally left to the later Redis phase.
  */
 final class CatalogSnapshot
 {

--- a/app/Support/QueryCache.php
+++ b/app/Support/QueryCache.php
@@ -505,6 +505,27 @@ class QueryCache
     }
 
     /**
+     * Return the generation currently used by a known cache namespace.
+     *
+     * Materialized database projections use the same token as QueryCache so a
+     * single ContentCache bump makes both layers unreachable atomically. The
+     * value is intentionally exposed only for the fixed namespaces above;
+     * arbitrary prefixes still use physical invalidation and have no stable
+     * generation contract.
+     *
+     * @param string $namespace Namespace prefix, with or without trailing '_'
+     */
+    public static function namespaceGeneration(string $namespace): int
+    {
+        $ns = str_ends_with($namespace, '_') ? $namespace : $namespace . '_';
+        if (!in_array($ns, self::NAMESPACE_PREFIXES, true)) {
+            throw new \InvalidArgumentException('Unknown generation-tracked cache namespace: ' . $namespace);
+        }
+
+        return self::currentGeneration($ns);
+    }
+
+    /**
      * Clear all cache entries with a given prefix
      *
      * For the known content namespaces this is an O(1) generation bump (the

--- a/app/Support/SearchIndexBuilder.php
+++ b/app/Support/SearchIndexBuilder.php
@@ -175,7 +175,17 @@ final class SearchIndexBuilder
             }
         }
         $ids = array_values($ids);
-        if ($ids === [] || !self::columnExists($db)) {
+        if ($ids === []) {
+            return;
+        }
+
+        // The same write paths that maintain search_index also own the
+        // catalog's principal-author projection. Keep this before the
+        // search_index schema guard so a partially upgraded installation can
+        // repair whichever derived structure is already available.
+        CatalogAuthorProjection::rebuildMany($db, $ids);
+
+        if (!self::columnExists($db)) {
             return;
         }
 

--- a/installer/database/migrations/migrate_0.7.71-rc.1.sql
+++ b/installer/database/migrations/migrate_0.7.71-rc.1.sql
@@ -2,8 +2,8 @@
 --
 -- Existing installs receive three nullable, write-maintained display columns
 -- that replace the public catalog's three correlated author subqueries. The
--- snapshot table shares bounded count/facet payloads between APCu workers and
--- is keyed by QueryCache's canonical catalog generation.
+-- snapshot table shares bounded count/facet payloads between APCu and
+-- file-backed SAPIs that share QueryCache's canonical installation generation.
 --
 -- Every DDL statement is guarded so interrupted/repeated upgrades are safe.
 

--- a/installer/database/migrations/migrate_0.7.71-rc.1.sql
+++ b/installer/database/migrations/migrate_0.7.71-rc.1.sql
@@ -1,0 +1,112 @@
+-- Migration 0.7.71-rc.1 — materialized catalog aggregates and author projection.
+--
+-- Existing installs receive three nullable, write-maintained display columns
+-- that replace the public catalog's three correlated author subqueries. The
+-- snapshot table shares bounded count/facet payloads between APCu workers and
+-- is keyed by QueryCache's canonical catalog generation.
+--
+-- Every DDL statement is guarded so interrupted/repeated upgrades are safe.
+
+SET @has_catalog_author_display = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'libri'
+      AND COLUMN_NAME = 'catalog_author_display'
+);
+SET @sql = IF(
+    @has_catalog_author_display = 0,
+    'ALTER TABLE `libri` ADD COLUMN `catalog_author_display` VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL COMMENT ''Derived principal-author display used by public catalog listings'' AFTER `search_index`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_catalog_author_name = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'libri'
+      AND COLUMN_NAME = 'catalog_author_name'
+);
+SET @sql = IF(
+    @has_catalog_author_name = 0,
+    'ALTER TABLE `libri` ADD COLUMN `catalog_author_name` VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL COMMENT ''Derived canonical name of the principal catalog author'' AFTER `catalog_author_display`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+SET @has_catalog_author_sort = (
+    SELECT COUNT(*) FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'libri'
+      AND COLUMN_NAME = 'catalog_author_sort'
+);
+SET @sql = IF(
+    @has_catalog_author_sort = 0,
+    'ALTER TABLE `libri` ADD COLUMN `catalog_author_sort` VARCHAR(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL COMMENT ''Derived surname/sort key for catalog author ordering'' AFTER `catalog_author_name`',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- Backfill in one grouped pass over libri_autori: principale wins over
+-- co-autore, then explicit credit order, then author id. Avoid three correlated
+-- scans per existing book during the migration itself.
+SET @old_group_concat_max_len = @@SESSION.group_concat_max_len;
+SET SESSION group_concat_max_len = 1000000;
+UPDATE `libri` l
+LEFT JOIN (
+    SELECT la.libro_id,
+           SUBSTRING_INDEX(GROUP_CONCAT(
+               CASE
+                   WHEN TRIM(COALESCE(a.pseudonimo, '')) <> ''
+                    AND TRIM(COALESCE(a.nome, '')) <> ''
+                    AND BINARY TRIM(COALESCE(a.pseudonimo, '')) <> BINARY TRIM(COALESCE(a.nome, ''))
+                       THEN CONCAT(TRIM(a.pseudonimo), ' (', TRIM(a.nome), ')')
+                   WHEN TRIM(COALESCE(a.nome, '')) <> '' THEN TRIM(a.nome)
+                   ELSE TRIM(COALESCE(a.pseudonimo, ''))
+               END
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id
+               SEPARATOR 0x1F
+           ), 0x1F, 1) AS author_display,
+           SUBSTRING_INDEX(GROUP_CONCAT(
+               TRIM(COALESCE(a.nome, ''))
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id
+               SEPARATOR 0x1F
+           ), 0x1F, 1) AS author_name,
+           SUBSTRING_INDEX(GROUP_CONCAT(
+               SUBSTRING_INDEX(
+                   COALESCE(NULLIF(TRIM(a.pseudonimo), ''), TRIM(COALESCE(a.nome, ''))),
+                   ' ', -1
+               )
+               ORDER BY (la.ruolo = 'principale') DESC,
+                        COALESCE(la.ordine_credito, 2147483647), la.autore_id
+               SEPARATOR 0x1F
+           ), 0x1F, 1) AS author_sort
+    FROM `libri_autori` la
+    JOIN `autori` a ON a.id = la.autore_id
+    WHERE la.ruolo IN ('principale', 'co-autore')
+    GROUP BY la.libro_id
+) projection ON projection.libro_id = l.id
+SET l.`catalog_author_display` = NULLIF(LEFT(projection.author_display, 512), ''),
+    l.`catalog_author_name` = NULLIF(LEFT(projection.author_name, 255), ''),
+    l.`catalog_author_sort` = NULLIF(LEFT(projection.author_sort, 160), '');
+SET SESSION group_concat_max_len = @old_group_concat_max_len;
+
+SET @has_catalog_author_sort_index = (
+    SELECT COUNT(*) FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'libri'
+      AND INDEX_NAME = 'idx_libri_catalog_author_sort'
+);
+SET @sql = IF(
+    @has_catalog_author_sort_index = 0,
+    'ALTER TABLE `libri` ADD INDEX `idx_libri_catalog_author_sort` (`catalog_author_sort`, `id`)',
+    'SELECT 1'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS `catalog_materialized_snapshots` (
+    `cache_key` CHAR(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+    `generation` BIGINT NOT NULL,
+    `payload` MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`cache_key`),
+    KEY `idx_catalog_snapshots_updated` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Generation-bound shared materialization of bounded catalog counts and facets';

--- a/installer/database/schema.sql
+++ b/installer/database/schema.sql
@@ -396,6 +396,9 @@ CREATE TABLE `libri` (
   `private_comment` text COLLATE utf8mb4_unicode_ci COMMENT 'Private comment (LibraryThing)',
   `parole_chiave` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `search_index` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `catalog_author_display` varchar(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Derived principal-author display used by public catalog listings',
+  `catalog_author_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Derived canonical name of the principal catalog author',
+  `catalog_author_sort` varchar(160) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL COMMENT 'Derived surname/sort key for catalog author ordering',
   `formato` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT 'cartaceo',
   `tipo_media` enum('libro','disco','audiolibro','dvd','altro') NOT NULL DEFAULT 'libro',
   `peso` float DEFAULT NULL,
@@ -463,6 +466,7 @@ CREATE TABLE `libri` (
   KEY `idx_libri_updated_at` (`updated_at`),
   KEY `idx_libri_deleted_created` (`deleted_at`,`created_at`),
   KEY `idx_libri_genere_deleted_created` (`genere_id`,`deleted_at`,`created_at`),
+  KEY `idx_libri_catalog_author_sort` (`catalog_author_sort`,`id`),
   FULLTEXT KEY `ft_libri_search` (`titolo`,`sottotitolo`,`descrizione`,`parole_chiave`),
   FULLTEXT KEY `ft_libri_search_index` (`search_index`),
   CONSTRAINT `fk_libri_mensola` FOREIGN KEY (`mensola_id`) REFERENCES `mensole` (`id`) ON DELETE SET NULL,
@@ -506,6 +510,14 @@ CREATE TABLE `libri_autori` (
   CONSTRAINT `libri_autori_ibfk_1` FOREIGN KEY (`libro_id`) REFERENCES `libri` (`id`) ON DELETE CASCADE,
   CONSTRAINT `libri_autori_ibfk_2` FOREIGN KEY (`autore_id`) REFERENCES `autori` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `catalog_materialized_snapshots` (
+  `cache_key` char(64) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  `generation` bigint NOT NULL,
+  `payload` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`cache_key`),
+  KEY `idx_catalog_snapshots_updated` (`updated_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Generation-bound shared materialization of bounded catalog counts and facets';
 -- Tracks only role links created by authoritative importers. Keeping this
 -- provenance outside libri_autori lets a re-import replace its own stale
 -- contributors without deleting an identical association added manually.

--- a/tests/catalog-materialization-db.unit.php
+++ b/tests/catalog-materialization-db.unit.php
@@ -1,0 +1,198 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Runtime behavior for the 0.7.71 catalog projections against the canonical
+ * schema. All rows use a unique test marker and are removed in finally.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+use App\Support\CatalogSnapshot;
+use App\Support\QueryCache;
+use App\Support\SearchIndexBuilder;
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+} catch (Throwable $e) {
+    echo 'SKIP: database not reachable (' . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+$required = $db->query(
+    "SELECT (SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() "
+    . "AND TABLE_NAME='libri' AND COLUMN_NAME LIKE 'catalog_author_%') AS cols, "
+    . "(SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() "
+    . "AND TABLE_NAME='catalog_materialized_snapshots') AS snapshots"
+)->fetch_assoc();
+if ((int) ($required['cols'] ?? 0) !== 3 || (int) ($required['snapshots'] ?? 0) !== 1) {
+    echo "SKIP: 0.7.71 catalog materialization migration is not applied\n";
+    exit(0);
+}
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$run = bin2hex(random_bytes(6));
+$title = 'ZZ071CAT ' . $run;
+$authorPrefix = 'ZZ071CAT-' . $run . '-';
+$bookId = 0;
+$authorIds = [];
+$logicalSnapshotKey = 'catalog_count_zz071_' . $run;
+$snapshotKey = hash('sha256', $logicalSnapshotKey);
+
+$cleanup = static function () use ($db, &$bookId, &$authorIds, $snapshotKey): void {
+    $stmt = $db->prepare('DELETE FROM catalog_materialized_snapshots WHERE cache_key = ?');
+    $stmt->bind_param('s', $snapshotKey);
+    $stmt->execute();
+    $stmt->close();
+    if ($bookId > 0) {
+        $db->query('DELETE FROM libri_autori WHERE libro_id = ' . $bookId);
+        $db->query('DELETE FROM libri WHERE id = ' . $bookId);
+    }
+    foreach ($authorIds as $authorId) {
+        $db->query('DELETE FROM autori WHERE id = ' . (int) $authorId);
+    }
+};
+
+try {
+    $cleanup();
+
+    $stmt = $db->prepare('INSERT INTO autori (nome, pseudonimo) VALUES (?, ?)');
+    $realName = $authorPrefix . 'Charles Dodgson';
+    $pseudonym = 'Lewis Carroll';
+    $stmt->bind_param('ss', $realName, $pseudonym);
+    $stmt->execute();
+    $principalId = (int) $db->insert_id;
+    $authorIds[] = $principalId;
+    $coauthorName = $authorPrefix . 'Backup Writer';
+    $emptyPseudonym = null;
+    $stmt->bind_param('ss', $coauthorName, $emptyPseudonym);
+    $stmt->execute();
+    $coauthorId = (int) $db->insert_id;
+    $authorIds[] = $coauthorId;
+    $stmt->close();
+
+    $stmt = $db->prepare('INSERT INTO libri (titolo, copie_totali, copie_disponibili) VALUES (?, 1, 1)');
+    $stmt->bind_param('s', $title);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+
+    $stmt = $db->prepare('INSERT INTO libri_autori (libro_id, autore_id, ruolo, ordine_credito) VALUES (?, ?, ?, ?)');
+    $role = 'co-autore';
+    $order = 1;
+    $stmt->bind_param('iisi', $bookId, $coauthorId, $role, $order);
+    $stmt->execute();
+    $role = 'principale';
+    $order = 99;
+    $stmt->bind_param('iisi', $bookId, $principalId, $role, $order);
+    $stmt->execute();
+    $stmt->close();
+
+    SearchIndexBuilder::rebuild($db, $bookId);
+    $row = $db->query(
+        'SELECT catalog_author_display, catalog_author_name, catalog_author_sort FROM libri WHERE id = ' . $bookId
+    )->fetch_assoc();
+    $check(($row['catalog_author_display'] ?? '') === 'Lewis Carroll (' . $realName . ')', 'runtime rebuild selects the principal and preserves pseudonym display');
+    $check(($row['catalog_author_name'] ?? '') === $realName, 'runtime rebuild stores the canonical principal name');
+    $check(($row['catalog_author_sort'] ?? '') === 'Carroll', 'runtime rebuild stores the preferred surname sort key');
+
+    $newPseudonym = 'Carroll Updated';
+    $stmt = $db->prepare('UPDATE autori SET pseudonimo = ? WHERE id = ?');
+    $stmt->bind_param('si', $newPseudonym, $principalId);
+    $stmt->execute();
+    $stmt->close();
+    SearchIndexBuilder::rebuildForAuthor($db, $principalId);
+    $row = $db->query('SELECT catalog_author_display, catalog_author_sort FROM libri WHERE id = ' . $bookId)->fetch_assoc();
+    $check(($row['catalog_author_display'] ?? '') === $newPseudonym . ' (' . $realName . ')', 'author edits refresh every linked catalog projection');
+    $check(($row['catalog_author_sort'] ?? '') === 'Updated', 'author edit refreshes the sort key');
+
+    $db->query("DELETE FROM libri_autori WHERE libro_id = {$bookId} AND ruolo = 'principale'");
+    SearchIndexBuilder::rebuild($db, $bookId);
+    $row = $db->query('SELECT catalog_author_name FROM libri WHERE id = ' . $bookId)->fetch_assoc();
+    $check(($row['catalog_author_name'] ?? '') === $coauthorName, 'projection falls back to the first co-author after principal removal');
+
+    $db->query('DELETE FROM libri_autori WHERE libro_id = ' . $bookId);
+    SearchIndexBuilder::rebuild($db, $bookId);
+    $row = $db->query('SELECT catalog_author_display FROM libri WHERE id = ' . $bookId)->fetch_assoc();
+    $check(array_key_exists('catalog_author_display', $row) && $row['catalog_author_display'] === null, 'projection clears stale fields when the last creator is removed');
+
+    $generation = QueryCache::namespaceGeneration('catalog_');
+    $loads = 0;
+    $first = CatalogSnapshot::remember($db, $logicalSnapshotKey, $generation, static function () use (&$loads): array {
+        $loads++;
+        return ['total' => 11, 'facets' => ['book' => 7]];
+    });
+    $second = CatalogSnapshot::remember($db, $logicalSnapshotKey, $generation, static function () use (&$loads): array {
+        $loads++;
+        return ['total' => 999];
+    });
+    $check($first === $second && $loads === 1, 'same-generation workers reuse one materialized aggregate');
+
+    $next = CatalogSnapshot::remember($db, $logicalSnapshotKey, $generation + 1, static function () use (&$loads): array {
+        $loads++;
+        return ['total' => 12];
+    });
+    $check(($next['total'] ?? 0) === 12 && $loads === 2, 'new catalog generation rebuilds the shared aggregate');
+
+    $old = CatalogSnapshot::remember($db, $logicalSnapshotKey, $generation, static function () use (&$loads): array {
+        $loads++;
+        return ['total' => 10];
+    });
+    $stored = $db->query(
+        "SELECT generation, JSON_UNQUOTE(JSON_EXTRACT(payload, '$.total')) AS total "
+        . "FROM catalog_materialized_snapshots WHERE cache_key = '" . $db->real_escape_string($snapshotKey) . "'"
+    )->fetch_assoc();
+    $check(($old['total'] ?? 0) === 10 && $loads === 3, 'an old in-flight generation receives a correct live value');
+    $check((int) ($stored['generation'] ?? 0) === $generation + 1 && (int) ($stored['total'] ?? 0) === 12, 'old generation cannot overwrite the newer shared snapshot');
+
+    $db->query(
+        "UPDATE catalog_materialized_snapshots SET updated_at = CURRENT_TIMESTAMP - INTERVAL 5 SECOND "
+        . "WHERE cache_key = '" . $db->real_escape_string($snapshotKey) . "'"
+    );
+    $expired = CatalogSnapshot::remember($db, $logicalSnapshotKey, $generation + 1, static function () use (&$loads): array {
+        $loads++;
+        return ['total' => 13];
+    }, 1);
+    $check(($expired['total'] ?? 0) === 13 && $loads === 4, 'expired same-generation snapshot rebuilds instead of staying stale forever');
+} catch (Throwable $e) {
+    $failed++;
+    echo '  FAIL exception: ' . $e->getMessage() . PHP_EOL;
+} finally {
+    try {
+        $cleanup();
+    } catch (Throwable $e) {
+        $failed++;
+        echo '  FAIL cleanup: ' . $e->getMessage() . PHP_EOL;
+    }
+    $db->close();
+}
+
+echo PHP_EOL;
+if ($failed > 0) {
+    echo "FAILED: {$failed} check(s) failed, {$passed} passed\n";
+    exit(1);
+}
+echo "ALL {$passed} PASS\n";

--- a/tests/catalog-materialization-db.unit.php
+++ b/tests/catalog-materialization-db.unit.php
@@ -25,14 +25,27 @@ foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as 
     $env[trim($key)] = trim(trim($value), "\"'");
 }
 
+// In CI the schema/DB gate provides a seeded database, so a missing
+// connection or an unapplied migration is a real failure that must turn the
+// pipeline red — never a silent green. Locally (no CI) the same conditions are
+// an acceptable skip so the test can be run ad hoc without a full DB.
+$requireDb = in_array(strtolower((string) getenv('CI')), ['1', 'true', 'yes'], true);
+$skipOrFail = static function (string $message) use ($requireDb): void {
+    if ($requireDb) {
+        fwrite(STDERR, 'FAIL: ' . $message . " (CI requires a seeded database)\n");
+        exit(1);
+    }
+    echo 'SKIP: ' . $message . "\n";
+    exit(0);
+};
+
 $socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
 try {
     $db = $socket !== '' && file_exists($socket)
         ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
         : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
 } catch (Throwable $e) {
-    echo 'SKIP: database not reachable (' . $e->getMessage() . ")\n";
-    exit(0);
+    $skipOrFail('database not reachable (' . $e->getMessage() . ')');
 }
 $db->set_charset('utf8mb4');
 
@@ -43,8 +56,7 @@ $required = $db->query(
     . "AND TABLE_NAME='catalog_materialized_snapshots') AS snapshots"
 )->fetch_assoc();
 if ((int) ($required['cols'] ?? 0) !== 3 || (int) ($required['snapshots'] ?? 0) !== 1) {
-    echo "SKIP: 0.7.71 catalog materialization migration is not applied\n";
-    exit(0);
+    $skipOrFail('0.7.71 catalog materialization migration is not applied');
 }
 
 $passed = 0;
@@ -118,6 +130,33 @@ try {
     $check(($row['catalog_author_display'] ?? '') === 'Lewis Carroll (' . $realName . ')', 'runtime rebuild selects the principal and preserves pseudonym display');
     $check(($row['catalog_author_name'] ?? '') === $realName, 'runtime rebuild stores the canonical principal name');
     $check(($row['catalog_author_sort'] ?? '') === 'Carroll', 'runtime rebuild stores the preferred surname sort key');
+
+    // Read-path completeness gate (findings C + D). isReadable() must reject the
+    // materialized columns while any linked book is missing its sort key — the
+    // migration backfill window (C) or a row nulled by a failed rebuild (D) —
+    // so the catalog falls back to the always-correct live subqueries. Probed on
+    // fresh connections because isReadable() caches its positive result per
+    // connection; tolerant of the baseline so a partially-backfilled fixture DB
+    // cannot make the transition assertions flaky.
+    $freshDb = static function () use ($socket, $env): \mysqli {
+        $conn = $socket !== '' && file_exists($socket)
+            ? new \mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+            : new \mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+        $conn->set_charset('utf8mb4');
+        return $conn;
+    };
+    $probeReadable = static function (\mysqli $conn): bool {
+        try {
+            return \App\Support\CatalogAuthorProjection::isReadable($conn);
+        } finally {
+            $conn->close();
+        }
+    };
+    $baseReadable = $probeReadable($freshDb());
+    $db->query("UPDATE libri SET catalog_author_sort = NULL WHERE id = {$bookId}");
+    $check($probeReadable($freshDb()) === false, 'isReadable() is false while a linked book has an author but no sort key');
+    SearchIndexBuilder::rebuild($db, $bookId);
+    $check($probeReadable($freshDb()) === $baseReadable, 'isReadable() returns to baseline once the projection is repaired');
 
     $newPseudonym = 'Carroll Updated';
     $stmt = $db->prepare('UPDATE autori SET pseudonimo = ? WHERE id = ?');

--- a/tests/catalog-materialization.unit.php
+++ b/tests/catalog-materialization.unit.php
@@ -33,7 +33,7 @@ $check(str_contains($snapshot, 'GET_LOCK') && str_contains($snapshot, 'RELEASE_L
 $check(str_contains($snapshot, 'return $loader();') && str_contains($snapshot, '!SchemaInfo::hasTable'), 'pre-migration installs fail open to live aggregates');
 $check(str_contains($projection, "la.ruolo IN ('principale', 'co-autore')"), 'projection excludes non-creator contributor roles');
 $check(str_contains($projection, "COALESCE(la.ordine_credito, 2147483647)"), 'projection selection has a deterministic credit-order tie-break');
-$check(str_contains($frontend, 'CatalogAuthorProjection::columnsExist($db)'), 'catalog keeps an explicit rolling-upgrade fallback');
+$check(str_contains($frontend, 'CatalogAuthorProjection::isReadable($db)'), 'catalog keeps an explicit rolling-upgrade fallback (completeness-gated: backfill window + failed rebuild)');
 $bulkDeleteStart = strpos($authorsApi, 'public function bulkDelete(');
 $bulkExportStart = strpos($authorsApi, 'public function bulkExport(');
 $bulkDelete = $bulkDeleteStart !== false && $bulkExportStart !== false

--- a/tests/catalog-materialization.unit.php
+++ b/tests/catalog-materialization.unit.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Static/runtime-independent contracts for catalog materialization. The real
+ * migration behavior lives in migration-0.7.71-rc.1.unit.php; these checks run
+ * even during a rolling-upgrade window where the canonical table is absent.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$queryCache = (string) file_get_contents($root . '/app/Support/QueryCache.php');
+$snapshot = (string) file_get_contents($root . '/app/Support/CatalogSnapshot.php');
+$projection = (string) file_get_contents($root . '/app/Support/CatalogAuthorProjection.php');
+$frontend = (string) file_get_contents($root . '/app/Controllers/FrontendController.php');
+$authorsApi = (string) file_get_contents($root . '/app/Controllers/AutoriApiController.php');
+$schema = (string) file_get_contents($root . '/installer/database/schema.sql');
+
+$check(str_contains($queryCache, 'public static function namespaceGeneration'), 'QueryCache exposes only its canonical namespace generation');
+$check(str_contains($queryCache, "throw new \\InvalidArgumentException('Unknown generation-tracked cache namespace:"), 'unknown namespaces cannot forge a materialization generation');
+$check(str_contains($snapshot, 'if ($generation <= 0'), 'degraded non-persistent generations bypass DB materialization');
+$check(str_contains($snapshot, 'stored_generation') && str_contains($snapshot, '> $generation'), 'an old request cannot overwrite a newer snapshot generation');
+$check(str_contains($snapshot, 'age_seconds') && str_contains($snapshot, '>= $ttl'), 'shared snapshots retain the short TTL safety net');
+$check(str_contains($snapshot, 'GET_LOCK') && str_contains($snapshot, 'RELEASE_LOCK'), 'cross-worker rebuilds use a bounded MySQL mutex');
+$check(str_contains($snapshot, 'return $loader();') && str_contains($snapshot, '!SchemaInfo::hasTable'), 'pre-migration installs fail open to live aggregates');
+$check(str_contains($projection, "la.ruolo IN ('principale', 'co-autore')"), 'projection excludes non-creator contributor roles');
+$check(str_contains($projection, "COALESCE(la.ordine_credito, 2147483647)"), 'projection selection has a deterministic credit-order tie-break');
+$check(str_contains($frontend, 'CatalogAuthorProjection::columnsExist($db)'), 'catalog keeps an explicit rolling-upgrade fallback');
+$bulkDeleteStart = strpos($authorsApi, 'public function bulkDelete(');
+$bulkExportStart = strpos($authorsApi, 'public function bulkExport(');
+$bulkDelete = $bulkDeleteStart !== false && $bulkExportStart !== false
+    ? substr($authorsApi, $bulkDeleteStart, $bulkExportStart - $bulkDeleteStart)
+    : '';
+$projectionRebuild = strpos($bulkDelete, 'SearchIndexBuilder::rebuildMany');
+$cacheInvalidation = strpos($bulkDelete, 'ContentCache::booksChanged');
+$check(
+    $projectionRebuild !== false
+        && $cacheInvalidation !== false
+        && $projectionRebuild < $cacheInvalidation,
+    'bulk author deletion rebuilds derived fields before publishing cache invalidation'
+);
+$check(str_contains($schema, 'catalog_materialized_snapshots'), 'fresh installs receive the snapshot table');
+$check(str_contains($schema, 'idx_libri_catalog_author_sort'), 'fresh installs receive the author ordering index');
+
+try {
+    \App\Support\QueryCache::namespaceGeneration('not-a-real-namespace');
+    $check(false, 'unknown namespace is rejected at runtime');
+} catch (InvalidArgumentException $e) {
+    $check(true, 'unknown namespace is rejected at runtime');
+}
+
+echo PHP_EOL;
+if ($failed > 0) {
+    echo "FAILED: {$failed} check(s) failed, {$passed} passed\n";
+    exit(1);
+}
+echo "ALL {$passed} PASS\n";

--- a/tests/migration-0.7.71-rc.1.unit.php
+++ b/tests/migration-0.7.71-rc.1.unit.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral upgrade coverage for the 0.7.71 catalog materialization schema.
+ * The real migration is retargeted onto isolated zz_* tables so an ordinary
+ * local run never alters application data or its canonical schema.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    $line = trim($line);
+    if ($line === '' || str_starts_with($line, '#') || !str_contains($line, '=')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ''), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+} catch (Throwable $e) {
+    echo 'SKIP: database not reachable (' . $e->getMessage() . ")\n";
+    exit(0);
+}
+$db->set_charset('utf8mb4');
+
+const M71_BOOKS = 'zz_m71_libri';
+const M71_AUTHORS = 'zz_m71_autori';
+const M71_LINKS = 'zz_m71_libri_autori';
+const M71_SNAPSHOTS = 'zz_m71_catalog_snapshots';
+
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$cleanup = static function () use ($db): void {
+    foreach ([M71_LINKS, M71_BOOKS, M71_AUTHORS, M71_SNAPSHOTS] as $table) {
+        $db->query('DROP TABLE IF EXISTS `' . $table . '`');
+    }
+};
+
+/** @return list<string> */
+function m71SplitSql(string $sql): array
+{
+    $statements = [];
+    $current = '';
+    $quote = null;
+    $length = strlen($sql);
+    for ($i = 0; $i < $length; $i++) {
+        $char = $sql[$i];
+        if ($quote !== null) {
+            $current .= $char;
+            if ($char === $quote) {
+                if ($i + 1 < $length && $sql[$i + 1] === $quote) {
+                    $current .= $sql[++$i];
+                } elseif ($i === 0 || $sql[$i - 1] !== '\\') {
+                    $quote = null;
+                }
+            }
+            continue;
+        }
+        if ($char === "'" || $char === '"') {
+            $quote = $char;
+            $current .= $char;
+            continue;
+        }
+        if ($char === ';') {
+            if (trim($current) !== '') {
+                $statements[] = trim($current);
+            }
+            $current = '';
+            continue;
+        }
+        $current .= $char;
+    }
+    if (trim($current) !== '') {
+        $statements[] = trim($current);
+    }
+    return $statements;
+}
+
+$applyMigration = static function () use ($db, $root): void {
+    $sql = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.71-rc.1.sql');
+    $sql = preg_replace('/^\s*--.*$/m', '', $sql) ?? $sql;
+    $sql = str_replace(
+        [
+            '`catalog_materialized_snapshots`', "'catalog_materialized_snapshots'",
+            '`libri_autori`', "'libri_autori'",
+            '`autori`', "'autori'",
+            '`libri`', "'libri'",
+        ],
+        [
+            '`' . M71_SNAPSHOTS . '`', "'" . M71_SNAPSHOTS . "'",
+            '`' . M71_LINKS . '`', "'" . M71_LINKS . "'",
+            '`' . M71_AUTHORS . '`', "'" . M71_AUTHORS . "'",
+            '`' . M71_BOOKS . '`', "'" . M71_BOOKS . "'",
+        ],
+        $sql
+    );
+    foreach (m71SplitSql($sql) as $statement) {
+        $db->query($statement);
+    }
+};
+
+try {
+    $cleanup();
+    $db->query(
+        'CREATE TABLE `' . M71_BOOKS . '` ('
+        . 'id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, '
+        . 'titolo VARCHAR(255) NOT NULL, search_index MEDIUMTEXT NULL'
+        . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+    $db->query(
+        'CREATE TABLE `' . M71_AUTHORS . '` ('
+        . 'id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, nome VARCHAR(255) NOT NULL, pseudonimo VARCHAR(255) NULL'
+        . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+    $db->query(
+        'CREATE TABLE `' . M71_LINKS . '` ('
+        . "libro_id INT NOT NULL, autore_id INT NOT NULL, ruolo VARCHAR(32) NOT NULL, ordine_credito INT NULL, "
+        . 'PRIMARY KEY (libro_id, autore_id, ruolo)'
+        . ') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+    );
+
+    $db->query("INSERT INTO `" . M71_BOOKS . "` (id, titolo) VALUES (1, 'Book One'), (2, 'Book Two'), (3, 'No Author')");
+    $db->query("INSERT INTO `" . M71_AUTHORS . "` (id, nome, pseudonimo) VALUES
+        (1, 'Charles Dodgson', 'Lewis Carroll'),
+        (2, 'Zed Coauthor', NULL),
+        (3, 'Second Choice', NULL),
+        (4, 'First Choice', NULL)");
+    $db->query("INSERT INTO `" . M71_LINKS . "` (libro_id, autore_id, ruolo, ordine_credito) VALUES
+        (1, 2, 'co-autore', 1),
+        (1, 1, 'principale', 99),
+        (2, 3, 'co-autore', 2),
+        (2, 4, 'co-autore', 1)");
+
+    $columnsBefore = $db->query(
+        "SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() "
+        . "AND TABLE_NAME='" . M71_BOOKS . "' AND COLUMN_NAME LIKE 'catalog_author_%'"
+    )->fetch_row();
+    $check((int) ($columnsBefore[0] ?? -1) === 0, 'old schema starts without catalog author projection');
+
+    $applyMigration();
+
+    $columnRows = $db->query(
+        "SELECT COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH FROM information_schema.COLUMNS "
+        . "WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='" . M71_BOOKS . "' "
+        . "AND COLUMN_NAME LIKE 'catalog_author_%' ORDER BY COLUMN_NAME"
+    )->fetch_all(MYSQLI_ASSOC);
+    $lengths = array_map(
+        static fn (mixed $length): int => (int) $length,
+        array_column($columnRows, 'CHARACTER_MAXIMUM_LENGTH', 'COLUMN_NAME')
+    );
+    $check($lengths === [
+        'catalog_author_display' => 512,
+        'catalog_author_name' => 255,
+        'catalog_author_sort' => 160,
+    ], 'migration adds all three projection columns with bounded lengths');
+
+    $index = $db->query(
+        "SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA=DATABASE() "
+        . "AND TABLE_NAME='" . M71_BOOKS . "' AND INDEX_NAME='idx_libri_catalog_author_sort'"
+    )->fetch_row();
+    $check((int) ($index[0] ?? 0) === 2, 'author sort index contains sort key and deterministic id tie-break');
+
+    $rows = $db->query(
+        'SELECT id, catalog_author_display, catalog_author_name, catalog_author_sort FROM `'
+        . M71_BOOKS . '` ORDER BY id'
+    )->fetch_all(MYSQLI_ASSOC);
+    $check(($rows[0]['catalog_author_display'] ?? null) === 'Lewis Carroll (Charles Dodgson)', 'principal role wins and pseudonym display matches AuthorName');
+    $check(($rows[0]['catalog_author_name'] ?? null) === 'Charles Dodgson', 'canonical principal name is materialized');
+    $check(($rows[0]['catalog_author_sort'] ?? null) === 'Carroll', 'preferred pseudonym surname becomes sort key');
+    $check(($rows[1]['catalog_author_name'] ?? null) === 'First Choice', 'credit order deterministically selects the first co-author');
+    $check(array_key_exists('catalog_author_display', $rows[2]) && $rows[2]['catalog_author_display'] === null, 'books without creators keep nullable projection fields');
+
+    $snapshotTable = $db->query(
+        "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA=DATABASE() "
+        . "AND TABLE_NAME='" . M71_SNAPSHOTS . "'"
+    )->fetch_row();
+    $check((int) ($snapshotTable[0] ?? 0) === 1, 'migration creates the shared catalog snapshot table');
+
+    $beforeSecondRun = json_encode($rows, JSON_THROW_ON_ERROR);
+    $applyMigration();
+    $afterSecondRun = json_encode($db->query(
+        'SELECT id, catalog_author_display, catalog_author_name, catalog_author_sort FROM `'
+        . M71_BOOKS . '` ORDER BY id'
+    )->fetch_all(MYSQLI_ASSOC), JSON_THROW_ON_ERROR);
+    $check($afterSecondRun === $beforeSecondRun, 'migration is idempotent and preserves the projection on a second run');
+
+    $frontend = (string) file_get_contents($root . '/app/Controllers/FrontendController.php');
+    $searchBuilder = (string) file_get_contents($root . '/app/Support/SearchIndexBuilder.php');
+    $check(str_contains($frontend, 'CatalogSnapshot::remember('), 'bounded count/facet path uses the shared materialization layer');
+    $check(str_contains($frontend, 'l.catalog_author_display AS autore'), 'catalog SELECT has the direct projection path');
+    $check(str_contains($searchBuilder, 'CatalogAuthorProjection::rebuildMany($db, $ids);'), 'existing search-index write funnel also rebuilds the author projection');
+    $check(version_compare('0.7.71-rc.1', '0.7.71', '<'), 'version_compare keeps the release candidate below stable');
+    $check(
+        \App\Support\Updater::shouldRunMigration('0.7.71-rc.1', '0.7.70-rc.1', '0.7.71-rc.1'),
+        'updater runs the migration when upgrading to this release candidate'
+    );
+    $check(
+        \App\Support\Updater::shouldRunMigration('0.7.71-rc.1', '0.7.70', '0.7.71'),
+        'updater runs the RC migration when an installation jumps directly to stable'
+    );
+    $check(
+        !\App\Support\Updater::shouldRunMigration('0.7.71-rc.1', '0.7.71-rc.1', '0.7.71'),
+        'updater does not rerun the migration during the RC-to-stable upgrade'
+    );
+} catch (Throwable $e) {
+    $failed++;
+    echo '  FAIL exception: ' . $e->getMessage() . PHP_EOL;
+} finally {
+    $cleanup();
+    $db->close();
+}
+
+echo PHP_EOL;
+if ($failed > 0) {
+    echo "FAILED: {$failed} check(s) failed, {$passed} passed\n";
+    exit(1);
+}
+echo "ALL {$passed} PASS\n";

--- a/tests/performance-cache-regressions.unit.php
+++ b/tests/performance-cache-regressions.unit.php
@@ -170,8 +170,8 @@ $boundedLoader = static function () use (&$boundedCalls): string {
     $boundedCalls++;
     return 'bounded-' . $boundedCalls;
 };
-$firstBounded = $rememberCatalogValue->invoke($controller, $boundedKey, $base, $boundedLoader);
-$secondBounded = $rememberCatalogValue->invoke($controller, $boundedKey, $base, $boundedLoader);
+$firstBounded = $rememberCatalogValue->invoke($controller, $unavailableDb, $boundedKey, $base, $boundedLoader);
+$secondBounded = $rememberCatalogValue->invoke($controller, $unavailableDb, $boundedKey, $base, $boundedLoader);
 $check($firstBounded === 'bounded-1' && $secondBounded === 'bounded-1' && $boundedCalls === 1, 'bounded catalogue state executes its loader once');
 
 $unboundedCalls = 0;
@@ -180,8 +180,8 @@ $unboundedLoader = static function () use (&$unboundedCalls): string {
     return 'unbounded-' . $unboundedCalls;
 };
 $unboundedFilters = array_replace($base, ['search' => $runKey]);
-$firstUnbounded = $rememberCatalogValue->invoke($controller, 'catalog_' . $runKey . '_unbounded', $unboundedFilters, $unboundedLoader);
-$secondUnbounded = $rememberCatalogValue->invoke($controller, 'catalog_' . $runKey . '_unbounded', $unboundedFilters, $unboundedLoader);
+$firstUnbounded = $rememberCatalogValue->invoke($controller, $unavailableDb, 'catalog_' . $runKey . '_unbounded', $unboundedFilters, $unboundedLoader);
+$secondUnbounded = $rememberCatalogValue->invoke($controller, $unavailableDb, 'catalog_' . $runKey . '_unbounded', $unboundedFilters, $unboundedLoader);
 $check($firstUnbounded === 'unbounded-1' && $secondUnbounded === 'unbounded-2' && $unboundedCalls === 2, 'unbounded catalogue state bypasses persistent cache on every call');
 
 // Cross-request caches can be exercised without a live query: pre-seed the

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.70-rc.1",
+  "version": "0.7.71-rc.1",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
## Summary

- materialize bounded catalog counts and facets in MySQL using the canonical catalog cache generation and a 120-second safety TTL
- replace three correlated author subqueries per catalog row with a write-maintained principal-author projection
- preserve rolling-upgrade compatibility with live-query fallbacks and an idempotent 0.7.71-rc.1 migration
- keep real-time copy availability outside shared catalog rows; Redis remains intentionally deferred

## Consistency and safety

- explicit ContentCache invalidation remains authoritative
- old in-flight generations cannot overwrite newer snapshots
- projection refresh reuses the existing SearchIndexBuilder write funnel
- author bulk deletion rebuilds derived fields before publishing the cache generation bump
- materialization fails open when schema, generation persistence, or MySQL locking is unavailable

## Validation

- full PHPStan: no errors
- catalog materialization static/runtime tests: 43 assertions passed
- performance cache regressions: 61 assertions passed
- schema and migration strict gate: passed
- APCu backend and cache-generation suites: 60 assertions passed
- locale, soft-delete, and Playwright policy checks: passed
- local catalog smoke: cold and warm HTML/API responses valid; EXPLAIN contains no dependent author subqueries

This is a stacked PR based on performance-litespeed-edge-cache. The three global-sweep circulation suites are left to GitHub CI because they require the dedicated pinakes_test database and intentionally refuse the local development database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Migliorate le prestazioni del catalogo tramite il riutilizzo di conteggi e filtri materializzati.
  * Visualizzazione e ordinamento dell’autore principale più rapidi e affidabili.
  * Aggiunto supporto al fallback durante gli aggiornamenti progressivi.

* **Correzioni**
  * Aggiornamento delle cache dopo la ricostruzione dei dati derivati, evitando risultati non aggiornati.
  * Gestione più sicura di cache scadute, aggiornamenti incompleti e configurazioni non disponibili.

* **Versione**
  * Rilasciata la versione `0.7.71-rc.1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->