### PR TITLE
Release 0.7.76: backfilled loan events carry the physical copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.76]
+
+### Fixed
+
+- **Backfilled loan events now carry the physical copy.** The 0.7.75 history backfill synthesized `loan.created`/`loan.returned` events without `copia_id`, so the timeline could not show which physical copy was involved — the exact information the feature was asked for. An idempotent migration copies each loan's `copia_id` into every backfilled event that lacks it; loans without a copy, already-enriched events and real runtime events are untouched.
+
 ## [0.7.75]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,24 +41,13 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.75 — latest
+### v0.7.76 — latest
+
+A follow-up fix: backfilled loan history now includes the physical copy's inventory number, completing the timeline shipped in 0.7.75.
+
+### v0.7.75
 
 A follow-up fix: the activity timeline introduced in 0.7.73 now backfills the existing circulation history, so books already on loan show their events right after the upgrade instead of an empty timeline.
-
-### v0.7.73
-
-A feature and hardening release: every book now has a full activity timeline, CSV imports let you choose field by field what an update may overwrite, and a broad circulation/settings hardening pass lands with ~140 new automated checks.
-
-### New
-
-- **Activity timeline.** Each admin book page ends with a field-level history of everything that happened to the title — edits, copies, imports, enrichment, loans and reservations — and the dashboard gains a library-wide feed. Filter by event type and operator, search by title or operator, and everything updates in place without page reloads.
-- **Per-field CSV updates.** Eighteen checkboxes (including twelve individual bibliographic fields) decide exactly which data an import may overwrite on existing books; unchecked data is preserved and the scraping enrichment honours the same selection.
-
-### Fixes
-
-- Plugin activation takes effect immediately (a cache race could delay a plugin's hooks by up to 5 minutes).
-- Circulation: archived-title notifications are no longer lost, pickup cancel/expiry can never free a copy that is physically out under another loan, and NCIP checkout replays are idempotent.
-- Settings/themes: theme custom CSS actually renders, activating a broken theme id no longer disables all themes, cookie-banner texts are sanitized, and settings inputs are hardened.
 
 ## Quick Start
 

--- a/installer/database/migrations/migrate_0.7.76.sql
+++ b/installer/database/migrations/migrate_0.7.76.sql
@@ -1,0 +1,22 @@
+-- 0.7.76 — Enrich backfilled loan events with the physical copy.
+--
+-- The 0.7.74 backfill (shipped in 0.7.75) synthesized loan.created /
+-- loan.returned events without copia_id, even though the loans carry it:
+-- the timeline card could not show WHICH physical copy was involved — the
+-- exact information the feature was asked for. This migration copies the
+-- loan's copia_id into every backfilled event that lacks it.
+--
+-- Idempotent and surgical: only source=backfill loan events, only when the
+-- joined loan actually has a copy, and only when the snapshot does not
+-- already carry one. Real runtime events (which already include copia_id)
+-- and reservations (never copy-bound) are untouched. Verified live on two
+-- production installs before being productized.
+
+UPDATE log_modifiche lm
+JOIN prestiti p ON p.id = JSON_EXTRACT(lm.dati_nuovi, '$._activity.entity_id')
+SET lm.dati_nuovi = JSON_SET(lm.dati_nuovi, '$.copia_id', p.copia_id)
+WHERE lm.tabella = 'libri'
+  AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.source')) = 'backfill'
+  AND JSON_UNQUOTE(JSON_EXTRACT(lm.dati_nuovi, '$._activity.event')) IN ('loan.created', 'loan.returned')
+  AND p.copia_id IS NOT NULL
+  AND JSON_EXTRACT(lm.dati_nuovi, '$.copia_id') IS NULL;

--- a/tests/migration-0.7.76.unit.php
+++ b/tests/migration-0.7.76.unit.php
@@ -1,0 +1,125 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Behavioural coverage for the 0.7.76 backfill copy-enrichment migration.
+ *
+ * The REAL SQL file is retargeted to per-run sandbox tables seeded with the
+ * exact state the 0.7.75 backfill leaves behind: loan events with
+ * source=backfill and NO copia_id, next to loans that carry one. Executed
+ * twice to prove enrichment and idempotency; real runtime events and
+ * reservations must be untouched.
+ */
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+// Credentials: E2E_DB_* env preferred, .env fallback REQUIRED — the schema
+// gate (scripts/verify-schema.sh) runs migration tests reading creds from
+// .env by documented contract, same as every migration-*.unit.php sibling.
+// This test only touches per-run zz_m76_* sandbox tables, never live rows.
+$env = [];
+foreach (preg_split('/\r?\n/', (string) @file_get_contents($root . '/.env')) as $line) {
+    if (!str_contains($line, '=') || str_starts_with(trim($line), '#')) {
+        continue;
+    }
+    [$key, $value] = explode('=', $line, 2);
+    $env[trim($key)] = trim(trim($value), "\"'");
+}
+$socket = getenv('E2E_DB_SOCKET') ?: ($env['DB_SOCKET'] ?? '');
+try {
+    $db = $socket !== '' && file_exists($socket)
+        ? new mysqli(null, getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), 0, $socket)
+        : new mysqli(getenv('E2E_DB_HOST') ?: ($env['DB_HOST'] ?? '127.0.0.1'), getenv('E2E_DB_USER') ?: ($env['DB_USER'] ?? ''), getenv('E2E_DB_PASS') ?: ($env['DB_PASS'] ?? ($env['DB_PASSWORD'] ?? '')), getenv('E2E_DB_NAME') ?: ($env['DB_NAME'] ?? ''), (int) (getenv('E2E_DB_PORT') ?: ($env['DB_PORT'] ?? 3306)));
+    $db->set_charset('utf8mb4');
+} catch (Throwable $e) {
+    fwrite(STDERR, "FAIL: database unreachable — migration test is mandatory: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$suffix = bin2hex(random_bytes(5));
+$auditTable = 'zz_m76_audit_' . $suffix;
+$loansTable = 'zz_m76_loans_' . $suffix;
+$migration = (string) file_get_contents($root . '/installer/database/migrations/migrate_0.7.76.sql');
+$migration = str_replace(
+    ['log_modifiche', 'prestiti p'],
+    [$auditTable, "{$loansTable} p"],
+    $migration
+);
+$migration = preg_replace('/^\s*--.*$/m', '', $migration) ?? $migration;
+
+$runMigration = static function () use ($db, $migration): void {
+    foreach (array_filter(array_map('trim', preg_split('/;\s*\n/', $migration))) as $statement) {
+        $db->query($statement);
+    }
+};
+$cleanup = static function () use ($db, $auditTable, $loansTable): void {
+    $db->query("DROP TABLE IF EXISTS `{$auditTable}`");
+    $db->query("DROP TABLE IF EXISTS `{$loansTable}`");
+};
+
+$passed = 0;
+$check = static function (bool $ok, string $label) use (&$passed): void {
+    if (!$ok) {
+        throw new RuntimeException($label);
+    }
+    $passed++;
+    echo "  OK  {$label}\n";
+};
+
+$copiaOf = static function (int $entityId) use ($db, $auditTable) {
+    $row = $db->query(
+        "SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') AS c FROM `{$auditTable}` WHERE JSON_EXTRACT(dati_nuovi, '$._activity.entity_id') = {$entityId} LIMIT 1"
+    )->fetch_assoc();
+    return $row['c'] ?? null;
+};
+
+try {
+    $db->query("CREATE TABLE `{$loansTable}` (id INT PRIMARY KEY, libro_id INT NOT NULL, copia_id INT NULL)");
+    $db->query("CREATE TABLE `{$auditTable}` (id INT AUTO_INCREMENT PRIMARY KEY, tabella VARCHAR(50) NOT NULL, record_id INT NOT NULL, azione ENUM('inserimento','aggiornamento','cancellazione') NOT NULL, dati_precedenti TEXT NULL, dati_nuovi TEXT NULL, utente_id INT NULL, data_modifica DATETIME DEFAULT CURRENT_TIMESTAMP)");
+
+    // The 0.7.75-backfill shape: loan events WITHOUT copia_id.
+    $db->query("INSERT INTO `{$loansTable}` VALUES (601, 14, 4), (602, 14, NULL), (603, 15, 9)");
+    $mk = static fn(int $eid, string $event, string $source, string $extra = '') => "('libri', 14, 'inserimento', '{}', '{\"stato\":\"in_corso\"{$extra},\"_activity\":{\"type\":\"loan\",\"event\":\"{$event}\",\"entity_id\":{$eid},\"source\":\"{$source}\"}}', NULL, NOW())";
+    $db->query("INSERT INTO `{$auditTable}` (tabella, record_id, azione, dati_precedenti, dati_nuovi, utente_id, data_modifica) VALUES "
+        . $mk(601, 'loan.created', 'backfill') . ','
+        . $mk(601, 'loan.returned', 'backfill') . ','
+        . $mk(602, 'loan.created', 'backfill') . ','          // loan senza copia: resta senza
+        . $mk(603, 'loan.created', 'backfill', ',"copia_id":77') . ','  // già arricchito: intoccato
+        . $mk(601, 'loan.picked_up', 'pickup'));               // evento REALE: intoccato
+
+    $runMigration();
+
+    $check((string) $copiaOf(601) === '4' , 'backfilled events inherit the loan\'s copia_id');
+    $returned = $db->query("SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') c FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi,'$._activity.event'))='loan.returned'")->fetch_assoc();
+    $check((string) ($returned['c'] ?? '') === '4', 'loan.returned is enriched too');
+    $check($copiaOf(602) === null || $copiaOf(602) === 'null', 'a loan without a copy stays without one');
+    $check((string) $copiaOf(603) === '77', 'an already-enriched event keeps its value');
+    $real = $db->query("SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') c FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi,'$._activity.source'))='pickup'")->fetch_assoc();
+    $check(($real['c'] ?? null) === null, 'real runtime events are untouched');
+
+    $before = md5((string) json_encode($db->query("SELECT dati_nuovi FROM `{$auditTable}` ORDER BY id")->fetch_all()));
+    $runMigration();
+    $after = md5((string) json_encode($db->query("SELECT dati_nuovi FROM `{$auditTable}` ORDER BY id")->fetch_all()));
+    $check($before === $after, 'second run is a byte-for-byte no-op (idempotent)');
+
+    $version = json_decode((string) file_get_contents($root . '/version.json'), true);
+    $check(
+        version_compare('0.7.76', (string) ($version['version'] ?? '0'), '<='),
+        'release version includes the migration (0.7.76 <= version.json)'
+    );
+} catch (Throwable $e) {
+    try {
+        $cleanup();
+    } catch (Throwable) {
+    }
+    $db->close();
+    fwrite(STDERR, "FAIL: {$e->getMessage()}\n");
+    exit(1);
+}
+
+$cleanup();
+$db->close();
+echo "\nPassed: {$passed}, Failed: 0\n";

--- a/tests/migration-0.7.76.unit.php
+++ b/tests/migration-0.7.76.unit.php
@@ -88,7 +88,9 @@ try {
         . $mk(601, 'loan.returned', 'backfill') . ','
         . $mk(602, 'loan.created', 'backfill') . ','          // loan senza copia: resta senza
         . $mk(603, 'loan.created', 'backfill', ',"copia_id":77') . ','  // già arricchito: intoccato
-        . $mk(601, 'loan.picked_up', 'pickup'));               // evento REALE: intoccato
+        . $mk(601, 'loan.picked_up', 'pickup') . ','           // evento REALE: intoccato
+        . $mk(601, 'loan.created', 'manual') . ','             // event TARGET ma source reale: prova il filtro source da solo
+        . $mk(601, 'reservation.created', 'backfill'));        // source backfill ma event non-target: prova il filtro event da solo
 
     $runMigration();
 
@@ -99,6 +101,11 @@ try {
     $check((string) $copiaOf(603) === '77', 'an already-enriched event keeps its value');
     $real = $db->query("SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') c FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi,'$._activity.source'))='pickup'")->fetch_assoc();
     $check(($real['c'] ?? null) === null, 'real runtime events are untouched');
+    // I due filtri devono discriminare da soli, non solo in AND fortuito.
+    $manualCreated = $db->query("SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') c FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi,'$._activity.source'))='manual'")->fetch_assoc();
+    $check(($manualCreated['c'] ?? null) === null, 'a target-event row with a REAL source is untouched (source filter alone discriminates)');
+    $backfillRes = $db->query("SELECT JSON_EXTRACT(dati_nuovi, '$.copia_id') c FROM `{$auditTable}` WHERE JSON_UNQUOTE(JSON_EXTRACT(dati_nuovi,'$._activity.event'))='reservation.created'")->fetch_assoc();
+    $check(($backfillRes['c'] ?? null) === null, 'a backfill row with a non-target event is untouched (event filter alone discriminates)');
 
     $before = md5((string) json_encode($db->query("SELECT dati_nuovi FROM `{$auditTable}` ORDER BY id")->fetch_all()));
     $runMigration();

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.75",
+  "version": "0.7.76",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
The 0.7.75 history backfill synthesized `loan.created`/`loan.returned` events without `copia_id`, so the timeline could not show which physical copy was involved — the exact information the feature was asked for.

`migrate_0.7.76.sql` copies each loan's `copia_id` into every backfilled event that lacks it. Surgical and idempotent: only `source=backfill` loan events, only when the joined loan has a copy, only when the snapshot does not already carry one. Loans without a copy, already-enriched events and real runtime events are untouched. Verified live on two production installs with this exact SQL before productizing.

Behavioural unit (7 checks) runs the real migration file: enrichment on created+returned, no-copy loans left alone, pre-enriched and runtime events untouched, byte-for-byte idempotency, version guard. Full local quality gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correzioni**
  * La cronologia dei prestiti migrata ora include il numero di inventario della copia fisica quando disponibile.
  * Gli eventi già completi, i prestiti senza copia e gli eventi operativi reali restano invariati.
  * La migrazione può essere eseguita nuovamente senza modificare dati già aggiornati.

* **Versione**
  * Aggiornata alla versione 0.7.76.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->