### PR TITLE
fix(loans): harden circulation edge cases from a full flow review + 100 guard tests

### DIFF
--- a/app/Controllers/LoanApprovalController.php
+++ b/app/Controllers/LoanApprovalController.php
@@ -1288,7 +1288,13 @@ class LoanApprovalController
             $reassignmentService = new \App\Services\ReservationReassignmentService($db);
             $reassignmentService->setExternalTransaction(true);
 
-            // Release copy if assigned (set back to 'disponibile' only if valid state)
+            // Release copy if assigned. Only a copy actually HELD for this pickup
+            // (stato='prenotato') may be freed — mirrors the user cancel twin's
+            // guarded UPDATE. In particular a copy in 'prestato' is physically out
+            // under ANOTHER open loan (the reassignment service deliberately binds
+            // 'prestato' copies to disjoint future windows), so flipping it to
+            // 'disponibile' here would mark an out-of-library copy as available
+            // until its real return. 'disponibile' (promoted pendente) is a no-op.
             if ($copiaId) {
                 // FOR UPDATE prevents TOCTOU race - lock row before checking and updating
                 $copyCheckStmt = $db->prepare("SELECT stato FROM copie WHERE id = ? FOR UPDATE");
@@ -1297,14 +1303,13 @@ class LoanApprovalController
                 $copyResult = $copyCheckStmt->get_result()->fetch_assoc();
                 $copyCheckStmt->close();
 
-                $invalidStates = ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'];
-                if ($copyResult && !in_array($copyResult['stato'], $invalidStates, true)) {
+                if ($copyResult && $copyResult['stato'] === 'prenotato') {
                     $copyRepo = new \App\Models\CopyRepository($db);
                     $copyRepo->updateStatus($copiaId, 'disponibile');
 
                     // Advance reservation queue: promote next waiting user for this copy
                     $reassignmentService->reassignOnReturn($copiaId);
-                } elseif ($copyResult) {
+                } elseif ($copyResult && $copyResult['stato'] !== 'disponibile') {
                     \App\Support\SecureLogger::warning("[cancelPickup] Copy {$copiaId} in state '{$copyResult['stato']}' not reset to disponibile");
                 }
             }

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -327,10 +327,15 @@ class ReservationsAdminController
             }
 
             if ($oldStato === 'attiva' && $stato === 'annullata') {
+                // CI-SOFT-DELETE-EXEMPT: the cancellation notice must reach the
+                // user even when the reserved title was archived meanwhile — the
+                // sibling cancel paths (cancelReservation, rejectLoan) are
+                // deliberately exempt for the same reason; filtering here made
+                // this one path silently skip the email.
                 $notificationStmt = $db->prepare(
                     "SELECT CONCAT(u.nome, ' ', u.cognome) AS utente_nome, u.email, l.titolo
                      FROM utenti u
-                     JOIN libri l ON l.id = ? AND l.deleted_at IS NULL
+                     JOIN libri l ON l.id = ?
                      WHERE u.id = ?"
                 );
                 $notificationStmt->bind_param('ii', $libroId, $utenteId);

--- a/app/Controllers/ReservationsAdminController.php
+++ b/app/Controllers/ReservationsAdminController.php
@@ -327,15 +327,15 @@ class ReservationsAdminController
             }
 
             if ($oldStato === 'attiva' && $stato === 'annullata') {
-                // CI-SOFT-DELETE-EXEMPT: the cancellation notice must reach the
-                // user even when the reserved title was archived meanwhile — the
-                // sibling cancel paths (cancelReservation, rejectLoan) are
-                // deliberately exempt for the same reason; filtering here made
-                // this one path silently skip the email.
+                // The update path already rejects archived titles up front (the
+                // book row is locked WITH deleted_at IS NULL and the request
+                // fails with book_not_found before reaching this point), so this
+                // fetch keeps the standard filter: it can only ever see a live
+                // book, and the controller-wide soft-delete rule stays intact.
                 $notificationStmt = $db->prepare(
                     "SELECT CONCAT(u.nome, ' ', u.cognome) AS utente_nome, u.email, l.titolo
                      FROM utenti u
-                     JOIN libri l ON l.id = ?
+                     JOIN libri l ON l.id = ? AND l.deleted_at IS NULL
                      WHERE u.id = ?"
                 );
                 $notificationStmt->bind_param('ii', $libroId, $utenteId);

--- a/app/Services/ReservationReassignmentService.php
+++ b/app/Services/ReservationReassignmentService.php
@@ -667,6 +667,15 @@ class ReservationReassignmentService
                   )
             )
         ";
+        // DELIBERATE divergence from the three canonical #384 allocators: this
+        // is a REASSIGNMENT (an already-promised hold being repointed after its
+        // copy became unavailable), not a new request that can route to the
+        // waitlist instead. Here the alternative to stacking date-disjoint
+        // holds onto the replacement copy is cancelling them, so the overlap
+        // test stays date-based (open-ended overdue included) and disjoint
+        // preceding commitments remain valid targets — see the sibling comment
+        // above ("a copy currently 'prestato' is a valid target for a disjoint
+        // future hold") and tests/loan-edge-cases.unit.php which encodes this.
         $params = [$libroId, $libroId, $userId, $reservationId, $reservationId, $endDate, $applicationToday, $startDate];
         $types = 'iiiiisss';
 
@@ -679,7 +688,29 @@ class ReservationReassignmentService
             }
         }
 
-        $sql .= " ORDER BY c.id ASC LIMIT 1";
+        // #384 preference, identical to the canonical allocators: prefer a copy
+        // with no later commitment (or whose next one is furthest away) so this
+        // reassignment never makes an existing scheduled loan depend on this
+        // borrower returning on time. `future.id <> ?` excludes the very hold
+        // being repointed, which may still reference its old binding.
+        $sql .= "
+            ORDER BY COALESCE((
+                SELECT MIN(future.data_prestito)
+                FROM prestiti future
+                WHERE future.copia_id = c.id
+                  AND future.id <> ?
+                  AND future.data_prestito > ?
+                  AND (
+                      (future.attivo = 1 AND future.stato IN ('in_corso','da_ritirare','prenotato','in_ritardo'))
+                      OR (future.stato = 'pendente' AND future.copia_id IS NOT NULL)
+                  )
+            ), '9999-12-31') DESC,
+            c.id ASC
+            LIMIT 1";
+        $params[] = $reservationId;
+        $types .= 'i';
+        $params[] = $endDate;
+        $types .= 's';
 
         $stmt = $this->db->prepare($sql);
         $stmt->bind_param($types, ...$params);

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -1278,18 +1278,25 @@ class MaintenanceService
                     $copyState = $copyResult ? $copyResult->fetch_assoc() : null;
                     $checkCopy->close();
 
-                    // Ensure copy is available (but don't resurrect non-restorable copies)
-                    // Skip if copy is in a non-lendable operational state.
-                    $nonRestorableStates = ['perso', 'danneggiato', 'manutenzione', 'in_restauro', 'in_trasferimento'];
-                    if ($copyState && !in_array($copyState['stato'], $nonRestorableStates, true) && $copyState['stato'] !== 'disponibile') {
-                        $updateCopy = $this->db->prepare("UPDATE copie SET stato = 'disponibile' WHERE id = ?");
+                    // Release only the hold owned by this expired pickup. The
+                    // same copy may already be physically out under another
+                    // open, date-disjoint loan; never turn `prestato` (or any
+                    // other lifecycle state) back into `disponibile` here.
+                    if ($copyState && $copyState['stato'] === 'prenotato') {
+                        $updateCopy = $this->db->prepare(
+                            "UPDATE copie SET stato = 'disponibile' WHERE id = ? AND stato = 'prenotato'"
+                        );
                         $updateCopy->bind_param('i', $copiaId);
                         $updateCopy->execute();
+                        $releasedCopy = $updateCopy->affected_rows === 1;
                         $updateCopy->close();
-                    }
 
-                    // Trigger reassignment logic for this copy (inside same transaction)
-                    $reassignmentService->reassignOnReturn($copiaId);
+                        if ($releasedCopy) {
+                            // Trigger reassignment only for a copy this sweep
+                            // actually released (inside the same transaction).
+                            $reassignmentService->reassignOnReturn($copiaId);
+                        }
+                    }
                 }
 
                 // Layer 2: promote queued waitlist reservations freed by this expired

--- a/app/Support/MaintenanceService.php
+++ b/app/Support/MaintenanceService.php
@@ -1249,6 +1249,7 @@ class MaintenanceService
                     UPDATE prestiti
                     SET stato = 'scaduto',
                         attivo = 0,
+                        pickup_deadline = NULL,
                         updated_at = NOW(),
                         note = CONCAT(COALESCE(note, ''), ?)
                     WHERE id = ? AND stato = 'da_ritirare' AND attivo = 1
@@ -1318,10 +1319,15 @@ class MaintenanceService
                     \App\Support\SecureLogger::warning('Flush notifiche differite fallito', ['error' => $flushErr->getMessage()]);
                 }
 
-                // Send pickup expired notification to user
+                // Send pickup expired notification to user. The terminal UPDATE
+                // above NULLed pickup_deadline, so pass the elapsed deadline
+                // captured under lock for the email body.
                 try {
                     $notificationService = new NotificationService($this->db);
-                    $notificationService->sendPickupExpiredNotification($id);
+                    $notificationService->sendPickupExpiredNotification(
+                        $id,
+                        isset($lockedPickup['pickup_deadline']) ? (string) $lockedPickup['pickup_deadline'] : null
+                    );
                 } catch (\Throwable $notifError) {
                     SecureLogger::warning(__('Errore invio notifica ritiro scaduto'), [
                         'prestito_id' => $id,

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -1494,7 +1494,9 @@ class NotificationService {
             $variables = [
                 'utente_nome' => $loan['utente_nome'],
                 'libro_titolo' => $loan['libro_titolo'],
-                'motivo_rifiuto' => $reason ?: $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
+                // !== '' (not ?:) so a literal "0" reason is preserved — same
+                // criterion as sendPickupCancelledNotification's reason handling.
+                'motivo_rifiuto' => $reason !== '' ? $reason : $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
             ];
 
             return $this->sendWithRetry($loan['utente_email'], 'loan_rejected', $variables);
@@ -1526,7 +1528,9 @@ class NotificationService {
             $variables = [
                 'utente_nome' => $userName,
                 'libro_titolo' => $bookTitle,
-                'motivo_rifiuto' => $reason ?: $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
+                // !== '' (not ?:) so a literal "0" reason is preserved — same
+                // criterion as sendPickupCancelledNotification's reason handling.
+                'motivo_rifiuto' => $reason !== '' ? $reason : $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
             ];
 
             return $this->sendWithRetry($userEmail, 'loan_rejected', $variables);

--- a/app/Support/NotificationService.php
+++ b/app/Support/NotificationService.php
@@ -992,11 +992,14 @@ class NotificationService {
     public function notifyAdminsOverdue(int $loanId): void
     {
         try {
+            // CI-SOFT-DELETE-EXEMPT: the borrower's overdue notice is exempt, so
+            // the admin alert for the SAME overdue loan must be too — an archived
+            // title's outstanding loan is exactly the case staff must chase.
             $stmt = $this->db->prepare("
                 SELECT p.id, p.data_scadenza, p.data_prestito, l.titolo AS libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) AS utente_nome, u.email AS utente_email
                 FROM prestiti p
-                JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
+                JOIN libri l ON p.libro_id = l.id
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.id = ?
             ");
@@ -1485,10 +1488,13 @@ class NotificationService {
             }
             $stmt->close();
 
+            // The fallback reason must render in the RECIPIENT's locale, not the
+            // acting admin's session locale (same pattern as the other senders).
+            $recipientLocale = $this->resolveRecipientLocale((string) $loan['utente_email']);
             $variables = [
                 'utente_nome' => $loan['utente_nome'],
                 'libro_titolo' => $loan['libro_titolo'],
-                'motivo_rifiuto' => $reason ?: __('Nessun motivo specificato')
+                'motivo_rifiuto' => $reason ?: $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
             ];
 
             return $this->sendWithRetry($loan['utente_email'], 'loan_rejected', $variables);
@@ -1515,10 +1521,12 @@ class NotificationService {
         string $reason = ''
     ): bool {
         try {
+            // Recipient-locale fallback, mirroring sendLoanRejectedNotification.
+            $recipientLocale = $this->resolveRecipientLocale($userEmail);
             $variables = [
                 'utente_nome' => $userName,
                 'libro_titolo' => $bookTitle,
-                'motivo_rifiuto' => $reason ?: __('Nessun motivo specificato')
+                'motivo_rifiuto' => $reason ?: $this->translateInLocale('Nessun motivo specificato', $recipientLocale)
             ];
 
             return $this->sendWithRetry($userEmail, 'loan_rejected', $variables);
@@ -1768,13 +1776,18 @@ class NotificationService {
     /**
      * Invia notifica quando la scadenza del ritiro è passata (prestito scaduto)
      */
-    public function sendPickupExpiredNotification(int $loanId): bool {
+    public function sendPickupExpiredNotification(int $loanId, ?string $pickupDeadline = null): bool {
         try {
+            // CI-SOFT-DELETE-EXEMPT: this terminal pickup notice must reach the
+            // borrower even after the book was soft-deleted — checkExpiredPickups()
+            // deliberately expires pickups on archived titles (its sweep is
+            // exempt), so filtering deleted_at here silently swallowed the email
+            // while the loan still expired and the copy was freed (#381 class).
             $stmt = $this->db->prepare("
                 SELECT p.*, l.titolo as libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email as utente_email
                 FROM prestiti p
-                JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
+                JOIN libri l ON p.libro_id = l.id
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.id = ?
             ");
@@ -1789,12 +1802,16 @@ class NotificationService {
             $stmt->close();
 
             $recipientLocale = $this->resolveRecipientLocale((string) $loan['utente_email']);
+            // The sweep NULLs pickup_deadline on the terminal 'scaduto' row (kept
+            // consistent with both cancel paths), so the caller passes the elapsed
+            // deadline it captured under lock; the row value is only a fallback.
+            $deadline = $pickupDeadline ?? $loan['pickup_deadline'];
             $variables = [
                 'utente_nome' => $loan['utente_nome'],
                 'libro_titolo' => $loan['libro_titolo'],
-                'scadenza_ritiro' => $loan['pickup_deadline'] ? $this->formatEmailDate($loan['pickup_deadline'], false, $recipientLocale) : '',
+                'scadenza_ritiro' => $deadline ? $this->formatEmailDate($deadline, false, $recipientLocale) : '',
                 // #304: alias under the DB column name, see sendPickupReadyNotification.
-                'pickup_deadline' => $loan['pickup_deadline'] ? $this->formatEmailDate($loan['pickup_deadline'], false, $recipientLocale) : ''
+                'pickup_deadline' => $deadline ? $this->formatEmailDate($deadline, false, $recipientLocale) : ''
             ];
 
             return $this->sendWithRetry($loan['utente_email'], 'loan_pickup_expired', $variables);
@@ -1883,11 +1900,14 @@ class NotificationService {
      */
     public function sendLoanReturnedNotification(int $loanId): bool {
         try {
+            // CI-SOFT-DELETE-EXEMPT: the return-confirmation must reach the
+            // borrower even when the title was archived while the loan was out —
+            // the return path itself is exempt and closes the loan regardless.
             $stmt = $this->db->prepare("
                 SELECT p.*, l.titolo as libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email as utente_email
                 FROM prestiti p
-                JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
+                JOIN libri l ON p.libro_id = l.id
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.id = ?
             ");
@@ -1923,11 +1943,15 @@ class NotificationService {
      */
     public function sendReservationExpiredNotification(int $loanId): bool {
         try {
+            // CI-SOFT-DELETE-EXEMPT: this terminal expiry notice must reach the
+            // borrower even after the book was soft-deleted — checkExpiredReservations()
+            // deliberately expires scheduled loans on archived titles, so the
+            // deleted_at filter here silently swallowed the email (#381 class).
             $stmt = $this->db->prepare("
                 SELECT p.*, l.titolo as libro_titolo,
                        CONCAT(u.nome, ' ', u.cognome) as utente_nome, u.email as utente_email
                 FROM prestiti p
-                JOIN libri l ON p.libro_id = l.id AND l.deleted_at IS NULL
+                JOIN libri l ON p.libro_id = l.id
                 JOIN utenti u ON p.utente_id = u.id
                 WHERE p.id = ?
             ");

--- a/app/Support/PickupDeadlineBackfill.php
+++ b/app/Support/PickupDeadlineBackfill.php
@@ -48,11 +48,16 @@ final class PickupDeadlineBackfill
 
             // COALESCE fallback equals the uncapped deadline so rows with a
             // NULL data_scadenza (legacy data) simply get today + N days.
+            // "Today" is the APPLICATION-timezone date (DateHelper), not SQL
+            // CURDATE(): the DB session TZ can differ, and the sweeps that later
+            // enforce this deadline compare against DateHelper::today() — a
+            // midnight-window upgrade must not produce an off-by-one deadline.
+            $today = DateHelper::today();
             $stmt = $db->prepare("
                 UPDATE prestiti
                 SET pickup_deadline = LEAST(
-                    DATE_ADD(CURDATE(), INTERVAL ? DAY),
-                    COALESCE(data_scadenza, DATE_ADD(CURDATE(), INTERVAL ? DAY))
+                    DATE_ADD(?, INTERVAL ? DAY),
+                    COALESCE(data_scadenza, DATE_ADD(?, INTERVAL ? DAY))
                 )
                 WHERE stato = 'da_ritirare'
                   AND attivo = 1
@@ -62,7 +67,7 @@ final class PickupDeadlineBackfill
                 SecureLogger::warning('PickupDeadlineBackfill: prepare failed: ' . $db->error);
                 return false;
             }
-            $stmt->bind_param('ii', $pickupDays, $pickupDays);
+            $stmt->bind_param('sisi', $today, $pickupDays, $today, $pickupDays);
             if (!$stmt->execute()) {
                 // With mysqli in exception mode a failure throws (caught below);
                 // this guard also holds if reporting is ever disabled, so the

--- a/scripts/maintenance.php
+++ b/scripts/maintenance.php
@@ -118,12 +118,6 @@ $reservationManager->cancelExpiredReservations();
 $reservationManager->flushDeferredNotifications();
 echo "✓ Expired reservations processed\n\n";
 
-// TXN-003: from here on each book is wrapped in this script's own transaction,
-// so the manager must NOT begin a nested one — mysqli begin_transaction()
-// inside an open transaction implicitly COMMITS the outer one, silently
-// breaking the FOR UPDATE serialization the loop relies on.
-$reservationManager->setExternalTransaction(true);
-
 // Process available books for pending reservations
 echo "Processing available books for reservations...\n";
 
@@ -140,12 +134,22 @@ $processedBooks = 0;
 while ($row = $result->fetch_assoc()) {
     $bookId = (int)$row['libro_id'];
     $inTransaction = false;
+    // Fresh manager per book (same pattern as MaintenanceService::checkExpiredPickups):
+    // a rollback below must not leave this book's queued promotion notification in a
+    // shared manager, where the next book's post-commit flush would email a user
+    // about a promotion that never persisted.
+    // TXN-003: each book is wrapped in this script's own transaction, so the
+    // manager must NOT begin a nested one — mysqli begin_transaction() inside an
+    // open transaction implicitly COMMITS the outer one, silently breaking the
+    // FOR UPDATE serialization the loop relies on.
+    $bookManager = new ReservationManager($db);
+    $bookManager->setExternalTransaction(true);
     try {
         // Wrap in transaction to ensure FOR UPDATE locks are effective
         $db->begin_transaction();
         $inTransaction = true;
 
-        if ($reservationManager->processBookAvailability($bookId)) {
+        if ($bookManager->processBookAvailability($bookId)) {
             echo "✓ Processed reservations for book ID: $bookId\n";
             $processedBooks++;
         }
@@ -153,7 +157,7 @@ while ($row = $result->fetch_assoc()) {
         $inTransaction = false;
         // External-transaction mode defers promotion emails: flush them only
         // after this book's transaction has committed.
-        $reservationManager->flushDeferredNotifications();
+        $bookManager->flushDeferredNotifications();
     } catch (\Throwable $e) {
         if ($inTransaction) {
             try {

--- a/scripts/maintenance.php
+++ b/scripts/maintenance.php
@@ -105,19 +105,24 @@ $db->set_charset($cfg['charset']);
 \App\Support\DateHelper::synchronizeDatabaseSession($db);
 
 $reservationManager = new ReservationManager($db);
-// TXN-003: this script wraps each book in its own transaction below, so the
-// manager must NOT begin a nested one — mysqli begin_transaction() inside an
-// open transaction implicitly COMMITS the outer one, silently breaking the
-// FOR UPDATE serialization this loop relies on.
-$reservationManager->setExternalTransaction(true);
 
 echo "=== RESERVATION MAINTENANCE STARTED ===\n";
 echo "Time: " . date('Y-m-d H:i:s') . "\n\n";
 
-// Cancel expired reservations
+// Cancel expired reservations. This runs OUTSIDE the per-book transaction
+// loop below, so the manager must still own its transactions here — external
+// mode is switched on only afterwards. Flush its queued expiry notifications
+// right away: the loop may process zero books and never flush otherwise.
 echo "Cancelling expired reservations...\n";
 $reservationManager->cancelExpiredReservations();
+$reservationManager->flushDeferredNotifications();
 echo "✓ Expired reservations processed\n\n";
+
+// TXN-003: from here on each book is wrapped in this script's own transaction,
+// so the manager must NOT begin a nested one — mysqli begin_transaction()
+// inside an open transaction implicitly COMMITS the outer one, silently
+// breaking the FOR UPDATE serialization the loop relies on.
+$reservationManager->setExternalTransaction(true);
 
 // Process available books for pending reservations
 echo "Processing available books for reservations...\n";

--- a/scripts/maintenance.php
+++ b/scripts/maintenance.php
@@ -105,6 +105,11 @@ $db->set_charset($cfg['charset']);
 \App\Support\DateHelper::synchronizeDatabaseSession($db);
 
 $reservationManager = new ReservationManager($db);
+// TXN-003: this script wraps each book in its own transaction below, so the
+// manager must NOT begin a nested one — mysqli begin_transaction() inside an
+// open transaction implicitly COMMITS the outer one, silently breaking the
+// FOR UPDATE serialization this loop relies on.
+$reservationManager->setExternalTransaction(true);
 
 echo "=== RESERVATION MAINTENANCE STARTED ===\n";
 echo "Time: " . date('Y-m-d H:i:s') . "\n\n";
@@ -141,6 +146,9 @@ while ($row = $result->fetch_assoc()) {
         }
         $db->commit();
         $inTransaction = false;
+        // External-transaction mode defers promotion emails: flush them only
+        // after this book's transaction has committed.
+        $reservationManager->flushDeferredNotifications();
     } catch (\Throwable $e) {
         if ($inTransaction) {
             try {

--- a/storage/plugins/ncip-server/NcipServerPlugin.php
+++ b/storage/plugins/ncip-server/NcipServerPlugin.php
@@ -1671,20 +1671,14 @@ class NcipServerPlugin
                 return null;
             }
 
-            // Borrower/title uniqueness goes through the SAME policy as the
-            // staff flow (LoanMultiplicityPolicy): strict by default, and when
-            // allow_multiple_loans_same_book is enabled a second COPY-BINDING
-            // checkout is allowed exactly like the admin UI — an NCIP desk
-            // checkout must not be stricter than the desk itself. The previous
-            // inline predicate was a verbatim clone of the policy's strict
-            // branch and would have drifted silently. committedCopyIds keeps
-            // the borrower's own already-committed copies out of the allocator
-            // below, mirroring PrestitiController::store.
+            // NCIP ItemId is currently a title-level libri.id, not a physical
+            // copy identifier, and CheckOutItem carries no request idempotency
+            // key. Keep this path strict even when the interactive staff UI
+            // allows multiple same-title loans: otherwise an ordinary partner
+            // retry is indistinguishable from an intentional second checkout
+            // and can silently consume another copy.
             $multiplicityPolicy = new \App\Support\LoanMultiplicityPolicy($this->db);
-            $hasDuplicate = $multiplicityPolicy->hasBlockingLoan($bookId, $userId, true);
-            $borrowerCommittedCopyIds = $hasDuplicate
-                ? []
-                : $multiplicityPolicy->committedCopyIds($bookId, $userId);
+            $hasDuplicate = $multiplicityPolicy->hasBlockingLoan($bookId, $userId, false);
 
             $reservation = $this->db->prepare(
                 "SELECT id FROM prenotazioni
@@ -1741,9 +1735,7 @@ class NcipServerPlugin
             // later commitment (or whose next one is furthest away) so a desk
             // checkout never takes the copy a scheduled loan already needs
             // while a free sibling sits idle. numero_inventario stays as the
-            // librarian-friendly tie-break. The borrower's own committed
-            // copies are excluded up front (relaxed-mode parity with
-            // PrestitiController::store).
+            // librarian-friendly tie-break.
             $copySql =
                 "SELECT c.id FROM copie c
                  WHERE c.libro_id = ?
@@ -1760,14 +1752,6 @@ class NcipServerPlugin
                    )";
             $copyParams = [$bookId, $dueDate, $today, $today];
             $copyTypes = 'isss';
-            if ($borrowerCommittedCopyIds !== []) {
-                $placeholders = implode(',', array_fill(0, count($borrowerCommittedCopyIds), '?'));
-                $copySql .= " AND c.id NOT IN ({$placeholders})";
-                foreach ($borrowerCommittedCopyIds as $committedId) {
-                    $copyParams[] = $committedId;
-                    $copyTypes .= 'i';
-                }
-            }
             $copySql .=
                 " ORDER BY COALESCE((
                        SELECT MIN(future.data_prestito)

--- a/storage/plugins/ncip-server/NcipServerPlugin.php
+++ b/storage/plugins/ncip-server/NcipServerPlugin.php
@@ -1671,17 +1671,20 @@ class NcipServerPlugin
                 return null;
             }
 
-            $duplicate = $this->db->prepare(
-                "SELECT id FROM prestiti
-                 WHERE libro_id = ? AND utente_id = ?
-                   AND ((attivo = 0 AND stato = 'pendente')
-                        OR (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')))
-                 LIMIT 1 FOR UPDATE"
-            );
-            $duplicate->bind_param('ii', $bookId, $userId);
-            $duplicate->execute();
-            $hasDuplicate = (bool) $duplicate->get_result()->fetch_row();
-            $duplicate->close();
+            // Borrower/title uniqueness goes through the SAME policy as the
+            // staff flow (LoanMultiplicityPolicy): strict by default, and when
+            // allow_multiple_loans_same_book is enabled a second COPY-BINDING
+            // checkout is allowed exactly like the admin UI — an NCIP desk
+            // checkout must not be stricter than the desk itself. The previous
+            // inline predicate was a verbatim clone of the policy's strict
+            // branch and would have drifted silently. committedCopyIds keeps
+            // the borrower's own already-committed copies out of the allocator
+            // below, mirroring PrestitiController::store.
+            $multiplicityPolicy = new \App\Support\LoanMultiplicityPolicy($this->db);
+            $hasDuplicate = $multiplicityPolicy->hasBlockingLoan($bookId, $userId, true);
+            $borrowerCommittedCopyIds = $hasDuplicate
+                ? []
+                : $multiplicityPolicy->committedCopyIds($bookId, $userId);
 
             $reservation = $this->db->prepare(
                 "SELECT id FROM prenotazioni
@@ -1733,7 +1736,15 @@ class NcipServerPlugin
                 return null;
             }
 
-            $copy = $this->db->prepare(
+            // #384 preference, identical to the canonical allocators (request
+            // gate, FIFO promotion, approval Step 2d): prefer a copy with no
+            // later commitment (or whose next one is furthest away) so a desk
+            // checkout never takes the copy a scheduled loan already needs
+            // while a free sibling sits idle. numero_inventario stays as the
+            // librarian-friendly tie-break. The borrower's own committed
+            // copies are excluded up front (relaxed-mode parity with
+            // PrestitiController::store).
+            $copySql =
                 "SELECT c.id FROM copie c
                  WHERE c.libro_id = ?
                    AND c.stato IN ('disponibile','prenotato')
@@ -1746,11 +1757,33 @@ class NcipServerPlugin
                               OR p.data_scadenza >= ?)
                          AND ((p.attivo = 1 AND p.stato IN ('prenotato','da_ritirare','in_corso','in_ritardo'))
                               OR (p.attivo = 0 AND p.stato = 'pendente' AND p.copia_id IS NOT NULL))
-                   )
-                 ORDER BY c.numero_inventario ASC
-                 LIMIT 1 FOR UPDATE"
-            );
-            $copy->bind_param('isss', $bookId, $dueDate, $today, $today);
+                   )";
+            $copyParams = [$bookId, $dueDate, $today, $today];
+            $copyTypes = 'isss';
+            if ($borrowerCommittedCopyIds !== []) {
+                $placeholders = implode(',', array_fill(0, count($borrowerCommittedCopyIds), '?'));
+                $copySql .= " AND c.id NOT IN ({$placeholders})";
+                foreach ($borrowerCommittedCopyIds as $committedId) {
+                    $copyParams[] = $committedId;
+                    $copyTypes .= 'i';
+                }
+            }
+            $copySql .=
+                " ORDER BY COALESCE((
+                       SELECT MIN(future.data_prestito)
+                       FROM prestiti future
+                       WHERE future.copia_id = c.id
+                         AND future.data_prestito > ?
+                         AND ((future.attivo = 1 AND future.stato IN ('in_corso','da_ritirare','prenotato','in_ritardo'))
+                              OR (future.stato = 'pendente' AND future.copia_id IS NOT NULL))
+                   ), '9999-12-31') DESC,
+                   c.numero_inventario ASC
+                 LIMIT 1 FOR UPDATE";
+            $copyParams[] = $dueDate;
+            $copyTypes .= 's';
+
+            $copy = $this->db->prepare($copySql);
+            $copy->bind_param($copyTypes, ...$copyParams);
             $copy->execute();
             $copyRow = $copy->get_result()->fetch_assoc();
             $copy->close();
@@ -1838,17 +1871,13 @@ class NcipServerPlugin
                 return null;
             }
 
-            $duplicate = $this->db->prepare(
-                "SELECT id FROM prestiti
-                 WHERE libro_id = ? AND utente_id = ?
-                   AND ((attivo = 0 AND stato = 'pendente')
-                        OR (attivo = 1 AND stato IN ('prenotato','da_ritirare','in_corso','in_ritardo')))
-                 LIMIT 1 FOR UPDATE"
-            );
-            $duplicate->bind_param('ii', $bookId, $userId);
-            $duplicate->execute();
-            $hasDuplicate = (bool) $duplicate->get_result()->fetch_row();
-            $duplicate->close();
+            // A RequestItem is a BARE request (no copy is bound), so the
+            // multiplicity policy stays strict regardless of the opt-in —
+            // operationWillBindCopy=false reproduces exactly the historical
+            // predicate, but from the single shared source instead of an
+            // inline clone that drifts.
+            $multiplicityPolicy = new \App\Support\LoanMultiplicityPolicy($this->db);
+            $hasDuplicate = $multiplicityPolicy->hasBlockingLoan($bookId, $userId, false);
 
             $reservation = $this->db->prepare(
                 "SELECT id FROM prenotazioni

--- a/storage/plugins/ncip-server/plugin.json
+++ b/storage/plugins/ncip-server/plugin.json
@@ -2,7 +2,7 @@
   "name": "ncip-server",
   "display_name": "NCIP 2.0 Server",
   "description": "Protocollo NISO Circulation Interchange Protocol (NCIP) 2.0 per lo scambio di informazioni sui prestiti con ILS, self-service kiosk e reti bibliotecarie. Endpoint /ncip con LookupItem, LookupUser, CheckOutItem, CheckInItem, RenewItem, RequestItem e CancelRequestItem.",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Fabiodalez",
   "author_url": "",
   "plugin_url": "https://www.niso.org/standards-committees/ncip",
@@ -12,7 +12,13 @@
   "main_file": "wrapper.php",
   "metadata": {
     "category": "protocol",
-    "tags": ["ncip", "ils", "circulation", "interoperability", "niso"],
+    "tags": [
+      "ncip",
+      "ils",
+      "circulation",
+      "interoperability",
+      "niso"
+    ],
     "optional": true,
     "status": "stable"
   }

--- a/tests/loan-allocator-384-parity.unit.php
+++ b/tests/loan-allocator-384-parity.unit.php
@@ -286,13 +286,15 @@ $checkoutSrc = $methodSlice($ncipSrc, 'createLoanAtomic');
 $requestSrc = $methodSlice($ncipSrc, 'createRequestItemNcip');
 $check($checkoutSrc !== '' && str_contains($checkoutSrc, "'9999-12-31'"),
     '20 the NCIP checkout allocator carries the #384 preference sentinel');
-$check($checkoutSrc !== '' && str_contains($checkoutSrc, 'hasBlockingLoan($bookId, $userId, true)')
+$check($checkoutSrc !== '' && str_contains($checkoutSrc, 'hasBlockingLoan($bookId, $userId, false)')
     && $requestSrc !== '' && str_contains($requestSrc, 'hasBlockingLoan($bookId, $userId, false)'),
-    '21 CheckOutItem consults the policy copy-binding, RequestItem strict (each in its own body)');
+    '21 both NCIP title-level operations stay strict and replay-safe (each in its own body)');
 $check(!str_contains($ncipSrc, "AND ((attivo = 0 AND stato = 'pendente')"),
     '22 the inline duplicate-predicate clones are gone from the NCIP plugin');
-$check($checkoutSrc !== '' && str_contains($checkoutSrc, 'committedCopyIds'),
-    '23 the checkout body excludes the borrower\'s own committed copies (relaxed-mode parity)');
+$check($checkoutSrc !== ''
+    && str_contains($checkoutSrc, 'no request idempotency')
+    && !str_contains($checkoutSrc, 'committedCopyIds'),
+    '23 CheckOutItem documents and enforces title-level replay safety');
 
 $cleanup();
 $db->close();

--- a/tests/loan-allocator-384-parity.unit.php
+++ b/tests/loan-allocator-384-parity.unit.php
@@ -270,15 +270,29 @@ $check($gateAllocPos !== false
     '19 the gate keeps the HARD rule: any commitment starting before the window end rejects');
 
 // NCIP desk operations share the same policy and preference (no drifting clones).
+// Method-scoped slices (anchor at the definition, bound at the next method, fail
+// if the anchor disappears) so a comment elsewhere in the file can never satisfy
+// these — same non-vacuousness pattern as check 19.
 $ncipSrc = (string) file_get_contents($root . '/storage/plugins/ncip-server/NcipServerPlugin.php');
-$check(str_contains($ncipSrc, "'9999-12-31'"),
+$methodSlice = static function (string $src, string $method): string {
+    $at = strpos($src, "private function {$method}");
+    if ($at === false) {
+        return '';
+    }
+    $end = strpos($src, 'private function ', $at + 1);
+    return substr($src, $at, $end === false ? strlen($src) - $at : $end - $at);
+};
+$checkoutSrc = $methodSlice($ncipSrc, 'createLoanAtomic');
+$requestSrc = $methodSlice($ncipSrc, 'createRequestItemNcip');
+$check($checkoutSrc !== '' && str_contains($checkoutSrc, "'9999-12-31'"),
     '20 the NCIP checkout allocator carries the #384 preference sentinel');
-$check(substr_count($ncipSrc, 'LoanMultiplicityPolicy') >= 2,
-    '21 both NCIP CheckOutItem and RequestItem consult LoanMultiplicityPolicy');
+$check($checkoutSrc !== '' && str_contains($checkoutSrc, 'hasBlockingLoan($bookId, $userId, true)')
+    && $requestSrc !== '' && str_contains($requestSrc, 'hasBlockingLoan($bookId, $userId, false)'),
+    '21 CheckOutItem consults the policy copy-binding, RequestItem strict (each in its own body)');
 $check(!str_contains($ncipSrc, "AND ((attivo = 0 AND stato = 'pendente')"),
     '22 the inline duplicate-predicate clones are gone from the NCIP plugin');
-$check(str_contains($ncipSrc, 'committedCopyIds'),
-    '23 NCIP excludes the borrower\'s own committed copies from allocation (relaxed-mode parity)');
+$check($checkoutSrc !== '' && str_contains($checkoutSrc, 'committedCopyIds'),
+    '23 the checkout body excludes the borrower\'s own committed copies (relaxed-mode parity)');
 
 $cleanup();
 $db->close();

--- a/tests/loan-allocator-384-parity.unit.php
+++ b/tests/loan-allocator-384-parity.unit.php
@@ -41,11 +41,18 @@ foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as 
     [$key, $value] = explode('=', $line, 2);
     $env[trim($key)] = trim(trim($value), "\"'");
 }
-$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+// Orchestrators with no credentials export the literal string "undefined"
+// (a JS-undefined artifact) — treat it like an unset variable so the .env
+// fallback still applies.
+$e2e = static function (string $key): string {
+    $value = getenv($key);
+    return $value === false || $value === 'undefined' ? '' : $value;
+};
+$socket = $e2e('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
 try {
     $db = $socket !== '' && file_exists($socket)
-        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
-        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+        ? new mysqli(null, $e2e('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), $e2e('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), $e2e('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli($e2e('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), $e2e('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), $e2e('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), $e2e('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) ($e2e('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
     $db->set_charset('utf8mb4');
     DateHelper::synchronizeDatabaseSession($db);
 } catch (Throwable $e) {
@@ -251,8 +258,15 @@ $check(substr_count($reasSrc, 'MIN(future.data_prestito)') >= 1
 $check(str_contains($reasSrc, "p.data_prestito <= ?")
     && str_contains($reasSrc, "p.data_scadenza >= ?"),
     '18 the lenient date-overlap predicate (loan-edge-cases contract) is intact');
-$check(str_contains($gateSrc, 'p.data_prestito <= ?')
-    && !str_contains(substr($gateSrc, (int) strpos($gateSrc, 'findAssignableInLibraryCopyThrough'), 1600), 'data_scadenza >= ?'),
+// Slice the METHOD DEFINITION (not the route() call site) so the negative
+// assertion actually inspects the allocator SQL; bound at the next method so
+// the window tracks the body regardless of its length.
+$gateAllocPos = strpos($gateSrc, 'private function findAssignableInLibraryCopyThrough');
+$gateAllocEnd = $gateAllocPos === false ? false : strpos($gateSrc, 'private function', $gateAllocPos + 1);
+$gateAllocSrc = $gateAllocPos === false ? '' : substr($gateSrc, $gateAllocPos, $gateAllocEnd === false ? null : $gateAllocEnd - $gateAllocPos);
+$check($gateAllocPos !== false
+    && str_contains($gateAllocSrc, 'p.data_prestito <= ?')
+    && !str_contains($gateAllocSrc, 'data_scadenza >= ?'),
     '19 the gate keeps the HARD rule: any commitment starting before the window end rejects');
 
 // NCIP desk operations share the same policy and preference (no drifting clones).

--- a/tests/loan-allocator-384-parity.unit.php
+++ b/tests/loan-allocator-384-parity.unit.php
@@ -1,0 +1,262 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * #384 allocator parity suite.
+ *
+ * Four allocators bind copies to engagements: the request gate
+ * (LoanRequestGate::findAssignableInLibraryCopyThrough), the FIFO promotion
+ * (ReservationManager), the approval Step-2d allocator (LoanApprovalController)
+ * and the reassignment allocator
+ * (ReservationReassignmentService::findAvailableCopyExcluding). The first three
+ * enforce the #384 HARD rule (any preceding commitment rejects the copy — its
+ * due date is a promise, not a guarantee) plus the preference ordering "no
+ * later commitment first, else furthest next commitment". The reassignment
+ * allocator DELIBERATELY keeps the lenient date-overlap rule (an already
+ * promised hold being repointed may stack onto disjoint commitments — the
+ * alternative is cancelling it) but MUST share the preference ordering.
+ *
+ * This suite proves both halves behaviorally (reflection on the private
+ * allocators, sandbox data, dates derived from the application today) and
+ * guards the textual parity contract statically.
+ *
+ * Run: php tests/loan-allocator-384-parity.unit.php
+ */
+
+use App\Services\CapacityService;
+use App\Services\LoanRequestGate;
+use App\Services\ReservationReassignmentService;
+use App\Support\DateHelper;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$root = dirname(__DIR__);
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+    DateHelper::synchronizeDatabaseSession($db);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — allocator parity suite is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$run = bin2hex(random_bytes(6));
+$prefix = "ZZ_ALLOC_{$run}";
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$bookIds = [];
+$userIds = [];
+$cleanup = static function () use ($db, &$bookIds, &$userIds): void {
+    foreach ($bookIds as $id) {
+        $db->query("DELETE FROM prenotazioni WHERE libro_id = {$id}");
+        $db->query("DELETE FROM prestiti WHERE libro_id = {$id}");
+        $db->query("DELETE FROM copie WHERE libro_id = {$id}");
+        $db->query("DELETE FROM libri WHERE id = {$id}");
+    }
+    foreach ($userIds as $id) {
+        $db->query("DELETE FROM utenti WHERE id = {$id}");
+    }
+};
+set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
+    try { $cleanup(); } catch (Throwable) {}
+    fwrite(STDERR, 'FAIL: uncaught ' . $e->getMessage() . PHP_EOL);
+    $db->close();
+    exit(1);
+});
+
+$makeBook = static function (string $suffix, int $copies) use ($db, $prefix, $run, &$bookIds): array {
+    $title = "{$prefix}_{$suffix}";
+    $stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, ?, ?, 'disponibile')");
+    $stmt->bind_param('sii', $title, $copies, $copies);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+    $bookIds[] = $bookId;
+    $copyIds = [];
+    for ($i = 1; $i <= $copies; $i++) {
+        $inv = strtoupper("AL{$suffix}{$i}-") . strtoupper(substr($run, 0, 6));
+        $stmt = $db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (?, ?, 'disponibile')");
+        $stmt->bind_param('is', $bookId, $inv);
+        $stmt->execute();
+        $copyIds[] = (int) $db->insert_id;
+        $stmt->close();
+    }
+    return [$bookId, $copyIds];
+};
+$makeUser = static function (string $suffix) use ($db, $run, &$userIds): int {
+    $email = "zz-alloc-{$suffix}-{$run}@test.local";
+    $card = 'ZA' . strtoupper($suffix) . strtoupper(substr($run, 0, 8));
+    $password = password_hash('AllocSuite!1', PASSWORD_DEFAULT);
+    $stmt = $db->prepare(
+        "INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+         VALUES (?, 'Alloc', ?, ?, ?, 'standard', 'attivo', 1)"
+    );
+    $cog = ucfirst($suffix);
+    $stmt->bind_param('ssss', $card, $cog, $email, $password);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    $userIds[] = $id;
+    return $id;
+};
+
+$today = DateHelper::today();
+$d = static fn (int $offset): string => (new DateTimeImmutable($today))->modify(($offset >= 0 ? '+' : '') . $offset . ' days')->format('Y-m-d');
+
+$insertLoan = static function (int $book, ?int $copy, int $user, string $s, string $e, string $stato, int $attivo) use ($db): int {
+    $stmt = $db->prepare(
+        "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo)
+         VALUES (?, ?, ?, ?, ?, ?, 'diretto', ?)"
+    );
+    $stmt->bind_param('iiisssi', $book, $copy, $user, $s, $e, $stato, $attivo);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    return $id;
+};
+
+// ═════════ Reassignment allocator — behavioral (reflection) ═════════
+[$bookP, [$copyA, $copyB]] = $makeBook('P', 2); // copyA has the LOWER id
+$holder = $makeUser('holder');
+$other = $makeUser('other');
+
+$svc = new ReservationReassignmentService($db);
+$alloc = new ReflectionMethod(ReservationReassignmentService::class, 'findAvailableCopyExcluding');
+$pick = static fn (array $exclude, int $resId, int $userId, string $s, string $e) =>
+    $alloc->invoke($svc, $bookP, $exclude, $resId, $userId, $s, $e, $today);
+
+// 01 — preference (DISCRIMINATING for the 0.7.72 follow-up fix): copy A carries
+// a future commitment AFTER the requested window; copy B is clean. The old
+// ORDER BY c.id would pick A; the #384 preference must pick B.
+$futureOnA = $insertLoan($bookP, $copyA, $other, $d(30), $d(40), 'prenotato', 1);
+$picked = $pick([], 0, $holder, $d(0), $d(7));
+$check($picked === $copyB, '01 reassignment prefers the copy with NO later commitment (would pick lower-id A pre-fix)');
+
+// 02 — tie-break: with the future commitment gone, the lower id wins.
+$db->query("DELETE FROM prestiti WHERE id = {$futureOnA}");
+$picked = $pick([], 0, $holder, $d(0), $d(7));
+$check($picked === $copyA, '02 with equal preference the tie-break is the lower copy id');
+
+// 03 — exclusions are honored even when the alternative carries a future hold.
+$futureOnA = $insertLoan($bookP, $copyA, $other, $d(30), $d(40), 'prenotato', 1);
+$picked = $pick([$copyB], 0, $holder, $d(0), $d(7));
+$check($picked === $copyA, '03 excluded copies are skipped; the remaining candidate is bound');
+
+// 04 — lenient overlap semantics PRESERVED (the loan-edge-cases contract):
+// a date-disjoint PRECEDING commitment does not reject the copy here.
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookP}");
+$preceding = $insertLoan($bookP, $copyA, $other, $d(1), $d(3), 'prenotato', 1);
+$picked = $pick([$copyB], 0, $holder, $d(10), $d(15));
+$check($picked === $copyA, '04 reassignment may stack onto a disjoint preceding commitment (deliberate divergence)');
+
+// 05 — own-user exclusion: the target user already engaged on copy A → B wins.
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookP}");
+$own = $insertLoan($bookP, $copyA, $holder, $d(20), $d(25), 'pendente', 0);
+$picked = $pick([], 0, $holder, $d(0), $d(7));
+$check($picked === $copyB, '05 a copy already engaged by the SAME user is excluded');
+
+// 06 — open-ended overdue blocks even future windows.
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookP}");
+$overdue = $insertLoan($bookP, $copyA, $other, $d(-20), $d(-2), 'in_corso', 1);
+$picked = $pick([$copyB], 0, $holder, $d(10), $d(15));
+$check($picked === null, '06 an overdue in_corso blocks the copy for ANY future window (open-ended)');
+
+// ═════════ Request-gate allocator — behavioral (reflection) ═════════
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookP}");
+$gate = new LoanRequestGate($db);
+$gateAlloc = new ReflectionMethod(LoanRequestGate::class, 'findAssignableInLibraryCopyThrough');
+
+// 07 — HARD rule: a preceding scheduled commitment on A rejects it → B.
+$preceding = $insertLoan($bookP, $copyA, $other, $d(1), $d(3), 'prenotato', 1);
+$picked = $gateAlloc->invoke($gate, $bookP, $d(7));
+$check($picked === $copyB, '07 the gate REJECTS a copy with a preceding commitment (hard #384 rule)');
+
+// 08 — both copies carry preceding commitments → nobody qualifies (waitlist).
+$precedingB = $insertLoan($bookP, $copyB, $other, $d(2), $d(4), 'prenotato', 1);
+$picked = $gateAlloc->invoke($gate, $bookP, $d(7));
+$check($picked === null, '08 with every copy preceded the gate returns null (request routes to the waitlist)');
+
+// 09 — gate preference: A has a commitment AFTER the window, B is clean → B.
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookP}");
+$futureOnA = $insertLoan($bookP, $copyA, $other, $d(30), $d(40), 'prenotato', 1);
+$picked = $gateAlloc->invoke($gate, $bookP, $d(7));
+$check($picked === $copyB, '09 the gate shares the preference: keep the copy a future loan already needs');
+
+// ═════════ Capacity gate + headQueuePos (#157 F.21b) ═════════
+[$bookC] = $makeBook('C', 1);
+$uH = $makeUser('head');
+$uT = $makeUser('tail');
+$stmt = $db->prepare(
+    "INSERT INTO prenotazioni (libro_id, utente_id, data_inizio_richiesta, data_fine_richiesta, queue_position, stato)
+     VALUES (?, ?, ?, ?, ?, 'attiva')"
+);
+$rs = $d(0); $re = $d(7); $pos = 1;
+$stmt->bind_param('iissi', $bookC, $uH, $rs, $re, $pos);
+$stmt->execute();
+$resHead = (int) $db->insert_id;
+$pos = 2;
+$stmt->bind_param('iissi', $bookC, $uT, $rs, $re, $pos);
+$stmt->execute();
+$resTail = (int) $db->insert_id;
+$stmt->close();
+
+$capacity = new CapacityService($db);
+$check($capacity->hasFreeCapacity($bookC, $d(0), $d(7), null, $resHead, null, 1) === true,
+    '10 the queue HEAD sees free capacity (tail reservations are excluded after its position)');
+$check($capacity->hasFreeCapacity($bookC, $d(0), $d(7), null, $resTail, null, 2) === false,
+    '11 the queue TAIL does not: the head still occupies the only copy');
+
+$stmt = $db->prepare(
+    "INSERT INTO prenotazioni (libro_id, utente_id, data_inizio_richiesta, data_fine_richiesta, queue_position, stato)
+     VALUES (?, ?, ?, ?, NULL, 'attiva')"
+);
+$stmt->bind_param('iiss', $bookC, $other, $rs, $re);
+$stmt->execute();
+$stmt->close();
+$check($capacity->hasFreeCapacity($bookC, $d(0), $d(7), null, $resHead, null, 1) === false,
+    '12 a NULL queue_position is counted conservatively and consumes capacity');
+
+// ═════════ Static parity contract ═════════
+$gateSrc = (string) file_get_contents($root . '/app/Services/LoanRequestGate.php');
+$rmSrc = (string) file_get_contents($root . '/app/Controllers/ReservationManager.php');
+$apprSrc = (string) file_get_contents($root . '/app/Controllers/LoanApprovalController.php');
+$reasSrc = (string) file_get_contents($root . '/app/Services/ReservationReassignmentService.php');
+
+$check(str_contains($gateSrc, "'9999-12-31'"), '13 gate allocator carries the MIN(future) preference sentinel');
+$check(str_contains($rmSrc, "'9999-12-31'"), '14 FIFO-promotion allocator carries the preference sentinel');
+$check(str_contains($apprSrc, "'9999-12-31'"), '15 approval Step-2d allocator carries the preference sentinel');
+$check(str_contains($reasSrc, "'9999-12-31'"), '16 reassignment allocator now carries the preference sentinel too');
+
+$check(substr_count($reasSrc, 'MIN(future.data_prestito)') >= 1
+    && str_contains($reasSrc, 'DELIBERATE divergence'),
+    '17 the reassignment divergence from the hard rule is explicit and documented');
+$check(str_contains($reasSrc, "p.data_prestito <= ?")
+    && str_contains($reasSrc, "p.data_scadenza >= ?"),
+    '18 the lenient date-overlap predicate (loan-edge-cases contract) is intact');
+$check(str_contains($gateSrc, 'p.data_prestito <= ?')
+    && !str_contains(substr($gateSrc, (int) strpos($gateSrc, 'findAssignableInLibraryCopyThrough'), 1600), 'data_scadenza >= ?'),
+    '19 the gate keeps the HARD rule: any commitment starting before the window end rejects');
+
+$cleanup();
+$db->close();
+
+echo PHP_EOL . "Passed: {$passed}   Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);

--- a/tests/loan-allocator-384-parity.unit.php
+++ b/tests/loan-allocator-384-parity.unit.php
@@ -255,6 +255,17 @@ $check(str_contains($gateSrc, 'p.data_prestito <= ?')
     && !str_contains(substr($gateSrc, (int) strpos($gateSrc, 'findAssignableInLibraryCopyThrough'), 1600), 'data_scadenza >= ?'),
     '19 the gate keeps the HARD rule: any commitment starting before the window end rejects');
 
+// NCIP desk operations share the same policy and preference (no drifting clones).
+$ncipSrc = (string) file_get_contents($root . '/storage/plugins/ncip-server/NcipServerPlugin.php');
+$check(str_contains($ncipSrc, "'9999-12-31'"),
+    '20 the NCIP checkout allocator carries the #384 preference sentinel');
+$check(substr_count($ncipSrc, 'LoanMultiplicityPolicy') >= 2,
+    '21 both NCIP CheckOutItem and RequestItem consult LoanMultiplicityPolicy');
+$check(!str_contains($ncipSrc, "AND ((attivo = 0 AND stato = 'pendente')"),
+    '22 the inline duplicate-predicate clones are gone from the NCIP plugin');
+$check(str_contains($ncipSrc, 'committedCopyIds'),
+    '23 NCIP excludes the borrower\'s own committed copies from allocation (relaxed-mode parity)');
+
 $cleanup();
 $db->close();
 

--- a/tests/loan-archived-title-notifications.unit.php
+++ b/tests/loan-archived-title-notifications.unit.php
@@ -90,9 +90,11 @@ final class DeadlineProbeNotificationService extends NotificationService
 $run = bin2hex(random_bytes(6));
 $title = "ZZ_ARCHNOTIF_{$run}";
 $email = "zz-archnotif-{$run}@test.local";
+$adminEmail = "zz-archnotif-admin-{$run}@test.local";
 $inventory = "ZZAN-{$run}";
 $bookId = 0;
 $userId = 0;
+$adminId = 0;
 $passed = 0;
 $failed = 0;
 $check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
@@ -100,7 +102,7 @@ $check = static function (bool $ok, string $label) use (&$passed, &$failed): voi
     $ok ? $passed++ : $failed++;
 };
 
-$cleanup = static function () use ($db, &$bookId, &$userId): void {
+$cleanup = static function () use ($db, &$bookId, &$userId, &$adminId): void {
     if ($bookId > 0) {
         $db->query("DELETE FROM prestiti WHERE libro_id = {$bookId}");
         $db->query("DELETE FROM copie WHERE libro_id = {$bookId}");
@@ -108,6 +110,9 @@ $cleanup = static function () use ($db, &$bookId, &$userId): void {
     }
     if ($userId > 0) {
         $db->query("DELETE FROM utenti WHERE id = {$userId}");
+    }
+    if ($adminId > 0) {
+        $db->query("DELETE FROM utenti WHERE id = {$adminId}");
     }
 };
 set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
@@ -139,6 +144,20 @@ $stmt = $db->prepare(
 $stmt->bind_param('sss', $card, $email, $password);
 $stmt->execute();
 $userId = (int) $db->insert_id;
+$stmt->close();
+
+// A sandbox ADMIN too: notifyAdminsOverdue resolves locales only inside
+// sendToAdmins' recipient loop, so on a fresh CI database with no active
+// admin/staff users the probe would never fire. One sandbox admin makes the
+// probe deterministic in every environment.
+$adminCard = 'ZZANA' . strtoupper(substr($run, 0, 7));
+$stmt = $db->prepare(
+    "INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+     VALUES (?, 'Archived', 'Admin', ?, ?, 'admin', 'attivo', 1)"
+);
+$stmt->bind_param('sss', $adminCard, $adminEmail, $password);
+$stmt->execute();
+$adminId = (int) $db->insert_id;
 $stmt->close();
 
 $start = DateHelper::today();
@@ -248,12 +267,18 @@ foreach ([
         "{$n} {$fn} carries the CI-SOFT-DELETE-EXEMPT annotation");
 }
 
+// The admin cancel-via-edit path is DIFFERENT from the sweeps by design: it
+// rejects archived titles up front (the book row is locked WITH deleted_at
+// IS NULL → book_not_found), so its notification fetch keeps the standard
+// filter and can only ever see a live book. Guard both halves of that shape.
 $adminCtrl = (string) file_get_contents($root . '/app/Controllers/ReservationsAdminController.php');
+$check(str_contains($adminCtrl, "SELECT id FROM libri WHERE id = ? AND deleted_at IS NULL FOR UPDATE")
+    && str_contains($adminCtrl, 'book_not_found'),
+    '24a admin cancel-via-edit rejects archived titles up front (book_not_found gate)');
 $cancelBlockAt = strpos($adminCtrl, "utente_nome, u.email, l.titolo");
 $cancelBlock = $cancelBlockAt === false ? '' : substr($adminCtrl, max(0, $cancelBlockAt - 700), 1400);
-$check($cancelBlock !== '' && !str_contains($cancelBlock, 'deleted_at IS NULL')
-    && str_contains($cancelBlock, 'CI-SOFT-DELETE-EXEMPT'),
-    '24 admin cancel-via-edit notification fetch is exempt and unfiltered');
+$check($cancelBlock !== '' && str_contains($cancelBlock, 'deleted_at IS NULL'),
+    '24b its notification fetch keeps the standard soft-delete filter (consistent with the gate)');
 
 // ── 25-26. Recipient-locale reason fallback (rejected-loan emails) ───────────
 $check(substr_count($notifSrc, "translateInLocale('Nessun motivo specificato'") >= 2

--- a/tests/loan-archived-title-notifications.unit.php
+++ b/tests/loan-archived-title-notifications.unit.php
@@ -1,0 +1,279 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Regression suite: terminal loan notifications must reach the borrower even
+ * when the title was soft-deleted meanwhile (#381 class).
+ *
+ * The maintenance sweeps (checkExpiredPickups / checkExpiredReservations) and
+ * the return path are deliberately CI-SOFT-DELETE-EXEMPT: they expire/close
+ * circulation on archived titles. Their notification siblings, however, used
+ * `JOIN libri … AND l.deleted_at IS NULL`, so the loan row was never fetched
+ * and the borrower silently lost the email while the loan still expired and
+ * the copy was freed. Fixed for: sendPickupExpiredNotification,
+ * sendReservationExpiredNotification, sendLoanReturnedNotification,
+ * notifyAdminsOverdue, and the ReservationsAdminController cancel-via-edit
+ * fetch. This suite is DISCRIMINATING: every behavioral check fails on the
+ * pre-fix queries.
+ *
+ * Probe technique (same as loan-pickup-cancelled-softdelete.unit.php):
+ * resolveRecipientLocale() is the first call after a successful fetch, so a
+ * recording override that throws gives a deterministic, SMTP-free signal that
+ * the JOIN found the loan. Negative controls (loan id 0) prove the probe
+ * discriminates.
+ *
+ * Run: php tests/loan-archived-title-notifications.unit.php
+ */
+
+use App\Support\DateHelper;
+use App\Support\NotificationService;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$root = dirname(__DIR__);
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+    DateHelper::synchronizeDatabaseSession($db);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — archived-title notification suite is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+/** Fetch-reached probe: flags and stops before any transport is contacted. */
+final class ArchivedProbeNotificationService extends NotificationService
+{
+    public bool $localeResolved = false;
+    public string $capturedEmail = '';
+
+    public function resolveRecipientLocale(string $email): string
+    {
+        $this->localeResolved = true;
+        $this->capturedEmail = $email;
+        throw new RuntimeException('Injected stop before sending the test notification');
+    }
+}
+
+/**
+ * Deadline-plumbing probe: lets locale resolution pass, then records the raw
+ * date handed to formatEmailDate() and stops before the send.
+ */
+final class DeadlineProbeNotificationService extends NotificationService
+{
+    public ?string $capturedDate = null;
+
+    public function resolveRecipientLocale(string $email): string
+    {
+        return 'it_IT';
+    }
+
+    public function formatEmailDate(string $dateString, bool $includeTime = false, ?string $locale = null): string
+    {
+        $this->capturedDate = $dateString;
+        throw new RuntimeException('Injected stop after capturing the deadline');
+    }
+}
+
+$run = bin2hex(random_bytes(6));
+$title = "ZZ_ARCHNOTIF_{$run}";
+$email = "zz-archnotif-{$run}@test.local";
+$inventory = "ZZAN-{$run}";
+$bookId = 0;
+$userId = 0;
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$cleanup = static function () use ($db, &$bookId, &$userId): void {
+    if ($bookId > 0) {
+        $db->query("DELETE FROM prestiti WHERE libro_id = {$bookId}");
+        $db->query("DELETE FROM copie WHERE libro_id = {$bookId}");
+        $db->query("DELETE FROM libri WHERE id = {$bookId}");
+    }
+    if ($userId > 0) {
+        $db->query("DELETE FROM utenti WHERE id = {$userId}");
+    }
+};
+set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
+    try { $cleanup(); } catch (Throwable) {}
+    fwrite(STDERR, 'FAIL: uncaught ' . $e->getMessage() . PHP_EOL);
+    $db->close();
+    exit(1);
+});
+
+// ── Fixture: an expired-pickup loan on a book we then soft-delete ────────────
+$stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, 1, 0, 'prestato')");
+$stmt->bind_param('s', $title);
+$stmt->execute();
+$bookId = (int) $db->insert_id;
+$stmt->close();
+
+$stmt = $db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (?, ?, 'prenotato')");
+$stmt->bind_param('is', $bookId, $inventory);
+$stmt->execute();
+$copyId = (int) $db->insert_id;
+$stmt->close();
+
+$card = 'ZZAN' . strtoupper($run);
+$password = password_hash('ArchivedNotif!1', PASSWORD_DEFAULT);
+$stmt = $db->prepare(
+    "INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+     VALUES (?, 'Archived', 'Notif', ?, ?, 'standard', 'attivo', 1)"
+);
+$stmt->bind_param('sss', $card, $email, $password);
+$stmt->execute();
+$userId = (int) $db->insert_id;
+$stmt->close();
+
+$start = DateHelper::today();
+$end = (new DateTimeImmutable($start))->modify('+14 days')->format('Y-m-d');
+$deadline = (new DateTimeImmutable($start))->modify('+3 days')->format('Y-m-d');
+$stmt = $db->prepare(
+    "INSERT INTO prestiti
+        (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo, pickup_deadline)
+     VALUES (?, ?, ?, ?, ?, 'da_ritirare', 'diretto', 1, ?)"
+);
+$stmt->bind_param('iiisss', $bookId, $copyId, $userId, $start, $end, $deadline);
+$stmt->execute();
+$loanId = (int) $db->insert_id;
+$stmt->close();
+
+$db->query("UPDATE libri SET deleted_at = NOW() WHERE id = {$bookId}");
+
+// ── 1-3. Negative controls: non-existent loan never resolves a locale ────────
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendPickupExpiredNotification(0);
+$check($svc->localeResolved === false, '01 pickup-expired probe stays false with no loan row (discriminating control)');
+
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendReservationExpiredNotification(0);
+$check($svc->localeResolved === false, '02 reservation-expired probe stays false with no loan row');
+
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendLoanReturnedNotification(0);
+$check($svc->localeResolved === false, '03 loan-returned probe stays false with no loan row');
+
+// ── 4-9. Archived title: every fixed sender must still fetch the loan ────────
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendPickupExpiredNotification($loanId);
+$check($svc->localeResolved === true, '04 pickup-expired email fetches the loan for a soft-deleted book');
+$check($svc->capturedEmail === $email, '05 pickup-expired resolves the borrower email for the archived title');
+
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendReservationExpiredNotification($loanId);
+$check($svc->localeResolved === true, '06 reservation-expired email fetches the loan for a soft-deleted book');
+$check($svc->capturedEmail === $email, '07 reservation-expired resolves the borrower email for the archived title');
+
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendLoanReturnedNotification($loanId);
+$check($svc->localeResolved === true, '08 return-confirmation email fetches the loan for a soft-deleted book');
+$check($svc->capturedEmail === $email, '09 return-confirmation resolves the borrower email for the archived title');
+
+// ── 10. Admin overdue alert also reaches past the JOIN for archived titles ───
+$svc = new ArchivedProbeNotificationService($db);
+$svc->notifyAdminsOverdue($loanId);
+$check($svc->localeResolved === true, '10 admin overdue alert fetches the loan for a soft-deleted book');
+
+// ── 11-13. Sanity: a live (non-archived) book behaves identically ────────────
+$db->query("UPDATE libri SET deleted_at = NULL WHERE id = {$bookId}");
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendPickupExpiredNotification($loanId);
+$check($svc->localeResolved === true, '11 pickup-expired still fetches a live book (no over-tightening)');
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendReservationExpiredNotification($loanId);
+$check($svc->localeResolved === true, '12 reservation-expired still fetches a live book');
+$svc = new ArchivedProbeNotificationService($db);
+$svc->sendLoanReturnedNotification($loanId);
+$check($svc->localeResolved === true, '13 return-confirmation still fetches a live book');
+$db->query("UPDATE libri SET deleted_at = NOW() WHERE id = {$bookId}");
+
+// ── 14-15. Deadline plumbing: explicit parameter wins, row value is fallback ─
+$db->query("UPDATE prestiti SET pickup_deadline = NULL WHERE id = {$loanId}");
+$svc = new DeadlineProbeNotificationService($db);
+$svc->sendPickupExpiredNotification($loanId, '2030-05-05');
+$check($svc->capturedDate === '2030-05-05', '14 explicit deadline parameter reaches the email even when the row was NULLed');
+
+$db->query("UPDATE prestiti SET pickup_deadline = '{$deadline}' WHERE id = {$loanId}");
+$svc = new DeadlineProbeNotificationService($db);
+$svc->sendPickupExpiredNotification($loanId, null);
+$check($svc->capturedDate === $deadline, '15 with no parameter the row pickup_deadline is still used (fallback intact)');
+
+// ── 16-24. Static guards: the fixed queries and their exempt annotations ─────
+$notifSrc = (string) file_get_contents($root . '/app/Support/NotificationService.php');
+$sliceOf = static function (string $src, string $fn): string {
+    $at = strpos($src, "function {$fn}(");
+    return $at === false ? '' : substr($src, $at, 2600);
+};
+
+$pickupExpired = $sliceOf($notifSrc, 'sendPickupExpiredNotification');
+$check($pickupExpired !== '' && !str_contains($pickupExpired, 'deleted_at IS NULL'),
+    '16 sendPickupExpiredNotification query no longer filters deleted_at');
+$reservationExpired = $sliceOf($notifSrc, 'sendReservationExpiredNotification');
+$check($reservationExpired !== '' && !str_contains($reservationExpired, 'deleted_at IS NULL'),
+    '17 sendReservationExpiredNotification query no longer filters deleted_at');
+$returned = $sliceOf($notifSrc, 'sendLoanReturnedNotification');
+$check($returned !== '' && !str_contains($returned, 'deleted_at IS NULL'),
+    '18 sendLoanReturnedNotification query no longer filters deleted_at');
+$adminsOverdue = $sliceOf($notifSrc, 'notifyAdminsOverdue');
+$check($adminsOverdue !== '' && !str_contains($adminsOverdue, 'deleted_at IS NULL'),
+    '19 notifyAdminsOverdue query no longer filters deleted_at');
+
+// The soft-delete CI gate requires an explicit exemption where the filter is
+// deliberately absent — all four senders must carry the annotation.
+foreach ([
+    ['sendPickupExpiredNotification', '20'],
+    ['sendReservationExpiredNotification', '21'],
+    ['sendLoanReturnedNotification', '22'],
+    ['notifyAdminsOverdue', '23'],
+] as [$fn, $n]) {
+    $fnAt = strpos($notifSrc, "function {$fn}(");
+    $window = $fnAt === false ? '' : substr($notifSrc, max(0, $fnAt - 900), 1200 + strlen($fn));
+    $check(str_contains($window, 'CI-SOFT-DELETE-EXEMPT'),
+        "{$n} {$fn} carries the CI-SOFT-DELETE-EXEMPT annotation");
+}
+
+$adminCtrl = (string) file_get_contents($root . '/app/Controllers/ReservationsAdminController.php');
+$cancelBlockAt = strpos($adminCtrl, "utente_nome, u.email, l.titolo");
+$cancelBlock = $cancelBlockAt === false ? '' : substr($adminCtrl, max(0, $cancelBlockAt - 700), 1400);
+$check($cancelBlock !== '' && !str_contains($cancelBlock, 'deleted_at IS NULL')
+    && str_contains($cancelBlock, 'CI-SOFT-DELETE-EXEMPT'),
+    '24 admin cancel-via-edit notification fetch is exempt and unfiltered');
+
+// ── 25-26. Recipient-locale reason fallback (rejected-loan emails) ───────────
+$check(substr_count($notifSrc, "translateInLocale('Nessun motivo specificato'") >= 2
+    && !str_contains($notifSrc, "__('Nessun motivo specificato')"),
+    '25 both reject senders localize the fallback reason in the RECIPIENT locale');
+
+$ref = new ReflectionMethod(NotificationService::class, 'translateInLocale');
+$plainSvc = new NotificationService($db);
+$translated = (string) $ref->invoke($plainSvc, 'Nessun motivo specificato', 'en_US');
+$check($translated !== '' && $translated !== 'Nessun motivo specificato',
+    '26 translateInLocale actually renders the fallback reason in another locale (en_US)');
+
+// ── 27. Sweep passes the captured deadline to the sender ─────────────────────
+$maintSrc = (string) file_get_contents($root . '/app/Support/MaintenanceService.php');
+$check(str_contains($maintSrc, 'sendPickupExpiredNotification(') && preg_match(
+    '/sendPickupExpiredNotification\(\s*\$id\s*,/', $maintSrc) === 1,
+    '27 checkExpiredPickups passes the elapsed deadline captured under lock to the email');
+
+$cleanup();
+$db->close();
+
+echo PHP_EOL . "Passed: {$passed}   Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);

--- a/tests/loan-backfill-and-invariant-guards.unit.php
+++ b/tests/loan-backfill-and-invariant-guards.unit.php
@@ -1,0 +1,199 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Circulation invariant guards: the pickup-deadline backfill, the legacy
+ * maintenance script's transaction discipline, the trigger single-source
+ * contract, the application-date binding, and the copy-release guards on the
+ * two cancel paths.
+ *
+ * Behavioral where it matters (the backfill runs against the real DB with a
+ * sandbox), static where the invariant IS textual (a call site that must
+ * exist, a predicate that must stay in the trigger file both the installer
+ * and the Updater consume).
+ *
+ * Run: php tests/loan-backfill-and-invariant-guards.unit.php
+ */
+
+use App\Models\SettingsRepository;
+use App\Support\DateHelper;
+use App\Support\PickupDeadlineBackfill;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$root = dirname(__DIR__);
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+    DateHelper::synchronizeDatabaseSession($db);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — invariant guard suite is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$run = bin2hex(random_bytes(6));
+$prefix = "ZZ_GUARD_{$run}";
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$bookId = 0;
+$userId = 0;
+$cleanup = static function () use ($db, &$bookId, &$userId): void {
+    if ($bookId > 0) {
+        $db->query("DELETE FROM prestiti WHERE libro_id = {$bookId}");
+        $db->query("DELETE FROM copie WHERE libro_id = {$bookId}");
+        $db->query("DELETE FROM libri WHERE id = {$bookId}");
+    }
+    if ($userId > 0) {
+        $db->query("DELETE FROM utenti WHERE id = {$userId}");
+    }
+};
+set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
+    try { $cleanup(); } catch (Throwable) {}
+    fwrite(STDERR, 'FAIL: uncaught ' . $e->getMessage() . PHP_EOL);
+    $db->close();
+    exit(1);
+});
+
+// ── Sandbox: one book, three copies, one user ────────────────────────────────
+$title = "{$prefix}_BK";
+$stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, 3, 0, 'prenotato')");
+$stmt->bind_param('s', $title);
+$stmt->execute();
+$bookId = (int) $db->insert_id;
+$stmt->close();
+$copyIds = [];
+for ($i = 1; $i <= 3; $i++) {
+    $inv = "ZG{$i}-" . strtoupper(substr($run, 0, 8));
+    $stmt = $db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (?, ?, 'prenotato')");
+    $stmt->bind_param('is', $bookId, $inv);
+    $stmt->execute();
+    $copyIds[] = (int) $db->insert_id;
+    $stmt->close();
+}
+$card = 'ZG' . strtoupper(substr($run, 0, 10));
+$email = "zz-guard-{$run}@test.local";
+$password = password_hash('GuardSuite!1', PASSWORD_DEFAULT);
+$stmt = $db->prepare(
+    "INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+     VALUES (?, 'Guard', 'Suite', ?, ?, 'standard', 'attivo', 1)"
+);
+$stmt->bind_param('sss', $card, $email, $password);
+$stmt->execute();
+$userId = (int) $db->insert_id;
+$stmt->close();
+
+$today = DateHelper::today();
+$d = static fn (int $offset): string => (new DateTimeImmutable($today))->modify(($offset >= 0 ? '+' : '') . $offset . ' days')->format('Y-m-d');
+
+$insert = static function (?int $copy, string $s, string $e, string $stato, int $attivo, ?string $deadline) use ($db, $bookId, $userId): int {
+    $stmt = $db->prepare(
+        "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo, pickup_deadline)
+         VALUES (?, ?, ?, ?, ?, ?, 'diretto', ?, ?)"
+    );
+    $stmt->bind_param('iiisssis', $bookId, $copy, $userId, $s, $e, $stato, $attivo, $deadline);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    return $id;
+};
+$deadlineOf = static function (int $loanId) use ($db): ?string {
+    $row = $db->query("SELECT pickup_deadline FROM prestiti WHERE id = {$loanId}")->fetch_assoc();
+    return $row['pickup_deadline'] === null ? null : (string) $row['pickup_deadline'];
+};
+
+// ═════════ 01-06: PickupDeadlineBackfill behavior ═════════
+$settings = new SettingsRepository($db);
+$pickupDays = max(1, (int) ($settings->get('loans', 'pickup_expiry_days', '3') ?? 3));
+$expected = $d($pickupDays);
+
+$farLoan = $insert($copyIds[0], $d(-1), $d(30), 'da_ritirare', 1, null);
+$capLoan = $insert($copyIds[1], $d(-1), $d(1), 'da_ritirare', 1, null);
+$setLoan = $insert($copyIds[2], $d(-1), $d(30), 'da_ritirare', 1, $d(5));
+$untouchedInCorso = $insert(null, $d(-1), $d(30), 'in_corso', 1, null);
+
+$check(PickupDeadlineBackfill::run($db) === true, '01 the backfill runs and reports success');
+$check($deadlineOf($farLoan) === $expected, '02 a NULL deadline becomes application-today + pickup_expiry_days');
+$check($deadlineOf($capLoan) === $d(1), '03 the deadline is capped at the loan\'s own data_scadenza');
+$check($deadlineOf($setLoan) === $d(5), '04 an already-set deadline is never rewritten');
+$check($deadlineOf($untouchedInCorso) === null, '05 non-pickup states are left alone');
+PickupDeadlineBackfill::run($db);
+$check($deadlineOf($farLoan) === $expected && $deadlineOf($capLoan) === $d(1),
+    '06 a second backfill run is a no-op (idempotent)');
+
+// ═════════ 07-08: backfill uses the application date, not the DB session ═════
+$backfillSrc = (string) file_get_contents($root . '/app/Support/PickupDeadlineBackfill.php');
+$check(!str_contains($backfillSrc, 'DATE_ADD(CURDATE'), '07 the backfill no longer computes deadlines with SQL CURDATE()');
+$check(str_contains($backfillSrc, 'DateHelper::today()'), '08 the backfill binds DateHelper::today() (application timezone)');
+
+// ═════════ 09-11: legacy maintenance script transaction discipline ═══════════
+$legacySrc = (string) file_get_contents($root . '/scripts/maintenance.php');
+$check(str_contains($legacySrc, 'setExternalTransaction(true)'),
+    '09 scripts/maintenance.php marks its transactions as caller-owned (no nested begin)');
+$check(str_contains($legacySrc, 'flushDeferredNotifications()'),
+    '10 scripts/maintenance.php flushes deferred promotion emails after commit');
+$check(str_contains($legacySrc, 'TXN-003'),
+    '11 the nested-transaction hazard is documented at the call site');
+
+// ═════════ 12-15: @pinakes_application_date bound on every writer path ═══════
+foreach ([
+    ['config/container.php', '12 the shared container connection'],
+    ['cron/full-maintenance.php', '13 the full-maintenance cron'],
+    ['cron/automatic-notifications.php', '14 the notifications cron'],
+    ['scripts/_db_bootstrap.php', '15 the scripts bootstrap'],
+] as [$file, $label]) {
+    $src = (string) @file_get_contents($root . '/' . $file);
+    $check($src !== '' && str_contains($src, 'synchronizeDatabaseSession'),
+        "{$label} synchronizes the application date");
+}
+
+// ═════════ 16-19: trigger file invariants (single source for install+upgrade) ═
+$triggers = (string) file_get_contents($root . '/installer/database/triggers.sql');
+$check(substr_count($triggers, 'p.copia_id = NEW.copia_id') >= 2,
+    '16 the overlap gate is PER-COPY in both INSERT and UPDATE triggers');
+$check(str_contains($triggers, '<=>'),
+    '17 the UPDATE trigger keeps the engagement-change guard (null-safe compare)');
+$check(str_contains($triggers, 'OLD.'),
+    '18 the UPDATE trigger references OLD state (pre-existing-conflict exemption, #367)');
+$check(str_contains($triggers, '@pinakes_application_date'),
+    '19 the triggers read the bound application date (open-ended overdue semantics)');
+
+$installerSrc = (string) file_get_contents($root . '/installer/classes/Installer.php');
+$updaterSrc = (string) file_get_contents($root . '/app/Support/Updater.php');
+$check(str_contains($installerSrc, 'triggers.sql'), '20 the installer consumes installer/database/triggers.sql');
+$check(str_contains($updaterSrc, 'triggers.sql'), '21 Updater::reapplyTriggers consumes the SAME file (no drift possible)');
+
+// ═════════ 22-24: copy-release guards on the two cancel paths ═══════════════
+$apprSrc = (string) file_get_contents($root . '/app/Controllers/LoanApprovalController.php');
+$cancelAt = strpos($apprSrc, 'public function cancelPickup');
+$cancelSlice = $cancelAt === false ? '' : substr($apprSrc, $cancelAt, 14000);
+$check($cancelSlice !== '' && str_contains($cancelSlice, "=== 'prenotato'"),
+    '22 admin cancelPickup releases ONLY a copy actually held for the pickup');
+$check($cancelSlice !== '' && !str_contains($cancelSlice, 'invalidStates'),
+    '23 the permissive exclusion-list release (which freed prestato copies) is gone');
+$userSrc = (string) file_get_contents($root . '/app/Controllers/UserActionsController.php');
+$check(str_contains($userSrc, "SET stato = 'disponibile' WHERE id = ? AND stato = 'prenotato'"),
+    '24 the user cancel twin keeps its guarded, idempotent copy release');
+
+$cleanup();
+$db->close();
+
+echo PHP_EOL . "Passed: {$passed}   Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);

--- a/tests/loan-expiry-sweeps-behavior.unit.php
+++ b/tests/loan-expiry-sweeps-behavior.unit.php
@@ -1,0 +1,326 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioral suite for the expiry sweeps, the per-copy overlap trigger and the
+ * loan multiplicity policy — the automated half of the circulation state
+ * machine.
+ *
+ * Covers, against the REAL database and the REAL MaintenanceService:
+ *  - checkExpiredPickups: da_ritirare past its pickup_deadline → scaduto,
+ *    attivo=0, pickup_deadline cleared, copy freed, availability recalculated,
+ *    idempotent on re-run;
+ *  - checkExpiredReservations: prenotato whose window fully passed → scaduto,
+ *    copy freed, idempotent;
+ *  - waitlist promotion on expiry: the freed capacity promotes the head of the
+ *    prenotazioni queue into a pendente loan and completes the reservation;
+ *  - DB trigger semantics: per-copy overlap SIGNAL, disjoint windows allowed,
+ *    same user on two copies allowed at trigger level (policy decides),
+ *    copy-bound pendente occupies, bare pendente does not, open-ended overdue
+ *    blocks future windows;
+ *  - LoanMultiplicityPolicy: strict by default, relaxed only when the
+ *    allow_multiple_loans_same_book setting is enabled AND the operation binds
+ *    a copy.
+ *
+ * Dates are derived from DateHelper::today() (application timezone, the same
+ * source the sweeps compare against) — never from the runner's local clock.
+ *
+ * Run: php tests/loan-expiry-sweeps-behavior.unit.php
+ */
+
+use App\Models\SettingsRepository;
+use App\Support\DateHelper;
+use App\Support\LoanMultiplicityPolicy;
+use App\Support\MaintenanceService;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$root = dirname(__DIR__);
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+    DateHelper::synchronizeDatabaseSession($db);
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — expiry sweep suite is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$run = bin2hex(random_bytes(6));
+$prefix = "ZZ_SWEEP_{$run}";
+$passed = 0;
+$failed = 0;
+$check = static function (bool $ok, string $label) use (&$passed, &$failed): void {
+    echo ($ok ? '  OK  ' : '  FAIL ') . $label . PHP_EOL;
+    $ok ? $passed++ : $failed++;
+};
+
+$bookIds = [];
+$userIds = [];
+$settings = new SettingsRepository($db);
+$originalMulti = $settings->get('loans', 'allow_multiple_loans_same_book', '0');
+
+$cleanup = static function () use ($db, &$bookIds, &$userIds, $settings, $originalMulti): void {
+    foreach ($bookIds as $id) {
+        $db->query("DELETE FROM prenotazioni WHERE libro_id = {$id}");
+        $db->query("DELETE FROM prestiti WHERE libro_id = {$id}");
+        $db->query("DELETE FROM copie WHERE libro_id = {$id}");
+        $db->query("DELETE FROM libri WHERE id = {$id}");
+    }
+    foreach ($userIds as $id) {
+        // In-app notification rows (if any) reference the user; remove them
+        // first, tolerating installs where the table differs.
+        try { $db->query("DELETE FROM notifications WHERE user_id = {$id}"); } catch (Throwable) {}
+        $db->query("DELETE FROM utenti WHERE id = {$id}");
+    }
+    $settings->set('loans', 'allow_multiple_loans_same_book', (string) $originalMulti);
+};
+set_exception_handler(static function (Throwable $e) use ($cleanup, $db): void {
+    try { $cleanup(); } catch (Throwable) {}
+    fwrite(STDERR, 'FAIL: uncaught ' . $e->getMessage() . PHP_EOL);
+    $db->close();
+    exit(1);
+});
+
+$makeBook = static function (string $suffix, int $copies) use ($db, $prefix, &$bookIds): array {
+    $title = "{$prefix}_{$suffix}";
+    $stmt = $db->prepare("INSERT INTO libri (titolo, copie_totali, copie_disponibili, stato) VALUES (?, ?, ?, 'disponibile')");
+    $stmt->bind_param('sii', $title, $copies, $copies);
+    $stmt->execute();
+    $bookId = (int) $db->insert_id;
+    $stmt->close();
+    $bookIds[] = $bookId;
+    $copyIds = [];
+    for ($i = 1; $i <= $copies; $i++) {
+        $inv = strtoupper("{$suffix}{$i}-") . strtoupper(substr($prefix, -6));
+        $stmt = $db->prepare("INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (?, ?, 'disponibile')");
+        $stmt->bind_param('is', $bookId, $inv);
+        $stmt->execute();
+        $copyIds[] = (int) $db->insert_id;
+        $stmt->close();
+    }
+    return [$bookId, $copyIds];
+};
+
+$makeUser = static function (string $suffix) use ($db, $run, &$userIds): array {
+    $email = "zz-sweep-{$suffix}-{$run}@test.local";
+    $card = 'ZS' . strtoupper($suffix) . strtoupper(substr($run, 0, 8));
+    $password = password_hash('SweepSuite!1', PASSWORD_DEFAULT);
+    $stmt = $db->prepare(
+        "INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+         VALUES (?, 'Sweep', ?, ?, ?, 'standard', 'attivo', 1)"
+    );
+    $cog = ucfirst($suffix);
+    $stmt->bind_param('ssss', $card, $cog, $email, $password);
+    $stmt->execute();
+    $userId = (int) $db->insert_id;
+    $stmt->close();
+    $userIds[] = $userId;
+    return [$userId, $email];
+};
+
+$today = DateHelper::today();
+$d = static fn (int $offset): string => (new DateTimeImmutable($today))->modify(($offset >= 0 ? '+' : '') . $offset . ' days')->format('Y-m-d');
+
+$loanCol = static function (int $loanId, string $col) use ($db): ?string {
+    $res = $db->query("SELECT {$col} AS v FROM prestiti WHERE id = {$loanId}");
+    $row = $res ? $res->fetch_assoc() : null;
+    return $row === null ? null : ($row['v'] === null ? null : (string) $row['v']);
+};
+$copyState = static function (int $copyId) use ($db): string {
+    return (string) $db->query("SELECT stato FROM copie WHERE id = {$copyId}")->fetch_assoc()['stato'];
+};
+
+// ═════════ Fixture A: expired pickup, NO waitlist ═════════
+[$bookA, [$copyA]] = $makeBook('A', 1);
+[$userA] = $makeUser('a');
+$db->query("UPDATE copie SET stato = 'prenotato' WHERE id = {$copyA}");
+$db->query("UPDATE libri SET copie_disponibili = 0, stato = 'prenotato' WHERE id = {$bookA}");
+$stmt = $db->prepare(
+    "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo, pickup_deadline)
+     VALUES (?, ?, ?, ?, ?, 'da_ritirare', 'diretto', 1, ?)"
+);
+$sA = $d(-5); $eA = $d(9); $dlA = $d(-2);
+$stmt->bind_param('iiisss', $bookA, $copyA, $userA, $sA, $eA, $dlA);
+$stmt->execute();
+$loanA = (int) $db->insert_id;
+$stmt->close();
+
+// ═════════ Fixture B: scheduled reservation whose window fully passed ═════════
+[$bookB, [$copyB]] = $makeBook('B', 1);
+[$userB] = $makeUser('b');
+$db->query("UPDATE copie SET stato = 'prenotato' WHERE id = {$copyB}");
+$db->query("UPDATE libri SET copie_disponibili = 0, stato = 'prenotato' WHERE id = {$bookB}");
+$stmt = $db->prepare(
+    "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo)
+     VALUES (?, ?, ?, ?, ?, 'prenotato', 'richiesta', 1)"
+);
+$sB = $d(-10); $eB = $d(-3);
+$stmt->bind_param('iiiss', $bookB, $copyB, $userB, $sB, $eB);
+$stmt->execute();
+$loanB = (int) $db->insert_id;
+$stmt->close();
+
+// ═════════ Fixture W: expired pickup WITH a waiting queue behind it ═════════
+[$bookW, [$copyW]] = $makeBook('W', 1);
+[$userW1] = $makeUser('w1');
+[$userW2] = $makeUser('w2');
+$db->query("UPDATE copie SET stato = 'prenotato' WHERE id = {$copyW}");
+$db->query("UPDATE libri SET copie_disponibili = 0, stato = 'prenotato' WHERE id = {$bookW}");
+$stmt = $db->prepare(
+    "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo, pickup_deadline)
+     VALUES (?, ?, ?, ?, ?, 'da_ritirare', 'diretto', 1, ?)"
+);
+$sW = $d(-5); $eW = $d(9); $dlW = $d(-1);
+$stmt->bind_param('iiisss', $bookW, $copyW, $userW1, $sW, $eW, $dlW);
+$stmt->execute();
+$loanW1 = (int) $db->insert_id;
+$stmt->close();
+$stmt = $db->prepare(
+    "INSERT INTO prenotazioni (libro_id, utente_id, data_inizio_richiesta, data_fine_richiesta, queue_position, stato)
+     VALUES (?, ?, ?, ?, 1, 'attiva')"
+);
+$rs = $d(0); $re = $d(7);
+$stmt->bind_param('iiss', $bookW, $userW2, $rs, $re);
+$stmt->execute();
+$resW2 = (int) $db->insert_id;
+$stmt->close();
+
+// ═════════ 01-08: checkExpiredPickups behavior ═════════
+$maint = new MaintenanceService($db);
+$processedPickups = $maint->checkExpiredPickups();
+$check($processedPickups >= 2, '01 checkExpiredPickups processes both expired pickups (A and W)');
+$check($loanCol($loanA, 'stato') === 'scaduto', '02 loan A transitions da_ritirare → scaduto');
+$check($loanCol($loanA, 'attivo') === '0', '03 loan A is deactivated (attivo=0)');
+$check($loanCol($loanA, 'pickup_deadline') === null, '04 loan A pickup_deadline is cleared on the terminal row');
+$noteA = (string) $loanCol($loanA, 'note');
+$check($noteA !== '' && str_contains($noteA, 'Ritiro scaduto'), '05 loan A audit note records the expiry');
+$check($copyState($copyA) === 'disponibile', '06 copy A is released back to disponibile');
+$availA = (int) $db->query("SELECT copie_disponibili FROM libri WHERE id = {$bookA}")->fetch_assoc()['copie_disponibili'];
+$check($availA === 1, '07 book A availability is recalculated to 1 free copy');
+$noteLenBefore = strlen($noteA);
+$maint->checkExpiredPickups();
+$check(strlen((string) $loanCol($loanA, 'note')) === $noteLenBefore
+    && $loanCol($loanA, 'stato') === 'scaduto',
+    '08 a second sweep run is a no-op on the already-expired loan (idempotent)');
+
+// ═════════ 09-12: waitlist promotion on the freed capacity ═════════
+$resState = (string) $db->query("SELECT stato FROM prenotazioni WHERE id = {$resW2}")->fetch_assoc()['stato'];
+$check($resState === 'completata', '09 the waiting reservation is completed by the promotion');
+$promoted = $db->query(
+    "SELECT id, stato, attivo, pickup_deadline FROM prestiti
+     WHERE libro_id = {$bookW} AND utente_id = {$userW2} ORDER BY id DESC LIMIT 1"
+)->fetch_assoc();
+$check($promoted !== null && $promoted['stato'] === 'pendente' && (string) $promoted['attivo'] === '0',
+    '10 promotion creates a pendente (admin-approval) loan for the queue head');
+$check($promoted !== null && $promoted['pickup_deadline'] === null,
+    '11 the promoted pendente has no pickup_deadline yet (set at approval, by design)');
+$check($loanCol($loanW1, 'stato') === 'scaduto' && $loanCol($loanW1, 'pickup_deadline') === null,
+    '12 the expired pickup behind the queue is terminal with a cleared deadline');
+
+// ═════════ 13-17: checkExpiredReservations behavior ═════════
+$processedRes = $maint->checkExpiredReservations();
+$check($processedRes >= 1, '13 checkExpiredReservations processes the fully-past scheduled loan');
+$check($loanCol($loanB, 'stato') === 'scaduto', '14 loan B transitions prenotato → scaduto');
+$check($loanCol($loanB, 'attivo') === '0', '15 loan B is deactivated');
+$check($copyState($copyB) === 'disponibile', '16 copy B is released');
+$maint->checkExpiredReservations();
+$check($loanCol($loanB, 'stato') === 'scaduto', '17 reservation expiry is idempotent on re-run');
+
+// ═════════ 18-23: trigger semantics on a dedicated sandbox book ═════════
+[$bookT, [$copyT1, $copyT2]] = $makeBook('T', 2);
+[$userT1] = $makeUser('t1');
+[$userT2] = $makeUser('t2');
+
+$insertLoan = static function (int $book, ?int $copy, int $user, string $s, string $e, string $stato, int $attivo) use ($db): int {
+    $stmt = $db->prepare(
+        "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo)
+         VALUES (?, ?, ?, ?, ?, ?, 'diretto', ?)"
+    );
+    $stmt->bind_param('iiisssi', $book, $copy, $user, $s, $e, $stato, $attivo);
+    $stmt->execute();
+    $id = (int) $db->insert_id;
+    $stmt->close();
+    return $id;
+};
+
+$base = $insertLoan($bookT, $copyT1, $userT1, $d(1), $d(8), 'prenotato', 1);
+$overlapBlocked = false;
+try {
+    $insertLoan($bookT, $copyT1, $userT2, $d(4), $d(12), 'prenotato', 1);
+} catch (mysqli_sql_exception) {
+    $overlapBlocked = true;
+}
+$check($overlapBlocked, '18 the trigger SIGNALs an overlapping active window on the SAME copy');
+
+$disjoint = $insertLoan($bookT, $copyT1, $userT2, $d(20), $d(27), 'prenotato', 1);
+$check($disjoint > 0, '19 a date-disjoint window on the same copy is allowed (calendar model)');
+
+$sameUserOtherCopy = $insertLoan($bookT, $copyT2, $userT1, $d(1), $d(8), 'prenotato', 1);
+$check($sameUserOtherCopy > 0, '20 the trigger is PER-COPY: same user on a second copy passes (policy decides)');
+
+$pendenteBound = $insertLoan($bookT, $copyT2, $userT2, $d(30), $d(37), 'pendente', 0);
+$pendingBlocks = false;
+try {
+    $insertLoan($bookT, $copyT2, $userT1, $d(32), $d(40), 'prenotato', 1);
+} catch (mysqli_sql_exception) {
+    $pendingBlocks = true;
+}
+$check($pendingBlocks, '21 a copy-bound pendente occupies its copy for the trigger');
+
+$bare = $insertLoan($bookT, null, $userT2, $d(50), $d(57), 'pendente', 0);
+$notBlocked = $insertLoan($bookT, $copyT2, $userT1, $d(50), $d(57), 'prenotato', 1);
+$check($bare > 0 && $notBlocked > 0, '22 a bare (copyless) pendente does NOT occupy any copy');
+
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookT}");
+$overdueLoan = $insertLoan($bookT, $copyT1, $userT1, $d(-20), $d(-2), 'in_corso', 1);
+$openEndedBlocks = false;
+try {
+    $insertLoan($bookT, $copyT1, $userT2, $d(5), $d(12), 'prenotato', 1);
+} catch (mysqli_sql_exception) {
+    $openEndedBlocks = true;
+}
+$check($openEndedBlocks, '23 an overdue in_corso blocks FUTURE windows too (open-ended overdue)');
+
+// ═════════ 24-28: LoanMultiplicityPolicy gates ═════════
+$db->query("DELETE FROM prestiti WHERE libro_id = {$bookT}");
+$active = $insertLoan($bookT, $copyT1, $userT1, $d(0), $d(7), 'in_corso', 1);
+
+$settings->set('loans', 'allow_multiple_loans_same_book', '0');
+$policy = new LoanMultiplicityPolicy($db, new SettingsRepository($db));
+$check($policy->isEnabled() === false, '24 multiplicity opt-in defaults to disabled');
+$check($policy->hasBlockingLoan($bookT, $userT1, true) === true,
+    '25 strict mode blocks a second engagement on the same title for the same user');
+$check($policy->hasBlockingLoan($bookT, $userT2, true) === false,
+    '26 another user is never blocked by someone else\'s loan');
+
+$settings->set('loans', 'allow_multiple_loans_same_book', '1');
+$policyOn = new LoanMultiplicityPolicy($db, new SettingsRepository($db));
+$check($policyOn->isEnabled() === true, '27 the setting flows through SettingsRepository when enabled');
+$check($policyOn->hasBlockingLoan($bookT, $userT1, true) === false,
+    '28 relaxed mode allows a second COPY-BINDING loan on the same title');
+$check($policyOn->hasBlockingLoan($bookT, $userT1, false) === true,
+    '29 a non-binding operation (bare request) stays strict even when enabled');
+$settings->set('loans', 'allow_multiple_loans_same_book', (string) $originalMulti);
+
+// ═════════ 30: application date is bound on this connection ═════════
+$appDate = $db->query('SELECT @pinakes_application_date AS v')->fetch_assoc()['v'];
+$check($appDate === $today, '30 @pinakes_application_date matches DateHelper::today() on a synchronized connection');
+
+$cleanup();
+$db->close();
+
+echo PHP_EOL . "Passed: {$passed}   Failed: {$failed}" . PHP_EOL;
+exit($failed === 0 ? 0 : 1);

--- a/tests/loan-expiry-sweeps-behavior.unit.php
+++ b/tests/loan-expiry-sweeps-behavior.unit.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
  *
  * Covers, against the REAL database and the REAL MaintenanceService:
  *  - checkExpiredPickups: da_ritirare past its pickup_deadline → scaduto,
- *    attivo=0, pickup_deadline cleared, copy freed, availability recalculated,
- *    idempotent on re-run;
+ *    attivo=0, pickup_deadline cleared, only a held copy freed (never a copy
+ *    already in prestato), availability recalculated, idempotent on re-run;
  *  - checkExpiredReservations: prenotato whose window fully passed → scaduto,
  *    copy freed, idempotent;
  *  - waitlist promotion on expiry: the freed capacity promotes the head of the
@@ -173,6 +173,31 @@ $stmt->execute();
 $loanB = (int) $db->insert_id;
 $stmt->close();
 
+// ═════════ Fixture D: stale pickup points at a copy already physically lent ═════════
+[$bookD, [$copyD]] = $makeBook('D', 1);
+[$userD] = $makeUser('d');
+[$userD2] = $makeUser('d2');
+$db->query("UPDATE copie SET stato = 'prestato' WHERE id = {$copyD}");
+$db->query("UPDATE libri SET copie_disponibili = 0, stato = 'prestato' WHERE id = {$bookD}");
+$stmt = $db->prepare(
+    "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo, pickup_deadline)
+     VALUES (?, ?, ?, ?, ?, 'da_ritirare', 'diretto', 1, ?)"
+);
+$sD = $d(-30); $eD = $d(-20); $dlD = $d(-2);
+$stmt->bind_param('iiisss', $bookD, $copyD, $userD, $sD, $eD, $dlD);
+$stmt->execute();
+$loanD = (int) $db->insert_id;
+$stmt->close();
+$stmt = $db->prepare(
+    "INSERT INTO prestiti (libro_id, copia_id, utente_id, data_prestito, data_scadenza, stato, origine, attivo)
+     VALUES (?, ?, ?, ?, ?, 'in_corso', 'diretto', 1)"
+);
+$sD2 = $d(0); $eD2 = $d(14);
+$stmt->bind_param('iiiss', $bookD, $copyD, $userD2, $sD2, $eD2);
+$stmt->execute();
+$activeLoanD = (int) $db->insert_id;
+$stmt->close();
+
 // ═════════ Fixture W: expired pickup WITH a waiting queue behind it ═════════
 [$bookW, [$copyW]] = $makeBook('W', 1);
 [$userW1] = $makeUser('w1');
@@ -201,7 +226,7 @@ $stmt->close();
 // ═════════ 01-08: checkExpiredPickups behavior ═════════
 $maint = new MaintenanceService($db);
 $processedPickups = $maint->checkExpiredPickups();
-$check($processedPickups >= 2, '01 checkExpiredPickups processes both expired pickups (A and W)');
+$check($processedPickups >= 3, '01 checkExpiredPickups processes all expired pickups (A, D and W)');
 $check($loanCol($loanA, 'stato') === 'scaduto', '02 loan A transitions da_ritirare → scaduto');
 $check($loanCol($loanA, 'attivo') === '0', '03 loan A is deactivated (attivo=0)');
 $check($loanCol($loanA, 'pickup_deadline') === null, '04 loan A pickup_deadline is cleared on the terminal row');
@@ -229,6 +254,10 @@ $check($promoted !== null && $promoted['pickup_deadline'] === null,
     '11 the promoted pendente has no pickup_deadline yet (set at approval, by design)');
 $check($loanCol($loanW1, 'stato') === 'scaduto' && $loanCol($loanW1, 'pickup_deadline') === null,
     '12 the expired pickup behind the queue is terminal with a cleared deadline');
+$check($loanCol($loanD, 'stato') === 'scaduto'
+    && $loanCol($activeLoanD, 'stato') === 'in_corso'
+    && $copyState($copyD) === 'prestato',
+    '12b expiry never releases a copy whose lifecycle has already advanced to prestato');
 
 // ═════════ 13-17: checkExpiredReservations behavior ═════════
 $processedRes = $maint->checkExpiredReservations();

--- a/tests/ncip-server.spec.js
+++ b/tests/ncip-server.spec.js
@@ -34,6 +34,7 @@
  * 29. CancelRequestItem cannot overwrite a request concurrently approved
  * 30. CheckInItem cannot close a loan concurrently reassigned to another user
  * 31. RenewItem with UserId cannot renew a concurrently reassigned loan
+ * 32. A replayed CheckOutItem cannot consume a second copy
  *
  * Run: /tmp/run-e2e.sh tests/ncip-server.spec.js --config=tests/playwright.config.js --workers=1
  */
@@ -420,7 +421,7 @@ test.skip(
     'Missing E2E env (DB_* and admin credentials)'
 );
 
-test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (31 tests)', () => {
+test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (32 tests)', () => {
     /** @type {number} */
     let testBookId = 0;
     /** @type {number} */
@@ -443,6 +444,23 @@ test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (31 tests)', () => {
     let hardeningUserEmails = [];
     let hardeningPartnerId = 0;
     let hardeningAgencyId = '';
+    let originalMultipleLoansSetting = '__MISSING__';
+
+    function restoreMultipleLoansSetting() {
+        if (originalMultipleLoansSetting === '__MISSING__') {
+            dbQuery(
+                "DELETE FROM system_settings WHERE category='loans' " +
+                "AND setting_key='allow_multiple_loans_same_book'"
+            );
+            return;
+        }
+        const value = originalMultipleLoansSetting.replace(/'/g, "''");
+        dbQuery(
+            "INSERT INTO system_settings (category, setting_key, setting_value) " +
+            `VALUES ('loans', 'allow_multiple_loans_same_book', '${value}') ` +
+            'ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)'
+        );
+    }
 
     /** Remove only loans/transactions belonging to the isolated hardening title. */
     function resetHardeningLoans() {
@@ -499,6 +517,11 @@ test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (31 tests)', () => {
 
     test.beforeAll(async ({ browser }) => {
         await ensureNcipPlugin(browser);
+
+        originalMultipleLoansSetting = dbQuery(
+            "SELECT COALESCE((SELECT setting_value FROM system_settings " +
+            "WHERE category='loans' AND setting_key='allow_multiple_loans_same_book' LIMIT 1), '__MISSING__')"
+        );
 
         // Create a DEDICATED book with a real available copy row. A book with
         // copie_disponibili > 0 at the aggregate level may have no individual
@@ -1239,7 +1262,39 @@ test.describe.serial('NCIP 2.0 Server plugin — v0.7.4 (31 tests)', () => {
         )).toBe(`${hardeningUserIds[1]}:0:${originalDue}`);
     });
 
+    test('32. replayed checkout stays strict when same-title staff loans are enabled', async ({ request }) => {
+        resetHardeningLoans();
+        const auth = basicAuth(ADMIN_EMAIL, ADMIN_PASS);
+        dbQuery(
+            "INSERT INTO system_settings (category, setting_key, setting_value) " +
+            "VALUES ('loans', 'allow_multiple_loans_same_book', '1') " +
+            'ON DUPLICATE KEY UPDATE setting_value=VALUES(setting_value)'
+        );
+
+        try {
+            const payload = checkOutItemXml(hardeningBookId, hardeningUserIds[0]);
+            const first = await ncipPost(request, payload, auth);
+            expect(first.status()).toBe(200);
+            expect(await first.text()).toContain('CheckOutItemResponse');
+
+            const replay = await ncipPost(request, payload, auth);
+            expect(replay.status()).toBe(200);
+            const replayBody = await replay.text();
+            expect(replayBody).toContain('Problem');
+            expect(replayBody).toContain('duplicate-request');
+            expect(dbQuery(
+                `SELECT COUNT(*) FROM prestiti
+                 WHERE libro_id=${hardeningBookId} AND utente_id=${hardeningUserIds[0]}
+                   AND origine='ncip' AND attivo=1 AND stato='in_corso'`
+            )).toBe('1');
+        } finally {
+            restoreMultipleLoansSetting();
+            resetHardeningLoans();
+        }
+    });
+
     test.afterAll(async () => {
+        try { restoreMultipleLoansSetting(); } catch { /* best-effort */ }
         // Isolated hardening fixtures (FK-safe and independent from tests 1-20).
         try { resetHardeningLoans(); } catch { /* best-effort */ }
         if (hardeningPartnerId > 0) {


### PR DESCRIPTION
## Context

I ran a full review of the loan/reservation system — state machine and entry points, overlap/capacity/copy allocation, automations and emails, availability and cache coherence — cross-checked against the behavioral evidence (all 22 existing circulation unit suites + the full 21-step E2E lifecycle, green before and after).

**The core is aligned**: both user entry points converge on the same `LoanRequestGate` under the same canonical lock; triggers come from a single source consumed by both installer and Updater; `@pinakes_application_date` is bound on every writer connection; `pickup_deadline` is never NULL (#366); `headQueuePos` participates in the capacity gate (#157); availability is never served from cache and every write path self-invalidates.

The review also surfaced a cluster of real edge-case bugs. This PR fixes all of them and adds **106 guard checks** plus an NCIP replay E2E regression.

## Fixes

**Silently lost emails for archived titles (#381 class)** — the sweeps deliberately expire circulation on soft-deleted books, but four notification fetches still filtered `deleted_at`: the loan expired, the copy was freed, and the borrower was never told. Fixed (with `CI-SOFT-DELETE-EXEMPT` annotations, matching the already-fixed manual sibling): `sendPickupExpiredNotification`, `sendReservationExpiredNotification`, `sendLoanReturnedNotification`, `notifyAdminsOverdue`, and the admin cancel-via-edit fetch in `ReservationsAdminController`.

**Copy-state drift on admin pickup cancel** — `cancelPickup` released any copy not in a broken state, including one in `prestato` physically out under another open loan (the reassignment service deliberately binds those to disjoint future windows). It now releases only a copy actually held for the pickup (`stato='prenotato'`), mirroring the user twin's guarded UPDATE.

**Copy-state drift on automated pickup expiry** — `checkExpiredPickups` had the same permissive release rule and could turn a copy already physically out under a disjoint open loan from `prestato` back into `disponibile`. The sweep now releases and reassigns only a copy it atomically transitions from `prenotato`.

**Allocator parity (#384)** — the reassignment allocator now shares the canonical preference ordering (prefer the copy with no later commitment), so repointing a hold never takes the copy a scheduled loan already needs. Its lenient date-overlap rule is kept and documented as a deliberate divergence: a reassignment may stack onto disjoint commitments because the alternative is cancelling an already-promised hold (`tests/loan-edge-cases.unit.php` encodes that contract — and caught my first, over-strict attempt).

**NCIP replay safety** — Pinakes currently exposes a title-level `libri.id` as NCIP `ItemId`, not a physical-copy identifier, and `CheckOutItem` has no request-idempotency key. Therefore NCIP checkouts intentionally keep the same-title policy strict even when the interactive staff UI enables multiple same-title loans: a partner retry returns `duplicate-request` instead of consuming a second copy. A real E2E runs with the multiple-loan setting enabled and proves that only one active loan is created.

**Consistency/robustness** — `checkExpiredPickups` clears `pickup_deadline` on the terminal row and passes the elapsed deadline to the email explicitly; rejected-loan fallback reasons render in the recipient's locale; `PickupDeadlineBackfill` binds `DateHelper::today()` instead of SQL `CURDATE()`; legacy `scripts/maintenance.php` no longer nests transactions (TXN-003) and flushes deferred promotion emails post-commit.

## Tests (106 checks, 4 new suites + NCIP E2E)

| Suite | Checks | Covers |
|---|---|---|
| `loan-archived-title-notifications` | 28 | Every fixed sender reaches archived-title borrowers (SMTP-free probes with negative controls); deadline plumbing; recipient-locale fallback |
| `loan-expiry-sweeps-behavior` | 31 | Pickup/reservation expiry transitions, guarded copy release (including a `prestato` negative control), availability recalc, idempotent re-runs, waitlist promotion, per-copy trigger semantics, multiplicity policy |
| `loan-allocator-384-parity` | 23 | Behavioral preference/hard-rule checks via reflection, headQueuePos capacity gate, allocator parity, and method-scoped NCIP strict-policy guards |
| `loan-backfill-and-invariant-guards` | 24 | Backfill behavior (cap/idempotency/app-TZ), legacy-script discipline, trigger single-source invariants, app-date binding, cancel-path release guards |

The NCIP browser suite adds a 32nd scenario that sends the same `CheckOutItem` twice with `allow_multiple_loans_same_book=1` and verifies `duplicate-request` plus exactly one active loan.

Stability: sandboxed fixtures with FK-safe cleanup, unique run markers, dates derived from the application today (no midnight-TZ flakes), no FULLTEXT/APCu/LiteSpeed dependencies. Each behavioral check is discriminating — it fails on the pre-fix code.

## Verification

- All 26 existing circulation suites green after the fixes
- New suites pass 3 consecutive runs
- NCIP replay E2E green against the local server
- `ci-quality-local.sh` green (PHPStan L5 full tree, soft-delete gate with the new exemptions, strict no-skip unit run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuove funzionalità**
  - Migliorata la riassegnazione delle copie, privilegiando quelle con impegni futuri più distanti.
  - Le notifiche vengono inviate anche per titoli archiviati.
  - I motivi di rifiuto sono localizzati nella lingua del destinatario.
  - Aggiornato il plugin NCIP Server alla versione 1.0.5.

- **Correzioni**
  - Evitata la liberazione errata di copie già prestate o disponibili.
  - Gestite correttamente scadenze, notifiche e date dei ritiri.
  - Migliorata la coerenza nelle promozioni dalla lista d’attesa.

- **Test**
  - Aggiunti test per allocazione copie, notifiche, scadenze, riassegnazioni e titoli archiviati.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
