### PR TITLE
feat(settings): single "Svuota cache" button that clears every cache

### DIFF
--- a/app/Controllers/SettingsController.php
+++ b/app/Controllers/SettingsController.php
@@ -13,6 +13,7 @@ use App\Support\SettingsEncryption;
 use App\Support\SharingProviders;
 use App\Support\SitemapGenerator;
 use App\Support\LiteSpeedCache;
+use App\Support\QueryCache;
 use mysqli;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -517,6 +518,10 @@ class SettingsController
             'litespeed_server_detected' => LiteSpeedCache::serverDetected(),
             'litespeed_cli_purge_configured' => LiteSpeedCache::cliPurgeConfigured(),
             'litespeed_lookup_bypass_installed' => LiteSpeedCache::lookupBypassInstalled(),
+            // Application-level query cache (runs on every server, LiteSpeed or
+            // not): expose its active backend so the maintenance panel can label
+            // where the cached datasets actually live (APCu vs storage/cache).
+            'query_cache_backend' => QueryCache::stats()['backend'],
         ];
     }
 
@@ -1061,39 +1066,57 @@ class SettingsController
     }
 
     /**
-     * Drop every Pinakes-tagged entry from the LiteSpeed edge cache on demand.
+     * Flush every cache Pinakes owns, in one action, from a single admin button.
      *
-     * Emitting X-LiteSpeed-Purge on THIS response is the interactive equivalent
-     * of the CLI loopback purge: LSWS discards the tagged edge entries when it
-     * processes the header, regardless of this (admin, cookie-bearing) request
-     * being itself uncacheable. A non-LiteSpeed server simply ignores the
-     * unknown header, so the signal is safe to send unconditionally.
+     * Two layers exist and this clears both: the application-level query cache
+     * (the O(1)-invalidated dataset cache behind book detail, reviews and
+     * catalog/search listings) — flushed on EVERY server — and, only where the
+     * server is LiteSpeed, its full-page edge cache — dropped by emitting
+     * X-LiteSpeed-Purge on this response (the interactive equivalent of the CLI
+     * loopback purge; LSWS discards the tagged edge entries when it processes
+     * the header, even though this admin request is itself uncacheable). A
+     * non-LiteSpeed server simply has no edge layer, so only the query cache is
+     * cleared and no header is sent.
+     *
+     * The query-cache flush runs in the PHP-FPM/web request, so QueryCache::flush()
+     * reaches the SAME APCu segment that serves pages — a CLI invocation cannot
+     * (CLI APCu is a separate segment), which is why this lives behind an admin
+     * button rather than a console command. The caches self-invalidate on every
+     * content change; this is the manual escape hatch when data was altered
+     * out-of-band (a direct DB edit, an import replay).
      */
-    public function purgeLiteSpeedCache(Request $request, Response $response, mysqli $db): Response
+    public function flushAllCaches(Request $request, Response $response, mysqli $db): Response
     {
         // CSRF validated by CsrfMiddleware
         $redirect = $this->redirect($response, '/admin/settings?tab=advanced');
 
-        // AdminAuthMiddleware also admits staff; a shared-cache flush is an
-        // admin-only action, so re-check the role inline before purging.
+        // AdminAuthMiddleware also admits staff; flushing a shared cache is an
+        // admin-only action, so re-check the role inline before flushing.
         if (($_SESSION['user']['tipo_utente'] ?? '') !== 'admin') {
             $_SESSION['error_message'] = __('Solo un amministratore può svuotare la cache.');
             return $redirect;
         }
 
-        // Only claim a purge when LiteSpeed caching is actually active on this
-        // server; otherwise the X-LiteSpeed-Purge header is a no-op and a
-        // success message would be misleading (e.g. on plain Apache).
-        if (!LiteSpeedCache::enabled() || !LiteSpeedCache::serverDetected()) {
-            $_SESSION['error_message'] = __('LiteSpeed non è attivo su questo server: non c\'è nulla da svuotare.');
+        // flush() returns false only on a real apcu_delete/unlink failure; a
+        // clean run over an empty cache still returns true. Surface a failure as
+        // an error so the admin does not read a misleading success.
+        if (!QueryCache::flush()) {
+            $_SESSION['error_message'] = __('Impossibile svuotare completamente la cache dell\'applicazione. Controlla i permessi di storage/cache.');
             return $redirect;
         }
 
-        $_SESSION['success_message'] = __('Cache edge LiteSpeed svuotata.');
-        return $redirect->withHeader(
-            'X-LiteSpeed-Purge',
-            LiteSpeedCache::purgeHeader([LiteSpeedCache::TAG_ALL])
-        );
+        $_SESSION['success_message'] = __('Cache svuotata.');
+
+        // Also drop the LiteSpeed edge cache when this server actually has one;
+        // on plain Apache/nginx the header is simply never sent.
+        if (LiteSpeedCache::enabled() && LiteSpeedCache::serverDetected()) {
+            return $redirect->withHeader(
+                'X-LiteSpeed-Purge',
+                LiteSpeedCache::purgeHeader([LiteSpeedCache::TAG_ALL])
+            );
+        }
+
+        return $redirect;
     }
 
     private function loadContactMessages(mysqli $db): array

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -722,10 +722,10 @@ return function (App $app): void {
         return $controller->regenerateSitemap($request, $response, $db);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
-    $app->post('/admin/settings/advanced/purge-litespeed', function ($request, $response) use ($app) {
+    $app->post('/admin/settings/advanced/flush-cache', function ($request, $response) use ($app) {
         $db = $app->getContainer()->get('db');
         $controller = new SettingsController();
-        return $controller->purgeLiteSpeedCache($request, $response, $db);
+        return $controller->flushAllCaches($request, $response, $db);
     })->add(new CsrfMiddleware())->add(new AdminAuthMiddleware());
 
     $app->post('/admin/settings/loans', function ($request, $response) use ($app) {

--- a/app/Views/settings/advanced-tab.php
+++ b/app/Views/settings/advanced-tab.php
@@ -6,26 +6,22 @@
 use App\Support\HtmlHelper;
 ?>
 <section data-settings-panel="advanced" class="settings-panel <?php echo $activeTab === 'advanced' ? 'block' : 'hidden'; ?>">
-  <?php if (!empty($isAdmin)
-           && empty($appSettings['litespeed_container_blocked'])
-           && ($appSettings['litespeed_enabled'] ?? '0') === '1'):
-    $liteSpeedActiveHere = !empty($appSettings['litespeed_server_detected']); ?>
-  <!-- LiteSpeed edge cache maintenance (own form, above the settings form) -->
+  <?php if (!empty($isAdmin)):
+    $queryCacheBackend = ($appSettings['query_cache_backend'] ?? 'file') === 'apcu' ? 'APCu' : 'storage/cache'; ?>
+  <!-- Unified cache maintenance: one button clears the application query cache
+       everywhere, plus the LiteSpeed edge cache where the server has one. -->
   <div class="bg-white border border-gray-200 rounded-2xl overflow-hidden mb-6 max-sm:!bg-transparent max-sm:!rounded-none max-sm:!shadow-none max-sm:!border-0">
     <div class="p-6 space-y-3 max-sm:!p-0">
-      <p class="text-sm text-gray-600"><i class="fas fa-broom text-gray-400 mr-1"></i><?= __("Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.") ?></p>
-      <form action="<?= htmlspecialchars(url('/admin/settings/advanced/purge-litespeed'), ENT_QUOTES, 'UTF-8') ?>" method="post">
+      <p class="text-sm text-gray-600"><i class="fas fa-broom text-gray-400 mr-1"></i><?= __("Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.") ?></p>
+      <form action="<?= htmlspecialchars(url('/admin/settings/advanced/flush-cache'), ENT_QUOTES, 'UTF-8') ?>" method="post">
         <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
         <button type="submit"
-                <?= $liteSpeedActiveHere ? '' : 'disabled aria-disabled="true"' ?>
                 class="inline-flex items-center gap-2 px-5 py-3 rounded-xl bg-gray-900 text-white text-sm font-semibold hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
           <i class="fas fa-broom"></i>
-          <?= __("Svuota cache edge") ?>
+          <?= __("Svuota cache") ?>
         </button>
       </form>
-      <?php if (!$liteSpeedActiveHere): ?>
-      <p class="text-xs text-amber-800"><i class="fas fa-exclamation-triangle mr-1"></i><?= __("LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.") ?></p>
-      <?php endif; ?>
+      <p class="text-xs text-gray-500"><?= __("Backend attivo:") ?> <code class="bg-gray-100 px-1 py-0.5 rounded"><?= htmlspecialchars($queryCacheBackend, ENT_QUOTES, 'UTF-8') ?></code></p>
     </div>
   </div>
   <?php endif; ?>

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -7005,10 +7005,10 @@
   "Protezione pre-cache non installata": "Pre-cache-beskyttelse ikke installeret",
   "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.": "LiteSpeed kan ikke aktiveres: public/.htaccess kan ikke skrives til eller opdateres sikkert.",
   "Verifica disponibilità": "Tjek tilgængelighed",
-  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.": "Ændringer i indholdet ugyldiggør allerede cachen automatisk. Brug denne knap til straks at rydde de anonyme sider, som LiteSpeed har gemt, og fremtvinge en øjeblikkelig opdatering.",
-  "Svuota cache edge": "Ryd edge-cache",
-  "Cache edge LiteSpeed svuotata.": "LiteSpeed edge-cache ryddet.",
   "Solo un amministratore può svuotare la cache.": "Kun en administrator kan rydde cachen.",
-  "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.": "LiteSpeed er ikke aktiv på denne server: der er intet at rydde.",
-  "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.": "LiteSpeed blev ikke registreret i denne forespørgsel: der er intet at rydde herfra."
+  "Backend attivo:": "Aktiv backend:",
+  "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.": "Programcachen kunne ikke ryddes helt. Kontrollér tilladelserne for storage/cache.",
+  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.": "Ændringer i indholdet ugyldiggør allerede cachen automatisk. Brug denne knap til straks at rydde hele cachen: de interne forespørgsler (bogdetaljer, anmeldelser, katalog- og søgelister) og, hvis serveren kører LiteSpeed, også de sider, der er gemt i edge-cachen.",
+  "Svuota cache": "Ryd cache",
+  "Cache svuotata.": "Cache ryddet."
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -7005,10 +7005,10 @@
   "Protezione pre-cache non installata": "Pre-Cache-Schutz nicht installiert",
   "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.": "LiteSpeed kann nicht aktiviert werden: public/.htaccess ist nicht beschreibbar oder kann nicht sicher aktualisiert werden.",
   "Verifica disponibilità": "Verfügbarkeit prüfen",
-  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.": "Inhaltsänderungen machen den Cache bereits automatisch ungültig. Mit dieser Schaltfläche leerst du sofort die von LiteSpeed gespeicherten anonymen Seiten und erzwingst eine sofortige Aktualisierung.",
-  "Svuota cache edge": "Edge-Cache leeren",
-  "Cache edge LiteSpeed svuotata.": "LiteSpeed-Edge-Cache geleert.",
   "Solo un amministratore può svuotare la cache.": "Nur ein Administrator kann den Cache leeren.",
-  "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.": "LiteSpeed ist auf diesem Server nicht aktiv: Es gibt nichts zu leeren.",
-  "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.": "LiteSpeed bei dieser Anfrage nicht erkannt: Hier gibt es nichts zu leeren."
+  "Backend attivo:": "Aktives Backend:",
+  "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.": "Der Anwendungs-Cache konnte nicht vollständig geleert werden. Überprüfe die Berechtigungen von storage/cache.",
+  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.": "Inhaltsänderungen machen den Cache bereits automatisch ungültig. Mit dieser Schaltfläche leerst du sofort den gesamten Cache: die internen Abfragen (Buchdetails, Rezensionen, Katalog- und Suchlisten) und, wenn der Server LiteSpeed verwendet, auch die im Edge-Cache gespeicherten Seiten.",
+  "Svuota cache": "Cache leeren",
+  "Cache svuotata.": "Cache geleert."
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -7005,10 +7005,10 @@
   "Protezione pre-cache non installata": "Pre-cache protection not installed",
   "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.": "LiteSpeed cannot be enabled: public/.htaccess is not writable or cannot be updated safely.",
   "Verifica disponibilità": "Check availability",
-  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.": "Content changes already invalidate the cache automatically. Use this button to immediately clear the anonymous pages stored by LiteSpeed and force an instant refresh.",
-  "Svuota cache edge": "Clear edge cache",
-  "Cache edge LiteSpeed svuotata.": "LiteSpeed edge cache cleared.",
   "Solo un amministratore può svuotare la cache.": "Only an administrator can clear the cache.",
-  "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.": "LiteSpeed is not active on this server: there is nothing to clear.",
-  "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.": "LiteSpeed not detected on this request: there is nothing to clear from here."
+  "Backend attivo:": "Active backend:",
+  "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.": "Could not fully clear the application cache. Check the storage/cache permissions.",
+  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.": "Content changes already invalidate the cache automatically. Use this button to immediately clear all caches: the internal queries (book detail, reviews, catalog and search listings) and, if the server runs LiteSpeed, the pages stored in the edge cache too.",
+  "Svuota cache": "Clear cache",
+  "Cache svuotata.": "Cache cleared."
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -7005,10 +7005,10 @@
   "Protezione pre-cache non installata": "Protection pré-cache non installée",
   "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.": "Impossible d'activer LiteSpeed : public/.htaccess n'est pas accessible en écriture ou ne peut pas être mis à jour en toute sécurité.",
   "Verifica disponibilità": "Vérifier la disponibilité",
-  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.": "Les modifications de contenu invalident déjà le cache automatiquement. Utilise ce bouton pour vider immédiatement les pages anonymes mémorisées par LiteSpeed et forcer une actualisation instantanée.",
-  "Svuota cache edge": "Vider le cache edge",
-  "Cache edge LiteSpeed svuotata.": "Cache edge LiteSpeed vidé.",
   "Solo un amministratore può svuotare la cache.": "Seul un administrateur peut vider le cache.",
-  "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.": "LiteSpeed n'est pas actif sur ce serveur : il n'y a rien à vider.",
-  "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.": "LiteSpeed non détecté sur cette requête : il n'y a rien à vider ici."
+  "Backend attivo:": "Backend actif :",
+  "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.": "Impossible de vider entièrement le cache de l'application. Vérifiez les permissions de storage/cache.",
+  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.": "Les modifications de contenu invalident déjà le cache automatiquement. Utilisez ce bouton pour vider immédiatement tout le cache : les requêtes internes (fiche du livre, avis, listes du catalogue et de recherche) et, si le serveur utilise LiteSpeed, aussi les pages stockées dans le cache edge.",
+  "Svuota cache": "Vider le cache",
+  "Cache svuotata.": "Cache vidé."
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -7005,10 +7005,10 @@
   "Protezione pre-cache non installata": "Protezione pre-cache non installata",
   "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.": "Impossibile abilitare LiteSpeed: public/.htaccess non è scrivibile o non può essere aggiornato in sicurezza.",
   "Verifica disponibilità": "Verifica disponibilità",
-  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.": "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito le pagine anonime memorizzate da LiteSpeed e forzare un aggiornamento immediato.",
-  "Svuota cache edge": "Svuota cache edge",
-  "Cache edge LiteSpeed svuotata.": "Cache edge LiteSpeed svuotata.",
   "Solo un amministratore può svuotare la cache.": "Solo un amministratore può svuotare la cache.",
-  "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.": "LiteSpeed non è attivo su questo server: non c'è nulla da svuotare.",
-  "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui.": "LiteSpeed non rilevato in questa richiesta: non c'è nulla da svuotare da qui."
+  "Backend attivo:": "Backend attivo:",
+  "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.": "Impossibile svuotare completamente la cache dell'applicazione. Controlla i permessi di storage/cache.",
+  "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.": "Le modifiche ai contenuti invalidano già la cache in automatico. Usa questo pulsante per svuotare subito tutta la cache: le query interne (scheda libro, recensioni, elenchi di catalogo e ricerca) e, se il server è LiteSpeed, anche le pagine memorizzate nell'edge cache.",
+  "Svuota cache": "Svuota cache",
+  "Cache svuotata.": "Cache svuotata."
 }

--- a/scripts/ci-quality-local.sh
+++ b/scripts/ci-quality-local.sh
@@ -34,6 +34,11 @@ if [ -f .env ]; then
 fi
 # Only non-secret fallbacks (socket path/host/port) — no password default.
 export E2E_DB_SOCKET="${E2E_DB_SOCKET:-${DB_SOCKET:-/opt/homebrew/var/mysql/mysql.sock}}"
+# A few DB-writing suites (loan-review-0764, loan-reservation-real-world-25,
+# multiple-copy-loans-238) read E2E_DB_NAME specifically and abort without it,
+# while the rest read DB_NAME. Mirror DB_NAME into E2E_DB_NAME so the local
+# gate runs them exactly like CI instead of counting them as failures.
+export E2E_DB_NAME="${E2E_DB_NAME:-${DB_NAME:-}}"
 export DB_HOST="${DB_HOST:-127.0.0.1}"
 export DB_PORT="${DB_PORT:-3306}"
 export DB_PASS="${DB_PASS:-${DB_PASSWORD:-}}"

--- a/tests/admin-features.spec.js
+++ b/tests/admin-features.spec.js
@@ -229,7 +229,7 @@ test.describe.serial('Admin Settings: all tabs', () => {
     const jsCode = `// E2E test ${RUN_ID}`;
     await page.fill('#custom_js_essential', jsCode);
 
-    await page.locator('section[data-settings-panel="advanced"] button[type="submit"]').first().click();
+    await page.locator('form[action$="/admin/settings/advanced"] button[type="submit"]').first().click();
     await page.waitForLoadState('networkidle');
 
     // Verify in DB
@@ -240,7 +240,7 @@ test.describe.serial('Admin Settings: all tabs', () => {
     await page.goto(`${BASE}/admin/settings?tab=advanced`);
     await page.locator('[data-settings-tab="advanced"]').click();
     await page.fill('#custom_js_essential', '');
-    await page.locator('section[data-settings-panel="advanced"] button[type="submit"]').first().click();
+    await page.locator('form[action$="/admin/settings/advanced"] button[type="submit"]').first().click();
     await page.waitForLoadState('networkidle');
   });
 

--- a/tests/full-test.spec.js
+++ b/tests/full-test.spec.js
@@ -1883,6 +1883,17 @@ test.describe.serial('Phase 11: Settings', () => {
     // hide-when-not-applicable fix; the rest of the Advanced tab still renders.
     await expect(page.locator('#litespeed_enabled')).toHaveCount(0);
     await expect(page.locator('#session_lifetime')).toBeVisible();
+
+    // The application query-cache flush is available on EVERY server (LiteSpeed
+    // or not) — it is the non-LiteSpeed counterpart to the edge-cache purge.
+    // Assert the maintenance form renders and that clicking it reports success
+    // (a green flash; a red flash would mean the flush failed). This runs in the
+    // PHP-FPM request so QueryCache::flush() reaches the same backend serving
+    // pages, which is exactly why it lives behind a button and not a CLI command.
+    const flushCacheForm = page.locator('form[action*="/admin/settings/advanced/flush-cache"]');
+    await expect(flushCacheForm).toBeVisible();
+    await flushCacheForm.locator('button[type="submit"]').click();
+    await expect(page.locator('.bg-green-50[role="alert"]')).toBeVisible({ timeout: 15000 });
   });
 
   test('11.10 CMS homepage link exists', async () => {

--- a/tests/litespeed-edge-cache.unit.php
+++ b/tests/litespeed-edge-cache.unit.php
@@ -191,15 +191,16 @@ $check(str_contains($htaccess, 'E=Cache-Vary:pinakes_locale'), 'locale participa
 $check(str_contains($htaccessDist, 'E=Cache-Control:no-cache'), 'fresh-install htaccess ships the lookup-time bypass');
 $check(str_contains($htaccess, "\n        CacheLookup on\n"), 'shipped htaccess enables LSCache request lookup');
 $check(str_contains($htaccessDist, 'CacheLookup on'), 'fresh-install htaccess enables LSCache request lookup');
-$check(str_contains($advancedSettingsView, 'advanced/purge-litespeed'), 'Advanced settings exposes the edge-cache purge button');
-$check(str_contains($routesSource, "/admin/settings/advanced/purge-litespeed"), 'edge-cache purge route is registered');
-$check(str_contains($settingsController, 'function purgeLiteSpeedCache'), 'purge controller action exists');
-$check(str_contains($settingsController, "'X-LiteSpeed-Purge'"), 'purge action emits the LiteSpeed purge header on its response');
-$purgeMethod = strstr($settingsController, 'function purgeLiteSpeedCache');
-$purgeBody = is_string($purgeMethod) ? substr($purgeMethod, 0, 1200) : '';
-$check(str_contains($purgeBody, "!== 'admin'"), 'edge purge re-checks the admin role (AdminAuthMiddleware also admits staff)');
-$check(str_contains($purgeBody, 'serverDetected') && str_contains($purgeBody, 'LiteSpeedCache::enabled'), 'edge purge only claims a flush when LiteSpeed is actually active here (no false success on Apache)');
-$check(str_contains($advancedSettingsView, 'disabled:cursor-not-allowed'), 'purge button is rendered disabled when this request is not served by LiteSpeed');
+$check(str_contains($advancedSettingsView, 'advanced/flush-cache'), 'Advanced settings exposes the unified cache-flush button');
+$check(str_contains($routesSource, "/admin/settings/advanced/flush-cache"), 'cache-flush route is registered');
+$check(str_contains($settingsController, 'function flushAllCaches'), 'unified flush controller action exists');
+$check(str_contains($settingsController, "'X-LiteSpeed-Purge'"), 'unified flush emits the LiteSpeed purge header on its response');
+$flushMethod = strstr($settingsController, 'function flushAllCaches');
+$flushBody = is_string($flushMethod) ? substr($flushMethod, 0, 2000) : '';
+$check(str_contains($flushBody, "!== 'admin'"), 'unified flush re-checks the admin role (AdminAuthMiddleware also admits staff)');
+$check(str_contains($flushBody, 'QueryCache::flush'), 'unified flush clears the application query cache on every server');
+$check(str_contains($flushBody, 'serverDetected') && str_contains($flushBody, 'LiteSpeedCache::enabled'), 'unified flush purges the edge cache only when LiteSpeed is actually active here');
+$check(!str_contains($advancedSettingsView, 'advanced/purge-litespeed') && !str_contains($routesSource, 'advanced/purge-litespeed'), 'the separate LiteSpeed purge button/route is gone — a single unified button clears everything');
 $check(str_contains($liveJs, "cache: 'no-store'"), 'availability hydration always bypasses HTTP cache');
 $check(str_contains($liveJs, 'hydrationGeneration'), 'obsolete hydration responses cannot overwrite a newer catalog render');
 $check(str_contains($liveJs, 'neutral, actionable fallback'), 'availability failures retain a usable neutral fallback');
@@ -222,7 +223,7 @@ foreach (glob(dirname(__DIR__) . '/locale/??_??.json') ?: [] as $localeFile) {
         $check(substr_count($localeJson, '"' . $durationKey . '":') === 1, basename($localeFile) . " has one {$durationKey} translation key");
     }
     $check(substr_count($localeJson, '"Verifica disponibilità":') === 1, basename($localeFile) . ' translates the neutral availability label');
-    $check(substr_count($localeJson, '"Svuota cache edge":') === 1, basename($localeFile) . ' translates the edge-cache purge button');
+    $check(substr_count($localeJson, '"Svuota cache":') === 1, basename($localeFile) . ' translates the unified cache-flush button');
     $check(substr_count($localeJson, '"Impossibile elaborare l\'immagine.":') === 1, basename($localeFile) . ' has one image-processing error key');
 }
 


### PR DESCRIPTION
## What

The Advanced settings tab shipped two separate cache-maintenance buttons in 0.7.71 — a LiteSpeed edge purge and an application query-cache flush. On a LiteSpeed server both showed at once (redundant), and the split was confusing. This replaces them with a **single "Svuota cache" button** that clears everything in one action.

- Always flushes the application query cache (`QueryCache::flush()`; backend is APCu or `storage/cache`, shown as a hint under the button).
- Additionally emits `X-LiteSpeed-Purge` to drop the LiteSpeed edge cache — but only where the server actually runs LiteSpeed.

On plain Apache/nginx (and the Docker image) only the query cache is cleared and no header is sent, so a non-LiteSpeed install no longer shows a control it can't use, and a LiteSpeed install no longer shows two buttons.

## Why the button (not a CLI command)

The flush runs inside the PHP-FPM request, so `QueryCache::flush()` reaches the **same APCu segment that serves pages** — a CLI invocation runs in a separate APCu segment and cannot. That is exactly why this lives behind an admin button.

## Changes

- Unify `purgeLiteSpeedCache()` + `flushApplicationCache()` into `flushAllCaches()` on `POST /admin/settings/advanced/flush-cache`; drop the `/purge-litespeed` route and its dead strings.
- Single admin-only maintenance card in `advanced-tab.php` (style copied verbatim from the existing sibling; form kept separate from the main settings form).
- Translations updated across all five locales (parity preserved).
- `ci-quality-local.sh` now exports `E2E_DB_NAME` (mirrored from `DB_NAME`) so the three DB-writing loan suites run locally exactly like CI instead of aborting as failures — a pre-existing local-gate gap, unrelated to the feature.

## Tests

- `ci-quality-local.sh` green: PHPStan L5, i18n parity + completeness, route / soft-delete / migration guards, all standalone unit tests.
- `litespeed-edge-cache.unit.php` updated to assert the unified button + that the old purge route/method are gone.
- `full-test.spec.js` 11.9 asserts the button clears the cache and shows a success flash.
- Full E2E suite: 137 passed. Verified live on Apache :8081 (single button → "Cache svuotata.").


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta un’azione unificata per svuotare la cache dell’applicazione e, quando disponibile, la cache edge LiteSpeed.
  * Il pannello avanzato mostra il backend di cache attivo e descrive le cache interessate.
  * L’operazione è disponibile esclusivamente agli amministratori.

* **Miglioramenti**
  * Aggiornati messaggi e traduzioni per descrivere la nuova procedura di svuotamento cache.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->