### PR TITLE
Fix client IP rate limits behind trusted proxies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,11 @@ SESSION_LIFETIME=3600
 # RECOMMENDED: true in production with valid SSL certificate
 FORCE_HTTPS=false
 
+# Trusted reverse proxies (comma-separated exact IPs or CIDR ranges)
+# Forwarded client-IP headers are ignored unless REMOTE_ADDR matches this list.
+# Configure only proxies that overwrite X-Forwarded-For; leave empty for direct access.
+TRUSTED_PROXIES=
+
 # Display Errors
 # Set to 'true' for development, 'false' for production
 # Controls PHP error display (errors are always logged)

--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ FORCE_HTTPS=false
 # Trusted reverse proxies (comma-separated exact IPs or CIDR ranges)
 # Forwarded client-IP headers are ignored unless REMOTE_ADDR matches this list.
 # Configure only proxies that overwrite X-Forwarded-For; leave empty for direct access.
+# Do NOT include ranges that also contain your clients (e.g. a broad 10.0.0.0/8
+# on a LAN): a client whose address matches this list is treated as a proxy and
+# skipped, collapsing patrons back onto the shared rate-limit bucket.
 TRUSTED_PROXIES=
 
 # Display Errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Full version-by-version history for Pinakes. The README shows only the latest re
 
 A small usability release: the two cache-maintenance controls on Settings → Advanced are unified into one.
 
+### Fixed
+
+- **Rate limits remain per-client behind trusted Docker/reverse proxies.** Forwarded client addresses are still ignored unless the immediate peer matches `TRUSTED_PROXIES`, but a validated proxy chain is now walked from right to left instead of trusting its caller-controlled first value. Private LAN client addresses are accepted after that trust boundary, preventing every patron behind the same proxy from sharing the registration/login bucket.
+
 ### Changed
 
 - **A single "Svuota cache" button clears every cache.** The Advanced settings tab previously showed two separate controls — a LiteSpeed edge-cache purge and an application query-cache flush. They are now one admin button that, in a single action, always flushes the application query cache (APCu or file backend, shown as a hint under the button) and additionally purges the LiteSpeed edge cache where the server actually runs LiteSpeed. On plain Apache/nginx and in the Docker image only the query cache is cleared and no purge header is sent, so a non-LiteSpeed install no longer shows a control it cannot use and a LiteSpeed install no longer shows two buttons. The flush runs inside the web request, so it reaches the same APCu segment that serves pages — which a CLI command cannot.

--- a/app/Middleware/RateLimitMiddleware.php
+++ b/app/Middleware/RateLimitMiddleware.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+use App\Support\ClientIpResolver;
 use App\Support\RateLimiter;
 
 class RateLimitMiddleware implements MiddlewareInterface
@@ -84,52 +85,11 @@ class RateLimitMiddleware implements MiddlewareInterface
     private function getClientIP(Request $request): string
     {
         $serverParams = $request->getServerParams();
-        $remoteAddr = $serverParams['REMOTE_ADDR'] ?? 'unknown';
-
-        // Security scan F1 (CWE-807): client-controlled forwarding headers are
-        // the rate-limiter's identity, and the limiter is the ONLY brute-force
-        // control on login/forgot-password/reset (no per-account lockout). Only
-        // honor those headers when the direct peer (REMOTE_ADDR) is a configured
-        // trusted reverse proxy — otherwise an unauthenticated client rotates
-        // X-Forwarded-For to mint an unlimited number of fresh buckets and
-        // defeats the throttle entirely. Default (Apache-direct, TRUSTED_PROXIES
-        // unset) → always key on the real peer address.
-        if (!\App\Support\HtmlHelper::isRemoteAddrTrustedProxy()) {
-            return $remoteAddr;
+        $headers = [];
+        foreach (['X-Forwarded-For', 'X-Real-IP', 'CF-Connecting-IP', 'True-Client-IP', 'X-Client-IP'] as $name) {
+            $headers[$name] = $request->getHeaderLine($name);
         }
 
-        // Check various headers that might contain the real IP
-        $headers = [
-            'X-Forwarded-For',
-            'X-Real-IP',
-            'X-Client-IP',
-            'CF-Connecting-IP',
-            'True-Client-IP'
-        ];
-
-        foreach ($headers as $header) {
-            $headerValue = $request->getHeaderLine($header);
-            if (!empty($headerValue)) {
-                // X-Forwarded-For can contain multiple IPs, take the first one
-                $ips = explode(',', $headerValue);
-                $ip = trim($ips[0]);
-                
-                if ($this->isValidIP($ip)) {
-                    return $ip;
-                }
-            }
-        }
-
-        // Fallback to REMOTE_ADDR
-        return $remoteAddr;
-    }
-
-    /**
-     * Validate IP address format
-     */
-    private function isValidIP(string $ip): bool
-    {
-        $filtered = filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE);
-        return $filtered !== false;
+        return ClientIpResolver::resolve((string) ($serverParams['REMOTE_ADDR'] ?? 'unknown'), $headers);
     }
 }

--- a/app/Support/ClientIpResolver.php
+++ b/app/Support/ClientIpResolver.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Support;
+
+/**
+ * Resolve a client IP without trusting caller-controlled forwarding headers.
+ */
+final class ClientIpResolver
+{
+    /**
+     * @param array<string, string> $forwardedHeaders Header names are
+     *        case-insensitive; values may contain comma-separated proxy hops.
+     */
+    public static function resolve(string $remoteAddr, array $forwardedHeaders): string
+    {
+        $remoteAddr = trim($remoteAddr);
+        if (!self::isValidIp($remoteAddr)) {
+            $remoteAddr = 'unknown';
+        }
+
+        // Forwarding headers are client-controlled unless the immediate peer is
+        // explicitly trusted. This is the security boundary for the limiter.
+        if ($remoteAddr === 'unknown' || !HtmlHelper::isTrustedProxyIp($remoteAddr)) {
+            return $remoteAddr;
+        }
+
+        $headers = [];
+        foreach ($forwardedHeaders as $name => $value) {
+            $headers[strtolower($name)] = trim($value);
+        }
+
+        $forwardedFor = $headers['x-forwarded-for'] ?? '';
+        if ($forwardedFor !== '') {
+            $chain = array_map('trim', explode(',', $forwardedFor));
+
+            // Reject the whole malformed chain. Skipping bad entries can join
+            // two unrelated sections and attribute a request to the wrong hop.
+            foreach ($chain as $hop) {
+                if (!self::isValidIp($hop)) {
+                    $chain = [];
+                    break;
+                }
+            }
+
+            if ($chain !== []) {
+                // Walk from the direct peer towards the client and strip only
+                // configured trusted proxies. The first untrusted hop is the
+                // client boundary. If every hop is trusted, the leftmost value
+                // remains the best client address supplied by the proxy chain.
+                $candidate = $remoteAddr;
+                foreach (array_reverse($chain) as $hop) {
+                    $candidate = $hop;
+                    if (!HtmlHelper::isTrustedProxyIp($hop)) {
+                        return $hop;
+                    }
+                }
+
+                return $candidate;
+            }
+        }
+
+        // Single-value headers support common proxies that do not emit XFF.
+        // Private and reserved client ranges are valid here: once the direct
+        // peer is trusted, rejecting LAN addresses would collapse every patron
+        // back onto the proxy's shared rate-limit bucket.
+        foreach (['x-real-ip', 'cf-connecting-ip', 'true-client-ip', 'x-client-ip'] as $name) {
+            $value = $headers[$name] ?? '';
+            if (self::isValidIp($value)) {
+                return $value;
+            }
+        }
+
+        return $remoteAddr;
+    }
+
+    private static function isValidIp(string $ip): bool
+    {
+        return $ip !== '' && filter_var($ip, FILTER_VALIDATE_IP) !== false;
+    }
+}

--- a/app/Support/ClientIpResolver.php
+++ b/app/Support/ClientIpResolver.php
@@ -14,14 +14,14 @@ final class ClientIpResolver
      */
     public static function resolve(string $remoteAddr, array $forwardedHeaders): string
     {
-        $remoteAddr = trim($remoteAddr);
-        if (!self::isValidIp($remoteAddr)) {
-            $remoteAddr = 'unknown';
+        $remoteAddr = self::normalizeIp($remoteAddr);
+        if ($remoteAddr === '') {
+            return 'unknown';
         }
 
         // Forwarding headers are client-controlled unless the immediate peer is
         // explicitly trusted. This is the security boundary for the limiter.
-        if ($remoteAddr === 'unknown' || !HtmlHelper::isTrustedProxyIp($remoteAddr)) {
+        if (!HtmlHelper::isTrustedProxyIp($remoteAddr)) {
             return $remoteAddr;
         }
 
@@ -32,41 +32,46 @@ final class ClientIpResolver
 
         $forwardedFor = $headers['x-forwarded-for'] ?? '';
         if ($forwardedFor !== '') {
-            $chain = array_map('trim', explode(',', $forwardedFor));
+            // X-Forwarded-For is authoritative once present: it decides the
+            // client alone. A present-but-malformed chain fails CLOSED to the
+            // trusted peer, NOT through to a spoofable single-value header —
+            // otherwise a caller could poison XFF with one junk hop to escape
+            // onto X-Real-IP and mint an unlimited number of fresh buckets.
+            // Rejecting the whole chain on any bad entry also avoids joining two
+            // unrelated sections and attributing a request to the wrong hop.
+            $chain = [];
+            foreach (explode(',', $forwardedFor) as $rawHop) {
+                $hop = self::normalizeIp($rawHop);
+                if ($hop === '') {
+                    return $remoteAddr;
+                }
+                $chain[] = $hop;
+            }
 
-            // Reject the whole malformed chain. Skipping bad entries can join
-            // two unrelated sections and attribute a request to the wrong hop.
-            foreach ($chain as $hop) {
-                if (!self::isValidIp($hop)) {
-                    $chain = [];
-                    break;
+            // Walk from the direct peer towards the client and strip only
+            // configured trusted proxies. The first untrusted hop is the client
+            // boundary. If every hop is trusted, the leftmost value remains the
+            // best client address supplied by the proxy chain.
+            $candidate = $remoteAddr;
+            foreach (array_reverse($chain) as $hop) {
+                $candidate = $hop;
+                if (!HtmlHelper::isTrustedProxyIp($hop)) {
+                    return $hop;
                 }
             }
 
-            if ($chain !== []) {
-                // Walk from the direct peer towards the client and strip only
-                // configured trusted proxies. The first untrusted hop is the
-                // client boundary. If every hop is trusted, the leftmost value
-                // remains the best client address supplied by the proxy chain.
-                $candidate = $remoteAddr;
-                foreach (array_reverse($chain) as $hop) {
-                    $candidate = $hop;
-                    if (!HtmlHelper::isTrustedProxyIp($hop)) {
-                        return $hop;
-                    }
-                }
-
-                return $candidate;
-            }
+            return $candidate;
         }
 
-        // Single-value headers support common proxies that do not emit XFF.
-        // Private and reserved client ranges are valid here: once the direct
-        // peer is trusted, rejecting LAN addresses would collapse every patron
-        // back onto the proxy's shared rate-limit bucket.
+        // Single-value headers support common proxies that do not emit XFF
+        // (e.g. Cloudflare's CF-Connecting-IP). They are consulted ONLY when XFF
+        // is absent — never as a fallback from a rejected XFF. Private and
+        // reserved client ranges are valid here: once the direct peer is
+        // trusted, rejecting LAN addresses would collapse every patron back onto
+        // the proxy's shared rate-limit bucket.
         foreach (['x-real-ip', 'cf-connecting-ip', 'true-client-ip', 'x-client-ip'] as $name) {
-            $value = $headers[$name] ?? '';
-            if (self::isValidIp($value)) {
+            $value = self::normalizeIp($headers[$name] ?? '');
+            if ($value !== '') {
                 return $value;
             }
         }
@@ -74,8 +79,31 @@ final class ClientIpResolver
         return $remoteAddr;
     }
 
-    private static function isValidIp(string $ip): bool
+    /**
+     * Normalise a single address token to a bare, valid IP, or '' when it is
+     * not a usable IP. Strips a bracketed IPv6 host and an IPv4 `:port` suffix
+     * so proxy-supplied hops like `[2001:db8::1]:443` or `203.0.113.9:51000`
+     * are not rejected as malformed.
+     */
+    private static function normalizeIp(string $ip): string
     {
-        return $ip !== '' && filter_var($ip, FILTER_VALIDATE_IP) !== false;
+        $ip = trim($ip);
+        if ($ip === '') {
+            return '';
+        }
+
+        if ($ip[0] === '[') {
+            // Bracketed IPv6, with or without a trailing :port.
+            $end = strpos($ip, ']');
+            if ($end === false) {
+                return '';
+            }
+            $ip = substr($ip, 1, $end - 1);
+        } elseif (substr_count($ip, ':') === 1) {
+            // Exactly one colon → IPv4:port, never a bare IPv6.
+            $ip = substr($ip, 0, (int) strpos($ip, ':'));
+        }
+
+        return filter_var($ip, FILTER_VALIDATE_IP) !== false ? $ip : '';
     }
 }

--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -217,13 +217,23 @@ class HtmlHelper
      */
     public static function isRemoteAddrTrustedProxy(): bool
     {
+        return self::isTrustedProxyIp((string) ($_SERVER['REMOTE_ADDR'] ?? ''));
+    }
+
+    /**
+     * Check an arbitrary IP against the configured trusted-proxy list.
+     *
+     * This is also used while walking an X-Forwarded-For chain: every hop from
+     * the direct peer towards the client must be classified independently.
+     */
+    public static function isTrustedProxyIp(string $remoteAddr): bool
+    {
         $trustedRaw = $_ENV['TRUSTED_PROXIES'] ?? getenv('TRUSTED_PROXIES');
         $trustedEnv = is_string($trustedRaw) ? $trustedRaw : '';
         if ($trustedEnv === '') {
             return false;
         }
 
-        $remoteAddr = $_SERVER['REMOTE_ADDR'] ?? '';
         if ($remoteAddr === '') {
             return false;
         }

--- a/app/Support/RememberMeService.php
+++ b/app/Support/RememberMeService.php
@@ -435,39 +435,18 @@ class RememberMeService
      */
     private function getClientIP(): ?string
     {
-        // Security scan F6 (CWE-807): this IP is written to the security audit
-        // log and the session-management UI. Only trust client-supplied
-        // forwarding headers when the direct peer is a configured trusted proxy;
-        // otherwise a client can forge the audit IP by setting X-Forwarded-For.
-        if (!HtmlHelper::isRemoteAddrTrustedProxy()) {
-            return $_SERVER['REMOTE_ADDR'] ?? null;
+        $remoteAddr = (string) ($_SERVER['REMOTE_ADDR'] ?? '');
+        if ($remoteAddr === '') {
+            return null;
         }
 
-        // Check various headers that might contain the real IP (behind proxy/load balancer)
-        $headers = [
-            'HTTP_X_FORWARDED_FOR',
-            'HTTP_X_REAL_IP',
-            'HTTP_X_CLIENT_IP',
-            'HTTP_CF_CONNECTING_IP',  // Cloudflare
-            'HTTP_TRUE_CLIENT_IP'
-        ];
-
-        foreach ($headers as $header) {
-            if (!empty($_SERVER[$header])) {
-                // X-Forwarded-For can contain multiple IPs, take the first one
-                $ips = explode(',', $_SERVER[$header]);
-                $ip = trim($ips[0]);
-
-                // Validate IP format and exclude private/reserved ranges to prevent spoofing
-                // Note: This assumes the app is behind a trusted proxy that sets these headers
-                if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                    return $ip;
-                }
-            }
-        }
-
-        // Fallback to REMOTE_ADDR
-        return $_SERVER['REMOTE_ADDR'] ?? null;
+        return ClientIpResolver::resolve($remoteAddr, [
+            'X-Forwarded-For' => (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? ''),
+            'X-Real-IP' => (string) ($_SERVER['HTTP_X_REAL_IP'] ?? ''),
+            'CF-Connecting-IP' => (string) ($_SERVER['HTTP_CF_CONNECTING_IP'] ?? ''),
+            'True-Client-IP' => (string) ($_SERVER['HTTP_TRUE_CLIENT_IP'] ?? ''),
+            'X-Client-IP' => (string) ($_SERVER['HTTP_X_CLIENT_IP'] ?? ''),
+        ]);
     }
 
     /**

--- a/app/Support/RememberMeService.php
+++ b/app/Support/RememberMeService.php
@@ -440,13 +440,17 @@ class RememberMeService
             return null;
         }
 
-        return ClientIpResolver::resolve($remoteAddr, [
+        $resolved = ClientIpResolver::resolve($remoteAddr, [
             'X-Forwarded-For' => (string) ($_SERVER['HTTP_X_FORWARDED_FOR'] ?? ''),
             'X-Real-IP' => (string) ($_SERVER['HTTP_X_REAL_IP'] ?? ''),
             'CF-Connecting-IP' => (string) ($_SERVER['HTTP_CF_CONNECTING_IP'] ?? ''),
             'True-Client-IP' => (string) ($_SERVER['HTTP_TRUE_CLIENT_IP'] ?? ''),
             'X-Client-IP' => (string) ($_SERVER['HTTP_X_CLIENT_IP'] ?? ''),
         ]);
+
+        // An unparseable REMOTE_ADDR resolves to the 'unknown' sentinel; keep
+        // the audit column null rather than writing a literal "unknown".
+        return $resolved === 'unknown' ? null : $resolved;
     }
 
     /**

--- a/tests/security-scan-findings.unit.php
+++ b/tests/security-scan-findings.unit.php
@@ -20,6 +20,7 @@ require __DIR__ . '/../vendor/autoload.php';
 
 use App\Middleware\RateLimitMiddleware;
 use App\Middleware\PrivateModeMiddleware;
+use App\Support\ClientIpResolver;
 use App\Support\RememberMeService;
 use App\Support\SettingsEncryption;
 
@@ -41,9 +42,6 @@ putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES']);
 
 echo "F1 — RateLimitMiddleware trusted-proxy gate\n";
-// In production Slim populates getServerParams() from $_SERVER, so the PSR-7
-// REMOTE_ADDR and $_SERVER['REMOTE_ADDR'] (which HtmlHelper's trusted-proxy
-// check reads) are the same value — mirror that here.
 $_SERVER['REMOTE_ADDR'] = '203.0.113.9';
 $factory = new \Slim\Psr7\Factory\ServerRequestFactory();
 $req = $factory->createServerRequest('POST', '/accedi', ['REMOTE_ADDR' => '203.0.113.9'])
@@ -57,6 +55,26 @@ putenv('TRUSTED_PROXIES=203.0.113.9');
 $_ENV['TRUSTED_PROXIES'] = '203.0.113.9';
 $check($invoke($mw, 'getClientIP', $req) === '8.8.8.8',
     'peer is a trusted proxy: forwarded header is honored');
+
+putenv('TRUSTED_PROXIES=172.21.0.0/16,10.0.0.0/8');
+$_ENV['TRUSTED_PROXIES'] = '172.21.0.0/16,10.0.0.0/8';
+$privateReq = $factory->createServerRequest('POST', '/registrati', ['REMOTE_ADDR' => '172.21.0.4'])
+    ->withHeader('X-Forwarded-For', '192.168.1.42');
+$check($invoke($mw, 'getClientIP', $privateReq) === '192.168.1.42',
+    'trusted Docker proxy: a private LAN client gets its own rate-limit bucket');
+
+$chainReq = $factory->createServerRequest('POST', '/registrati', ['REMOTE_ADDR' => '172.21.0.4'])
+    ->withHeader('X-Forwarded-For', '198.51.100.27, 10.0.0.8');
+$check($invoke($mw, 'getClientIP', $chainReq) === '198.51.100.27',
+    'forwarded chain is walked right-to-left and trusted intermediate proxies are stripped');
+
+$spoofedPrefixReq = $factory->createServerRequest('POST', '/registrati', ['REMOTE_ADDR' => '172.21.0.4'])
+    ->withHeader('X-Forwarded-For', '8.8.8.8, 198.51.100.27');
+$check($invoke($mw, 'getClientIP', $spoofedPrefixReq) === '198.51.100.27',
+    'untrusted boundary prevents a caller-prepended XFF value becoming the bucket key');
+
+$check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => 'invalid, 10.0.0.8']) === '172.21.0.4',
+    'malformed XFF chain fails safely to the direct peer');
 putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES']);
 
@@ -72,6 +90,12 @@ putenv('TRUSTED_PROXIES=203.0.113.50');
 $_ENV['TRUSTED_PROXIES'] = '203.0.113.50';
 $check($invoke($svc, 'getClientIP') === '8.8.4.4',
     'peer is a trusted proxy: forwarded audit IP honored');
+$_SERVER['REMOTE_ADDR'] = '172.21.0.4';
+$_SERVER['HTTP_X_FORWARDED_FOR'] = '192.168.1.43';
+putenv('TRUSTED_PROXIES=172.21.0.0/16');
+$_ENV['TRUSTED_PROXIES'] = '172.21.0.0/16';
+$check($invoke($svc, 'getClientIP') === '192.168.1.43',
+    'trusted proxy: private LAN address is preserved in session audit data');
 putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES'], $_SERVER['HTTP_X_FORWARDED_FOR']);
 

--- a/tests/security-scan-findings.unit.php
+++ b/tests/security-scan-findings.unit.php
@@ -75,6 +75,27 @@ $check($invoke($mw, 'getClientIP', $spoofedPrefixReq) === '198.51.100.27',
 
 $check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => 'invalid, 10.0.0.8']) === '172.21.0.4',
     'malformed XFF chain fails safely to the direct peer');
+
+// A present-but-poisoned XFF must NOT fall through to a spoofable single-value
+// header — otherwise a caller behind a trusted proxy prepends one junk hop and
+// rotates X-Real-IP to mint unlimited rate-limit buckets.
+$check(ClientIpResolver::resolve('172.21.0.4', [
+        'X-Forwarded-For' => 'junk, 198.51.100.27',
+        'X-Real-IP' => '8.8.8.8',
+    ]) === '172.21.0.4',
+    'poisoned XFF fails closed to the trusted peer, never onto a spoofable X-Real-IP');
+
+// Single-value headers are still honored when XFF is entirely absent (proxies
+// like Cloudflare that emit CF-Connecting-IP but no XFF).
+$check(ClientIpResolver::resolve('172.21.0.4', ['X-Real-IP' => '198.51.100.9']) === '198.51.100.9',
+    'X-Real-IP is honored when X-Forwarded-For is absent');
+
+// Proxy-supplied hops carrying a port / IPv6 brackets are normalised, not
+// rejected as malformed.
+$check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => '[2001:db8::1]:443']) === '2001:db8::1',
+    'a bracketed IPv6 XFF hop with a port is normalised to the bare address');
+$check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => '198.51.100.27:51000']) === '198.51.100.27',
+    'an IPv4 XFF hop with a port is normalised to the bare address');
 putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES']);
 
@@ -96,6 +117,9 @@ putenv('TRUSTED_PROXIES=172.21.0.0/16');
 $_ENV['TRUSTED_PROXIES'] = '172.21.0.0/16';
 $check($invoke($svc, 'getClientIP') === '192.168.1.43',
     'trusted proxy: private LAN address is preserved in session audit data');
+$_SERVER['REMOTE_ADDR'] = 'not-an-ip';
+$check($invoke($svc, 'getClientIP') === null,
+    'an unparseable REMOTE_ADDR yields a null audit IP, not the literal "unknown"');
 putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES'], $_SERVER['HTTP_X_FORWARDED_FOR']);
 


### PR DESCRIPTION
## Summary
- resolve forwarded client IPs only after the direct peer matches `TRUSTED_PROXIES`
- walk `X-Forwarded-For` from right to left and preserve private LAN client addresses
- reuse the resolver for remember-me session audit data and document the setting

## Verification
- PHPStan: no errors
- `php tests/security-scan-findings.unit.php`: 17 passed
- standalone PHP suite: 142 passed; 3 destructive suites refused without a dedicated `E2E_DB_NAME` as designed
- paired `pinakes-docker` smoke test: 46 passed, 0 failed

Fixes fabiodalez-dev/pinakes-docker#6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta la configurazione opzionale dei proxy fidati tramite indirizzi IP o intervalli CIDR.
  * Supportata la corretta identificazione degli indirizzi client dietro proxy autorizzati.

* **Correzioni**
  * Migliorata la gestione dei rate limit per accessi effettuati dietro proxy o Docker.
  * Prevenuto lo spoofing degli indirizzi IP tramite header inoltrati.
  * Gestite in modo sicuro catene di proxy, valori non validi e indirizzi IPv6 con porta.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->