### PR TITLE
ci(release): outage-aware npm audit in the release workflow

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -114,7 +114,7 @@ jobs:
           # npm bundled with Node 22 still POSTs the retired quick-audit
           # endpoint (400 since 2026-09-04); npm 11+ talks to the bulk one.
           # Tool upgrade, not a dependency: nothing from it ships in any asset.
-          npm install -g npm@11 --silent
+          npm install -g npm@11.19.1 --silent
           npm ci --silent
           bash scripts/ci-npm-audit.sh .
 
@@ -358,7 +358,7 @@ jobs:
       - name: Install and audit locked dependencies
         run: |
           # Same retired quick-audit endpoint workaround as the root audit.
-          npm install -g npm@11 --silent
+          npm install -g npm@11.19.1 --silent
           npm ci --silent
           bash scripts/ci-npm-audit.sh .
           npm --prefix frontend ci --silent

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,10 +55,14 @@ jobs:
           composer validate --strict
           composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
           composer audit --no-dev --abandoned=ignore
+          # npm bundled with Node 22 POSTs the retired quick-audit endpoint;
+          # npm 11 uses the bulk one, and the wrapper distinguishes real
+          # advisories from registry outages (retry, then loud neutral).
+          npm install -g npm@11 --silent
           npm ci --silent
-          npm audit --audit-level=high
+          bash scripts/ci-npm-audit.sh .
           npm --prefix frontend ci --silent
-          npm --prefix frontend audit --audit-level=high
+          bash scripts/ci-npm-audit.sh frontend
           npm --prefix frontend run lint
           npm --prefix frontend run build
           npm run test:ci-policy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           # npm bundled with Node 22 POSTs the retired quick-audit endpoint;
           # npm 11 uses the bulk one, and the wrapper distinguishes real
           # advisories from registry outages (retry, then loud neutral).
-          npm install -g npm@11 --silent
+          npm install -g npm@11.19.1 --silent
           npm ci --silent
           bash scripts/ci-npm-audit.sh .
           npm --prefix frontend ci --silent

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -11,3 +11,4 @@ rules:
   adhoc-packages:
     ignore:
       - ci-quality.yml
+      - release.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -10,5 +10,8 @@
 rules:
   adhoc-packages:
     ignore:
-      - ci-quality.yml
-      - release.yml
+      # Line-pinned on purpose: if the steps move, the finding resurfaces
+      # instead of being silently masked for the whole file.
+      - ci-quality.yml:117
+      - ci-quality.yml:361
+      - release.yml:61

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
-## [0.7.78]
+## [0.7.79]
 
-The Emeroteca reaches the Android app ([PR #411](https://github.com/fabiodalez-dev/Pinakes/pull/411)).
+The Emeroteca reaches the Android app (re-cut of the unpublished 0.7.78: its tag-triggered build died on the npm registry's retired audit endpoint before any asset was produced, and tags are immutable — same recovery as 0.7.74/0.7.75) ([PR #411](https://github.com/fabiodalez-dev/Pinakes/pull/411)).
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.78 — latest
+### v0.7.79 — latest
 
 **The Emeroteca reaches the Android app** ([PR #411](https://github.com/fabiodalez-dev/Pinakes/pull/411)): the emeroteca plugin (now 1.3.0) exposes a read-only mobile API — `/api/v1/periodicals/*` — reusing the Mobile API plugin's authentication, quota and HTTPS middleware. Mastheads with cursor pagination and search, volume years with holdings, issues with per-copy state, article-level tables of contents, and issue PDFs only when publicly enabled. The bridge is inert unless BOTH plugins are active, and the [Android app](https://github.com/fabiodalez-dev/Pinakes-Android) (from release 1.5.0) shows its new Emeroteca section only after probing the capability — no server upgrade means the section simply never appears. No core migration.
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.78",
+  "version": "0.7.79",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
The v0.7.78 tag run failed in **Install locked build inputs**: `release.yml` still called bare `npm audit`, which hit the npm registry's retired quick-audit endpoint (503 — same root cause #413 just fixed for `ci-quality.yml`).

Same treatment: upgrade to npm 11 (bulk advisory endpoint; zizmor `adhoc-packages` ignore extended to `release.yml` with the rationale in `.github/zizmor.yml`) and route both audit calls through `scripts/ci-npm-audit.sh`, which fails only on a recognizable advisory report signature and treats every other non-zero exit as infrastructure (retry ×3 → loud neutral; known-CVE coverage continues via the dependency-diff policy and Trivy).

Verified locally: zizmor 1.30 clean over the whole workflows tree, yaml parses; the wrapper's behaviour was proven in #413 (0 vulnerabilities on a normal run, ECONNREFUSED simulation retries and exits neutral).

Needed before re-cutting 0.7.78: tag-triggered runs use the workflow file at the tag's commit, so this must be on main before the next tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Manutenzione**
  - Aggiornati i controlli automatici di sicurezza delle dipendenze durante le build di rilascio, con maggiore affidabilità nella gestione dei tentativi e delle indisponibilità temporanee del registro.
  - Allineato l’ambiente di esecuzione degli audit per garantire verifiche più coerenti tra applicazione principale e frontend.
  - Adeguate le regole dei controlli di sicurezza della pipeline per evitare segnalazioni non pertinenti nei flussi di rilascio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->