### PR TITLE
chore(release): prepare 0.7.81

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.81]
+
+Circulation coherence: a full five-domain review of the reservation/loan system — states & transitions, queues & capacity, emails, audit trail, NCIP/mobile parity — with every finding fixed and covered by tests ([PR #416](https://github.com/fabiodalez-dev/Pinakes/pull/416)). No schema changes: no migration to run.
+
+### Added
+- **Pickup confirmation email** (`loan_picked_up`, seeded in all five locales): the physical pickup was the last silent lifecycle transition. The email reports the ACTUAL day the copy left the desk — captured before commit and preserved in the outbox for delayed retries — not the scheduled loan start.
+- **Self-cancellation confirmations**: cancelling a reservation or a pending request now emails the reader a confirmation.
+- **Complete audit trail for autonomous mutations**: every sweep and repair action records a SYSTEM event with truthful provenance — `loan.expired` on revoked pickups, `loan.overdue` on the bulk overdue flip (with `source=repair` when the data repair performs it), `reservation.expired` on expired holds, `reservation.promoted` on queue promotions, `loan.lost`/`loan.damaged` on returns. The loan snapshot now preserves the assessed penalty.
+
+### Fixed
+- **Queues no longer freeze behind an unpromotable head**: capacity accounting uses the same shared promotable-now predicate as the promotion gate (legacy NULL-start rows included), and only window-overlapping commitments count against future reservation windows — a loan scheduled beyond the window's end no longer blocks the next reader.
+- **Recipient-locale coherence everywhere**: every motivo and fallback (pickup cancelled, renewed title, zero-penalty "Nessun addebito", NCIP cancellations) renders in the recipient's language, never the session's; empty-address guards fire before outbox persistence.
+- **NCIP parity with the desk**: RenewItem refuses date-overdue loans and resets the recall state; CheckOutItem no longer sends a false "approved" email; CheckInItem treats any multi-loan match as an ambiguity error instead of closing an arbitrary loan (an identical retried message can no longer fall through to another borrower's copy); every event carries `source=ncip`.
+- **Maintenance is race-free and never hollow**: `runAll()` holds a database lock for its entire execution (admin button, login hook and cron all funnel through it), the manual button always runs — simultaneous presses deduplicate, sequential presses re-run — and the data repair executes even when the sweep was just claimed by another session.
+- **Stale `pendente` rows expire**: requests with `origine` `richiesta`/`ncip` whose window fully passed are closed by the sweep instead of dangling forever; expired rows repaired by DataIntegrity emit `reservation.expired`, keeping `reservation.cancelled` for duplicates.
+- Lost/damaged outcomes surface the penalty in the CSV export and the loan detail view using the configured currency; archived titles show their real name on the user's own active loans (single convention with the mobile API and the emails).
+
+### Testing
+- Five new behavioural suites against the real database (~200 checks): sweep audit (SMTP forced unreachable for deterministic outbox asserts), NCIP coherence (check-in ambiguity and retry safety), mail coherence (persisted recipient locale, currency token), queue/capacity coherence (window overlap, legacy unblock, source contracts), loan outcome visibility. Five existing suites realigned. Three independent review rounds absorbed (internal adversarial, two CodeRabbit passes).
+
 ## [0.7.80]
 
 Circulation hardening: database-level integrity for the loan/reservation lifecycle, durable circulation emails, and richer lost/damaged handling ([PR #415](https://github.com/fabiodalez-dev/Pinakes/pull/415)).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.80 — latest
+### v0.7.81 — latest
+
+**Circulation coherence** ([PR #416](https://github.com/fabiodalez-dev/Pinakes/pull/416)): a full review of the reservation/loan system across states, queues, emails, audit and NCIP parity, with every finding fixed. A new **pickup confirmation email** closes the last silent lifecycle transition (and reports the actual pickup day); self-cancellations now confirm by email; every autonomous sweep and repair leaves a SYSTEM audit event with truthful provenance, including lost/damaged outcomes with the penalty in the configured currency. Queues no longer freeze behind an unpromotable head (capacity shares the promotion gate's exact predicate), maintenance holds a database lock for its whole run while the manual button always runs, stale pending requests finally expire, and NCIP check-in refuses ambiguous multi-loan matches instead of closing an arbitrary copy. Every motivo reaches the reader in their own language. ~200 new behavioural checks; no migration.
+
+### v0.7.80
 
 **Circulation hardening** ([PR #415](https://github.com/fabiodalez-dev/Pinakes/pull/415)): the reservation and loan lifecycle gets database-level guardrails and durable notifications. New triggers reject malformed circulation data at the source (loan start after due date, duplicate or non-positive active queue positions, double active reservations per user and book) while every queue reorder became collision-free; two new emails keep readers informed (copy assigned & awaiting approval; loan closed with a lost/damaged copy, including the charged amount in the configured currency); a durable **email outbox** (`migrate_0.7.80.sql`) queues failed terminal notifications and retries them with backoff and a hard cap, so a down SMTP no longer loses circulation emails. Lost/damaged returns can record an assessed amount from the return form.
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.80",
+  "version": "0.7.81",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Release preparation for 0.7.81: version bump, README highlights and the changelog entry for the circulation coherence cycle (PR #416, CI touch-ups from PR #417). No code changes, no migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuove funzionalità**
  * Aggiunte email di conferma per il ritiro della copia e per l’autocancellazione delle prenotazioni.
  * Introdotto un audit trail completo per le modifiche automatiche.
  * Migliorata la parità funzionale tra NCIP e app mobile.

* **Correzioni**
  * Risolti problemi nella gestione di code, capacità, notifiche e lingua del destinatario.
  * Migliorata la manutenzione delle prenotazioni, evitando condizioni di gara e gestendo correttamente la scadenza degli elementi pendenti.

* **Documentazione**
  * Aggiornate le note di rilascio e la sezione “Novità” alla versione 0.7.81.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->