### PR TITLE
Release 0.7.72 — unified "Svuota cache" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.72]
+
+A small usability release: the two cache-maintenance controls on Settings → Advanced are unified into one.
+
+### Changed
+
+- **A single "Svuota cache" button clears every cache.** The Advanced settings tab previously showed two separate controls — a LiteSpeed edge-cache purge and an application query-cache flush. They are now one admin button that, in a single action, always flushes the application query cache (APCu or file backend, shown as a hint under the button) and additionally purges the LiteSpeed edge cache where the server actually runs LiteSpeed. On plain Apache/nginx and in the Docker image only the query cache is cleared and no purge header is sent, so a non-LiteSpeed install no longer shows a control it cannot use and a LiteSpeed install no longer shows two buttons. The flush runs inside the web request, so it reaches the same APCu segment that serves pages — which a CLI command cannot.
+
 ## [0.7.71]
 
 A performance release: a full caching overhaul for anonymous traffic (issue #387), delivered as one stable jump from 0.7.68. Every install upgrades with identical behaviour on a cold cache; the optional LiteSpeed edge cache is off by default and configured by administrators. Existing installs receive an idempotent catalog-materialization migration.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.71 — latest
+### v0.7.72 — latest
+
+A small usability release: the two cache-maintenance controls on *Settings → Advanced* are unified into one.
+
+### Changed
+
+- **A single "Svuota cache" button clears every cache.** It always flushes the application query cache (APCu or file backend, shown as a hint) and additionally purges the LiteSpeed edge cache where the server actually runs LiteSpeed — so a non-LiteSpeed install no longer shows a control it can't use, and a LiteSpeed install no longer shows two buttons. The flush runs inside the web request, so it reaches the same APCu segment that serves pages, which a CLI command cannot.
+
+### v0.7.71
 
 A performance release: a full caching overhaul for anonymous traffic (issue #387). The pages the public sees — home, catalog/search and book pages — are served from cache instead of rebuilt on every request, while copy availability stays live. Upgrades cleanly with no behaviour change on a cold cache; the optional LiteSpeed edge cache is off by default.
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Stable release **0.7.72**.

Bumps `version.json` to 0.7.72, adds the CHANGELOG `[0.7.72]` entry and the README "What's New" section (demoting 0.7.71).

**Content**: the two cache-maintenance controls on Settings → Advanced were unified into a single admin button in #395 (already merged to main). This PR is the version/docs bump only.

- No migration, no schema change, no new dependency.
- Code already validated by full CI on #395 (fresh installers, upgrade-from-latest, full E2E, browser regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Unificati i controlli di manutenzione della cache in un unico pulsante **“Svuota cache”** nelle impostazioni avanzate.
  * Il comando svuota sempre la cache delle query e, quando disponibile, anche la cache edge LiteSpeed.

* **Documentazione**
  * Aggiornate le note di rilascio e la documentazione per la versione 0.7.72.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->