### PR TITLE
Release 0.7.75: readable activity cards, activity backfill, patched fast-uri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
-## [0.7.74]
+## [0.7.75]
 
 ### Fixed
 
+- **Readable event cards.** The change list no longer shows a redundant `libro_id` row (the event is already anchored to its book), `utente_id` resolves to the account's display name instead of a bare number, and bare ISO dates render in the interface's localized format. Purely a rendering fix: it applies retroactively to events already recorded.
+- **Build toolchain advisory cleared.** The frontend lockfile pins a patched `fast-uri` (four high-severity advisories published 2026-09-02, reachable only through the dev-time webpack toolchain — nothing shipped was affected); the compiled assets are byte-identical.
 - **The activity timeline now includes pre-existing circulation.** The feed shipped in 0.7.73 recorded events from the moment of the action only, so every upgraded install started with an empty timeline even for books currently on loan. An idempotent migration backfills one `loan.created` event per existing loan (plus `loan.returned` for closed ones) and one `reservation.created` per reservation, with the historical timestamps, a NULL operator (rendered as "Sistema") and `source=backfill`; equivalent events already recorded for real are preserved, never duplicated.
 
 ## [0.7.73]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.74 — latest
+### v0.7.75 — latest
 
 A follow-up fix: the activity timeline introduced in 0.7.73 now backfills the existing circulation history, so books already on loan show their events right after the upgrade instead of an empty timeline.
 

--- a/app/Support/ActivityLog.php
+++ b/app/Support/ActivityLog.php
@@ -27,6 +27,22 @@ final class ActivityLog
      */
     public const SYSTEM_OPERATOR = 0;
 
+    /**
+     * Bureaucracy fields hidden from CIRCULATION event cards: the header
+     * already tells the story (event + date), the requested period stays via
+     * data_inizio/fine_richiesta, and queue positions/duplicate datetime
+     * pairs only add noise (production feedback, 2026-09-02).
+     */
+    private const LOAN_NOISE_FIELDS = [
+        'queue_position',
+        'data_prenotazione',
+        'data_scadenza_prenotazione',
+        'attivo',
+        'renewals',
+        'origine',
+        'copia_id',
+    ];
+
     private const HIDDEN_FIELDS = [
         '_activity',
         'libro_id',
@@ -499,11 +515,15 @@ final class ActivityLog
         $after = self::decodeSnapshot($row['dati_nuovi'] ?? null);
         $meta = isset($after['_activity']) && is_array($after['_activity']) ? $after['_activity'] : [];
         unset($after['_activity']);
+        $type = (string) ($meta['type'] ?? 'edit');
 
         $changes = [];
         $keys = array_unique(array_merge(array_keys($before), array_keys($after)));
         foreach ($keys as $key) {
             if (in_array($key, self::HIDDEN_FIELDS, true)) {
+                continue;
+            }
+            if ($type === 'loan' && in_array($key, self::LOAN_NOISE_FIELDS, true)) {
                 continue;
             }
             $old = $before[$key] ?? null;
@@ -515,7 +535,7 @@ final class ActivityLog
         }
 
         $row['meta'] = $meta;
-        $row['type'] = (string) ($meta['type'] ?? 'edit');
+        $row['type'] = $type;
         $row['event'] = (string) ($meta['event'] ?? '');
         $row['book_title'] = (string) ($row['book_title'] ?? $meta['book_title'] ?? '');
         $row['operator_name'] = (string) ($row['operator_name'] ?? $meta['operator_name'] ?? '');

--- a/app/Support/ActivityLog.php
+++ b/app/Support/ActivityLog.php
@@ -40,7 +40,6 @@ final class ActivityLog
         'attivo',
         'renewals',
         'origine',
-        'copia_id',
     ];
 
     private const HIDDEN_FIELDS = [
@@ -724,11 +723,74 @@ final class ActivityLog
             }
             $stmt->close();
 
-            return ['items' => self::resolveUserReferences($db, $items), 'page' => $page, 'pages' => $pages, 'total' => $total];
+            $items = self::resolveUserReferences($db, $items);
+            $items = self::resolveCopyReferences($db, $items);
+            return ['items' => $items, 'page' => $page, 'pages' => $pages, 'total' => $total];
         } catch (\Throwable $e) {
             SecureLogger::warning('ActivityLog read failed', ['error' => $e->getMessage()]);
             return ['items' => [], 'page' => 1, 'pages' => 1, 'total' => 0];
         }
+    }
+
+    /**
+     * Replace raw copia_id values with the copy's inventory number — "which
+     * physical copy was picked up" is real information, a bare id is not.
+     * Same batch pattern as resolveUserReferences; '#id' fallback for a
+     * copy that no longer exists.
+     *
+     * @param list<array<string,mixed>> $items
+     * @return list<array<string,mixed>>
+     */
+    private static function resolveCopyReferences(mysqli $db, array $items): array
+    {
+        $ids = [];
+        foreach ($items as $item) {
+            foreach (($item['changes'] ?? []) as $change) {
+                if (($change['field'] ?? '') !== 'copia_id') {
+                    continue;
+                }
+                foreach (['before', 'after'] as $side) {
+                    $value = $change[$side] ?? null;
+                    if (is_numeric($value) && (int) $value > 0) {
+                        $ids[(int) $value] = true;
+                    }
+                }
+            }
+        }
+        if ($ids === []) {
+            return $items;
+        }
+
+        $labels = [];
+        try {
+            $list = implode(',', array_keys($ids));
+            $result = $db->query("SELECT id, numero_inventario FROM copie WHERE id IN ({$list})");
+            while ($result && ($row = $result->fetch_assoc())) {
+                $label = trim((string) ($row['numero_inventario'] ?? ''));
+                if ($label !== '') {
+                    $labels[(int) $row['id']] = $label;
+                }
+            }
+        } catch (\Throwable) {
+            return $items;
+        }
+
+        foreach ($items as &$item) {
+            foreach ($item['changes'] as &$change) {
+                if (($change['field'] ?? '') !== 'copia_id') {
+                    continue;
+                }
+                foreach (['before', 'after'] as $side) {
+                    $value = $change[$side] ?? null;
+                    if (is_numeric($value) && (int) $value > 0) {
+                        $change[$side] = $labels[(int) $value] ?? ('#' . (int) $value);
+                    }
+                }
+            }
+        }
+        unset($item, $change);
+
+        return $items;
     }
 
     /**

--- a/app/Support/ActivityLog.php
+++ b/app/Support/ActivityLog.php
@@ -29,6 +29,7 @@ final class ActivityLog
 
     private const HIDDEN_FIELDS = [
         '_activity',
+        'libro_id',
         'descrizione_plain',
         'search_index',
         'updated_at',
@@ -703,10 +704,70 @@ final class ActivityLog
             }
             $stmt->close();
 
-            return ['items' => $items, 'page' => $page, 'pages' => $pages, 'total' => $total];
+            return ['items' => self::resolveUserReferences($db, $items), 'page' => $page, 'pages' => $pages, 'total' => $total];
         } catch (\Throwable $e) {
             SecureLogger::warning('ActivityLog read failed', ['error' => $e->getMessage()]);
             return ['items' => [], 'page' => 1, 'pages' => 1, 'total' => 0];
         }
+    }
+
+    /**
+     * Replace raw utente_id values in the decoded change lists with the
+     * user's display name ("Utente 5" tells the reader nothing). One query
+     * for the whole page of items; a deleted account falls back to "#id".
+     *
+     * @param list<array<string,mixed>> $items
+     * @return list<array<string,mixed>>
+     */
+    private static function resolveUserReferences(mysqli $db, array $items): array
+    {
+        $ids = [];
+        foreach ($items as $item) {
+            foreach (($item['changes'] ?? []) as $change) {
+                if (($change['field'] ?? '') !== 'utente_id') {
+                    continue;
+                }
+                foreach (['before', 'after'] as $side) {
+                    $value = $change[$side] ?? null;
+                    if (is_numeric($value) && (int) $value > 0) {
+                        $ids[(int) $value] = true;
+                    }
+                }
+            }
+        }
+        if ($ids === []) {
+            return $items;
+        }
+
+        $names = [];
+        try {
+            $list = implode(',', array_keys($ids));
+            $result = $db->query("SELECT id, TRIM(CONCAT(nome, ' ', cognome)) AS name FROM utenti WHERE id IN ({$list})");
+            while ($result && ($row = $result->fetch_assoc())) {
+                $name = trim((string) ($row['name'] ?? ''));
+                if ($name !== '') {
+                    $names[(int) $row['id']] = $name;
+                }
+            }
+        } catch (\Throwable) {
+            return $items;
+        }
+
+        foreach ($items as &$item) {
+            foreach ($item['changes'] as &$change) {
+                if (($change['field'] ?? '') !== 'utente_id') {
+                    continue;
+                }
+                foreach (['before', 'after'] as $side) {
+                    $value = $change[$side] ?? null;
+                    if (is_numeric($value) && (int) $value > 0) {
+                        $change[$side] = $names[(int) $value] ?? ('#' . (int) $value);
+                    }
+                }
+            }
+        }
+        unset($item, $change);
+
+        return $items;
     }
 }

--- a/app/Views/partials/activity-feed.php
+++ b/app/Views/partials/activity-feed.php
@@ -25,6 +25,11 @@ $renderActivityValue = static function (mixed $value, string $field): string {
         if ($label !== null) {
             return __($label);
         }
+        // Bare ISO dates read poorly ("2026-07-07"): render them in the
+        // same localized format the event header already uses.
+        if (preg_match('/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}(:\d{2})?)?$/', $value) === 1) {
+            return format_date($value, str_contains($value, ':'), '/');
+        }
     }
     if (is_array($value)) {
         return (string) json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);

--- a/app/Views/partials/activity-feed.php
+++ b/app/Views/partials/activity-feed.php
@@ -26,9 +26,16 @@ $renderActivityValue = static function (mixed $value, string $field): string {
             return __($label);
         }
         // Bare ISO dates read poorly ("2026-07-07"): render them in the
-        // same localized format the event header already uses.
+        // same localized format the event header already uses. Sentinel
+        // boundary times (midnight / 23:59) are storage artifacts, not
+        // information: show the date alone.
         if (preg_match('/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}(:\d{2})?)?$/', $value) === 1) {
-            return format_date($value, str_contains($value, ':'), '/');
+            $boundary = preg_match('/ (00:00|23:59)(:\d{2})?$/', $value) === 1;
+            return format_date($value, str_contains($value, ':') && !$boundary, '/');
+        }
+        // A resolved-but-deleted account comes through as '#<id>'.
+        if ($field === 'utente_id' && preg_match('/^#(\d+)$/', $value, $m) === 1) {
+            return sprintf(__('Account eliminato (#%d)'), (int) $m[1]);
         }
     }
     if (is_array($value)) {

--- a/app/Views/partials/activity-feed.php
+++ b/app/Views/partials/activity-feed.php
@@ -204,6 +204,10 @@ $activityPageUrl = static function (int $page) use ($activityBaseUrl, $activityP
                               <span class="break-words"><?= htmlspecialchars((string) ($renderActivityValue($change['after'], (string) $change['field'])), ENT_QUOTES, 'UTF-8') ?></span>
                             <?php elseif (($activity['azione'] ?? '') === 'cancellazione'): ?>
                               <span class="break-words line-through text-gray-500"><?= htmlspecialchars((string) ($renderActivityValue($change['before'], (string) $change['field'])), ENT_QUOTES, 'UTF-8') ?></span>
+                            <?php elseif ($change['before'] === null || $change['before'] === ''): ?>
+                              <?php /* Nothing meaningful was replaced: "Non impostato ➜ X"
+                                       repeated on every row is clutter — show the value alone. */ ?>
+                              <span class="break-words"><?= htmlspecialchars((string) ($renderActivityValue($change['after'], (string) $change['field'])), ENT_QUOTES, 'UTF-8') ?></span>
                             <?php else: ?>
                               <span class="break-words text-gray-500 line-through"><?= htmlspecialchars((string) ($renderActivityValue($change['before'], (string) $change['field'])), ENT_QUOTES, 'UTF-8') ?></span>
                               <i class="fas fa-arrow-right mx-2 text-xs text-gray-400" aria-hidden="true"></i>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3900,9 +3900,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/locale/da_DK.json
+++ b/locale/da_DK.json
@@ -7066,5 +7066,6 @@
   "Diretto": "Direkte",
   "NCIP": "NCIP",
   "Cerca nella cronologia": "Søg i historikken",
-  "Ritiro del prestito scaduto": "Afhentning af lån udløbet"
+  "Ritiro del prestito scaduto": "Afhentning af lån udløbet",
+  "Account eliminato (#%d)": "Slettet konto (#%d)"
 }

--- a/locale/de_DE.json
+++ b/locale/de_DE.json
@@ -7066,5 +7066,6 @@
   "Diretto": "Direkt",
   "NCIP": "NCIP",
   "Cerca nella cronologia": "In der Chronik suchen",
-  "Ritiro del prestito scaduto": "Abholung der Ausleihe abgelaufen"
+  "Ritiro del prestito scaduto": "Abholung der Ausleihe abgelaufen",
+  "Account eliminato (#%d)": "Gelöschtes Konto (#%d)"
 }

--- a/locale/en_US.json
+++ b/locale/en_US.json
@@ -7066,5 +7066,6 @@
   "Diretto": "Direct",
   "NCIP": "NCIP",
   "Cerca nella cronologia": "Search the timeline",
-  "Ritiro del prestito scaduto": "Loan pickup expired"
+  "Ritiro del prestito scaduto": "Loan pickup expired",
+  "Account eliminato (#%d)": "Deleted account (#%d)"
 }

--- a/locale/fr_FR.json
+++ b/locale/fr_FR.json
@@ -7066,5 +7066,6 @@
   "Diretto": "Direct",
   "NCIP": "NCIP",
   "Cerca nella cronologia": "Rechercher dans l'historique",
-  "Ritiro del prestito scaduto": "Retrait du prêt expiré"
+  "Ritiro del prestito scaduto": "Retrait du prêt expiré",
+  "Account eliminato (#%d)": "Compte supprimé (#%d)"
 }

--- a/locale/it_IT.json
+++ b/locale/it_IT.json
@@ -7066,5 +7066,6 @@
   "Diretto": "Diretto",
   "NCIP": "NCIP",
   "Cerca nella cronologia": "Cerca nella cronologia",
-  "Ritiro del prestito scaduto": "Ritiro del prestito scaduto"
+  "Ritiro del prestito scaduto": "Ritiro del prestito scaduto",
+  "Account eliminato (#%d)": "Account eliminato (#%d)"
 }

--- a/tests/activity-feed-374.spec.js
+++ b/tests/activity-feed-374.spec.js
@@ -43,7 +43,29 @@ const RUN = Date.now().toString(36) + 'af';
 const TITLE_V1 = `ActivityFeedLibro ${RUN}`;
 const TITLE_V2 = `ActivityFeedLibroDue ${RUN}`;
 const PATRON_EMAIL = `zz-feed-patron-${RUN}@test.local`;
+const BORROWER_EMAIL = `zz-feed-borrower-${RUN}@test.local`;
+const BORROWER_SURNAME = `CopyProbe${RUN}`;
+const COPY_INVENTORY = `INV-374-${RUN}`.toUpperCase();
 let bookId = '';
+
+async function fillAutocomplete(page, inputSelector, suggestSelector, query, apiUrlFragment) {
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    await page.fill(inputSelector, '');
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes(apiUrlFragment) && resp.status() === 200,
+      { timeout: 15000 },
+    );
+    await page.locator(inputSelector).pressSequentially(query, { delay: 50 });
+    await responsePromise;
+    const suggestionItem = page.locator(`${suggestSelector} .suggestion-item`).first();
+    if (await suggestionItem.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await suggestionItem.click();
+      return;
+    }
+    await page.waitForTimeout(300);
+  }
+  throw new Error(`autocomplete never suggested for ${query}`);
+}
 
 async function loginAsAdmin(page) {
   await page.goto(`${BASE}/admin/dashboard`);
@@ -62,9 +84,11 @@ function feedCleanup() {
   }
   dbQuery(
     `DELETE lm FROM log_modifiche lm JOIN libri l ON l.id=lm.record_id AND lm.tabella='libri' WHERE l.titolo IN ('${sqlEscape(TITLE_V1)}','${sqlEscape(TITLE_V2)}');`
+    + `DELETE p FROM prestiti p JOIN libri l ON l.id=p.libro_id WHERE l.titolo IN ('${sqlEscape(TITLE_V1)}','${sqlEscape(TITLE_V2)}');`
     + `DELETE c FROM copie c JOIN libri l ON l.id=c.libro_id WHERE l.titolo IN ('${sqlEscape(TITLE_V1)}','${sqlEscape(TITLE_V2)}');`
     + `DELETE FROM libri WHERE titolo IN ('${sqlEscape(TITLE_V1)}','${sqlEscape(TITLE_V2)}');`
-    + `DELETE FROM utenti WHERE email='${sqlEscape(PATRON_EMAIL)}';`,
+    + `DELETE FROM utenti WHERE email='${sqlEscape(PATRON_EMAIL)}';`
+    + `DELETE FROM utenti WHERE email='${sqlEscape(BORROWER_EMAIL)}';`,
   );
 }
 
@@ -140,6 +164,55 @@ test.describe.serial('Activity feed (#374)', () => {
     await expect(page.locator('#activity-feed')).toContainText('Libro aggiornato');
 
     expect(errors).toEqual([]);
+  });
+
+  test('a real admin loan records the physical copy and the timeline shows its inventory number', async ({ page }) => {
+    test.setTimeout(120000);
+    await loginAsAdmin(page);
+
+    // Real fixtures: a named borrower and a physical copy with a known
+    // inventory number. The LOAN itself goes through the real admin form,
+    // so the copy assignment is the production allocator's, not ours.
+    const adminHash = dbQuery(
+      `SELECT password FROM utenti WHERE email='${sqlEscape(process.env.E2E_ADMIN_EMAIL)}' LIMIT 1`,
+    );
+    dbQuery(
+      `INSERT INTO utenti (codice_tessera, nome, cognome, email, password, tipo_utente, stato, email_verificata)
+       VALUES ('CP${RUN.slice(0, 8).toUpperCase()}', 'Probe', '${sqlEscape(BORROWER_SURNAME)}', '${sqlEscape(BORROWER_EMAIL)}', '${sqlEscape(adminHash)}', 'standard', 'attivo', 1)`,
+    );
+    dbQuery(
+      `INSERT INTO copie (libro_id, numero_inventario, stato) VALUES (${Number(bookId)}, '${sqlEscape(COPY_INVENTORY)}', 'disponibile')`,
+    );
+    const copyId = dbQuery(`SELECT id FROM copie WHERE numero_inventario='${sqlEscape(COPY_INVENTORY)}' LIMIT 1`);
+    dbQuery(`UPDATE libri SET copie_totali=1, copie_disponibili=1 WHERE id=${Number(bookId)}`);
+
+    // Create the loan through the REAL admin form (same driving pattern as
+    // full-test Phase 14.2: autocomplete pickers + app-timezone loan date).
+    await page.goto(`${BASE}/admin/loans/create`);
+    await page.waitForLoadState('domcontentloaded');
+    await fillAutocomplete(page, '#utente_search', '#utente_suggest', BORROWER_SURNAME, '/api/search/utenti');
+    await fillAutocomplete(page, '#libro_search', '#libro_suggest', TITLE_V2, '/api/search/libri');
+    expect(Number(await page.locator('#libro_id').inputValue())).toBe(Number(bookId));
+    const appLoanDate = await page.locator('#data_prestito').inputValue();
+    expect(appLoanDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    await page.locator('form button[type="submit"]').first().click();
+    await page.waitForURL((url) => url.searchParams.get('created') === '1', { timeout: 20000 });
+
+    // DB truth: the production allocator bound OUR physical copy to the loan.
+    const loanCopy = dbQuery(
+      `SELECT copia_id FROM prestiti WHERE libro_id=${Number(bookId)} AND attivo=1 ORDER BY id DESC LIMIT 1`,
+    );
+    expect(Number(loanCopy)).toBe(Number(copyId));
+
+    // UI truth: the timeline shows the loan with the resolved inventory
+    // number and the borrower's name — never the raw ids.
+    await page.goto(`${BASE}/admin/books/${bookId}?activity_type=loan`);
+    const feed = page.locator('#activity-feed');
+    await expect(feed).toBeVisible({ timeout: 10000 });
+    await expect(feed).toContainText('Prestito creato');
+    await expect(feed).toContainText(COPY_INVENTORY);
+    await expect(feed).toContainText(BORROWER_SURNAME);
+    await expect(feed).not.toContainText(`#${copyId}`);
   });
 
   test('the dashboard feed renders and the type filter is allow-listed', async ({ page }) => {

--- a/tests/activity-feed-374.unit.php
+++ b/tests/activity-feed-374.unit.php
@@ -214,6 +214,38 @@ try {
         !array_intersect_key($loanChanges, array_flip(['attivo', 'queue_position', 'origine'])),
         'circulation bureaucracy fields (attivo, queue_position, origine) are hidden from loan cards'
     );
+
+    // copia_id resolves to the copy inventory number ("which physical copy
+    // was picked up" is information; a bare id is not).
+    $db->query("INSERT INTO copie (libro_id, numero_inventario, stato) VALUES ({$bookId}, 'INV-374-TEST', 'disponibile')");
+    $copyId = (int) $db->insert_id;
+    $check(
+        ActivityLog::recordBookEvent(
+            $db,
+            $bookId,
+            'aggiornamento',
+            'loan',
+            'loan.picked_up',
+            ['stato' => 'da_ritirare'],
+            ['stato' => 'in_corso', 'copia_id' => $copyId],
+            operatorId: ActivityLog::SYSTEM_OPERATOR,
+            bookTitle: $title,
+            source: 'pickup'
+        ),
+        'pickup event with a copy reference is written'
+    );
+    $pickupFeed = ActivityLog::forBook($db, $bookId, 1, 20);
+    $copyValue = null;
+    foreach ($pickupFeed['items'] as $item) {
+        if (($item['event'] ?? '') === 'loan.picked_up') {
+            foreach ($item['changes'] as $change) {
+                if ($change['field'] === 'copia_id') {
+                    $copyValue = $change['after'];
+                }
+            }
+        }
+    }
+    $check($copyValue === 'INV-374-TEST', 'copia_id resolves to the copy inventory number');
     $check(($loanChanges['utente_id'] ?? null) === 'Audit Operator', 'utente_id resolves to the account display name');
 
     $stmt = $db->prepare('DELETE FROM utenti WHERE id = ?');
@@ -257,9 +289,9 @@ try {
     // forBook type filter mirrors the dashboard allow-list behaviour.
     $loanOnly = ActivityLog::forBook($db, $bookId, 1, 20, null, 'loan');
     $loanTypes = array_unique(array_map(static fn(array $i): string => (string) $i['type'], $loanOnly['items']));
-    $check($loanOnly['total'] === 2 && $loanTypes === ['loan'], 'forBook type filter narrows to the requested type');
+    $check($loanOnly['total'] === 3 && $loanTypes === ['loan'], 'forBook type filter narrows to the requested type');
     $ignoredType = ActivityLog::forBook($db, $bookId, 1, 20, null, 'not-a-type');
-    $check($ignoredType['total'] === 4, 'forBook ignores out-of-allow-list types');
+    $check($ignoredType['total'] === 5, 'forBook ignores out-of-allow-list types');
 } catch (Throwable $e) {
     $db->rollback();
     $db->close();

--- a/tests/activity-feed-374.unit.php
+++ b/tests/activity-feed-374.unit.php
@@ -182,12 +182,49 @@ try {
     $matchingOperators = array_filter($operators, static fn(array $operator): bool => $operator['id'] === $operatorId);
     $check(count($matchingOperators) === 1, 'operator filter options are read from audit rows');
 
+    // Readability contract: libro_id is hidden from the change list (the
+    // event is already anchored to its book) and utente_id resolves to the
+    // account's display name — "Utente 5" tells the reader nothing.
+    $check(
+        ActivityLog::recordBookEvent(
+            $db,
+            $bookId,
+            'inserimento',
+            'loan',
+            'loan.created',
+            [],
+            ['libro_id' => $bookId, 'utente_id' => $operatorId, 'stato' => 'in_corso'],
+            operatorId: ActivityLog::SYSTEM_OPERATOR,
+            bookTitle: $title,
+            source: 'backfill'
+        ),
+        'backfill-shaped loan event is written'
+    );
+    $readable = ActivityLog::forBook($db, $bookId, 1, 20);
+    $loanChanges = [];
+    foreach ($readable['items'] as $item) {
+        if (($item['event'] ?? '') === 'loan.created') {
+            foreach ($item['changes'] as $change) {
+                $loanChanges[$change['field']] = $change['after'];
+            }
+        }
+    }
+    $check(!array_key_exists('libro_id', $loanChanges), 'libro_id is hidden from the rendered change list');
+    $check(($loanChanges['utente_id'] ?? null) === 'Audit Operator', 'utente_id resolves to the account display name');
+
     $stmt = $db->prepare('DELETE FROM utenti WHERE id = ?');
     $stmt->bind_param('i', $operatorId);
     $stmt->execute();
     $stmt->close();
     $detachedFeed = ActivityLog::forBook($db, $bookId, 1, 20);
-    $check($detachedFeed['items'][0]['operator_name'] === 'Audit Operator', 'operator name survives account deletion in event metadata');
+    $detachedEnrich = null;
+    foreach ($detachedFeed['items'] as $item) {
+        if (($item['event'] ?? '') === 'enrich.updated') {
+            $detachedEnrich = $item;
+            break;
+        }
+    }
+    $check(($detachedEnrich['operator_name'] ?? null) === 'Audit Operator', 'operator name survives account deletion in event metadata');
 
     // SYSTEM_OPERATOR sentinel: an automatic action running inside a reader's
     // HTTP session must not be attributed to that session user.
@@ -215,9 +252,10 @@ try {
 
     // forBook type filter mirrors the dashboard allow-list behaviour.
     $loanOnly = ActivityLog::forBook($db, $bookId, 1, 20, null, 'loan');
-    $check($loanOnly['total'] === 1 && $loanOnly['items'][0]['type'] === 'loan', 'forBook type filter narrows to the requested type');
+    $loanTypes = array_unique(array_map(static fn(array $i): string => (string) $i['type'], $loanOnly['items']));
+    $check($loanOnly['total'] === 2 && $loanTypes === ['loan'], 'forBook type filter narrows to the requested type');
     $ignoredType = ActivityLog::forBook($db, $bookId, 1, 20, null, 'not-a-type');
-    $check($ignoredType['total'] === 3, 'forBook ignores out-of-allow-list types');
+    $check($ignoredType['total'] === 4, 'forBook ignores out-of-allow-list types');
 } catch (Throwable $e) {
     $db->rollback();
     $db->close();

--- a/tests/activity-feed-374.unit.php
+++ b/tests/activity-feed-374.unit.php
@@ -193,7 +193,7 @@ try {
             'loan',
             'loan.created',
             [],
-            ['libro_id' => $bookId, 'utente_id' => $operatorId, 'stato' => 'in_corso'],
+            ['libro_id' => $bookId, 'utente_id' => $operatorId, 'stato' => 'in_corso', 'attivo' => 1, 'queue_position' => 3, 'origine' => 'richiesta'],
             operatorId: ActivityLog::SYSTEM_OPERATOR,
             bookTitle: $title,
             source: 'backfill'
@@ -210,6 +210,10 @@ try {
         }
     }
     $check(!array_key_exists('libro_id', $loanChanges), 'libro_id is hidden from the rendered change list');
+    $check(
+        !array_intersect_key($loanChanges, array_flip(['attivo', 'queue_position', 'origine'])),
+        'circulation bureaucracy fields (attivo, queue_position, origine) are hidden from loan cards'
+    );
     $check(($loanChanges['utente_id'] ?? null) === 'Audit Operator', 'utente_id resolves to the account display name');
 
     $stmt = $db->prepare('DELETE FROM utenti WHERE id = ?');

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.74",
+  "version": "0.7.75",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Retargets the unpublished 0.7.74 line (its release workflow failed on the blocking npm audit gate when four high-severity `fast-uri` advisories were published mid-day; the tag stays orphaned by immutability policy) and adds a production-feedback fix:

- **Readable event cards**: the change list drops the redundant `libro_id` row, `utente_id` resolves to the account's display name (single query per page, `#id` fallback for deleted accounts), bare ISO dates render localized. Rendering-only — applies retroactively to already-recorded events.
- **Patched `fast-uri`** in the frontend lockfile (dev-time webpack toolchain only; Node 22 rebuild yields byte-identical assets).
- **Activity-history backfill** unchanged from the 0.7.74 line (`migrate_0.7.74.sql`, valid at `<= 0.7.75`, 11-check behavioural unit).

Activity unit suite grows to 26 checks; full local quality gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correzioni**
  - L’elenco delle modifiche nelle attività non mostra più la riga ridondante `libro_id`.
  - I riferimenti `utente_id` vengono visualizzati con il nome dell’account, mantenendo un riferimento identificativo se l’account non è più disponibile.
  - Le date ISO nel feed delle attività vengono formattate secondo il formato localizzato dell’interfaccia.

- **Documentazione**
  - Aggiornata l’indicazione della versione corrente alla **v0.7.75**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->