### PR TITLE
chore(release): prepare 0.7.82

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 Full version-by-version history for Pinakes. The README shows only the latest release; everything older lives here.
 
+## [0.7.82]
+
+The Emeroteca becomes a working serials desk, and the core gains the extension points it was missing ([PR #419](https://github.com/fabiodalez-dev/Pinakes/pull/419)). The bundled plugin goes to **1.4.0**; its schema migrates itself on upgrade. No core migration.
+
+### Added
+- **Barcodes at the desk.** A masthead now carries the EAN-13 base derived from its ISSN (the 977 prefix) and an issue carries its own barcode with the add-on that identifies it, both indexed. The Kardex has a scanner — the same self-hosted one the copy tracking uses — that resolves a scan to the issue and offers to receive it. The ISSN itself is validated by checksum, not merely by shape: a mistyped one used to be accepted and would have produced a barcode pointing at another journal. e-ISSN and ISSN-L are recorded too.
+- **Claims and subscriptions**, the part of the Kardex that was missing: a subscriptions table (supplier, cost, dates, renewal, badged when expiring), the acquisition mode and price on the issue, and a claim workflow with its counters and dates — including a bulk claim over a volume year that never touches the current year and never re-claims what it already claimed.
+- **Exports and labels**: KBART TSV and an ACNP-style CSV of the holdings, and issue labels with their barcode through the same machinery as copy labels.
+- **Merging duplicate mastheads**, in one transaction: volume years fold together, colliding issue numbers are resolved by a documented rule where the held copy keeps the plain number and the loser is renumbered rather than dropped, subscriptions and title history follow the survivor, and the transaction refuses to commit unless the issue count afterwards equals the sum before.
+- **Periodicals reach the outside world**: an OAI-PMH set in Dublin Core, serial records in all four Z39.50/SRU formats with a Bath ISSN index, entries in the sitemap, and a hint in the catalogue search pointing at the section that actually holds what the reader looked for.
+- **Core extension points**: `sitemap.entries` and `search.external_suggestions` filters, `publisher.merging`/`publisher.deleting`/`genre.merging` actions with a `shelf.can_delete` veto, and `ActivityLog::recordEntityEvent()` so plugins can audit their own tables.
+
+### Fixed
+- **Merging two publishers no longer silently detaches what a plugin attached to them.** The core repointed only its own tables before deleting the duplicate, so every masthead linked to it lost its publisher without an error or a log line; the same applied to genres, and a shelf occupied only by issues could be deleted. Listeners now run inside those transactions, before the delete.
+- **Possession and physical condition are separate fields.** They shared one column, so an issue that was held but damaged silently left the holdings count — the consistency statement lied. The upgrade migrates the legacy rows without losing any, and withdrawn issues now leave the public catalogue and its counts.
+- **The declared holdings statement means the same thing everywhere.** Three implementations disagreed: the list ignored it, the issues page appended it, and the export replaced everything with it — so the file sent to union catalogues silently lost the issues actually held.
+- Publishing or revoking an issue PDF is finally auditable, exported cells cannot carry spreadsheet formulas, an ISSN is validated before being exported rather than merely reformatted, and the admin list no longer runs one query per row.
+
 ## [0.7.81]
 
 Circulation coherence: a full five-domain review of the reservation/loan system — states & transitions, queues & capacity, emails, audit trail, NCIP/mobile parity — with every finding fixed and covered by tests ([PR #416](https://github.com/fabiodalez-dev/Pinakes/pull/416)). No schema changes: no migration to run.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Pinakes is a self-hosted, full-featured ILS for schools, municipalities, and pri
 
 Highlights of the latest release are below. The full version-by-version history (v0.7.59 → v0.6.x) lives in **[CHANGELOG.md](CHANGELOG.md)**.
 
-### v0.7.81 — latest
+### v0.7.82 — latest
+
+**The Emeroteca becomes a working serials desk** ([PR #419](https://github.com/fabiodalez-dev/Pinakes/pull/419)): the periodicals plugin (now 1.4.0) gains what running one actually requires. Issues carry a **barcode** — the 977 EAN-13 derived from the ISSN, with the add-on that identifies the single issue — so a scan at the desk finds the issue and offers to receive it; the ISSN is validated by checksum, and e-ISSN and ISSN-L are recorded. **Subscriptions and claims** complete the Kardex: supplier, cost, expiry with its badge, and the chase for an issue that never arrived. Possession and physical condition become separate fields, so a held-but-damaged issue no longer vanishes from the holdings count. Duplicate mastheads can be **merged** without losing an issue, holdings **export** as KBART and ACNP, issues **print as labels**, and the titles finally reach **OAI-PMH, Z39.50/SRU, the sitemap and the catalogue search**. On the core side, merging or deleting a publisher, genre or shelf now notifies the plugins that reference it — previously it detached their rows in silence. Plugin schema migrates itself; no core migration.
+
+### v0.7.81
 
 **Circulation coherence** ([PR #416](https://github.com/fabiodalez-dev/Pinakes/pull/416)): a full review of the reservation/loan system across states, queues, emails, audit and NCIP parity, with every finding fixed. A new **pickup confirmation email** closes the last silent lifecycle transition (and reports the actual pickup day); self-cancellations now confirm by email; every autonomous sweep and repair leaves a SYSTEM audit event with truthful provenance, including lost/damaged outcomes with the penalty in the configured currency. Queues no longer freeze behind an unpromotable head (capacity shares the promotion gate's exact predicate), maintenance holds a database lock for its whole run while the manual button always runs, stale pending requests finally expire, and NCIP check-in refuses ambiguous multi-loan matches instead of closing an arbitrary copy. Every motivo reaches the reader in their own language. ~200 new behavioural checks; no migration.
 

--- a/tests/emeroteca-schema-140.unit.php
+++ b/tests/emeroteca-schema-140.unit.php
@@ -673,7 +673,10 @@ try {
             'git -C ' . $root . ' show ' . escapeshellarg($ref . ':storage/plugins/emeroteca/plugin.json') . ' 2>/dev/null'
         );
         $version = is_string($manifest) ? (json_decode($manifest, true)['version'] ?? '') : '';
-        if (is_string($version) && $version !== '' && version_compare($version, '1.4.0', '<')) {
+        // Exactly 1.3.0: the embedded baseline describes THAT schema. A ref
+        // shipping 1.2.x would compare it against a different one and report a
+        // mismatch that says nothing about this branch.
+        if ($version === '1.3.0') {
             $mainSrc = $candidate;
             note("1.3.0 baseline cross-checked against {$ref} (plugin {$version})");
             break;

--- a/tests/emeroteca-schema-140.unit.php
+++ b/tests/emeroteca-schema-140.unit.php
@@ -654,13 +654,33 @@ try {
         }
     }
 
-    // ── 2d. the embedded 1.3.0 baseline still matches origin/main ──────
+    // ── 2d. the embedded 1.3.0 baseline still matches the released source ──
+    // Anchored to a ref that actually SHIPS 1.3.0, not to origin/main: once
+    // this branch is merged main carries 1.4.0 and comparing against it would
+    // fail for the wrong reason. Candidate refs are probed in order and the
+    // plugin version is verified before the comparison is trusted.
     $root = escapeshellarg(dirname(__DIR__));
-    $mainSrc = @shell_exec(
-        'git -C ' . $root . ' show origin/main:storage/plugins/emeroteca/EmerotecaPlugin.php 2>/dev/null'
-    );
+    $mainSrc = null;
+    foreach (['v0.7.81', 'origin/main'] as $ref) {
+        $candidate = @shell_exec(
+            'git -C ' . $root . ' show ' . escapeshellarg($ref . ':storage/plugins/emeroteca/EmerotecaPlugin.php') . ' 2>/dev/null'
+        );
+        if (!is_string($candidate) || trim($candidate) === '') {
+            continue;
+        }
+        // Only a ref whose manifest predates 1.4.0 can serve as the baseline.
+        $manifest = @shell_exec(
+            'git -C ' . $root . ' show ' . escapeshellarg($ref . ':storage/plugins/emeroteca/plugin.json') . ' 2>/dev/null'
+        );
+        $version = is_string($manifest) ? (json_decode($manifest, true)['version'] ?? '') : '';
+        if (is_string($version) && $version !== '' && version_compare($version, '1.4.0', '<')) {
+            $mainSrc = $candidate;
+            note("1.3.0 baseline cross-checked against {$ref} (plugin {$version})");
+            break;
+        }
+    }
     if (!is_string($mainSrc) || trim($mainSrc) === '') {
-        note('origin/main not resolvable (shallow clone?) — embedded 1.3.0 baseline not cross-checked');
+        note('no ref shipping plugin < 1.4.0 is resolvable (shallow clone?) — embedded 1.3.0 baseline not cross-checked');
     } else {
         foreach ($LEGACY_130 as $table => $legacyColumns) {
             if (preg_match('/CREATE TABLE IF NOT EXISTS ' . preg_quote($table, '/') . ' \(.*?\n\s*SQL;/s', $mainSrc, $m) !== 1) {

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
   "name": "Pinakes",
-  "version": "0.7.81",
+  "version": "0.7.82",
   "description": "Library Management System - Sistema di Gestione Bibliotecaria"
 }


### PR DESCRIPTION
Release preparation for 0.7.82: version bump, README highlights and the changelog entry for the Emeroteca 1.4.0 cycle (PR #419).

Carries one test fix that main needs regardless: the schema suite cross-checked its embedded 1.3.0 baseline against `origin/main`, which now ships 1.4.0, so the check failed for the wrong reason as soon as the branch merged. It now probes candidate refs and verifies the plugin version before trusting the comparison.

No code changes, no core migration — the plugin migrates its own schema on upgrade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuove funzionalità**
  - La Emeroteca diventa un banco periodici completo, con codici a barre EAN-13 derivati dall’ISSN e scansione nel Kardex.
  - Aggiunti gestione di abbonamenti e reclami, esportazioni KBART/ACNP, stampa di etichette e fusione delle testate duplicate.
  - I periodici sono disponibili tramite OAI-PMH, Z39.50/SRU, sitemap e ricerca catalogo.
  - Introdotta la versione 0.7.82 con migrazione automatica dello schema della Emeroteca.

- **Correzioni**
  - Migliorate validazione ISSN, gestione di possesso e condizioni fisiche, coerenza dei dati, sicurezza delle esportazioni e prestazioni delle liste amministrative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->