### PR TITLE
Release 0.7.74: backfill the activity timeline from existing circulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.74]
+
+### Fixed
+
+- **The activity timeline now includes pre-existing circulation.** The feed shipped in 0.7.73 recorded events from the moment of the action only, so every upgraded install started with an empty timeline even for books currently on loan. An idempotent migration backfills one `loan.created` event per existing loan (plus `loan.returned` for closed ones) and one `reservation.created` per reservation, with the historical timestamps, a NULL operator (rendered as "Sistema") and `source=backfill`; loans already audited for real are left untouched.
+
 ## [0.7.73]
 
 A feature and hardening release: a full activity timeline for every book, per-field control over CSV imports, a circulation and settings hardening pass backed by ~140 new checks, and an immediate-effect fix for plugin activation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Full version-by-version history for Pinakes. The README shows only the latest re
 
 ### Fixed
 
-- **The activity timeline now includes pre-existing circulation.** The feed shipped in 0.7.73 recorded events from the moment of the action only, so every upgraded install started with an empty timeline even for books currently on loan. An idempotent migration backfills one `loan.created` event per existing loan (plus `loan.returned` for closed ones) and one `reservation.created` per reservation, with the historical timestamps, a NULL operator (rendered as "Sistema") and `source=backfill`; loans already audited for real are left untouched.
+- **The activity timeline now includes pre-existing circulation.** The feed shipped in 0.7.73 recorded events from the moment of the action only, so every upgraded install started with an empty timeline even for books currently on loan. An idempotent migration backfills one `loan.created` event per existing loan (plus `loan.returned` for closed ones) and one `reservation.created` per reservation, with the historical timestamps, a NULL operator (rendered as "Sistema") and `source=backfill`; equivalent events already recorded for real are preserved, never duplicated.
 
 ## [0.7.73]
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.73 — latest
+### v0.7.74 — latest
+
+A follow-up fix: the activity timeline introduced in 0.7.73 now backfills the existing circulation history, so books already on loan show their events right after the upgrade instead of an empty timeline.
+
+### v0.7.73
 
 A feature and hardening release: every book now has a full activity timeline, CSV imports let you choose field by field what an update may overwrite, and a broad circulation/settings hardening pass lands with ~140 new automated checks.
 
@@ -55,14 +59,6 @@ A feature and hardening release: every book now has a full activity timeline, CS
 - Plugin activation takes effect immediately (a cache race could delay a plugin's hooks by up to 5 minutes).
 - Circulation: archived-title notifications are no longer lost, pickup cancel/expiry can never free a copy that is physically out under another loan, and NCIP checkout replays are idempotent.
 - Settings/themes: theme custom CSS actually renders, activating a broken theme id no longer disables all themes, cookie-banner texts are sanitized, and settings inputs are hardened.
-
-### v0.7.72
-
-A small usability release: the two cache-maintenance controls on *Settings → Advanced* are unified into one.
-
-### Changed
-
-- **A single "Svuota cache" button clears every cache.** It always flushes the application query cache (APCu or file backend, shown as a hint) and additionally purges the LiteSpeed edge cache where the server actually runs LiteSpeed — so a non-LiteSpeed install no longer shows a control it can't use, and a LiteSpeed install no longer shows two buttons. The flush runs inside the web request, so it reaches the same APCu segment that serves pages, which a CLI command cannot.
 
 ## Quick Start
 

--- a/installer/database/migrations/migrate_0.7.74.sql
+++ b/installer/database/migrations/migrate_0.7.74.sql
@@ -1,0 +1,56 @@
+-- 0.7.74 — Backfill the activity timeline from existing circulation data.
+--
+-- The activity feed shipped in 0.7.73 records events at action time only:
+-- every upgraded install started with an empty timeline even for books
+-- currently on loan, which reads as a bug (real report: an overdue loan
+-- with an empty "Cronologia modifiche"). This migration synthesizes one
+-- loan.created event per existing loan (plus loan.returned for closed
+-- ones) and one reservation.created per existing reservation, using the
+-- historical timestamps and a NULL operator (rendered as "Sistema",
+-- source "backfill"). Fully idempotent: every INSERT is guarded by a
+-- NOT EXISTS on the (type, event, entity_id) triple, so re-runs and
+-- installs that already logged real events are untouched.
+
+INSERT INTO log_modifiche (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica)
+SELECT 'libri', p.libro_id, 'inserimento', '{}',
+  JSON_OBJECT('libro_id', p.libro_id, 'utente_id', p.utente_id,
+    'data_prestito', p.data_prestito, 'data_scadenza', p.data_scadenza, 'stato', p.stato,
+    '_activity', JSON_OBJECT('type','loan','event','loan.created','entity_id',p.id,
+      'book_title', l.titolo, 'source','backfill')),
+  NULL, COALESCE(p.created_at, CONCAT(p.data_prestito, ' 00:00:00'))
+FROM prestiti p JOIN libri l ON l.id = p.libro_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM log_modifiche lm WHERE lm.tabella = 'libri'
+    AND JSON_EXTRACT(lm.dati_nuovi, '$._activity.entity_id') = p.id
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.type')) = 'loan'
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.event')) = 'loan.created');
+
+INSERT INTO log_modifiche (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica)
+SELECT 'libri', p.libro_id, 'aggiornamento', JSON_OBJECT('stato', 'in_corso'),
+  JSON_OBJECT('libro_id', p.libro_id, 'utente_id', p.utente_id,
+    'data_prestito', p.data_prestito, 'data_scadenza', p.data_scadenza,
+    'data_restituzione', p.data_restituzione, 'stato', p.stato,
+    '_activity', JSON_OBJECT('type','loan','event','loan.returned','entity_id',p.id,
+      'book_title', l.titolo, 'source','backfill')),
+  NULL, CONCAT(p.data_restituzione, ' 12:00:00')
+FROM prestiti p JOIN libri l ON l.id = p.libro_id
+WHERE p.data_restituzione IS NOT NULL
+  AND NOT EXISTS (
+  SELECT 1 FROM log_modifiche lm WHERE lm.tabella = 'libri'
+    AND JSON_EXTRACT(lm.dati_nuovi, '$._activity.entity_id') = p.id
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.type')) = 'loan'
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.event')) = 'loan.returned');
+
+INSERT INTO log_modifiche (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica)
+SELECT 'libri', r.libro_id, 'inserimento', '{}',
+  JSON_OBJECT('libro_id', r.libro_id, 'utente_id', r.utente_id,
+    'data_prenotazione', r.data_prenotazione, 'stato', r.stato,
+    '_activity', JSON_OBJECT('type','loan','event','reservation.created','entity_id',r.id,
+      'book_title', l.titolo, 'source','backfill')),
+  NULL, COALESCE(r.data_prenotazione, NOW())
+FROM prenotazioni r JOIN libri l ON l.id = r.libro_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM log_modifiche lm WHERE lm.tabella = 'libri'
+    AND JSON_EXTRACT(lm.dati_nuovi, '$._activity.entity_id') = r.id
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.type')) = 'loan'
+    AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.event')) = 'reservation.created');

--- a/installer/database/migrations/migrate_0.7.74.sql
+++ b/installer/database/migrations/migrate_0.7.74.sql
@@ -41,13 +41,17 @@ WHERE p.data_restituzione IS NOT NULL
     AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.type')) = 'loan'
     AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.event')) = 'loan.returned');
 
+-- NB: reservations use _activity.type='loan' ON PURPOSE — it mirrors
+-- ActivityLog::recordReservationEvent(), and the feed's single
+-- "Prestiti e prenotazioni" filter covers both (there is no separate
+-- 'reservation' entry in ActivityLog::TYPES).
 INSERT INTO log_modifiche (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica)
 SELECT 'libri', r.libro_id, 'inserimento', '{}',
   JSON_OBJECT('libro_id', r.libro_id, 'utente_id', r.utente_id,
     'data_prenotazione', r.data_prenotazione, 'stato', r.stato,
     '_activity', JSON_OBJECT('type','loan','event','reservation.created','entity_id',r.id,
       'book_title', l.titolo, 'source','backfill')),
-  NULL, COALESCE(r.data_prenotazione, NOW())
+  NULL, COALESCE(r.data_prenotazione, r.created_at)
 FROM prenotazioni r JOIN libri l ON l.id = r.libro_id
 WHERE NOT EXISTS (
   SELECT 1 FROM log_modifiche lm WHERE lm.tabella = 'libri'

--- a/tests/migration-0.7.74.unit.php
+++ b/tests/migration-0.7.74.unit.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural coverage for the 0.7.74 activity-history backfill migration.
+ *
+ * The REAL SQL file is retargeted to per-run sandbox tables seeded with the
+ * pre-0.7.74 state (loans and reservations present, empty audit table — the
+ * exact state every 0.7.73 upgrade left behind), then executed twice: once to
+ * prove the synthesized events, once to prove idempotency. A pre-existing
+ * real event must also survive untouched and suppress its own backfill row.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — migration test is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$suffix = bin2hex(random_bytes(5));
+$auditTable = 'zz_m74_audit_' . $suffix;
+$loansTable = 'zz_m74_loans_' . $suffix;
+$resTable = 'zz_m74_res_' . $suffix;
+$booksTable = 'zz_m74_books_' . $suffix;
+$migration = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.74.sql');
+$migration = str_replace(
+    ['log_modifiche', 'prestiti p', 'prenotazioni r', ' libri l'],
+    [$auditTable, "{$loansTable} p", "{$resTable} r", " {$booksTable} l"],
+    $migration
+);
+$migration = preg_replace('/^\s*--.*$/m', '', $migration) ?? $migration;
+
+$runMigration = static function () use ($db, $migration): void {
+    foreach (array_filter(array_map('trim', preg_split('/;\s*\n/', $migration))) as $statement) {
+        $db->query($statement);
+    }
+};
+$cleanup = static function () use ($db, $auditTable, $loansTable, $resTable, $booksTable): void {
+    foreach ([$auditTable, $loansTable, $resTable, $booksTable] as $t) {
+        $db->query("DROP TABLE IF EXISTS `{$t}`");
+    }
+};
+
+$passed = 0;
+$check = static function (bool $ok, string $label) use (&$passed): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $passed++;
+    echo "  OK  {$label}\n";
+};
+
+try {
+    // Pre-0.7.74 state: circulation data exists, the audit table is empty.
+    $db->query("CREATE TABLE `{$booksTable}` (id INT PRIMARY KEY, titolo VARCHAR(255) NOT NULL)");
+    $db->query("CREATE TABLE `{$loansTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, utente_id INT NOT NULL, data_prestito DATE NOT NULL, data_scadenza DATE NOT NULL, data_restituzione DATE NULL, stato VARCHAR(20) NOT NULL, created_at DATETIME NULL)");
+    $db->query("CREATE TABLE `{$resTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, utente_id INT NOT NULL, data_prenotazione DATETIME NULL, stato VARCHAR(20) NOT NULL)");
+    $db->query("CREATE TABLE `{$auditTable}` (id INT AUTO_INCREMENT PRIMARY KEY, tabella VARCHAR(50) NOT NULL, record_id INT NOT NULL, azione ENUM('inserimento','aggiornamento','cancellazione') NOT NULL, dati_precedenti TEXT NULL, dati_nuovi TEXT NULL, utente_id INT NULL, data_modifica DATETIME DEFAULT CURRENT_TIMESTAMP)");
+
+    $db->query("INSERT INTO `{$booksTable}` VALUES (14, 'Libro in prestito'), (15, 'Libro restituito'), (16, 'Libro prenotato')");
+    $db->query("INSERT INTO `{$loansTable}` VALUES (2, 14, 5, '2026-07-07', '2026-08-07', NULL, 'in_ritardo', '2026-07-07 17:10:13')");
+    $db->query("INSERT INTO `{$loansTable}` VALUES (3, 15, 6, '2026-05-01', '2026-06-01', '2026-05-20', 'restituito', '2026-05-01 09:00:00')");
+    $db->query("INSERT INTO `{$resTable}` VALUES (7, 16, 5, '2026-08-01 10:00:00', 'attiva')");
+    // A loan whose creation was ALREADY audited for real must not be duplicated.
+    $db->query("INSERT INTO `{$loansTable}` VALUES (4, 14, 9, '2026-09-01', '2026-10-01', NULL, 'in_corso', '2026-09-01 08:00:00')");
+    $db->query("INSERT INTO `{$auditTable}` (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica) VALUES ('libri', 14, 'inserimento', '{}', '{\"stato\":\"in_corso\",\"_activity\":{\"type\":\"loan\",\"event\":\"loan.created\",\"entity_id\":4,\"book_title\":\"Libro in prestito\",\"source\":\"manual\"}}', 1, '2026-09-01 08:00:00')");
+
+    $runMigration();
+
+    $count = static function (string $event) use ($db, $auditTable): int {
+        return (int) $db->query(
+            "SELECT COUNT(*) FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi, '$._activity.event')) = '{$event}'"
+        )->fetch_row()[0];
+    };
+
+    $check($count('loan.created') === 3, 'every loan has exactly one loan.created (2 backfilled + 1 pre-existing real)');
+    $check($count('loan.returned') === 1, 'the returned loan gets its loan.returned event');
+    $check($count('reservation.created') === 1, 'the reservation gets its reservation.created event');
+
+    $row = $db->query("SELECT azione, utente_id, data_modifica, dati_nuovi FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = 2")->fetch_assoc();
+    $meta = json_decode((string) $row['dati_nuovi'], true)['_activity'] ?? [];
+    $check($row['azione'] === 'inserimento' && $row['utente_id'] === null, 'backfilled event has NULL operator (renders as Sistema)');
+    $check($row['data_modifica'] === '2026-07-07 17:10:13', 'backfilled event keeps the historical loan timestamp');
+    $check(($meta['source'] ?? '') === 'backfill' && ($meta['book_title'] ?? '') === 'Libro in prestito', 'metadata carries source=backfill and the book title');
+
+    $preExisting = (int) $db->query("SELECT COUNT(*) FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = 4")->fetch_row()[0];
+    $check($preExisting === 1, 'a loan already audited for real is not backfilled again');
+
+    $before = (int) $db->query("SELECT COUNT(*) FROM `{$auditTable}`")->fetch_row()[0];
+    $runMigration();
+    $after = (int) $db->query("SELECT COUNT(*) FROM `{$auditTable}`")->fetch_row()[0];
+    $check($before === $after, 'second run is a no-op (idempotent)');
+
+    $version = json_decode((string) file_get_contents($root . '/version.json'), true);
+    $check(
+        version_compare('0.7.74', (string) ($version['version'] ?? '0'), '<='),
+        'release version includes the migration (0.7.74 <= version.json)'
+    );
+} catch (Throwable $e) {
+    try {
+        $cleanup();
+    } catch (Throwable) {
+    }
+    $db->close();
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$cleanup();
+$db->close();
+echo "\nPassed: {$passed}, Failed: 0\n";

--- a/tests/migration-0.7.74.unit.php
+++ b/tests/migration-0.7.74.unit.php
@@ -16,19 +16,20 @@ require $root . '/vendor/autoload.php';
 
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-$env = [];
-foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
-    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
-        continue;
-    }
-    [$key, $value] = explode('=', $line, 2);
-    $env[trim($key)] = trim(trim($value), "\"'");
+// E2E-runner credentials only (no .env fallback): this test creates and
+// drops tables in the configured database, so it must go through the
+// serial runner that points at the dedicated test DB.
+$dbName = getenv('E2E_DB_NAME') ?: '';
+$dbUser = getenv('E2E_DB_USER') ?: '';
+if ($dbName === '' || $dbUser === '') {
+    fwrite(STDERR, "FAIL: refusing to run — export E2E_DB_NAME/E2E_DB_USER (plus E2E_DB_SOCKET or E2E_DB_HOST/E2E_DB_PASS) via the E2E runner.\n");
+    exit(1);
 }
-$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+$socket = getenv('E2E_DB_SOCKET') ?: '';
 try {
     $db = $socket !== '' && file_exists($socket)
-        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
-        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+        ? new mysqli(null, $dbUser, getenv('E2E_DB_PASS') ?: '', $dbName, 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: '127.0.0.1', $dbUser, getenv('E2E_DB_PASS') ?: '', $dbName, (int) (getenv('E2E_DB_PORT') ?: 3306));
     $db->set_charset('utf8mb4');
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: database unreachable — migration test is mandatory: {$e->getMessage()}\n");
@@ -72,13 +73,15 @@ try {
     // Pre-0.7.74 state: circulation data exists, the audit table is empty.
     $db->query("CREATE TABLE `{$booksTable}` (id INT PRIMARY KEY, titolo VARCHAR(255) NOT NULL)");
     $db->query("CREATE TABLE `{$loansTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, utente_id INT NOT NULL, data_prestito DATE NOT NULL, data_scadenza DATE NOT NULL, data_restituzione DATE NULL, stato VARCHAR(20) NOT NULL, created_at DATETIME NULL)");
-    $db->query("CREATE TABLE `{$resTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, utente_id INT NOT NULL, data_prenotazione DATETIME NULL, stato VARCHAR(20) NOT NULL)");
+    $db->query("CREATE TABLE `{$resTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, utente_id INT NOT NULL, data_prenotazione DATETIME NULL, stato VARCHAR(20) NOT NULL, created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)");
     $db->query("CREATE TABLE `{$auditTable}` (id INT AUTO_INCREMENT PRIMARY KEY, tabella VARCHAR(50) NOT NULL, record_id INT NOT NULL, azione ENUM('inserimento','aggiornamento','cancellazione') NOT NULL, dati_precedenti TEXT NULL, dati_nuovi TEXT NULL, utente_id INT NULL, data_modifica DATETIME DEFAULT CURRENT_TIMESTAMP)");
 
     $db->query("INSERT INTO `{$booksTable}` VALUES (14, 'Libro in prestito'), (15, 'Libro restituito'), (16, 'Libro prenotato')");
     $db->query("INSERT INTO `{$loansTable}` VALUES (2, 14, 5, '2026-07-07', '2026-08-07', NULL, 'in_ritardo', '2026-07-07 17:10:13')");
     $db->query("INSERT INTO `{$loansTable}` VALUES (3, 15, 6, '2026-05-01', '2026-06-01', '2026-05-20', 'restituito', '2026-05-01 09:00:00')");
-    $db->query("INSERT INTO `{$resTable}` VALUES (7, 16, 5, '2026-08-01 10:00:00', 'attiva')");
+    $db->query("INSERT INTO `{$resTable}` VALUES (7, 16, 5, '2026-08-01 10:00:00', 'attiva', '2026-08-01 10:00:00')");
+    // NULL data_prenotazione must fall back to the historical created_at, never NOW().
+    $db->query("INSERT INTO `{$resTable}` VALUES (8, 16, 6, NULL, 'attiva', '2026-06-15 09:30:00')");
     // A loan whose creation was ALREADY audited for real must not be duplicated.
     $db->query("INSERT INTO `{$loansTable}` VALUES (4, 14, 9, '2026-09-01', '2026-10-01', NULL, 'in_corso', '2026-09-01 08:00:00')");
     $db->query("INSERT INTO `{$auditTable}` (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica) VALUES ('libri', 14, 'inserimento', '{}', '{\"stato\":\"in_corso\",\"_activity\":{\"type\":\"loan\",\"event\":\"loan.created\",\"entity_id\":4,\"book_title\":\"Libro in prestito\",\"source\":\"manual\"}}', 1, '2026-09-01 08:00:00')");
@@ -93,7 +96,11 @@ try {
 
     $check($count('loan.created') === 3, 'every loan has exactly one loan.created (2 backfilled + 1 pre-existing real)');
     $check($count('loan.returned') === 1, 'the returned loan gets its loan.returned event');
-    $check($count('reservation.created') === 1, 'the reservation gets its reservation.created event');
+    $check($count('reservation.created') === 2, 'every reservation gets its reservation.created event');
+    $resType = $db->query("SELECT JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi, '$._activity.type')) FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = 7 AND JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi, '$._activity.event')) = 'reservation.created'")->fetch_row()[0];
+    $check($resType === 'loan', "reservation events keep type='loan' (mirrors ActivityLog::recordReservationEvent and the shared feed filter)");
+    $nullDateTs = $db->query("SELECT data_modifica FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = 8 AND JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi, '$._activity.event')) = 'reservation.created'")->fetch_row()[0];
+    $check($nullDateTs === '2026-06-15 09:30:00', 'NULL data_prenotazione falls back to the historical created_at, never NOW()');
 
     $row = $db->query("SELECT azione, utente_id, data_modifica, dati_nuovi FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = 2")->fetch_assoc();
     $meta = json_decode((string) $row['dati_nuovi'], true)['_activity'] ?? [];

--- a/tests/migration-0.7.74.unit.php
+++ b/tests/migration-0.7.74.unit.php
@@ -16,20 +16,23 @@ require $root . '/vendor/autoload.php';
 
 mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 
-// E2E-runner credentials only (no .env fallback): this test creates and
-// drops tables in the configured database, so it must go through the
-// serial runner that points at the dedicated test DB.
-$dbName = getenv('E2E_DB_NAME') ?: '';
-$dbUser = getenv('E2E_DB_USER') ?: '';
-if ($dbName === '' || $dbUser === '') {
-    fwrite(STDERR, "FAIL: refusing to run — export E2E_DB_NAME/E2E_DB_USER (plus E2E_DB_SOCKET or E2E_DB_HOST/E2E_DB_PASS) via the E2E runner.\n");
-    exit(1);
+// Credentials: E2E_DB_* env preferred, .env fallback REQUIRED — the schema
+// gate (scripts/verify-schema.sh, line 24 of its contract) runs migration
+// tests reading creds from .env, same as every migration-*.unit.php sibling.
+// This test only touches per-run zz_m74_* sandbox tables, never live rows.
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
 }
-$socket = getenv('E2E_DB_SOCKET') ?: '';
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
 try {
     $db = $socket !== '' && file_exists($socket)
-        ? new mysqli(null, $dbUser, getenv('E2E_DB_PASS') ?: '', $dbName, 0, $socket)
-        : new mysqli(getenv('E2E_DB_HOST') ?: '127.0.0.1', $dbUser, getenv('E2E_DB_PASS') ?: '', $dbName, (int) (getenv('E2E_DB_PORT') ?: 3306));
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
     $db->set_charset('utf8mb4');
 } catch (Throwable $e) {
     fwrite(STDERR, "FAIL: database unreachable — migration test is mandatory: {$e->getMessage()}\n");

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.73",
+  "version": "0.7.74",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
The activity feed shipped in 0.7.73 records events at action time only, so every upgraded install started with an empty timeline even for books currently on loan — a production install reported an overdue loan with a blank "Cronologia modifiche", which reads as a bug.

`migrate_0.7.74.sql` backfills one `loan.created` event per existing loan (plus `loan.returned` for closed ones) and one `reservation.created` per reservation, with historical timestamps, a NULL operator (rendered as "Sistema") and `source=backfill`. Fully idempotent: every INSERT is guarded by `NOT EXISTS` on the (type, event, entity_id) triple, so re-runs and loans already audited for real are untouched.

I verified the exact same SQL live on the reporting install (and on bibliodoc) before productizing it; the behavioural unit runs the real migration file against a sandbox seeded with the pre-0.7.74 state (9 checks: effect, timestamps, metadata, non-duplication, idempotency, version guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * La cronologia delle attività ora include gli eventi storici per prestiti, restituzioni e prenotazioni già esistenti.
  * Gli eventi conservano le date originali e vengono indicati come generati dal sistema.
  * Le attività già registrate non vengono duplicate, anche dopo riesecuzioni o aggiornamenti successivi.

* **Documentazione**
  * Aggiornate le note di rilascio alla versione 0.7.74.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->