### PR TITLE
fix(security): reject non-integer CIDR prefixes in TRUSTED_PROXIES

### DIFF
--- a/app/Support/HtmlHelper.php
+++ b/app/Support/HtmlHelper.php
@@ -255,7 +255,11 @@ class HtmlHelper
             // address families match.
             if (strpos($entry, '/') !== false) {
                 [$network, $prefixLen] = explode('/', $entry, 2);
-                if (!is_numeric($prefixLen)) {
+                // Accept ONLY decimal digits before casting. is_numeric() also
+                // passes '0.5', '1e2', '+5' etc., and (int) '0.5' === 0 would
+                // silently widen 10.0.0.0/0.5 to /0 — trusting every peer and
+                // collapsing the whole X-Forwarded-For security boundary.
+                if (preg_match('/^\d+$/D', $prefixLen) !== 1) {
                     continue;
                 }
                 $prefixLen = (int) $prefixLen;

--- a/tests/security-scan-findings.unit.php
+++ b/tests/security-scan-findings.unit.php
@@ -103,10 +103,14 @@ putenv('TRUSTED_PROXIES=10.0.0.0/0.5');
 $_ENV['TRUSTED_PROXIES'] = '10.0.0.0/0.5';
 $check(\App\Support\HtmlHelper::isTrustedProxyIp('8.8.8.8') === false,
     'a fractional CIDR prefix (/0.5) is rejected, not widened to /0 (trust-all)');
-putenv('TRUSTED_PROXIES=10.0.0.0/1e2');
-$_ENV['TRUSTED_PROXIES'] = '10.0.0.0/1e2';
+// /1e0 is the DISCRIMINATING scientific-notation case: (int) '1e0' === 1, so the
+// old is_numeric() gate widened 0.0.0.0/1e0 to /1 and trusted 8.8.8.8; the
+// digit-only regex rejects it. (/1e2 casts to 100 > 32 and was already dropped
+// by the bounds check, so it would pass with or without the fix — not a proof.)
+putenv('TRUSTED_PROXIES=0.0.0.0/1e0');
+$_ENV['TRUSTED_PROXIES'] = '0.0.0.0/1e0';
 $check(\App\Support\HtmlHelper::isTrustedProxyIp('8.8.8.8') === false,
-    'a scientific-notation CIDR prefix (/1e2) is rejected');
+    'a scientific-notation CIDR prefix (/1e0) is rejected, not widened to /1 (trust-half)');
 // A well-formed CIDR still matches, so the guard did not over-tighten.
 putenv('TRUSTED_PROXIES=10.0.0.0/8');
 $_ENV['TRUSTED_PROXIES'] = '10.0.0.0/8';

--- a/tests/security-scan-findings.unit.php
+++ b/tests/security-scan-findings.unit.php
@@ -96,6 +96,22 @@ $check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => '[2001:db8:
     'a bracketed IPv6 XFF hop with a port is normalised to the bare address');
 $check(ClientIpResolver::resolve('172.21.0.4', ['X-Forwarded-For' => '198.51.100.27:51000']) === '198.51.100.27',
     'an IPv4 XFF hop with a port is normalised to the bare address');
+
+// A non-integer CIDR prefix must be rejected, not silently truncated by (int):
+// 10.0.0.0/0.5 → (int)0 → /0 would trust EVERY peer and collapse the boundary.
+putenv('TRUSTED_PROXIES=10.0.0.0/0.5');
+$_ENV['TRUSTED_PROXIES'] = '10.0.0.0/0.5';
+$check(\App\Support\HtmlHelper::isTrustedProxyIp('8.8.8.8') === false,
+    'a fractional CIDR prefix (/0.5) is rejected, not widened to /0 (trust-all)');
+putenv('TRUSTED_PROXIES=10.0.0.0/1e2');
+$_ENV['TRUSTED_PROXIES'] = '10.0.0.0/1e2';
+$check(\App\Support\HtmlHelper::isTrustedProxyIp('8.8.8.8') === false,
+    'a scientific-notation CIDR prefix (/1e2) is rejected');
+// A well-formed CIDR still matches, so the guard did not over-tighten.
+putenv('TRUSTED_PROXIES=10.0.0.0/8');
+$_ENV['TRUSTED_PROXIES'] = '10.0.0.0/8';
+$check(\App\Support\HtmlHelper::isTrustedProxyIp('10.1.2.3') === true,
+    'a valid integer CIDR prefix (/8) still matches a peer inside the range');
 putenv('TRUSTED_PROXIES');
 unset($_ENV['TRUSTED_PROXIES']);
 


### PR DESCRIPTION
Addresses a CodeRabbit **outside-diff-range** finding on the 0.7.72 trusted-proxy work (CWE-20, Improper Input Validation).

## Problem

In `HtmlHelper::isTrustedProxyIp()` the CIDR matcher gated the prefix with `is_numeric($prefixLen)`, which passes `0.5`, `1e2`, `+5`, etc. Since `(int) "0.5" === 0`, a misconfigured `TRUSTED_PROXIES=10.0.0.0/0.5` was silently widened to `/0` — **every peer becomes trusted**, so a direct (unproxied) client could then control `X-Forwarded-For`, the rate-limit bucket key and the audit IP.

Not attacker-controlled (requires an admin to write a fractional prefix), so low probability — but the failure mode is a full trust-boundary collapse, and it is pre-existing code in the exact boundary the 0.7.72 hardening tightened.

## Fix

Accept **only decimal-digit** prefixes before the `(int)` cast:

```php
if (preg_match(/^d+$/D, $prefixLen) !== 1) {
    continue;
}
```

## Tests (`security-scan-findings.unit.php`, 25/25)

- `10.0.0.0/0.5` → `8.8.8.8` is NOT trusted (no silent `/0`).
- `10.0.0.0/1e2` → rejected.
- `10.0.0.0/8` → `10.1.2.3` still matches (guard did not over-tighten).

`ci-quality-local.sh` green (PHPStan L5, all unit tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni di sicurezza**
  * Rafforzata la validazione dei prefissi CIDR per i proxy attendibili.
  * Rifiutati valori non interi, come `/0.5` e `/1e2`, che potevano ampliare involontariamente la rete considerata attendibile.
  * Mantenuto il corretto funzionamento dei prefissi validi, come `/8`.

* **Test**
  * Aggiunti controlli di regressione per i prefissi CIDR non validi e validi.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->