### PR TITLE
Release 0.7.73

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,29 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
-## [0.7.73-rc.1]
+## [0.7.73]
+
+A feature and hardening release: a full activity timeline for every book, per-field control over CSV imports, a circulation and settings hardening pass backed by ~140 new checks, and an immediate-effect fix for plugin activation.
 
 ### Added
 
-- **Activity feed for issue #374.** Admin and staff can inspect a field-level timeline at the bottom of each admin book page and a paginated library-wide feed at the bottom of the dashboard, filtered by event type and operator. Manual edits, physical copies, imports, enrichment, loans and reservations now write to the existing `log_modifiche` audit table; all interface strings are available in every shipped locale.
+- **Activity feed (issue #374).** Admin and staff can inspect a field-level timeline at the bottom of each admin book page and a paginated library-wide feed at the bottom of the dashboard. Both can be filtered by event type and operator, searched server-side by book title or operator name, and update in place via AJAX (filters, search and pagination swap the feed without a page reload; the list scrolls inside its own container). Manual edits, physical copies, imports, enrichment, loans and reservations write to the existing `log_modifiche` audit table; all interface strings ship in every locale.
+- **Per-field updates for existing books in CSV/TSV import (issue #380).** Eighteen field-family checkboxes — including twelve individual bibliographic fields (ISBN, EAN, title, subtitle, year, language, edition, pages, format, price, series, Dewey) — decide which data an import may overwrite on books already in the catalogue. Unchecked families are preserved untouched, and the post-import scraping enrichment honours the same selection.
 
 ### Changed
 
 - **Audit history survives operator deletion.** The `log_modifiche.utente_id` foreign key now uses `ON DELETE SET NULL`, while each new event also retains the operator display name in its JSON metadata. Existing installations receive the change through an idempotent migration.
+- **Audit events are atomic with their mutations.** Every circulation audit event is recorded inside the same transaction as the change it describes, with the before-snapshot taken after the row lock — a concurrent transition can no longer be misattributed. Automatic loan approvals are attributed to the system rather than to the requesting reader, and an expired pickup records its own `loan.expired` event instead of a generic cancellation.
+
+### Fixed
+
+- **Plugin activation now takes effect immediately.** The cross-request active-plugins + hooks payload was invalidated with a point delete, so a slower concurrent request could re-cache the pre-activation payload for up to 5 minutes and a freshly activated plugin's hooks stayed invisible. Invalidation now bumps a generation embedded in the cache key: stale writers land under the old generation, unreachable to every subsequent reader.
+- **Circulation hardening.** Notifications for archived titles are no longer silently lost (four sweep/notification fetches still filtered soft-deleted books after the loan had been expired on purpose); cancelling or expiring a pickup releases only a copy actually held for it (`prenotato`), never a copy physically out under another open loan; the reassignment allocator shares the canonical copy-preference ordering (issue #384); NCIP checkout replays return `duplicate-request` instead of consuming a second copy; the legacy maintenance script no longer nests transactions and flushes deferred promotion emails post-commit.
+- **Settings and themes hardening.** Activating a non-existent theme no longer deactivates every theme; the theme's custom CSS is actually rendered on the frontend (re-sanitized at render); the derived `--primary-dark` variable is emitted instead of falling back to a hardcoded colour; cookie-banner HTML descriptions are sanitized before persistence; the llms.txt API section renders when the API is enabled; settings inputs are hardened against array-typed POST values and out-of-range SMTP ports.
+
+### Testing
+
+- ~140 new checks land with this release: 106 circulation checks across four new suites plus an NCIP replay E2E, 31 settings/themes checks, a behavioural E2E for the loan-form UX (discussion #238), the CSV scraping-family gate, and the plugin-cache generation contract. The comprehensive browser suite grows to 145 tests.
 
 ## [0.7.72]
 

--- a/README.md
+++ b/README.md
@@ -41,90 +41,28 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.72 — latest
+### v0.7.73 — latest
+
+A feature and hardening release: every book now has a full activity timeline, CSV imports let you choose field by field what an update may overwrite, and a broad circulation/settings hardening pass lands with ~140 new automated checks.
+
+### New
+
+- **Activity timeline.** Each admin book page ends with a field-level history of everything that happened to the title — edits, copies, imports, enrichment, loans and reservations — and the dashboard gains a library-wide feed. Filter by event type and operator, search by title or operator, and everything updates in place without page reloads.
+- **Per-field CSV updates.** Eighteen checkboxes (including twelve individual bibliographic fields) decide exactly which data an import may overwrite on existing books; unchecked data is preserved and the scraping enrichment honours the same selection.
+
+### Fixes
+
+- Plugin activation takes effect immediately (a cache race could delay a plugin's hooks by up to 5 minutes).
+- Circulation: archived-title notifications are no longer lost, pickup cancel/expiry can never free a copy that is physically out under another loan, and NCIP checkout replays are idempotent.
+- Settings/themes: theme custom CSS actually renders, activating a broken theme id no longer disables all themes, cookie-banner texts are sanitized, and settings inputs are hardened.
+
+### v0.7.72
 
 A small usability release: the two cache-maintenance controls on *Settings → Advanced* are unified into one.
 
 ### Changed
 
 - **A single "Svuota cache" button clears every cache.** It always flushes the application query cache (APCu or file backend, shown as a hint) and additionally purges the LiteSpeed edge cache where the server actually runs LiteSpeed — so a non-LiteSpeed install no longer shows a control it can't use, and a LiteSpeed install no longer shows two buttons. The flush runs inside the web request, so it reaches the same APCu segment that serves pages, which a CLI command cannot.
-
-### v0.7.71
-
-A performance release: a full caching overhaul for anonymous traffic (issue #387). The pages the public sees — home, catalog/search and book pages — are served from cache instead of rebuilt on every request, while copy availability stays live. Upgrades cleanly with no behaviour change on a cold cache; the optional LiteSpeed edge cache is off by default.
-
-### New
-
-- **Anonymous pages are cached, availability stays live.** A single-backend query cache (APCu, else file) with O(1) generation invalidation serves the book-detail data, the reviews block and the bounded catalog/search listings; catalog counts, facets and each book's principal author are materialized in the database. Copy availability is stripped from every cached payload and re-read live, so a stale "available" count can never be shown.
-- **Optional LiteSpeed full-page edge cache.** On LiteSpeed/OpenLiteSpeed you can enable a true full-page cache from *Settings → Advanced*: anonymous home, catalog and book pages are served by the server with no PHP on a hit, with per-page TTLs and a one-click purge. Logged-in users, private mode, mutations and anything with a visitor cookie always bypass it. The section is hidden on servers that are not LiteSpeed (and in the Docker image), so you never see a control that can't work.
-
-### Fixes and delivery
-
-- **The LiteSpeed edge cache toggle now actually caches.** Earlier prereleases wrote the privacy rules but not the `CacheLookup on` directive, so the server ignored them; enabling it now writes the directive, and an upgrade repairs an existing install in place.
-- **Fewer render-blocking requests.** The audiobook player's CSS/JS load only on pages that actually have an audiobook, and the icon fonts no longer block the first paint.
-
-### Upgrade Notes
-
-- **A catalog-materialization migration runs automatically** and is idempotent; existing installs upgrade with no manual step. Back up your database before updating anyway (the in-app updater does this automatically). Redis support is deliberately deferred. See **[CHANGELOG.md](CHANGELOG.md)**.
-
-### v0.7.68
-
-Circulation fixes. A request for a book that is currently out no longer fails on approval — it becomes a real waitlist reservation — and the copy chosen for a loan is now picked consistently everywhere, so a scheduled future loan never comes to depend on someone else returning early.
-
-### Fixes
-
-- **A request for an already-loaned single-copy book becomes a reservation instead of failing (#384).** Approving such a request used to return an error; it now lands on the waitlist when no copy is free through the requested dates, and proceeds as a normal loan when one is.
-- **Copy allocation is consistent across the request gate, approval and waitlist promotion (#384).** A copy whose availability would depend on an earlier borrower returning on time is never bound, and a free copy without a later scheduled loan is preferred over one a future loan already needs.
-- **A "waiting for pickup" loan can be cancelled again (#381)**, resolving to cancelled — or expired when the pickup deadline has passed — and restoring the copy without touching other loans or reservations. The cancel/expire email now also reaches the borrower even when the book has since been archived.
-- **Author photos entered as a URL now display (#382)** — the image is downloaded on save instead of stored as a bare link. See **[CHANGELOG.md](CHANGELOG.md)**.
-
-### v0.7.67
-
-A reliability fix for plugin upgrades: a foreign key or column added by a bundled plugin is now applied automatically after an in-place upgrade of an already-active plugin, instead of being silently skipped.
-
-- **Plugin schema self-heal now covers foreign keys and columns, not only tables.** An admin-UI upgrade runs a plugin's old code until the next page load, so a foreign key or column introduced in a release never ran at upgrade time even though the version was bumped. The boot-time self-heal now detects a declared foreign key or column missing and re-applies it on the next request — `ncip_transactions`' foreign keys and `libri.file_url`/`libri.audio_url` heal themselves with no manual step. See **[CHANGELOG.md](CHANGELOG.md)**.
-
-### v0.7.61
-
-Physical-copy management from the book page, with availability derived from the copies — plus a per-user interface language and a safe upgrade path for existing catalogues.
-
-### New
-
-- **Manage physical copies from the book page** — every book now has a *Copie Fisiche* section (even one with no copies) to add copies, edit each copy's status (available, maintenance, under restoration, in transfer, lost, damaged), and delete copies. Availability is derived from the copies; an out-of-circulation copy lowers the total on its own.
-- **Per-user interface language** — each account keeps its own language, set from the profile/language switcher or by an admin from the *Edit user* form, instead of everyone being forced to Italian regardless of the install language ([#238](https://github.com/fabiodalez-dev/Pinakes/discussions/238)).
-
-### Fixes
-
-- **Book creation and copy changes are atomic** — a book and its initial copies are committed together, and the bulk *increase copies* endpoint allocates collision-free inventory codes, promotes the wait-list, and validates its input.
-- **New users inherit the installation language** instead of the old hard-coded Italian default; an admin can set any user's language from the *Edit user* form (#238).
-
-### Upgrade Notes
-
-- **Legacy availability is migrated automatically** (`migrate_0.7.61-rc.1.sql`). Books that predate copy tracking are backfilled into real copies *before* availability is recalculated, so availability carries over from the old counters to the new copy-derived model without being zeroed. Active loans and reservations are preserved, and out-of-circulation copies are left untouched. See **[CHANGELOG.md](CHANGELOG.md)** for the full notes, including how to recover a catalogue already zeroed by an intermediate version.
-
-### v0.7.60
-
-A maintenance release: UPC barcode support, a read-only availability field, and a PHP 8.5 scraping fix.
-
-### New
-
-- **UPC-A barcodes are supported** — the barcode field now accepts a 12-digit UPC-A (board games and other non-book items) and stores it as its 13-digit GTIN, so it validates, searches and de-duplicates like an EAN-13. CSV and TSV import both handle it, and the field reads **EAN/UPC** in every locale (#348).
-
-### Fixes
-
-- **ISBN scraping works on PHP 8.5 again** — a deprecated `curl_close()` notice was leaking into the JSON response and breaking the import with "Risposta non valida dal servizio ISBN.".
-- **The availability field in the book editor is now read-only** — it is derived from the physical copies, so editing it was a silent no-op (#351). Set a copy's status to make it unavailable.
-- **The scroll-to-top button no longer covers the Save button** at the bottom of the book form.
-
-### Internal
-
-- The GitHub Actions security audit no longer breaks on upstream action tag drift, and the NCIP CheckOut regression test is now deterministic under sharded runs.
-
-### Upgrade Notes
-
-- No database changes. Back up your database before updating anyway (the in-app updater does this automatically).
-
-> Older releases → **[CHANGELOG.md](CHANGELOG.md)**.
 
 ## Quick Start
 

--- a/tests/migration-0.7.73-rc.1.unit.php
+++ b/tests/migration-0.7.73-rc.1.unit.php
@@ -96,7 +96,13 @@ try {
     $check(array_key_exists('utente_id', $audit) && $audit['utente_id'] === null, 'deleting an operator preserves and detaches the audit row');
 
     $version = json_decode((string) file_get_contents($root . '/version.json'), true);
-    $check(($version['version'] ?? '') === '0.7.73-rc.1', 'release version includes the migration');
+    // Same comparison the Updater uses: the migration runs when its version
+    // sorts <= the release. Equality with the rc would break on the stable
+    // finalize (0.7.73-rc.1 <= 0.7.73 is the real invariant).
+    $check(
+        version_compare('0.7.73-rc.1', (string) ($version['version'] ?? '0'), '<='),
+        'release version includes the migration (0.7.73-rc.1 <= version.json)'
+    );
     $schema = (string) file_get_contents($root . '/installer/database/schema.sql');
     $check(str_contains($schema, 'log_modifiche_ibfk_1` FOREIGN KEY (`utente_id`) REFERENCES `utenti` (`id`) ON DELETE SET NULL'), 'fresh-install schema has the same retention rule');
 } catch (Throwable $e) {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.73-rc.1",
+  "version": "0.7.73",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Finalize the stable 0.7.73 release: version bump, consolidated changelog and README highlights for the 0.7.73-rc.1 line (activity feed #374, per-field CSV import updates #380, circulation + settings/themes hardening, plugin hooks cache fix #404, ~140 new checks).

Verified on the rc line: fresh browser install + full 145-test suite, real admin-UI upgrade 0.7.72 → rc.1 with the complete post-upgrade suite (137 passed + 8 install-phase skips by design), and the 3-level published-asset verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunta una timeline delle attività per campo nei libri e una dashboard del feed a livello di biblioteca.
  * Introdotte caselle di selezione per sovrascrivere singoli campi durante gli import CSV/TSV, rispettate anche dall’arricchimento tramite scraping.
  * Migliorati filtri e ricerca server-side nel feed delle attività.

* **Correzioni**
  * L’attivazione dei plugin ora è immediata.
  * Risolti problemi di circolazione, notifiche, temi, CSS personalizzato e impostazioni.

* **Documentazione**
  * Pubblicate le note della release stabile 0.7.73 e aggiornato il riepilogo delle novità.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->